### PR TITLE
Revisit @Transactional

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/channel/ChannelTemplateManager.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/ChannelTemplateManager.java
@@ -26,11 +26,10 @@ package com.synopsys.integration.alert.channel;
 import java.util.Date;
 import java.util.List;
 
-import javax.transaction.Transactional;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.channel.event.ChannelEvent;
@@ -43,7 +42,6 @@ import com.synopsys.integration.alert.database.audit.AuditEntryRepository;
 import com.synopsys.integration.alert.database.audit.AuditNotificationRepository;
 import com.synopsys.integration.alert.database.audit.relation.AuditNotificationRelation;
 
-@Transactional
 @Component
 public class ChannelTemplateManager {
     private final Gson gson;
@@ -65,6 +63,7 @@ public class ChannelTemplateManager {
         }
     }
 
+    @Transactional
     public boolean sendEvent(final AlertEvent event) {
         final String destination = event.getDestination();
         if (event instanceof ChannelEvent) {

--- a/src/main/java/com/synopsys/integration/alert/channel/slack/SlackChannel.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/slack/SlackChannel.java
@@ -30,8 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.transaction.Transactional;
-
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -52,7 +50,6 @@ import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.rest.request.Request;
 
 @Component(value = SlackChannel.COMPONENT_NAME)
-@Transactional
 public class SlackChannel extends RestDistributionChannel<GlobalChannelConfigEntity, SlackDistributionConfigEntity, SlackChannelEvent> {
     public static final String COMPONENT_NAME = "channel_slack";
     public static final String SLACK_API = "https://hooks.slack.com";

--- a/src/main/java/com/synopsys/integration/alert/common/descriptor/config/CommonTypeConverter.java
+++ b/src/main/java/com/synopsys/integration/alert/common/descriptor/config/CommonTypeConverter.java
@@ -23,8 +23,6 @@
  */
 package com.synopsys.integration.alert.common.descriptor.config;
 
-import javax.transaction.Transactional;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -48,7 +46,6 @@ public class CommonTypeConverter {
         this.contentConverter = contentConverter;
     }
 
-    @Transactional
     public Config populateCommonFieldsFromEntity(final CommonDistributionConfig channelConfig, final CommonDistributionConfigEntity commonEntity) {
         channelConfig.setId(contentConverter.getStringValue(commonEntity.getId()));
         channelConfig.setDistributionConfigId(contentConverter.getStringValue(commonEntity.getDistributionConfigId()));

--- a/src/main/java/com/synopsys/integration/alert/common/distribution/CommonDistributionConfigReader.java
+++ b/src/main/java/com/synopsys/integration/alert/common/distribution/CommonDistributionConfigReader.java
@@ -27,10 +27,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import javax.transaction.Transactional;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.common.descriptor.config.CommonTypeConverter;
 import com.synopsys.integration.alert.database.entity.CommonDistributionConfigEntity;

--- a/src/main/java/com/synopsys/integration/alert/database/RepositoryAccessor.java
+++ b/src/main/java/com/synopsys/integration/alert/database/RepositoryAccessor.java
@@ -33,6 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.synopsys.integration.alert.database.entity.DatabaseEntity;
 
 @Transactional
+// TODO we should strongly consider only allowing reads from a repository accessor; deletes should not necessarily be atomic transactions
 public abstract class RepositoryAccessor {
     private final JpaRepository<? extends DatabaseEntity, Long> repository;
 

--- a/src/main/java/com/synopsys/integration/alert/database/audit/AuditEntryRepository.java
+++ b/src/main/java/com/synopsys/integration/alert/database/audit/AuditEntryRepository.java
@@ -25,14 +25,10 @@ package com.synopsys.integration.alert.database.audit;
 
 import java.util.List;
 
-import javax.transaction.Transactional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
-@Transactional
 public interface AuditEntryRepository extends JpaRepository<AuditEntryEntity, Long> {
-    public AuditEntryEntity findFirstByCommonConfigIdOrderByTimeLastSentDesc(final Long commonConfigId);
+    AuditEntryEntity findFirstByCommonConfigIdOrderByTimeLastSentDesc(final Long commonConfigId);
 
-    public List<AuditEntryEntity> findByCommonConfigId(final Long commonConfigId);
-
+    List<AuditEntryEntity> findByCommonConfigId(final Long commonConfigId);
 }

--- a/src/main/java/com/synopsys/integration/alert/database/audit/AuditNotificationRepository.java
+++ b/src/main/java/com/synopsys/integration/alert/database/audit/AuditNotificationRepository.java
@@ -25,17 +25,13 @@ package com.synopsys.integration.alert.database.audit;
 
 import java.util.List;
 
-import javax.transaction.Transactional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.synopsys.integration.alert.database.audit.relation.AuditNotificationRelation;
 import com.synopsys.integration.alert.database.audit.relation.AuditNotificationRelationPK;
 
-@Transactional
 public interface AuditNotificationRepository extends JpaRepository<AuditNotificationRelation, AuditNotificationRelationPK> {
-    public List<AuditNotificationRelation> findByAuditEntryId(final Long auditEntryId);
+    List<AuditNotificationRelation> findByAuditEntryId(final Long auditEntryId);
 
-    public List<AuditNotificationRelation> findByNotificationId(final Long notificationId);
-
+    List<AuditNotificationRelation> findByNotificationId(final Long notificationId);
 }

--- a/src/main/java/com/synopsys/integration/alert/database/channel/email/EmailGlobalRepository.java
+++ b/src/main/java/com/synopsys/integration/alert/database/channel/email/EmailGlobalRepository.java
@@ -23,11 +23,7 @@
  */
 package com.synopsys.integration.alert.database.channel.email;
 
-import javax.transaction.Transactional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
-@Transactional
 public interface EmailGlobalRepository extends JpaRepository<EmailGlobalConfigEntity, Long> {
-
 }

--- a/src/main/java/com/synopsys/integration/alert/database/channel/email/EmailGroupDistributionRepository.java
+++ b/src/main/java/com/synopsys/integration/alert/database/channel/email/EmailGroupDistributionRepository.java
@@ -23,11 +23,7 @@
  */
 package com.synopsys.integration.alert.database.channel.email;
 
-import javax.transaction.Transactional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
-@Transactional
 public interface EmailGroupDistributionRepository extends JpaRepository<EmailGroupDistributionConfigEntity, Long> {
-
 }

--- a/src/main/java/com/synopsys/integration/alert/database/channel/hipchat/HipChatDistributionRepository.java
+++ b/src/main/java/com/synopsys/integration/alert/database/channel/hipchat/HipChatDistributionRepository.java
@@ -23,11 +23,7 @@
  */
 package com.synopsys.integration.alert.database.channel.hipchat;
 
-import javax.transaction.Transactional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
-@Transactional
 public interface HipChatDistributionRepository extends JpaRepository<HipChatDistributionConfigEntity, Long> {
-
 }

--- a/src/main/java/com/synopsys/integration/alert/database/channel/hipchat/HipChatGlobalRepository.java
+++ b/src/main/java/com/synopsys/integration/alert/database/channel/hipchat/HipChatGlobalRepository.java
@@ -23,10 +23,7 @@
  */
 package com.synopsys.integration.alert.database.channel.hipchat;
 
-import javax.transaction.Transactional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
-@Transactional
 public interface HipChatGlobalRepository extends JpaRepository<HipChatGlobalConfigEntity, Long> {
 }

--- a/src/main/java/com/synopsys/integration/alert/database/channel/slack/SlackDistributionRepository.java
+++ b/src/main/java/com/synopsys/integration/alert/database/channel/slack/SlackDistributionRepository.java
@@ -23,11 +23,7 @@
  */
 package com.synopsys.integration.alert.database.channel.slack;
 
-import javax.transaction.Transactional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
-@Transactional
 public interface SlackDistributionRepository extends JpaRepository<SlackDistributionConfigEntity, Long> {
-
 }

--- a/src/main/java/com/synopsys/integration/alert/database/entity/repository/CommonDistributionRepository.java
+++ b/src/main/java/com/synopsys/integration/alert/database/entity/repository/CommonDistributionRepository.java
@@ -23,15 +23,12 @@
  */
 package com.synopsys.integration.alert.database.entity.repository;
 
-import javax.transaction.Transactional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.synopsys.integration.alert.database.entity.CommonDistributionConfigEntity;
 
-@Transactional
 public interface CommonDistributionRepository extends JpaRepository<CommonDistributionConfigEntity, Long> {
-    public CommonDistributionConfigEntity findByDistributionConfigIdAndDistributionType(final Long distributionConfigId, final String distributionType);
+    CommonDistributionConfigEntity findByDistributionConfigIdAndDistributionType(final Long distributionConfigId, final String distributionType);
 
-    public CommonDistributionConfigEntity findByName(String name);
+    CommonDistributionConfigEntity findByName(String name);
 }

--- a/src/main/java/com/synopsys/integration/alert/database/entity/repository/ConfiguredProjectsRepository.java
+++ b/src/main/java/com/synopsys/integration/alert/database/entity/repository/ConfiguredProjectsRepository.java
@@ -23,13 +23,10 @@
  */
 package com.synopsys.integration.alert.database.entity.repository;
 
-import javax.transaction.Transactional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.synopsys.integration.alert.database.entity.ConfiguredProjectEntity;
 
-@Transactional
 public interface ConfiguredProjectsRepository extends JpaRepository<ConfiguredProjectEntity, Long> {
-    public ConfiguredProjectEntity findByProjectName(final String projectName);
+    ConfiguredProjectEntity findByProjectName(final String projectName);
 }

--- a/src/main/java/com/synopsys/integration/alert/database/entity/repository/NotificationRepository.java
+++ b/src/main/java/com/synopsys/integration/alert/database/entity/repository/NotificationRepository.java
@@ -26,14 +26,11 @@ package com.synopsys.integration.alert.database.entity.repository;
 import java.util.Date;
 import java.util.List;
 
-import javax.transaction.Transactional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import com.synopsys.integration.alert.database.entity.NotificationEntity;
 
-@Transactional
 public interface NotificationRepository extends JpaRepository<NotificationEntity, Long> {
     @Query("SELECT entity FROM NotificationEntity entity WHERE entity.createdAt BETWEEN ?1 AND ?2 ORDER BY created_at asc")
     List<NotificationEntity> findByCreatedAtBetween(final Date startDate, final Date endDate);

--- a/src/main/java/com/synopsys/integration/alert/database/entity/repository/NotificationTypeRepository.java
+++ b/src/main/java/com/synopsys/integration/alert/database/entity/repository/NotificationTypeRepository.java
@@ -23,14 +23,11 @@
  */
 package com.synopsys.integration.alert.database.entity.repository;
 
-import javax.transaction.Transactional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.synopsys.integration.alert.database.entity.NotificationTypeEntity;
 import com.synopsys.integration.blackduck.api.generated.enumeration.NotificationType;
 
-@Transactional
 public interface NotificationTypeRepository extends JpaRepository<NotificationTypeEntity, Long> {
-    public NotificationTypeEntity findByType(final NotificationType type);
+    NotificationTypeEntity findByType(final NotificationType type);
 }

--- a/src/main/java/com/synopsys/integration/alert/database/entity/repository/VulnerabilityRepository.java
+++ b/src/main/java/com/synopsys/integration/alert/database/entity/repository/VulnerabilityRepository.java
@@ -25,13 +25,10 @@ package com.synopsys.integration.alert.database.entity.repository;
 
 import java.util.List;
 
-import javax.transaction.Transactional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.synopsys.integration.alert.database.entity.VulnerabilityEntity;
 
-@Transactional
 public interface VulnerabilityRepository extends JpaRepository<VulnerabilityEntity, Long> {
-    public List<VulnerabilityEntity> findByNotificationId(Long notificationId);
+    List<VulnerabilityEntity> findByNotificationId(Long notificationId);
 }

--- a/src/main/java/com/synopsys/integration/alert/database/provider/blackduck/data/BlackDuckProjectRepositoryAccessor.java
+++ b/src/main/java/com/synopsys/integration/alert/database/provider/blackduck/data/BlackDuckProjectRepositoryAccessor.java
@@ -34,6 +34,7 @@ import com.synopsys.integration.alert.database.RepositoryAccessor;
 import com.synopsys.integration.alert.database.entity.DatabaseEntity;
 
 @Component
+@Transactional
 public class BlackDuckProjectRepositoryAccessor extends RepositoryAccessor {
     private final BlackDuckProjectRepository blackDuckProjectRepository;
 

--- a/src/main/java/com/synopsys/integration/alert/database/provider/blackduck/data/relation/UserProjectRelationRepositoryAccessor.java
+++ b/src/main/java/com/synopsys/integration/alert/database/provider/blackduck/data/relation/UserProjectRelationRepositoryAccessor.java
@@ -32,7 +32,6 @@ import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
-@Transactional
 public class UserProjectRelationRepositoryAccessor {
     private final UserProjectRelationRepository userProjectRelationRepository;
 
@@ -56,9 +55,9 @@ public class UserProjectRelationRepositoryAccessor {
         return userProjectRelationRepository.findByBlackDuckUserId(blackDuckUserId);
     }
 
+    @Transactional
     public List<UserProjectRelation> deleteAndSaveAll(final Set<UserProjectRelation> userProjectRelations) {
         userProjectRelationRepository.deleteAllInBatch();
         return userProjectRelationRepository.saveAll(userProjectRelations);
     }
-
 }

--- a/src/main/java/com/synopsys/integration/alert/database/purge/PurgeReader.java
+++ b/src/main/java/com/synopsys/integration/alert/database/purge/PurgeReader.java
@@ -28,8 +28,6 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
 
-import javax.transaction.Transactional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemReader;
@@ -37,7 +35,6 @@ import org.springframework.batch.item.ItemReader;
 import com.synopsys.integration.alert.database.entity.NotificationContent;
 import com.synopsys.integration.alert.workflow.NotificationManager;
 
-@Transactional
 public class PurgeReader implements ItemReader<List<NotificationContent>> {
     private final static Logger logger = LoggerFactory.getLogger(PurgeReader.class);
     private final NotificationManager notificationManager;

--- a/src/main/java/com/synopsys/integration/alert/database/purge/PurgeWriter.java
+++ b/src/main/java/com/synopsys/integration/alert/database/purge/PurgeWriter.java
@@ -25,8 +25,6 @@ package com.synopsys.integration.alert.database.purge;
 
 import java.util.List;
 
-import javax.transaction.Transactional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemWriter;
@@ -34,7 +32,6 @@ import org.springframework.batch.item.ItemWriter;
 import com.synopsys.integration.alert.database.entity.NotificationContent;
 import com.synopsys.integration.alert.workflow.NotificationManager;
 
-@Transactional
 public class PurgeWriter implements ItemWriter<List<NotificationContent>> {
     private final static Logger logger = LoggerFactory.getLogger(PurgeWriter.class);
     private final NotificationManager notificationManager;

--- a/src/main/java/com/synopsys/integration/alert/database/relation/repository/DistributionNotificationTypeRepository.java
+++ b/src/main/java/com/synopsys/integration/alert/database/relation/repository/DistributionNotificationTypeRepository.java
@@ -25,14 +25,11 @@ package com.synopsys.integration.alert.database.relation.repository;
 
 import java.util.List;
 
-import javax.transaction.Transactional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.synopsys.integration.alert.database.relation.DistributionNotificationTypeRelation;
 import com.synopsys.integration.alert.database.relation.key.DistributionNotificationTypeRelationPK;
 
-@Transactional
 public interface DistributionNotificationTypeRepository extends JpaRepository<DistributionNotificationTypeRelation, DistributionNotificationTypeRelationPK> {
-    public List<DistributionNotificationTypeRelation> findByCommonDistributionConfigId(final Long commonDistributionConfigId);
+    List<DistributionNotificationTypeRelation> findByCommonDistributionConfigId(final Long commonDistributionConfigId);
 }

--- a/src/main/java/com/synopsys/integration/alert/database/relation/repository/DistributionProjectRepository.java
+++ b/src/main/java/com/synopsys/integration/alert/database/relation/repository/DistributionProjectRepository.java
@@ -25,16 +25,13 @@ package com.synopsys.integration.alert.database.relation.repository;
 
 import java.util.List;
 
-import javax.transaction.Transactional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.synopsys.integration.alert.database.relation.key.DistributionProjectRelationPK;
 import com.synopsys.integration.alert.database.relation.DistributionProjectRelation;
+import com.synopsys.integration.alert.database.relation.key.DistributionProjectRelationPK;
 
-@Transactional
 public interface DistributionProjectRepository extends JpaRepository<DistributionProjectRelation, DistributionProjectRelationPK> {
-    public List<DistributionProjectRelation> findByCommonDistributionConfigId(final Long commonDistributionConfigId);
+    List<DistributionProjectRelation> findByCommonDistributionConfigId(final Long commonDistributionConfigId);
 
-    public List<DistributionProjectRelation> findByProjectId(final Long projectId);
+    List<DistributionProjectRelation> findByProjectId(final Long projectId);
 }

--- a/src/main/java/com/synopsys/integration/alert/database/scheduling/SchedulingRepository.java
+++ b/src/main/java/com/synopsys/integration/alert/database/scheduling/SchedulingRepository.java
@@ -23,11 +23,7 @@
  */
 package com.synopsys.integration.alert.database.scheduling;
 
-import javax.transaction.Transactional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
-@Transactional
 public interface SchedulingRepository extends JpaRepository<SchedulingConfigEntity, Long> {
-
 }

--- a/src/main/java/com/synopsys/integration/alert/web/actions/ConfiguredProjectsActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/actions/ConfiguredProjectsActions.java
@@ -71,6 +71,8 @@ public class ConfiguredProjectsActions {
         return configuredProjects;
     }
 
+    @Transactional
+    // TODO investigate the impact of private methods on transactions; the transaction is not complete until after all of the private methods have executed
     public void saveConfiguredProjects(final long entityId, final List<String> configuredProjects) {
         if (configuredProjects != null) {
             removeOldDistributionProjectRelations(entityId);
@@ -92,14 +94,12 @@ public class ConfiguredProjectsActions {
         });
     }
 
-    @Transactional
-    void removeOldDistributionProjectRelations(final Long commonDistributionConfigId) {
+    private void removeOldDistributionProjectRelations(final Long commonDistributionConfigId) {
         final List<DistributionProjectRelation> distributionProjects = distributionProjectRepository.findByCommonDistributionConfigId(commonDistributionConfigId);
         distributionProjectRepository.deleteAll(distributionProjects);
     }
 
-    @Transactional
-    void addNewDistributionProjectRelations(final Long commonDistributionConfigId, final List<String> configuredProjectsFromRestModel) {
+    private void addNewDistributionProjectRelations(final Long commonDistributionConfigId, final List<String> configuredProjectsFromRestModel) {
         for (final String projectName : configuredProjectsFromRestModel) {
             final Long projectId;
             final ConfiguredProjectEntity foundEntity = configuredProjectsRepository.findByProjectName(projectName);

--- a/src/main/java/com/synopsys/integration/alert/web/actions/ConfiguredProjectsActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/actions/ConfiguredProjectsActions.java
@@ -27,12 +27,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import javax.transaction.Transactional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.database.entity.CommonDistributionConfigEntity;
 import com.synopsys.integration.alert.database.entity.ConfiguredProjectEntity;
@@ -40,7 +39,6 @@ import com.synopsys.integration.alert.database.entity.repository.ConfiguredProje
 import com.synopsys.integration.alert.database.relation.DistributionProjectRelation;
 import com.synopsys.integration.alert.database.relation.repository.DistributionProjectRepository;
 
-@Transactional
 @Component
 public class ConfiguredProjectsActions {
     private static final Logger logger = LoggerFactory.getLogger(ConfiguredProjectsActions.class);
@@ -62,6 +60,7 @@ public class ConfiguredProjectsActions {
         return distributionProjectRepository;
     }
 
+    @Transactional
     public List<String> getConfiguredProjects(final CommonDistributionConfigEntity commonEntity) {
         final List<DistributionProjectRelation> distributionProjects = distributionProjectRepository.findByCommonDistributionConfigId(commonEntity.getId());
         final List<String> configuredProjects = new ArrayList<>(distributionProjects.size());
@@ -82,6 +81,7 @@ public class ConfiguredProjectsActions {
         }
     }
 
+    @Transactional
     public void cleanUpConfiguredProjects() {
         final List<ConfiguredProjectEntity> configuredProjects = configuredProjectsRepository.findAll();
         configuredProjects.forEach(configuredProject -> {
@@ -92,12 +92,14 @@ public class ConfiguredProjectsActions {
         });
     }
 
-    private void removeOldDistributionProjectRelations(final Long commonDistributionConfigId) {
+    @Transactional
+    void removeOldDistributionProjectRelations(final Long commonDistributionConfigId) {
         final List<DistributionProjectRelation> distributionProjects = distributionProjectRepository.findByCommonDistributionConfigId(commonDistributionConfigId);
         distributionProjectRepository.deleteAll(distributionProjects);
     }
 
-    private void addNewDistributionProjectRelations(final Long commonDistributionConfigId, final List<String> configuredProjectsFromRestModel) {
+    @Transactional
+    void addNewDistributionProjectRelations(final Long commonDistributionConfigId, final List<String> configuredProjectsFromRestModel) {
         for (final String projectName : configuredProjectsFromRestModel) {
             final Long projectId;
             final ConfiguredProjectEntity foundEntity = configuredProjectsRepository.findByProjectName(projectName);
@@ -110,5 +112,4 @@ public class ConfiguredProjectsActions {
             distributionProjectRepository.save(new DistributionProjectRelation(commonDistributionConfigId, projectId));
         }
     }
-
 }

--- a/src/main/java/com/synopsys/integration/alert/web/actions/NotificationTypesActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/actions/NotificationTypesActions.java
@@ -26,19 +26,18 @@ package com.synopsys.integration.alert.web.actions;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.transaction.Transactional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.database.entity.CommonDistributionConfigEntity;
 import com.synopsys.integration.alert.database.entity.repository.NotificationTypeRepository;
 import com.synopsys.integration.alert.database.relation.DistributionNotificationTypeRelation;
 import com.synopsys.integration.alert.database.relation.repository.DistributionNotificationTypeRepository;
 
-@Transactional
 @Component
 public class NotificationTypesActions {
     private static final Logger logger = LoggerFactory.getLogger(NotificationTypesActions.class);
@@ -60,6 +59,7 @@ public class NotificationTypesActions {
         return distributionNotificationTypeRepository;
     }
 
+    @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
     public List<String> getNotificationTypes(final CommonDistributionConfigEntity commonEntity) {
         final List<DistributionNotificationTypeRelation> foundRelations = distributionNotificationTypeRepository.findByCommonDistributionConfigId(commonEntity.getId());
         return foundRelations.stream().map(DistributionNotificationTypeRelation::getNotificationType).collect(Collectors.toList());
@@ -75,13 +75,14 @@ public class NotificationTypesActions {
         }
     }
 
+    @Transactional
     public void removeOldNotificationTypes(final Long commonDistributionConfigId) {
         final List<DistributionNotificationTypeRelation> distributionProjects = distributionNotificationTypeRepository.findByCommonDistributionConfigId(commonDistributionConfigId);
         distributionNotificationTypeRepository.deleteAll(distributionProjects);
     }
 
-    private void addNewDistributionNotificationTypes(final Long commonDistributionConfigId, final List<String> notificationTypesFromRestModel) {
+    @Transactional
+    void addNewDistributionNotificationTypes(final Long commonDistributionConfigId, final List<String> notificationTypesFromRestModel) {
         notificationTypesFromRestModel.forEach(notificationType -> distributionNotificationTypeRepository.save(new DistributionNotificationTypeRelation(commonDistributionConfigId, notificationType)));
     }
-
 }

--- a/src/main/java/com/synopsys/integration/alert/web/actions/NotificationTypesActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/actions/NotificationTypesActions.java
@@ -82,7 +82,7 @@ public class NotificationTypesActions {
     }
 
     @Transactional
-    void addNewDistributionNotificationTypes(final Long commonDistributionConfigId, final List<String> notificationTypesFromRestModel) {
+    public void addNewDistributionNotificationTypes(final Long commonDistributionConfigId, final List<String> notificationTypesFromRestModel) {
         notificationTypesFromRestModel.forEach(notificationType -> distributionNotificationTypeRepository.save(new DistributionNotificationTypeRelation(commonDistributionConfigId, notificationType)));
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/web/audit/AuditEntryActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/audit/AuditEntryActions.java
@@ -30,8 +30,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import javax.transaction.Transactional;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +38,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.channel.ChannelTemplateManager;
 import com.synopsys.integration.alert.channel.event.ChannelEvent;
@@ -60,8 +59,9 @@ import com.synopsys.integration.alert.workflow.NotificationManager;
 import com.synopsys.integration.alert.workflow.processor.NotificationProcessor;
 import com.synopsys.integration.exception.IntegrationException;
 
-@Transactional
 @Component
+@Transactional
+// TODO not all methods in this class need to be Transactional
 public class AuditEntryActions {
     private final Logger logger = LoggerFactory.getLogger(AuditEntryActions.class);
 
@@ -259,5 +259,4 @@ public class AuditEntryActions {
 
         return new AuditEntryConfig(id, distributionConfigName, eventType, timeCreated, timeLastSent, status, errorMessage, errorStackTrace, notificationConfig);
     }
-
 }

--- a/src/main/java/com/synopsys/integration/alert/web/channel/actions/CommonDistributionConfigActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/channel/actions/CommonDistributionConfigActions.java
@@ -41,7 +41,6 @@ import com.synopsys.integration.alert.web.actions.NotificationTypesActions;
 import com.synopsys.integration.alert.web.model.CommonDistributionConfig;
 
 @Component
-@Transactional
 public class CommonDistributionConfigActions {
     private final ConfiguredProjectsActions configuredProjectsActions;
     private final NotificationTypesActions notificationTypesActions;
@@ -57,6 +56,7 @@ public class CommonDistributionConfigActions {
         this.contentConverter = contentConverter;
     }
 
+    @Transactional
     public void validateCommonConfig(final CommonDistributionConfig commonConfig, final Map<String, String> fieldErrors) {
         if (StringUtils.isNotBlank(commonConfig.getName())) {
             final CommonDistributionConfigEntity entity = commonDistributionRepository.findByName(commonConfig.getName());
@@ -116,8 +116,8 @@ public class CommonDistributionConfigActions {
         final FrequencyType frequencyType = Enum.valueOf(FrequencyType.class, commonConfig.getFrequency());
         final Boolean filterByProject = contentConverter.getBooleanValue(commonConfig.getFilterByProject());
         final FormatType formatType = Enum.valueOf(FormatType.class, commonConfig.getFormatType());
-        final CommonDistributionConfigEntity commonEntity = new CommonDistributionConfigEntity(distributionConfigId, commonConfig.getDistributionType(), commonConfig.getName(), commonConfig.getProviderName(), frequencyType,
-            filterByProject, formatType);
+        final CommonDistributionConfigEntity commonEntity =
+            new CommonDistributionConfigEntity(distributionConfigId, commonConfig.getDistributionType(), commonConfig.getName(), commonConfig.getProviderName(), frequencyType, filterByProject, formatType);
         final Long longId = contentConverter.getLongValue(commonConfig.getId());
         commonEntity.setId(longId);
         return commonEntity;

--- a/src/main/java/com/synopsys/integration/alert/web/channel/actions/CommonDistributionConfigActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/channel/actions/CommonDistributionConfigActions.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.common.ContentConverter;
 import com.synopsys.integration.alert.common.enumeration.FormatType;
@@ -40,6 +41,7 @@ import com.synopsys.integration.alert.web.actions.NotificationTypesActions;
 import com.synopsys.integration.alert.web.model.CommonDistributionConfig;
 
 @Component
+@Transactional
 public class CommonDistributionConfigActions {
     private final ConfiguredProjectsActions configuredProjectsActions;
     private final NotificationTypesActions notificationTypesActions;
@@ -87,12 +89,14 @@ public class CommonDistributionConfigActions {
         }
     }
 
+    @Transactional
     public void deleteCommonEntity(final long id) {
         commonDistributionRepository.deleteById(id);
         configuredProjectsActions.cleanUpConfiguredProjects();
         notificationTypesActions.removeOldNotificationTypes(id);
     }
 
+    @Transactional
     public void saveCommonEntity(final CommonDistributionConfig commonChannelConfig, final long distributionId) {
         if (commonChannelConfig != null) {
             CommonDistributionConfigEntity commonChannelEntity = createCommonEntity(commonChannelConfig);

--- a/src/main/java/com/synopsys/integration/alert/workflow/MessageReceiver.java
+++ b/src/main/java/com/synopsys/integration/alert/workflow/MessageReceiver.java
@@ -26,7 +26,6 @@ package com.synopsys.integration.alert.workflow;
 import javax.jms.Message;
 import javax.jms.MessageListener;
 import javax.jms.TextMessage;
-import javax.transaction.Transactional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,9 +33,7 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.common.event.AlertEvent;
 
-@Transactional
 public abstract class MessageReceiver<E extends AlertEvent> implements MessageListener {
-
     private final Logger logger = LoggerFactory.getLogger(MessageReceiver.class);
     private final Class<E> clazz;
     private final Gson gson;

--- a/src/main/java/com/synopsys/integration/alert/workflow/NotificationManager.java
+++ b/src/main/java/com/synopsys/integration/alert/workflow/NotificationManager.java
@@ -30,10 +30,9 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import javax.transaction.Transactional;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.database.audit.AuditEntryEntity;
 import com.synopsys.integration.alert.database.audit.AuditEntryRepository;
@@ -41,21 +40,17 @@ import com.synopsys.integration.alert.database.audit.AuditNotificationRepository
 import com.synopsys.integration.alert.database.audit.relation.AuditNotificationRelation;
 import com.synopsys.integration.alert.database.entity.NotificationContent;
 import com.synopsys.integration.alert.database.entity.repository.NotificationContentRepository;
-import com.synopsys.integration.alert.database.entity.repository.VulnerabilityRepository;
 
 @Component
 @Transactional
 public class NotificationManager {
     private final NotificationContentRepository notificationContentRepository;
-    private final VulnerabilityRepository vulnerabilityRepository;
     private final AuditEntryRepository auditEntryRepository;
     private final AuditNotificationRepository auditNotificationRepository;
 
     @Autowired
-    public NotificationManager(final NotificationContentRepository notificationContentRepository, final VulnerabilityRepository vulnerabilityRepository, final AuditEntryRepository auditEntryRepository,
-            final AuditNotificationRepository auditNotificationRepository) {
+    public NotificationManager(final NotificationContentRepository notificationContentRepository, final AuditEntryRepository auditEntryRepository, final AuditNotificationRepository auditNotificationRepository) {
         this.notificationContentRepository = notificationContentRepository;
-        this.vulnerabilityRepository = vulnerabilityRepository;
         this.auditEntryRepository = auditEntryRepository;
         this.auditNotificationRepository = auditNotificationRepository;
     }
@@ -103,5 +98,4 @@ public class NotificationManager {
         auditEntryRepository.deleteAll(auditEntryList);
 
     }
-
 }

--- a/src/main/java/com/synopsys/integration/alert/workflow/NotificationManager.java
+++ b/src/main/java/com/synopsys/integration/alert/workflow/NotificationManager.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.database.audit.AuditEntryEntity;
@@ -42,7 +43,6 @@ import com.synopsys.integration.alert.database.entity.NotificationContent;
 import com.synopsys.integration.alert.database.entity.repository.NotificationContentRepository;
 
 @Component
-@Transactional
 public class NotificationManager {
     private final NotificationContentRepository notificationContentRepository;
     private final AuditEntryRepository auditEntryRepository;
@@ -55,18 +55,22 @@ public class NotificationManager {
         this.auditNotificationRepository = auditNotificationRepository;
     }
 
+    @Transactional
     public NotificationContent saveNotification(final NotificationContent notification) {
         return notificationContentRepository.save(notification);
     }
 
+    @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
     public List<NotificationContent> findByIds(final List<Long> notificationIds) {
         return notificationContentRepository.findAllById(notificationIds);
     }
 
+    @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
     public List<NotificationContent> findByCreatedAtBetween(final Date startDate, final Date endDate) {
         return notificationContentRepository.findByCreatedAtBetween(startDate, endDate);
     }
 
+    @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
     public List<NotificationContent> findByCreatedAtBefore(final Date date) {
         return notificationContentRepository.findByCreatedAtBefore(date);
     }
@@ -84,6 +88,7 @@ public class NotificationManager {
         notifications.forEach(this::deleteNotification);
     }
 
+    @Transactional
     public void deleteNotification(final NotificationContent notification) {
         notificationContentRepository.delete(notification);
         deleteAuditEntries(notification.getId());

--- a/src/main/java/com/synopsys/integration/alert/workflow/startup/StartupManager.java
+++ b/src/main/java/com/synopsys/integration/alert/workflow/startup/StartupManager.java
@@ -30,8 +30,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import javax.transaction.Transactional;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -39,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
@@ -61,7 +60,6 @@ import com.synopsys.integration.rest.proxy.ProxyInfo;
 import com.synopsys.integration.rest.proxy.ProxyInfoBuilder;
 
 @Component
-@Transactional
 public class StartupManager {
     private final Logger logger = LoggerFactory.getLogger(StartupManager.class);
 
@@ -105,8 +103,8 @@ public class StartupManager {
 
     @Autowired
     public StartupManager(final SchedulingRepository schedulingRepository, final AlertProperties alertProperties, final BlackDuckProperties blackDuckProperties,
-    final DailyTask dailyTask, final OnDemandTask onDemandTask, final PurgeTask purgeTask, final PhoneHomeTask phoneHometask, final AlertStartupInitializer alertStartupInitializer,
-    final List<ProviderDescriptor> providerDescriptorList) {
+        final DailyTask dailyTask, final OnDemandTask onDemandTask, final PurgeTask purgeTask, final PhoneHomeTask phoneHometask, final AlertStartupInitializer alertStartupInitializer,
+        final List<ProviderDescriptor> providerDescriptorList) {
         this.schedulingRepository = schedulingRepository;
         this.alertProperties = alertProperties;
         this.blackDuckProperties = blackDuckProperties;
@@ -206,6 +204,7 @@ public class StartupManager {
         }
     }
 
+    @Transactional
     public void initializeCronJobs() {
         final List<SchedulingConfigEntity> globalSchedulingConfigs = schedulingRepository.findAll();
         String dailyDigestHourOfDay = null;
@@ -240,6 +239,7 @@ public class StartupManager {
         logger.debug("Phone home next run:       {}", phoneHomeTask.getFormatedNextRunTime());
     }
 
+    @Transactional
     private Boolean purgeOldData() {
         try {
             logger.info("Begin startup purge of old data");

--- a/src/main/java/com/synopsys/integration/alert/workflow/startup/StartupManager.java
+++ b/src/main/java/com/synopsys/integration/alert/workflow/startup/StartupManager.java
@@ -240,7 +240,7 @@ public class StartupManager {
     }
 
     @Transactional
-    private Boolean purgeOldData() {
+    public Boolean purgeOldData() {
         try {
             logger.info("Begin startup purge of old data");
             final List<SchedulingConfigEntity> globalSchedulingConfigs = schedulingRepository.findAll();

--- a/src/test/java/com/synopsys/integration/alert/audit/controller/AuditEntryActionsTest.java
+++ b/src/test/java/com/synopsys/integration/alert/audit/controller/AuditEntryActionsTest.java
@@ -30,7 +30,6 @@ import com.synopsys.integration.alert.database.audit.AuditEntryRepository;
 import com.synopsys.integration.alert.database.audit.AuditNotificationRepository;
 import com.synopsys.integration.alert.database.entity.NotificationContent;
 import com.synopsys.integration.alert.database.entity.repository.NotificationContentRepository;
-import com.synopsys.integration.alert.database.entity.repository.VulnerabilityRepository;
 import com.synopsys.integration.alert.mock.entity.MockNotificationContent;
 import com.synopsys.integration.alert.mock.model.MockCommonDistributionRestModel;
 import com.synopsys.integration.alert.web.audit.AuditEntryActions;
@@ -67,7 +66,6 @@ public class AuditEntryActionsTest {
     public void testResendNotificationException() {
         final AuditEntryRepository auditEntryRepository = Mockito.mock(AuditEntryRepository.class);
         final NotificationContentRepository notificationRepository = Mockito.mock(NotificationContentRepository.class);
-        final VulnerabilityRepository vulnerabilityRepository = Mockito.mock(VulnerabilityRepository.class);
         final AuditNotificationRepository auditNotificationRepository = Mockito.mock(AuditNotificationRepository.class);
         final CommonDistributionConfigReader commonDistributionConfigReader = Mockito.mock(CommonDistributionConfigReader.class);
         final MockAuditEntryEntity mockAuditEntryEntity = new MockAuditEntryEntity();
@@ -75,7 +73,7 @@ public class AuditEntryActionsTest {
         Mockito.when(auditEntryRepository.findById(Mockito.anyLong())).thenReturn(Optional.of(mockAuditEntryEntity.createEmptyEntity()));
         Mockito.when(commonDistributionConfigReader.getPopulatedConfig(Mockito.anyLong())).thenReturn(null);
         Mockito.when(notificationRepository.findAllById(Mockito.anyList())).thenReturn(Arrays.asList(mockNotificationEntity.createEntity()));
-        final AuditEntryActions auditEntryActions = new AuditEntryActions(auditEntryRepository, new NotificationManager(notificationRepository, vulnerabilityRepository, auditEntryRepository, auditNotificationRepository),
+        final AuditEntryActions auditEntryActions = new AuditEntryActions(auditEntryRepository, new NotificationManager(notificationRepository, auditEntryRepository, auditNotificationRepository),
             auditNotificationRepository, commonDistributionConfigReader, null, null, null, null);
 
         AlertPagedModel<AuditEntryConfig> restModel = null;
@@ -112,7 +110,6 @@ public class AuditEntryActionsTest {
         Mockito.when(auditEntryRepository.findAll(Mockito.any(PageRequest.class))).thenReturn(pageResponse);
 
         final NotificationContentRepository notificationRepository = Mockito.mock(NotificationContentRepository.class);
-        final VulnerabilityRepository vulnerabilityRepository = Mockito.mock(VulnerabilityRepository.class);
         final AuditNotificationRepository auditNotificationRepository = Mockito.mock(AuditNotificationRepository.class);
         final CommonDistributionConfigReader commonDistributionConfigReader = Mockito.mock(CommonDistributionConfigReader.class);
 
@@ -122,7 +119,7 @@ public class AuditEntryActionsTest {
         final NotificationContentConverter notificationContentConverter = new NotificationContentConverter(contentConverter);
         Mockito.when(commonDistributionConfigReader.getPopulatedConfig(Mockito.anyLong())).thenReturn(Optional.of(mockCommonDistributionRestModel.createRestModel()));
         Mockito.when(notificationRepository.findAllById(Mockito.anyList())).thenReturn(Arrays.asList(notificationContent));
-        final AuditEntryActions auditEntryActions = new AuditEntryActions(auditEntryRepository, new NotificationManager(notificationRepository, vulnerabilityRepository, auditEntryRepository, auditNotificationRepository),
+        final AuditEntryActions auditEntryActions = new AuditEntryActions(auditEntryRepository, new NotificationManager(notificationRepository, auditEntryRepository, auditNotificationRepository),
             auditNotificationRepository, commonDistributionConfigReader, notificationContentConverter, null, null, null);
 
         final AlertPagedModel<AuditEntryConfig> restModel = auditEntryActions.get(currentPage, pageSize, null, null, null);
@@ -153,7 +150,6 @@ public class AuditEntryActionsTest {
         Mockito.when(auditEntryRepository.findAll(Mockito.any(PageRequest.class))).thenReturn(pageResponse);
 
         final NotificationContentRepository notificationRepository = Mockito.mock(NotificationContentRepository.class);
-        final VulnerabilityRepository vulnerabilityRepository = Mockito.mock(VulnerabilityRepository.class);
         final AuditNotificationRepository auditNotificationRepository = Mockito.mock(AuditNotificationRepository.class);
         final CommonDistributionConfigReader commonDistributionConfigReader = Mockito.mock(CommonDistributionConfigReader.class);
         final MockCommonDistributionRestModel mockCommonDistributionRestModel = new MockCommonDistributionRestModel();
@@ -162,7 +158,7 @@ public class AuditEntryActionsTest {
         final NotificationContent notificationContent = new MockNotificationContent(new Date(), "provider", new Date(), "notificationType", "{content: \"content is here...\"}", 1L).createEntity();
         Mockito.when(commonDistributionConfigReader.getPopulatedConfig(Mockito.anyLong())).thenReturn(Optional.of(mockCommonDistributionRestModel.createRestModel()));
         Mockito.when(notificationRepository.findAllById(Mockito.anyList())).thenReturn(Arrays.asList(notificationContent));
-        final AuditEntryActions auditEntryActions = new AuditEntryActions(auditEntryRepository, new NotificationManager(notificationRepository, vulnerabilityRepository, auditEntryRepository, auditNotificationRepository),
+        final AuditEntryActions auditEntryActions = new AuditEntryActions(auditEntryRepository, new NotificationManager(notificationRepository, auditEntryRepository, auditNotificationRepository),
             auditNotificationRepository, commonDistributionConfigReader, notificationContentConverter, null, null, null);
 
         final AlertPagedModel<AuditEntryConfig> restModel = auditEntryActions.get(currentPage, pageSize, null, null, null);

--- a/src/test/java/com/synopsys/integration/alert/audit/controller/AuditEntryControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/audit/controller/AuditEntryControllerTestIT.java
@@ -1,7 +1,5 @@
 package com.synopsys.integration.alert.audit.controller;
 
-import javax.transaction.Transactional;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -23,6 +21,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;

--- a/src/test/java/com/synopsys/integration/alert/audit/controller/AuditEntryHandlerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/audit/controller/AuditEntryHandlerTestIT.java
@@ -16,8 +16,6 @@ import static org.junit.Assert.assertNotNull;
 
 import java.sql.Date;
 
-import javax.transaction.Transactional;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -33,6 +31,7 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.synopsys.integration.alert.Application;

--- a/src/test/java/com/synopsys/integration/alert/channel/email/EmailDistributionTypeConverterTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/email/EmailDistributionTypeConverterTestIT.java
@@ -1,7 +1,5 @@
 package com.synopsys.integration.alert.channel.email;
 
-import javax.transaction.Transactional;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -16,6 +14,7 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.synopsys.integration.alert.Application;

--- a/src/test/java/com/synopsys/integration/alert/channel/hipchat/HipChatDistributionTypeConverterTest.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/hipchat/HipChatDistributionTypeConverterTest.java
@@ -1,7 +1,5 @@
 package com.synopsys.integration.alert.channel.hipchat;
 
-import javax.transaction.Transactional;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -16,6 +14,7 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.synopsys.integration.alert.Application;

--- a/src/test/java/com/synopsys/integration/alert/channel/slack/SlackDistributionTypeConverterTest.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/slack/SlackDistributionTypeConverterTest.java
@@ -1,7 +1,5 @@
 package com.synopsys.integration.alert.channel.slack;
 
-import javax.transaction.Transactional;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -16,6 +14,7 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.synopsys.integration.alert.Application;

--- a/src/test/java/com/synopsys/integration/alert/database/relation/repository/DistributionProjectRepositoryTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/database/relation/repository/DistributionProjectRepositoryTestIT.java
@@ -13,8 +13,6 @@ package com.synopsys.integration.alert.database.relation.repository;
 
 import static org.junit.Assert.assertEquals;
 
-import javax.transaction.Transactional;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -28,6 +26,7 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.synopsys.integration.alert.Application;

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckMessageContentCollectorFactoryTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckMessageContentCollectorFactoryTest.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.assertFalse;
 
 import java.util.Set;
 
-import javax.transaction.Transactional;
-
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -20,6 +18,7 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.synopsys.integration.alert.Application;

--- a/src/test/java/com/synopsys/integration/alert/web/controller/ControllerTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/controller/ControllerTest.java
@@ -2,8 +2,6 @@ package com.synopsys.integration.alert.web.controller;
 
 import java.nio.charset.Charset;
 
-import javax.transaction.Transactional;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -26,6 +24,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
@@ -118,8 +117,8 @@ public abstract class ControllerTest {
     @WithMockUser(roles = "ADMIN")
     public void testPostConfig() throws Exception {
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(restUrl)
-                .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
-                .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
         request.content(gson.toJson(config));
         request.contentType(contentType);
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isCreated());
@@ -130,8 +129,8 @@ public abstract class ControllerTest {
     public void testPutConfig() throws Exception {
         final CommonDistributionConfigEntity commonEntity = commonDistributionRepository.save(distributionMockUtil.createEntity());
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.put(restUrl)
-                .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
-                .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
         config.setDistributionConfigId(String.valueOf(entity.getId()));
         config.setId(String.valueOf(commonEntity.getId()));
         request.content(gson.toJson(config));
@@ -146,8 +145,8 @@ public abstract class ControllerTest {
         final CommonDistributionConfigEntity commonEntity = commonDistributionRepository.save(distributionMockUtil.createEntity());
         final String deleteUrl = restUrl + "?id=" + commonEntity.getId();
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.delete(deleteUrl)
-                .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
-                .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isAccepted());
     }
 
@@ -158,8 +157,8 @@ public abstract class ControllerTest {
         final CommonDistributionConfigEntity commonEntity = commonDistributionRepository.save(distributionMockUtil.createEntity());
         final String testRestUrl = restUrl + "/test";
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(testRestUrl)
-                .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
-                .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
         config.setDistributionConfigId(String.valueOf(entity.getId()));
         config.setId(String.valueOf(commonEntity.getId()));
         request.content(gson.toJson(config));
@@ -173,8 +172,8 @@ public abstract class ControllerTest {
     public void testValidConfig() throws Exception {
         final String testRestUrl = restUrl + "/validate";
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(testRestUrl)
-                .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
-                .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
         request.content(gson.toJson(config));
         request.contentType(contentType);
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk());

--- a/src/test/java/com/synopsys/integration/alert/web/controller/DescriptorControllerTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/controller/DescriptorControllerTest.java
@@ -7,8 +7,6 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.transaction.Transactional;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -32,6 +30,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
@@ -98,8 +97,8 @@ public class DescriptorControllerTest {
         final List<UIComponent> componentList = gson.fromJson(body, componentListType.getType());
         assertNotNull(componentList);
         final List<UIComponent> expected = descriptorMap.getDescriptor("channel_email").getAllUIConfigs()
-                                           .stream()
-                                           .map(uiConfig -> uiConfig.generateUIComponent()).collect(Collectors.toList());
+                                               .stream()
+                                               .map(uiConfig -> uiConfig.generateUIComponent()).collect(Collectors.toList());
         assertEquals(expected.size(), componentList.size());
     }
 

--- a/src/test/java/com/synopsys/integration/alert/web/controller/GlobalControllerTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/controller/GlobalControllerTest.java
@@ -3,8 +3,6 @@ package com.synopsys.integration.alert.web.controller;
 import java.nio.charset.Charset;
 import java.util.List;
 
-import javax.transaction.Transactional;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -27,6 +25,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
@@ -91,7 +90,7 @@ public abstract class GlobalControllerTest {
         // this helps ensure that the environment is clean for the test.
         final List<? extends DatabaseEntity> entityList = repositoryAccessor.readEntities();
         entityList.forEach(entity -> getGlobalRepositoryAccessor().deleteEntity(entity.getId()));
-        
+
         config = getGlobalConfig();
         entity = getGlobalEntity();
         entity = repositoryAccessor.saveEntity(entity);
@@ -103,8 +102,8 @@ public abstract class GlobalControllerTest {
     @WithMockUser(roles = "ADMIN")
     public void testGetConfig() throws Exception {
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(restUrl)
-                                                      .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
-                                                      .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk());
     }
 
@@ -112,8 +111,8 @@ public abstract class GlobalControllerTest {
     @WithMockUser(roles = "ADMIN")
     public void testPostConfig() throws Exception {
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(restUrl)
-                                                      .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
-                                                      .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
         request.content(gson.toJson(config));
         request.contentType(contentType);
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isCreated());
@@ -123,8 +122,8 @@ public abstract class GlobalControllerTest {
     @WithMockUser(roles = "ADMIN")
     public void testPutConfig() throws Exception {
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.put(restUrl)
-                                                      .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
-                                                      .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
         ;
         config.setId(String.valueOf(entity.getId()));
         request.content(gson.toJson(config));
@@ -137,8 +136,8 @@ public abstract class GlobalControllerTest {
     public void testDeleteConfig() throws Exception {
         final String deleteUrl = restUrl + "?id=" + entity.getId();
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.delete(deleteUrl)
-                                                      .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
-                                                      .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isAccepted());
     }
 
@@ -147,8 +146,8 @@ public abstract class GlobalControllerTest {
     public void testTestConfig() throws Exception {
         final String testRestUrl = restUrl + "/test";
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(testRestUrl)
-                                                      .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
-                                                      .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
         ;
         request.content(gson.toJson(config));
         request.contentType(contentType);
@@ -160,8 +159,8 @@ public abstract class GlobalControllerTest {
     public void testValidateConfig() throws Exception {
         final String testRestUrl = restUrl + "/validate";
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(testRestUrl)
-                                                      .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
-                                                      .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
         ;
         request.content(gson.toJson(config));
         request.contentType(contentType);

--- a/src/test/java/com/synopsys/integration/alert/web/controller/HomeControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/web/controller/HomeControllerTestIT.java
@@ -4,7 +4,6 @@ import java.util.UUID;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
-import javax.transaction.Transactional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -31,6 +30,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;

--- a/src/test/java/com/synopsys/integration/alert/web/controller/LoginControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/web/controller/LoginControllerTestIT.java
@@ -2,8 +2,6 @@ package com.synopsys.integration.alert.web.controller;
 
 import java.nio.charset.Charset;
 
-import javax.transaction.Transactional;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -25,6 +23,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;

--- a/src/test/java/com/synopsys/integration/alert/workflow/filter/NotificationFilterTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/workflow/filter/NotificationFilterTestIT.java
@@ -7,8 +7,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import javax.transaction.Transactional;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -24,6 +22,7 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.synopsys.integration.alert.Application;

--- a/src/test/java/com/synopsys/integration/alert/workflow/filter/NotificationToChannelEventConverterTest.java
+++ b/src/test/java/com/synopsys/integration/alert/workflow/filter/NotificationToChannelEventConverterTest.java
@@ -9,8 +9,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import javax.transaction.Transactional;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,6 +23,7 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.synopsys.integration.alert.Application;

--- a/src/test/java/com/synopsys/integration/alert/workflow/processor/MessageContentAggregatorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/workflow/processor/MessageContentAggregatorTest.java
@@ -11,8 +11,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import javax.transaction.Transactional;
-
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -28,6 +26,7 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.synopsys.integration.alert.Application;

--- a/src/test/java/com/synopsys/integration/alert/workflow/processor/NotificationProcessorIT.java
+++ b/src/test/java/com/synopsys/integration/alert/workflow/processor/NotificationProcessorIT.java
@@ -11,8 +11,6 @@
  */
 package com.synopsys.integration.alert.workflow.processor;
 
-import javax.transaction.Transactional;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -26,6 +24,7 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.synopsys.integration.alert.Application;


### PR DESCRIPTION
- I have cut down the number of classes in src/main/java that use @Transactional to 12. 
- I have eliminated the use of javax transactions in favor of spring for consistency.
- There is still some work to be done to ensure that private methods are being utilized correctly in transactions (methods annotated with @Transactional must be public or they will be ignored).