### PR TITLE
Ps policy duplication fix

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckProviderContentTypes.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckProviderContentTypes.java
@@ -39,6 +39,8 @@ import com.synopsys.integration.alert.common.enumeration.FieldContentIdentifier;
 import com.synopsys.integration.alert.common.field.JsonField;
 import com.synopsys.integration.alert.common.provider.ProviderContentType;
 import com.synopsys.integration.blackduck.api.generated.enumeration.NotificationType;
+import com.synopsys.integration.blackduck.notification.content.ComponentVersionStatus;
+import com.synopsys.integration.blackduck.notification.content.PolicyInfo;
 import com.synopsys.integration.blackduck.notification.content.VulnerabilitySourceQualifiedId;
 
 public class BlackDuckProviderContentTypes {
@@ -78,8 +80,10 @@ public class BlackDuckProviderContentTypes {
     public static final String JSON_FIELD_DELETED_VULNERABILITY_IDS = "deletedVulnerabilityIds[*]";
 
     // labels
+    public static final String LABEL_COMPONENT_VERSION_STATUS = "Component Version Status";
     public static final String LABEL_COMPONENT_NAME = "Component";
     public static final String LABEL_COMPONENT_VERSION_NAME = "Component Version";
+    public static final String LABEL_POLICY_INFO_LIST = "Policy Infos";
     public static final String LABEL_POLICY_NAME = "Policy";
     public static final String LABEL_PROJECT_NAME = "Project";
     public static final String LABEL_PROJECT_VERSION_NAME = "Project Version";
@@ -127,6 +131,7 @@ public class BlackDuckProviderContentTypes {
             createStringField(createJsonPath("$.%s.%s", JSON_FIELD_CONTENT, JSON_FIELD_LAST_NAME), JSON_FIELD_LAST_NAME, FieldContentIdentifier.CATEGORY_ITEM, LABEL_POLICY_OVERRIDE_LAST_NAME),
             createStringField(createJsonPath("$.%s.%s.%s", JSON_FIELD_CONTENT, JSON_FIELD_POLICY_INFOS, JSON_FIELD_POLICY_NAME), JSON_FIELD_POLICY_NAME, FieldContentIdentifier.CATEGORY_ITEM, LABEL_POLICY_NAME),
             createStringField(createJsonPath("$.%s.%s.%s", JSON_FIELD_CONTENT, JSON_FIELD_POLICY_INFOS, JSON_FIELD_POLICY), JSON_FIELD_POLICY, FieldContentIdentifier.CATEGORY_ITEM, LABEL_POLICY_NAME + JsonField.LABEL_URL_SUFFIX)
+
         )
     );
     private static final Type VULNERABILITY_TYPE = new TypeToken<VulnerabilitySourceQualifiedId>() {}.getType();
@@ -158,15 +163,9 @@ public class BlackDuckProviderContentTypes {
             Arrays.asList(createJsonPath("$.%s", CONFIG_MAPPING_CONFIGURED_PROJECTS), createJsonPath("$.%s", CONFIG_MAPPING_PROJECT_NAME_PATTERN))),
         createStringField(createJsonPath("$.%s.%s", JSON_FIELD_CONTENT, JSON_FIELD_PROJECT_VERSION_NAME), JSON_FIELD_PROJECT_VERSION_NAME, FieldContentIdentifier.SUB_TOPIC, LABEL_PROJECT_VERSION_NAME),
         createStringField(createJsonPath("$.%s.%s", JSON_FIELD_CONTENT, JSON_FIELD_PROJECT_VERSION), JSON_FIELD_PROJECT_VERSION, FieldContentIdentifier.SUB_TOPIC_URL, LABEL_PROJECT_VERSION_NAME + JsonField.LABEL_URL_SUFFIX),
-        createStringField(createJsonPath("$.%s.%s.%s", JSON_FIELD_CONTENT, JSON_FIELD_COMPONENT_VERSION_STATUSES, JSON_FIELD_COMPONENT_NAME), JSON_FIELD_COMPONENT_NAME, FieldContentIdentifier.CATEGORY_ITEM, LABEL_COMPONENT_NAME),
-        createStringField(createJsonPath("$.%s.%s.%s", JSON_FIELD_CONTENT, JSON_FIELD_COMPONENT_VERSION_STATUSES, JSON_FIELD_COMPONENT), JSON_FIELD_COMPONENT, FieldContentIdentifier.CATEGORY_ITEM,
-            LABEL_COMPONENT_NAME + JsonField.LABEL_URL_SUFFIX),
-        createStringField(createJsonPath("$.%s.%s.%s", JSON_FIELD_CONTENT, JSON_FIELD_COMPONENT_VERSION_STATUSES, JSON_FIELD_COMPONENT_VERSION_NAME), JSON_FIELD_COMPONENT_VERSION_NAME, FieldContentIdentifier.CATEGORY_ITEM,
-            LABEL_COMPONENT_VERSION_NAME),
-        createStringField(createJsonPath("$.%s.%s.%s", JSON_FIELD_CONTENT, JSON_FIELD_COMPONENT_VERSION_STATUSES, JSON_FIELD_COMPONENT_VERSION), JSON_FIELD_COMPONENT_VERSION, FieldContentIdentifier.CATEGORY_ITEM,
-            LABEL_COMPONENT_VERSION_NAME + JsonField.LABEL_URL_SUFFIX),
-        createStringField(createJsonPath("$.%s.%s.%s", JSON_FIELD_CONTENT, JSON_FIELD_POLICY_INFOS, JSON_FIELD_POLICY_NAME), JSON_FIELD_POLICY_NAME, FieldContentIdentifier.CATEGORY_ITEM, LABEL_POLICY_NAME),
-        createStringField(createJsonPath("$.%s.%s.%s", JSON_FIELD_CONTENT, JSON_FIELD_POLICY_INFOS, JSON_FIELD_POLICY), JSON_FIELD_POLICY, FieldContentIdentifier.CATEGORY_ITEM, LABEL_POLICY_NAME + JsonField.LABEL_URL_SUFFIX)
+        createObjectField(createJsonPath("$.%s", JSON_FIELD_CONTENT, JSON_FIELD_COMPONENT_VERSION_STATUSES), JSON_FIELD_COMPONENT_VERSION_STATUSES, FieldContentIdentifier.CATEGORY_ITEM, LABEL_COMPONENT_VERSION_STATUS,
+            new TypeRef<List<ComponentVersionStatus>>() {}),
+        createObjectField(createJsonPath("$.%s", JSON_FIELD_CONTENT, JSON_FIELD_POLICY_INFOS), JSON_FIELD_POLICY_INFOS, FieldContentIdentifier.CATEGORY_ITEM, LABEL_POLICY_INFO_LIST, new TypeRef<List<PolicyInfo>>() {})
     );
     public static final ProviderContentType RULE_VIOLATION = new ProviderContentType(
         NotificationType.RULE_VIOLATION.name(),

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckProviderContentTypes.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckProviderContentTypes.java
@@ -163,9 +163,9 @@ public class BlackDuckProviderContentTypes {
             Arrays.asList(createJsonPath("$.%s", CONFIG_MAPPING_CONFIGURED_PROJECTS), createJsonPath("$.%s", CONFIG_MAPPING_PROJECT_NAME_PATTERN))),
         createStringField(createJsonPath("$.%s.%s", JSON_FIELD_CONTENT, JSON_FIELD_PROJECT_VERSION_NAME), JSON_FIELD_PROJECT_VERSION_NAME, FieldContentIdentifier.SUB_TOPIC, LABEL_PROJECT_VERSION_NAME),
         createStringField(createJsonPath("$.%s.%s", JSON_FIELD_CONTENT, JSON_FIELD_PROJECT_VERSION), JSON_FIELD_PROJECT_VERSION, FieldContentIdentifier.SUB_TOPIC_URL, LABEL_PROJECT_VERSION_NAME + JsonField.LABEL_URL_SUFFIX),
-        createObjectField(createJsonPath("$.%s", JSON_FIELD_CONTENT, JSON_FIELD_COMPONENT_VERSION_STATUSES), JSON_FIELD_COMPONENT_VERSION_STATUSES, FieldContentIdentifier.CATEGORY_ITEM, LABEL_COMPONENT_VERSION_STATUS,
+        createObjectField(createJsonPath("$.%s.%s", JSON_FIELD_CONTENT, JSON_FIELD_COMPONENT_VERSION_STATUSES), JSON_FIELD_COMPONENT_VERSION_STATUSES, FieldContentIdentifier.CATEGORY_ITEM, LABEL_COMPONENT_VERSION_STATUS,
             new TypeRef<List<ComponentVersionStatus>>() {}),
-        createObjectField(createJsonPath("$.%s", JSON_FIELD_CONTENT, JSON_FIELD_POLICY_INFOS), JSON_FIELD_POLICY_INFOS, FieldContentIdentifier.CATEGORY_ITEM, LABEL_POLICY_INFO_LIST, new TypeRef<List<PolicyInfo>>() {})
+        createObjectField(createJsonPath("$.%s.%s", JSON_FIELD_CONTENT, JSON_FIELD_POLICY_INFOS), JSON_FIELD_POLICY_INFOS, FieldContentIdentifier.CATEGORY_ITEM, LABEL_POLICY_INFO_LIST, new TypeRef<List<PolicyInfo>>() {})
     );
     public static final ProviderContentType RULE_VIOLATION = new ProviderContentType(
         NotificationType.RULE_VIOLATION.name(),

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyMessageContentCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyMessageContentCollector.java
@@ -78,7 +78,7 @@ public class BlackDuckPolicyMessageContentCollector extends MessageContentCollec
 
     private void processPolicy(final List<CategoryItem> categoryItems, final JsonFieldAccessor jsonFieldAccessor, final List<JsonField<?>> notificationFields, final NotificationContent notificationContent) {
         final List<JsonField<PolicyInfo>> policyFields = getFieldsOfType(notificationFields, new TypeRef<PolicyInfo>() {});
-        final List<JsonField<ComponentVersionStatus>> componentFields = getFieldsOfType(notificationFields, new TypeRef<PolicyInfo>() {});
+        final List<JsonField<ComponentVersionStatus>> componentFields = getFieldsOfType(notificationFields, new TypeRef<ComponentVersionStatus>() {});
         try {
             final List<PolicyInfo> policyItems = getFieldValueObjectsByLabel(jsonFieldAccessor, policyFields, BlackDuckProviderContentTypes.LABEL_POLICY_INFO_LIST);
             final List<ComponentVersionStatus> componentVersionStatuses = getFieldValueObjectsByLabel(jsonFieldAccessor, componentFields, BlackDuckProviderContentTypes.LABEL_COMPONENT_VERSION_STATUS);
@@ -91,7 +91,7 @@ public class BlackDuckPolicyMessageContentCollector extends MessageContentCollec
                         componentItems = policyItemMap.get(policyUrl);
                     } else {
                         componentItems = new TreeSet<>();
-                        policyItemMap.put(policyUrl, new TreeSet<>());
+                        policyItemMap.put(policyUrl, componentItems);
                     }
                     if (StringUtils.isNotBlank(versionStatus.componentName)) {
                         componentItems.add(new LinkableItem(BlackDuckProviderContentTypes.LABEL_COMPONENT_NAME, versionStatus.componentName));

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyMessageContentCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyMessageContentCollector.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -69,7 +70,7 @@ public class BlackDuckPolicyMessageContentCollector extends MessageContentCollec
 
     @Override
     protected void addCategoryItems(final List<CategoryItem> categoryItems, final JsonFieldAccessor jsonFieldAccessor, final List<JsonField<?>> notificationFields, final NotificationContent notificationContent) {
-        if (notificationContent.getNotificationType().equals("POLICY_OVERRIDE")) {
+        if (NotificationType.POLICY_OVERRIDE.name().equals(notificationContent.getNotificationType())) {
             processPolicyOverride(categoryItems, jsonFieldAccessor, notificationFields, notificationContent);
         } else {
             processPolicy(categoryItems, jsonFieldAccessor, notificationFields, notificationContent);
@@ -82,43 +83,47 @@ public class BlackDuckPolicyMessageContentCollector extends MessageContentCollec
         try {
             final List<PolicyInfo> policyItems = getFieldValueObjectsByLabel(jsonFieldAccessor, policyFields, BlackDuckProviderContentTypes.LABEL_POLICY_INFO_LIST);
             final List<ComponentVersionStatus> componentVersionStatuses = getFieldValueObjectsByLabel(jsonFieldAccessor, componentFields, BlackDuckProviderContentTypes.LABEL_COMPONENT_VERSION_STATUS);
-            final Map<String, SortedSet<LinkableItem>> policyItemMap = new TreeMap<>();
+            final Map<String, SortedSet<LinkableItem>> policyItemMap = mapPolicyToComponents(componentVersionStatuses);
 
-            for (final ComponentVersionStatus versionStatus : componentVersionStatuses) {
-                for (final String policyUrl : versionStatus.policies) {
-                    final SortedSet<LinkableItem> componentItems;
-                    if (policyItemMap.containsKey(policyUrl)) {
-                        componentItems = policyItemMap.get(policyUrl);
-                    } else {
-                        componentItems = new TreeSet<>();
-                        policyItemMap.put(policyUrl, componentItems);
-                    }
-                    if (StringUtils.isNotBlank(versionStatus.componentName)) {
-                        componentItems.add(new LinkableItem(BlackDuckProviderContentTypes.LABEL_COMPONENT_NAME, versionStatus.componentName));
-                    }
-                    if (StringUtils.isNotBlank(versionStatus.componentVersionName)) {
-                        componentItems.add(new LinkableItem(BlackDuckProviderContentTypes.LABEL_COMPONENT_VERSION_NAME, versionStatus.componentVersionName));
-                    }
-                }
-            }
-
-            final ItemOperation operation;
-            try {
-                operation = getOperationFromNotification(notificationContent);
-            } catch (final IllegalArgumentException e) {
-                logger.error("Unrecognized notification type", e);
+            final ItemOperation operation = getOperationFromNotification(notificationContent);
+            if (operation == null) {
                 return;
             }
             for (final PolicyInfo policyItem : policyItems) {
                 final String policyUrl = policyItem.policy;
                 final String policyName = policyItem.policyName;
-                final LinkableItem policyLinkableItem = new LinkableItem(BlackDuckProviderContentTypes.LABEL_POLICY_NAME, policyName);
+                final LinkableItem policyLinkableItem = new LinkableItem(BlackDuckProviderContentTypes.LABEL_POLICY_NAME, policyName, policyUrl);
                 final SortedSet<LinkableItem> applicableItems = policyItemMap.get(policyUrl);
-                addApplicableItems(categoryItems, notificationContent.getId(), policyLinkableItem, policyUrl, operation, Optional.empty(), applicableItems);
+                addApplicableItems(categoryItems, notificationContent.getId(), policyLinkableItem, policyUrl, operation, applicableItems);
             }
         } catch (final AlertException ex) {
             logger.error("Mishandled the expected type of a notification field", ex);
         }
+    }
+
+    private Map<String, SortedSet<LinkableItem>> mapPolicyToComponents(final List<ComponentVersionStatus> componentVersionStatuses) {
+        final Map<String, SortedSet<LinkableItem>> policyItemMap = new TreeMap<>();
+
+        for (final ComponentVersionStatus versionStatus : componentVersionStatuses) {
+            for (final String policyUrl : versionStatus.policies) {
+                final SortedSet<LinkableItem> componentItems;
+                if (policyItemMap.containsKey(policyUrl)) {
+                    componentItems = policyItemMap.get(policyUrl);
+                } else {
+                    componentItems = new TreeSet<>();
+                    policyItemMap.put(policyUrl, componentItems);
+                }
+
+                if (StringUtils.isNotBlank(versionStatus.componentName)) {
+                    componentItems.add(new LinkableItem(BlackDuckProviderContentTypes.LABEL_COMPONENT_NAME, versionStatus.componentName, versionStatus.component));
+                }
+
+                if (StringUtils.isNotBlank(versionStatus.componentVersionName)) {
+                    componentItems.add(new LinkableItem(BlackDuckProviderContentTypes.LABEL_COMPONENT_VERSION_NAME, versionStatus.componentVersionName, versionStatus.componentVersion));
+                }
+            }
+        }
+        return policyItemMap;
     }
 
     private void processPolicyOverride(final List<CategoryItem> categoryItems, final JsonFieldAccessor jsonFieldAccessor, final List<JsonField<?>> notificationFields, final NotificationContent notificationContent) {
@@ -132,47 +137,48 @@ public class BlackDuckPolicyMessageContentCollector extends MessageContentCollec
         applicableItems.addAll(componentItems);
         applicableItems.addAll(componentVersionItems);
 
-        Optional<LinkableItem> combinedNameItem = Optional.empty();
         if (firstName.isPresent() && lastName.isPresent()) {
             final String value = String.format("%s %s", firstName.get().getValue(), lastName.get().getValue());
-            combinedNameItem = Optional.of(new LinkableItem(BlackDuckProviderContentTypes.LABEL_POLICY_OVERRIDE_BY, value));
+            applicableItems.add(new LinkableItem(BlackDuckProviderContentTypes.LABEL_POLICY_OVERRIDE_BY, value));
         }
 
-        final ItemOperation operation;
-        try {
-            operation = getOperationFromNotification(notificationContent);
-        } catch (final IllegalArgumentException e) {
-            logger.error("Unrecognized notification type", e);
+        final ItemOperation operation = getOperationFromNotification(notificationContent);
+        if (operation == null) {
             return;
         }
+
         for (final LinkableItem policyItem : policyItems) {
             final String policyUrl = policyItem.getUrl().orElse("");
-            addApplicableItems(categoryItems, notificationContent.getId(), policyItem, policyUrl, operation, combinedNameItem, applicableItems);
+            addApplicableItems(categoryItems, notificationContent.getId(), policyItem, policyUrl, operation, applicableItems);
         }
     }
 
-    protected ItemOperation getOperationFromNotification(final NotificationContent notificationContent) {
+    private ItemOperation getOperationFromNotification(final NotificationContent notificationContent) {
+        final ItemOperation operation;
         final String notificationType = notificationContent.getNotificationType();
         if (NotificationType.RULE_VIOLATION_CLEARED.name().equals(notificationType)) {
-            return ItemOperation.DELETE;
+            operation = ItemOperation.DELETE;
         } else if (NotificationType.RULE_VIOLATION.name().equals(notificationType)) {
-            return ItemOperation.ADD;
+            operation = ItemOperation.ADD;
         } else if (NotificationType.POLICY_OVERRIDE.name().equals(notificationType)) {
-            return ItemOperation.DELETE;
+            operation = ItemOperation.DELETE;
+        } else {
+            operation = null;
         }
-        throw new IllegalArgumentException(String.format("The notification type '%s' is not valid for this collector.", notificationType));
+        logger.error("Unrecognized notification type: The notification type '{}' is not valid for this collector.", notificationType);
+        return operation;
     }
 
-    private void addApplicableItems(final List<CategoryItem> categoryItems, final Long notificationId, final LinkableItem policyItem, final String policyUrl, final ItemOperation operation,
-        final Optional<LinkableItem> nameItem, final SortedSet<LinkableItem> applicableItems) {
+    private void addApplicableItems(final List<CategoryItem> categoryItems, final Long notificationId, final LinkableItem policyItem, final String policyUrl, final ItemOperation operation, final SortedSet<LinkableItem> applicableItems) {
+        final List<String> keyItems = applicableItems.stream().map(LinkableItem::getValue).collect(Collectors.toList());
+        String[] keyArray = new String[keyItems.size() + 1];
+        keyArray = keyItems.toArray(keyArray);
+        keyArray[keyArray.length - 1] = policyUrl;
+        final CategoryKey categoryKey = CategoryKey.from(CATEGORY_TYPE, keyArray);
+
         for (final LinkableItem item : applicableItems) {
-            final CategoryKey categoryKey = CategoryKey.from(CATEGORY_TYPE, policyUrl);
             final SortedSet<LinkableItem> linkableItems;
-            if (nameItem.isPresent()) {
-                linkableItems = createLinkableItemSet(policyItem, item, nameItem.get());
-            } else {
-                linkableItems = createLinkableItemSet(policyItem, item);
-            }
+            linkableItems = createLinkableItemSet(policyItem, item);
             addItem(categoryItems, new CategoryItem(categoryKey, operation, notificationId, linkableItems));
         }
     }

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyMessageContentCollectorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyMessageContentCollectorTest.java
@@ -48,7 +48,7 @@ public class BlackDuckPolicyMessageContentCollectorTest {
     @Test
     public void insertMultipleAndVerifyCorrectNumberOfCategoryItemsTest() throws Exception {
         final String topicName = "example";
-        final int numberOfRulesCleared = 3;
+        final int numberOfRulesCleared = 4;
         final int numberOfPoliciesOverriden = 1;
         final int policyOverlap = 1;
 

--- a/src/test/resources/json/policyRuleClearedNotification.json
+++ b/src/test/resources/json/policyRuleClearedNotification.json
@@ -11,25 +11,40 @@
         "bomComponentVersionPolicyStatus": "https://a-hub-server.blackduck.com/api/projects/d9205017-4630-4f0c-8127-170e1db03d6f/versions/ec2a759d-e27d-4445-adb2-3176f8a78d24/components/18dbecb7-a3b5-418b-9af1-44bf61ae0319/versions/3ef95202-5b60-4a62-ab07-02740212fd96/policy-status",
         "componentIssueLink": "https://a-hub-server.blackduck.com/api/projects/d9205017-4630-4f0c-8127-170e1db03d6f/versions/ec2a759d-e27d-4445-adb2-3176f8a78d24/components/18dbecb7-a3b5-418b-9af1-44bf61ae0319/component-versions/3ef95202-5b60-4a62-ab07-02740212fd96/issues",
         "policies": [
-          "https://a-hub-server.blackduck.com/api/policy-rules/fedc4472-34b4-4c12-88bb-9fa63bae40a3",
-          "https://a-hub-server.blackduck.com/api/policy-rules/0b602e42-e339-46ab-8061-b2219088f233",
-          "https://a-hub-server.blackduck.com/api/policy-rules/9f34466a-a088-45a6-8048-35f96fcb989f"
+          "https://a-hub-server.blackduck.com/api/policy-rules/0000003-0003-0003-0003-000000000003",
+          "https://a-hub-server.blackduck.com/api/policy-rules/0000002-0002-0002-0002-000000000002",
+          "https://a-hub-server.blackduck.com/api/policy-rules/0000001-0001-0001-0001-000000000001"
+        ],
+        "bomComponent": "https://a-hub-server.blackduck.com/api/projects/d9205017-4630-4f0c-8127-170e1db03d6f/versions/ec2a759d-e27d-4445-adb2-3176f8a78d24/components/18dbecb7-a3b5-418b-9af1-44bf61ae0319/versions/3ef95202-5b60-4a62-ab07-02740212fd96"
+      },
+      {
+        "componentVersion": "https://a-hub-server.blackduck.com/api/components/18dbecb7-a3b5-418b-9af1-44bf61ae0319/versions/3ef95202-5b60-4a62-ab07-02740212fd96",
+        "componentName": "Apache Commons FileUpload",
+        "componentVersionName": "1.2.2",
+        "bomComponentVersionPolicyStatus": "https://a-hub-server.blackduck.com/api/projects/d9205017-4630-4f0c-8127-170e1db03d6f/versions/ec2a759d-e27d-4445-adb2-3176f8a78d24/components/18dbecb7-a3b5-418b-9af1-44bf61ae0319/versions/3ef95202-5b60-4a62-ab07-02740212fd96/policy-status",
+        "componentIssueLink": "https://a-hub-server.blackduck.com/api/projects/d9205017-4630-4f0c-8127-170e1db03d6f/versions/ec2a759d-e27d-4445-adb2-3176f8a78d24/components/18dbecb7-a3b5-418b-9af1-44bf61ae0319/component-versions/3ef95202-5b60-4a62-ab07-02740212fd96/issues",
+        "policies": [
+          "https://a-hub-server.blackduck.com/api/policy-rules/0000004-0004-0004-0004-000000000004"
         ],
         "bomComponent": "https://a-hub-server.blackduck.com/api/projects/d9205017-4630-4f0c-8127-170e1db03d6f/versions/ec2a759d-e27d-4445-adb2-3176f8a78d24/components/18dbecb7-a3b5-418b-9af1-44bf61ae0319/versions/3ef95202-5b60-4a62-ab07-02740212fd96"
       }
     ],
     "policyInfos": [
       {
-        "policy": "https://a-hub-server.blackduck.com/api/policy-rules/9f34466a-a088-45a6-8048-35f96fcb989f",
+        "policy": "https://a-hub-server.blackduck.com/api/policy-rules/0000001-0001-0001-0001-000000000001",
         "policyName": "No Apache Commons File Upload"
       },
       {
-        "policy": "https://a-hub-server.blackduck.com/api/policy-rules/0b602e42-e339-46ab-8061-b2219088f233",
+        "policy": "https://a-hub-server.blackduck.com/api/policy-rules/0000002-0002-0002-0002-000000000002",
         "policyName": "No Apache Commons File Upload 1.2.1"
       },
       {
-        "policy": "https://a-hub-server.blackduck.com/api/policy-rules/fedc4472-34b4-4c12-88bb-9fa63bae40a3",
+        "policy": "https://a-hub-server.blackduck.com/api/policy-rules/0000003-0003-0003-0003-000000000003",
         "policyName": "No Commons FileUpload 1.2.1"
+      },
+      {
+        "policy": "https://a-hub-server.blackduck.com/api/policy-rules/0000004-0004-0004-0004-000000000004",
+        "policyName": "No Commons FileUpload 1.2.2"
       }
     ]
   },


### PR DESCRIPTION

**Changes proposed in this pull request:**

* Fix the construction of the policy rule messages to avoid creating N x M categories which creates incorrect policy messages. 

This affects the RULE_VIOLATION and RULE_VIOLATION_CLEARED
N = # of policies (policyInfos attribute in JSON)
M = # of components (componentVersionStatuses in JSON)

For each policy and component a new category message would be created even if the component doesn't violate the policy.  

The fix is to map the components to the policies they are affected by and then create the category items from that.
