### PR TITLE
Removed RestDistributionChannel and added a rest utility class

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/channel/hipchat/descriptor/HipChatGlobalDescriptorActionApi.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/hipchat/descriptor/HipChatGlobalDescriptorActionApi.java
@@ -23,43 +23,49 @@
  */
 package com.synopsys.integration.alert.channel.hipchat.descriptor;
 
-import java.util.Optional;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.channel.hipchat.HipChatChannel;
-import com.synopsys.integration.alert.common.rest.model.TestConfigModel;
+import com.synopsys.integration.alert.channel.rest.RestChannelUtility;
 import com.synopsys.integration.alert.common.descriptor.action.DescriptorActionApi;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldAccessor;
+import com.synopsys.integration.alert.common.rest.model.TestConfigModel;
 import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.rest.RestConstants;
 import com.synopsys.integration.rest.client.IntHttpClient;
 import com.synopsys.integration.rest.request.Request;
+import com.synopsys.integration.rest.request.Response;
 
 @Component
 public class HipChatGlobalDescriptorActionApi extends DescriptorActionApi {
+    private final Logger logger = LoggerFactory.getLogger(HipChatGlobalDescriptorActionApi.class);
+
     private final HipChatChannel hipChatChannel;
+    private final RestChannelUtility restChannelUtility;
 
     @Autowired
-    public HipChatGlobalDescriptorActionApi(final HipChatChannel hipChatChannel) {
+    public HipChatGlobalDescriptorActionApi(final HipChatChannel hipChatChannel, final RestChannelUtility restChannelUtility) {
         this.hipChatChannel = hipChatChannel;
+        this.restChannelUtility = restChannelUtility;
     }
 
     @Override
     public void testConfig(final TestConfigModel testConfig) throws IntegrationException {
         final FieldAccessor fieldAccessor = testConfig.getFieldAccessor();
-        final Optional<String> apiKey = fieldAccessor.getString(HipChatDescriptor.KEY_API_KEY);
-        final Optional<String> configuredApiUrl = fieldAccessor.getString(HipChatDescriptor.KEY_HOST_SERVER);
-        if (!apiKey.isPresent()) {
-            throw new AlertException("ERROR: Missing API key in the global HipChat config.");
-        }
-        if (!configuredApiUrl.isPresent()) {
-            throw new AlertException("ERROR: Missing the server URL in the global HipChat config.");
-        }
-
-        final IntHttpClient intHttpClient = hipChatChannel.getChannelRestConnectionFactory().createIntHttpClient();
-        hipChatChannel.testApiKeyAndApiUrlConnection(intHttpClient, configuredApiUrl.get(), apiKey.get());
+        final String apiKey = fieldAccessor.getString(HipChatDescriptor.KEY_API_KEY).orElseThrow(() -> new AlertException("ERROR: Missing API key in the global HipChat config."));
+        final String configuredApiUrl = fieldAccessor.getString(HipChatDescriptor.KEY_HOST_SERVER).orElseThrow(() -> new AlertException("ERROR: Missing the server URL in the global HipChat config."));
         final Integer parsedRoomId;
         try {
             final String testRoomId = testConfig.getDestination().orElse(null);
@@ -68,9 +74,49 @@ public class HipChatGlobalDescriptorActionApi extends DescriptorActionApi {
             throw new AlertException("The provided room id is an invalid number.");
         }
 
+        final IntHttpClient intHttpClient = restChannelUtility.getIntHttpClient();
+        testApiKeyAndApiUrlConnection(intHttpClient, configuredApiUrl, apiKey);
+
         final String htmlMessage = "This is a test message sent by Alert.";
-        final Request testRequest = hipChatChannel.createRequest(configuredApiUrl.get(), apiKey.get(), parsedRoomId, Boolean.TRUE, "red", htmlMessage);
-        hipChatChannel.sendMessageRequest(intHttpClient, testRequest, "test");
+        final Request testRequest = hipChatChannel.createRequest(configuredApiUrl, apiKey, parsedRoomId, Boolean.TRUE, "red", htmlMessage);
+        restChannelUtility.sendMessageRequest(intHttpClient, testRequest, "test");
+    }
+
+    private void testApiKeyAndApiUrlConnection(final IntHttpClient intHttpClient, final String configuredApiUrl, final String apiKey) throws IntegrationException {
+        if (StringUtils.isBlank(apiKey)) {
+            throw new AlertException("Invalid API key: API key not provided");
+        }
+        if (StringUtils.isBlank(configuredApiUrl)) {
+            throw new AlertException("Invalid server URL: server URL not provided");
+        }
+        if (intHttpClient == null) {
+            throw new AlertException("Connection error: see logs for more information.");
+        }
+        try {
+            sendTestRequest(intHttpClient, configuredApiUrl, apiKey);
+        } catch (final IntegrationException integrationException) {
+            logger.error("Unable to create a response", integrationException);
+            throw new AlertException("Invalid API key: " + integrationException.getMessage());
+        }
+    }
+
+    private void sendTestRequest(final IntHttpClient intHttpClient, final String configuredApiUrl, final String apiKey) throws IntegrationException {
+        final String url = configuredApiUrl + "/v2/room/*/notification";
+        final Map<String, Set<String>> queryParameters = new HashMap<>();
+        queryParameters.put("auth_test", new HashSet<>(Collections.singleton("true")));
+
+        final Map<String, String> requestHeaders = new HashMap<>();
+        requestHeaders.put("Authorization", "Bearer " + apiKey);
+        requestHeaders.put("Content-Type", "application/json");
+
+        final Request request = restChannelUtility.createPostMessageRequest(url, requestHeaders, queryParameters);
+        try (final Response response = restChannelUtility.sendGenericRequest(intHttpClient, request)) {
+            if (RestConstants.OK_200 > response.getStatusCode() || response.getStatusCode() >= RestConstants.BAD_REQUEST_400) {
+                throw new AlertException("Invalid API key: " + response.getStatusMessage());
+            }
+        } catch (final IOException ioException) {
+            throw new AlertException(ioException.getMessage(), ioException);
+        }
     }
 
 }

--- a/src/test/java/com/synopsys/integration/alert/channel/rest/RestDistributionChannelTest.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/rest/RestDistributionChannelTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.channel.ChannelTest;
 import com.synopsys.integration.alert.common.AlertProperties;
+import com.synopsys.integration.alert.common.channel.DistributionChannel;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
 import com.synopsys.integration.rest.HttpMethod;
 import com.synopsys.integration.rest.body.StringBodyContent;
@@ -126,7 +127,7 @@ public class RestDistributionChannelTest extends ChannelTest {
         return builder.build();
     }
 
-    private RestDistributionChannel createMockRestDistributionChannel(final Gson gson, final AlertProperties alertProperties, final BlackDuckProperties blackDuckProperties,
+    private DistributionChannel createMockRestDistributionChannel(final Gson gson, final AlertProperties alertProperties, final BlackDuckProperties blackDuckProperties,
         final ChannelRestConnectionFactory channelRestConnectionFactory, final Request request) {
         //        final RestDistributionChannel<GlobalChannelConfigEntity, DistributionChannelConfigEntity, DistributionEvent> restChannel = new RestDistributionChannel<GlobalChannelConfigEntity, DistributionChannelConfigEntity, DistributionEvent>(
         //                gson,

--- a/src/test/java/com/synopsys/integration/alert/channel/slack/SlackChannelTest.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/slack/SlackChannelTest.java
@@ -36,6 +36,7 @@ import com.google.gson.Gson;
 import com.synopsys.integration.alert.ProxyManager;
 import com.synopsys.integration.alert.channel.ChannelTest;
 import com.synopsys.integration.alert.channel.rest.ChannelRestConnectionFactory;
+import com.synopsys.integration.alert.channel.rest.RestChannelUtility;
 import com.synopsys.integration.alert.channel.slack.descriptor.SlackDescriptor;
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.enumeration.FormatType;
@@ -68,7 +69,8 @@ public class SlackChannelTest extends ChannelTest {
         final ProxyManager proxyManager = Mockito.mock(ProxyManager.class);
         Mockito.when(proxyManager.createProxyInfo()).thenReturn(ProxyInfo.NO_PROXY_INFO);
         final ChannelRestConnectionFactory channelRestConnectionFactory = new ChannelRestConnectionFactory(testAlertProperties, proxyManager);
-        final SlackChannel slackChannel = new SlackChannel(gson, testAlertProperties, auditUtility, channelRestConnectionFactory);
+        final RestChannelUtility restChannelUtility = new RestChannelUtility(channelRestConnectionFactory);
+        final SlackChannel slackChannel = new SlackChannel(gson, testAlertProperties, auditUtility, restChannelUtility);
 
         final AggregateMessageContent messageContent = createMessageContent(getClass().getSimpleName() + ": Request");
 
@@ -91,7 +93,8 @@ public class SlackChannelTest extends ChannelTest {
         final ChannelRestConnectionFactory channelRestConnectionFactory = Mockito.mock(ChannelRestConnectionFactory.class);
         final AlertProperties alertProperties = Mockito.mock(AlertProperties.class);
         final DefaultAuditUtility auditUtility = Mockito.mock(DefaultAuditUtility.class);
-        final SlackChannel channel = new SlackChannel(new Gson(), alertProperties, auditUtility, channelRestConnectionFactory);
+        final RestChannelUtility restChannelUtility = new RestChannelUtility(channelRestConnectionFactory);
+        final SlackChannel channel = new SlackChannel(new Gson(), alertProperties, auditUtility, restChannelUtility);
 
         final Map<String, ConfigurationFieldModel> fieldModels = new HashMap<>();
         final FieldAccessor fieldAccessor = new FieldAccessor(fieldModels);
@@ -126,7 +129,8 @@ public class SlackChannelTest extends ChannelTest {
         Mockito.when(content.getValue()).thenReturn("Value");
         Mockito.when(event.getContent()).thenReturn(content);
 
-        final SlackChannel channel = new SlackChannel(new Gson(), alertProperties, auditUtility, channelRestConnectionFactory);
+        final RestChannelUtility restChannelUtility = new RestChannelUtility(channelRestConnectionFactory);
+        final SlackChannel channel = new SlackChannel(new Gson(), alertProperties, auditUtility, restChannelUtility);
 
         try {
             channel.createRequests(event);
@@ -150,7 +154,8 @@ public class SlackChannelTest extends ChannelTest {
         Mockito.when(event.getFieldAccessor()).thenReturn(fieldAccessor);
         Mockito.when(event.getContent()).thenReturn(content);
 
-        final SlackChannel channel = new SlackChannel(new Gson(), alertProperties, auditUtility, channelRestConnectionFactory);
+        final RestChannelUtility restChannelUtility = new RestChannelUtility(channelRestConnectionFactory);
+        final SlackChannel channel = new SlackChannel(new Gson(), alertProperties, auditUtility, restChannelUtility);
 
         try {
             assertTrue(channel.createRequests(event).isEmpty());
@@ -175,7 +180,8 @@ public class SlackChannelTest extends ChannelTest {
         Mockito.when(event.getFieldAccessor()).thenReturn(fieldAccessor);
         Mockito.when(event.getContent()).thenReturn(content);
 
-        final SlackChannel channel = new SlackChannel(new Gson(), alertProperties, auditUtility, channelRestConnectionFactory);
+        final RestChannelUtility restChannelUtility = new RestChannelUtility(channelRestConnectionFactory);
+        final SlackChannel channel = new SlackChannel(new Gson(), alertProperties, auditUtility, restChannelUtility);
 
         final List<Request> requests = channel.createRequests(event);
         assertFalse(requests.isEmpty());
@@ -202,7 +208,8 @@ public class SlackChannelTest extends ChannelTest {
         Mockito.when(event.getFieldAccessor()).thenReturn(fieldAccessor);
         Mockito.when(event.getContent()).thenReturn(content);
 
-        final SlackChannel channel = new SlackChannel(new Gson(), alertProperties, auditUtility, channelRestConnectionFactory);
+        final RestChannelUtility restChannelUtility = new RestChannelUtility(channelRestConnectionFactory);
+        final SlackChannel channel = new SlackChannel(new Gson(), alertProperties, auditUtility, restChannelUtility);
 
         final List<Request> requests = channel.createRequests(event);
         assertFalse(requests.isEmpty());
@@ -231,7 +238,8 @@ public class SlackChannelTest extends ChannelTest {
         Mockito.when(event.getFieldAccessor()).thenReturn(fieldAccessor);
         Mockito.when(event.getContent()).thenReturn(content);
 
-        final SlackChannel channel = new SlackChannel(new Gson(), alertProperties, auditUtility, channelRestConnectionFactory);
+        final RestChannelUtility restChannelUtility = new RestChannelUtility(channelRestConnectionFactory);
+        final SlackChannel channel = new SlackChannel(new Gson(), alertProperties, auditUtility, restChannelUtility);
 
         final List<Request> requests = channel.createRequests(event);
         assertFalse(requests.isEmpty());
@@ -260,7 +268,8 @@ public class SlackChannelTest extends ChannelTest {
         Mockito.when(event.getFieldAccessor()).thenReturn(fieldAccessor);
         Mockito.when(event.getContent()).thenReturn(content);
 
-        final SlackChannel channel = new SlackChannel(new Gson(), alertProperties, auditUtility, channelRestConnectionFactory);
+        final RestChannelUtility restChannelUtility = new RestChannelUtility(channelRestConnectionFactory);
+        final SlackChannel channel = new SlackChannel(new Gson(), alertProperties, auditUtility, restChannelUtility);
 
         final List<Request> requests = channel.createRequests(event);
         assertFalse(requests.isEmpty());
@@ -312,7 +321,10 @@ public class SlackChannelTest extends ChannelTest {
     @Test
     public void testCreateHtmlMessage() throws IntegrationException {
         final TestAlertProperties testAlertProperties = new TestAlertProperties();
-        final SlackChannel slackChannel = new SlackChannel(gson, testAlertProperties, null, null);
+        final RestChannelUtility restChannelUtility = new RestChannelUtility(null);
+        final RestChannelUtility restChannelUtilitySpy = Mockito.spy(restChannelUtility);
+        Mockito.doNothing().when(restChannelUtilitySpy).sendMessage(Mockito.any(), Mockito.anyString());
+        final SlackChannel slackChannel = new SlackChannel(gson, testAlertProperties, null, restChannelUtilitySpy);
         final AggregateMessageContent messageContent = createMessageContent(getClass().getSimpleName() + ": Request");
 
         final Map<String, ConfigurationFieldModel> fieldModels = new HashMap<>();
@@ -323,11 +335,10 @@ public class SlackChannelTest extends ChannelTest {
         final FieldAccessor fieldAccessor = new FieldAccessor(fieldModels);
         final DistributionEvent event = new DistributionEvent("1L", SlackChannel.COMPONENT_NAME, RestConstants.formatDate(new Date()), BlackDuckProvider.COMPONENT_NAME, FormatType.DEFAULT.name(), messageContent, fieldAccessor);
 
-        final SlackChannel spySlackChannel = Mockito.spy(slackChannel);
-        final List<Request> request = spySlackChannel.createRequests(event);
+        slackChannel.sendMessage(event);
 
-        assertFalse(request.isEmpty());
-        Mockito.verify(spySlackChannel).createPostMessageRequest(Mockito.anyString(), Mockito.anyMap(), Mockito.anyString());
+        //        assertFalse(request.isEmpty());
+        Mockito.verify(restChannelUtilitySpy).sendMessage(Mockito.any(), Mockito.anyString());
     }
 
     @Test
@@ -346,6 +357,6 @@ public class SlackChannelTest extends ChannelTest {
         final SlackChannel spySlackChannel = Mockito.spy(slackChannel);
         final List<Request> requests = slackChannel.createRequests(event);
         assertTrue(requests.isEmpty());
-        Mockito.verify(spySlackChannel, Mockito.times(0)).createPostMessageRequest(Mockito.anyString(), Mockito.anyMap(), Mockito.anyString());
+        Mockito.verify(spySlackChannel, Mockito.times(0)).sendMessage(Mockito.any());
     }
 }


### PR DESCRIPTION
Removed RestDistributionChannel from the hierarchy of DistributionChannels. Replaced the functionality there with a utility class that can now be used if you want to make rest calls in your channel.

This was originally being changed in anticipation of the MS Teams channel which looks to be getting pushed back now. Now it's just a QOL improvement