### PR TITLE
Fix startup variables

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/common/ConfigurationFieldModelConverter.java
+++ b/src/main/java/com/synopsys/integration/alert/common/ConfigurationFieldModelConverter.java
@@ -59,6 +59,7 @@ public class ConfigurationFieldModelConverter {
         return new FieldAccessor(fields);
     }
 
+    // TODO verify if we need this method or if we can just use the method this calls
     public final Map<String, ConfigurationFieldModel> convertFromFieldModel(final FieldModel fieldModel) throws AlertDatabaseConstraintException {
         return convertToConfigurationFieldModelMap(fieldModel);
     }

--- a/src/main/java/com/synopsys/integration/alert/component/settings/SettingsDescriptorActionApi.java
+++ b/src/main/java/com/synopsys/integration/alert/component/settings/SettingsDescriptorActionApi.java
@@ -91,12 +91,9 @@ public class SettingsDescriptorActionApi extends NoTestActionApi {
     }
 
     private void saveDefaultAdminUserPassword(final FieldModel fieldModel) {
-        final Optional<FieldValueModel> optionalPassword = fieldModel.getField(SettingsDescriptor.KEY_DEFAULT_SYSTEM_ADMIN_PWD);
-        if (optionalPassword.isPresent()) {
-            final String password = optionalPassword.flatMap(FieldValueModel::getValue).orElse("");
-            if (StringUtils.isNotBlank(password)) {
-                userAccessor.changeUserPassword(UserAccessor.DEFAULT_ADMIN_USER, password);
-            }
+        final String password = fieldModel.getField(SettingsDescriptor.KEY_DEFAULT_SYSTEM_ADMIN_PWD).flatMap(FieldValueModel::getValue).orElse("");
+        if (StringUtils.isNotBlank(password)) {
+            userAccessor.changeUserPassword(UserAccessor.DEFAULT_ADMIN_USER, password);
         }
     }
 

--- a/src/main/java/com/synopsys/integration/alert/web/config/ConfigActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/config/ConfigActions.java
@@ -125,13 +125,13 @@ public class ConfigActions {
 
     public FieldModel saveConfig(final FieldModel fieldModel) throws AlertException, AlertFieldException {
         validateConfig(fieldModel, new HashMap<>());
-        final String descriptorName = fieldModel.getDescriptorName();
-        final String context = fieldModel.getContext();
-        final Map<String, ConfigurationFieldModel> configurationFieldModelMap = modelConverter.convertFromFieldModel(fieldModel);
+        final FieldModel modifiedFieldModel = fieldModelProcessor.performSaveAction(fieldModel);
+        final String descriptorName = modifiedFieldModel.getDescriptorName();
+        final String context = modifiedFieldModel.getContext();
+        final Map<String, ConfigurationFieldModel> configurationFieldModelMap = modelConverter.convertFromFieldModel(modifiedFieldModel);
         final ConfigurationModel configuration = configurationAccessor.createConfiguration(descriptorName, EnumUtils.getEnum(ConfigContextEnum.class, context), configurationFieldModelMap.values());
         final FieldModel dbSavedModel = fieldModelProcessor.convertToFieldModel(configuration);
-        final FieldModel combinedModel = dbSavedModel.fill(fieldModel);
-        return fieldModelProcessor.performSaveAction(combinedModel);
+        return dbSavedModel.fill(modifiedFieldModel);
     }
 
     public String validateConfig(final FieldModel fieldModel, final Map<String, String> fieldErrors) throws AlertFieldException {
@@ -160,11 +160,11 @@ public class ConfigActions {
 
     public FieldModel updateConfig(final Long id, final FieldModel fieldModel) throws AlertException, AlertFieldException {
         validateConfig(fieldModel, new HashMap<>());
-        final Collection<ConfigurationFieldModel> updatedFields = fieldModelProcessor.fillFieldModelWithExistingData(id, fieldModel);
+        final FieldModel updatedFieldModel = fieldModelProcessor.performUpdateAction(fieldModel);
+        final Collection<ConfigurationFieldModel> updatedFields = fieldModelProcessor.fillFieldModelWithExistingData(id, updatedFieldModel);
         final ConfigurationModel configurationModel = configurationAccessor.updateConfiguration(id, updatedFields);
         final FieldModel dbSavedModel = fieldModelProcessor.convertToFieldModel(configurationModel);
-        final FieldModel combinedModel = dbSavedModel.fill(fieldModel);
-        return fieldModelProcessor.performUpdateAction(combinedModel);
+        return dbSavedModel.fill(updatedFieldModel);
     }
 
 }

--- a/src/main/java/com/synopsys/integration/alert/web/config/FieldModelProcessor.java
+++ b/src/main/java/com/synopsys/integration/alert/web/config/FieldModelProcessor.java
@@ -85,18 +85,15 @@ public class FieldModelProcessor {
 
     public FieldModel performDeleteAction(final ConfigurationModel configurationModel) throws AlertDatabaseConstraintException {
         final FieldModel fieldModel = convertToFieldModel(configurationModel);
-        final Optional<DescriptorActionApi> descriptorActionApi = retrieveDescriptorActionApi(fieldModel);
-        return descriptorActionApi.map(actionApi -> actionApi.deleteConfig(fieldModel)).orElse(fieldModel);
+        return retrieveDescriptorActionApi(fieldModel).map(actionApi -> actionApi.deleteConfig(fieldModel)).orElse(fieldModel);
     }
 
     public FieldModel performSaveAction(final FieldModel fieldModel) {
-        final Optional<DescriptorActionApi> descriptorActionApi = retrieveDescriptorActionApi(fieldModel);
-        return descriptorActionApi.map(actionApi -> actionApi.saveConfig(fieldModel)).orElse(fieldModel);
+        return retrieveDescriptorActionApi(fieldModel).map(actionApi -> actionApi.saveConfig(fieldModel)).orElse(fieldModel);
     }
 
     public FieldModel performUpdateAction(final FieldModel fieldModel) {
-        final Optional<DescriptorActionApi> descriptorActionApi = retrieveDescriptorActionApi(fieldModel);
-        return descriptorActionApi.map(actionApi -> actionApi.updateConfig(fieldModel)).orElse(fieldModel);
+        return retrieveDescriptorActionApi(fieldModel).map(actionApi -> actionApi.updateConfig(fieldModel)).orElse(fieldModel);
     }
 
     public Map<String, String> validateFieldModel(final FieldModel fieldModel) {
@@ -171,6 +168,17 @@ public class FieldModelProcessor {
         }
 
         return new FieldModel(configId.toString(), descriptorName, configurationModel.getDescriptorContext().name(), fields);
+    }
+
+    public Map<String, FieldValueModel> convertToFieldValuesMap(final Collection<ConfigurationFieldModel> configurationFieldModels) {
+        final Map<String, FieldValueModel> fields = new HashMap<>();
+        for (final ConfigurationFieldModel fieldModel : configurationFieldModels) {
+            final String key = fieldModel.getFieldKey();
+            final Collection<String> values = fieldModel.getFieldValues();
+            final FieldValueModel fieldValueModel = new FieldValueModel(values, fieldModel.isSet());
+            fields.put(key, fieldValueModel);
+        }
+        return fields;
     }
 
     private void populateAndSecureFields(final ConfigurationFieldModel fieldModel, final Map<String, FieldValueModel> fields) {

--- a/src/main/java/com/synopsys/integration/alert/workflow/startup/AlertStartupInitializer.java
+++ b/src/main/java/com/synopsys/integration/alert/workflow/startup/AlertStartupInitializer.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -48,6 +49,9 @@ import com.synopsys.integration.alert.component.settings.SettingsDescriptor;
 import com.synopsys.integration.alert.database.api.configuration.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.database.api.configuration.model.ConfigurationModel;
 import com.synopsys.integration.alert.database.api.configuration.model.DefinedFieldModel;
+import com.synopsys.integration.alert.web.config.FieldModelProcessor;
+import com.synopsys.integration.alert.web.model.configuration.FieldModel;
+import com.synopsys.integration.alert.web.model.configuration.FieldValueModel;
 
 @Component
 public class AlertStartupInitializer {
@@ -57,15 +61,17 @@ public class AlertStartupInitializer {
     private final BaseDescriptorAccessor descriptorAccessor;
     private final BaseConfigurationAccessor fieldConfigurationAccessor;
     private final ConfigurationFieldModelConverter modelConverter;
+    private final FieldModelProcessor fieldModelProcessor;
 
     @Autowired
     public AlertStartupInitializer(final DescriptorMap descriptorMap, final Environment environment, final BaseDescriptorAccessor descriptorAccessor, final BaseConfigurationAccessor fieldConfigurationAccessor,
-        final ConfigurationFieldModelConverter modelConverter) {
+        final ConfigurationFieldModelConverter modelConverter, final FieldModelProcessor fieldModelProcessor) {
         this.descriptorMap = descriptorMap;
         this.environment = environment;
         this.descriptorAccessor = descriptorAccessor;
         this.fieldConfigurationAccessor = fieldConfigurationAccessor;
         this.modelConverter = modelConverter;
+        this.fieldModelProcessor = fieldModelProcessor;
     }
 
     public void initializeConfigs() throws IllegalArgumentException, SecurityException {
@@ -88,7 +94,7 @@ public class AlertStartupInitializer {
                                                    .flatMap(configurationModel -> configurationModel.getField(fieldKey))
                                                    .flatMap(ConfigurationFieldModel::getFieldValue)
                                                    .map(value -> Boolean.valueOf(value)).orElse(Boolean.FALSE);
-            final String environmentFieldKey = convertKeyToPropery(SettingsDescriptor.SETTINGS_COMPONENT, fieldKey);
+            final String environmentFieldKey = convertKeyToProperty(SettingsDescriptor.SETTINGS_COMPONENT, fieldKey);
             final Optional<String> environmentValue = getEnvironmentValue(environmentFieldKey);
 
             environmentOverride = environmentValue.map(envValue -> Boolean.valueOf(envValue)).orElse(overwriteSavedInDB);
@@ -125,7 +131,7 @@ public class AlertStartupInitializer {
         final Set<ConfigurationFieldModel> configurationModels = new HashSet<>();
         for (final DefinedFieldModel fieldModel : fieldsForDescriptor) {
             final String key = fieldModel.getKey();
-            final String convertedKey = convertKeyToPropery(descriptorName, key);
+            final String convertedKey = convertKeyToProperty(descriptorName, key);
             final boolean hasEnvironmentValue = hasEnvironmentValue(convertedKey);
             logger.info("  {}", convertedKey);
             logger.debug("       Environment Variable Found - {}", hasEnvironmentValue);
@@ -143,17 +149,32 @@ public class AlertStartupInitializer {
                 if (overwriteCurrentConfig) {
                     final ConfigurationModel configurationModel = foundConfigurationModels.get(0);
                     logger.info("  Overwriting configuration values with environment for descriptor.");
-                    fieldConfigurationAccessor.updateConfiguration(configurationModel.getConfigurationId(), configurationModels);
+                    final Collection<ConfigurationFieldModel> updatedFields = updateAction(descriptorName, configurationModels);
+                    fieldConfigurationAccessor.updateConfiguration(configurationModel.getConfigurationId(), updatedFields);
                 }
             } else {
                 logger.info("  Writing initial configuration values from environment for descriptor.");
-                fieldConfigurationAccessor.createConfiguration(descriptorName, ConfigContextEnum.GLOBAL, configurationModels);
-
+                final Collection<ConfigurationFieldModel> savedFields = saveAction(descriptorName, configurationModels);
+                fieldConfigurationAccessor.createConfiguration(descriptorName, ConfigContextEnum.GLOBAL, savedFields);
             }
         }
     }
 
-    private String convertKeyToPropery(final String descriptorName, final String key) {
+    private Collection<ConfigurationFieldModel> updateAction(final String descriptorName, final Collection<ConfigurationFieldModel> configurationFieldModels) throws AlertDatabaseConstraintException {
+        final Map<String, FieldValueModel> fieldValueModelMap = fieldModelProcessor.convertToFieldValuesMap(configurationFieldModels);
+        final FieldModel fieldModel = new FieldModel(descriptorName, ConfigContextEnum.GLOBAL.name(), fieldValueModelMap);
+        final FieldModel updatedFieldModel = fieldModelProcessor.performUpdateAction(fieldModel);
+        return modelConverter.convertFromFieldModel(updatedFieldModel).values();
+    }
+
+    private Collection<ConfigurationFieldModel> saveAction(final String descriptorName, final Collection<ConfigurationFieldModel> configurationFieldModels) throws AlertDatabaseConstraintException {
+        final Map<String, FieldValueModel> fieldValueModelMap = fieldModelProcessor.convertToFieldValuesMap(configurationFieldModels);
+        final FieldModel fieldModel = new FieldModel(descriptorName, ConfigContextEnum.GLOBAL.name(), fieldValueModelMap);
+        final FieldModel savedFieldModel = fieldModelProcessor.performSaveAction(fieldModel);
+        return modelConverter.convertFromFieldModel(savedFieldModel).values();
+    }
+
+    private String convertKeyToProperty(final String descriptorName, final String key) {
         final String keyUnderscores = key.replace(".", "_");
         return String.join("_", "alert", descriptorName, keyUnderscores).toUpperCase();
     }

--- a/src/test/java/com/synopsys/integration/alert/workflow/startup/AlertStartupInitializerTest.java
+++ b/src/test/java/com/synopsys/integration/alert/workflow/startup/AlertStartupInitializerTest.java
@@ -22,6 +22,7 @@ import com.synopsys.integration.alert.common.security.EncryptionUtility;
 import com.synopsys.integration.alert.component.settings.SettingsDescriptor;
 import com.synopsys.integration.alert.database.api.configuration.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.database.api.configuration.model.ConfigurationModel;
+import com.synopsys.integration.alert.web.config.FieldModelProcessor;
 
 public class AlertStartupInitializerTest {
 
@@ -39,7 +40,8 @@ public class AlertStartupInitializerTest {
         final List<ProviderDescriptor> providerDescriptors = List.of();
         final List<ComponentDescriptor> componentDescriptors = List.of();
         final DescriptorMap descriptorMap = new DescriptorMap(channelDescriptors, providerDescriptors, componentDescriptors);
-        final AlertStartupInitializer initializer = new AlertStartupInitializer(descriptorMap, environment, baseDescriptorAccessor, baseConfigurationAccessor, modelConverter);
+        final FieldModelProcessor fieldModelProcessor = new FieldModelProcessor(baseDescriptorAccessor, baseConfigurationAccessor, descriptorMap, modelConverter, null);
+        final AlertStartupInitializer initializer = new AlertStartupInitializer(descriptorMap, environment, baseDescriptorAccessor, baseConfigurationAccessor, modelConverter, fieldModelProcessor);
         initializer.initializeConfigs();
         Mockito.verify(baseDescriptorAccessor, Mockito.times(2)).getFieldsForDescriptor(Mockito.anyString(), Mockito.any(ConfigContextEnum.class));
         // 2 times for the settings descriptor and once for the HipChatDescriptor
@@ -57,7 +59,8 @@ public class AlertStartupInitializerTest {
         final EncryptionUtility encryptionUtility = Mockito.mock(EncryptionUtility.class);
         Mockito.when(encryptionUtility.isInitialized()).thenReturn(Boolean.TRUE);
         final ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, baseDescriptorAccessor);
-        final AlertStartupInitializer initializer = new AlertStartupInitializer(descriptorMap, environment, baseDescriptorAccessor, baseConfigurationAccessor, modelConverter);
+        final FieldModelProcessor fieldModelProcessor = new FieldModelProcessor(baseDescriptorAccessor, baseConfigurationAccessor, descriptorMap, modelConverter, null);
+        final AlertStartupInitializer initializer = new AlertStartupInitializer(descriptorMap, environment, baseDescriptorAccessor, baseConfigurationAccessor, modelConverter, fieldModelProcessor);
         initializer.initializeConfigs();
         // called to get the settings component configuration and fields.
         Mockito.verify(baseDescriptorAccessor).getFieldsForDescriptor(Mockito.anyString(), Mockito.any(ConfigContextEnum.class));
@@ -83,9 +86,10 @@ public class AlertStartupInitializerTest {
         final String value = "newValue";
         Mockito.when(environment.getProperty(Mockito.anyString())).thenReturn(value);
 
-        final AlertStartupInitializer initializer = new AlertStartupInitializer(descriptorMap, environment, baseDescriptorAccessor, baseConfigurationAccessor, modelConverter);
+        final FieldModelProcessor fieldModelProcessor = new FieldModelProcessor(baseDescriptorAccessor, baseConfigurationAccessor, descriptorMap, modelConverter, null);
+        final AlertStartupInitializer initializer = new AlertStartupInitializer(descriptorMap, environment, baseDescriptorAccessor, baseConfigurationAccessor, modelConverter, fieldModelProcessor);
         initializer.initializeConfigs();
-        Mockito.verify(baseDescriptorAccessor, Mockito.times(2)).getFieldsForDescriptor(Mockito.anyString(), Mockito.any(ConfigContextEnum.class));
+        Mockito.verify(baseDescriptorAccessor, Mockito.times(4)).getFieldsForDescriptor(Mockito.anyString(), Mockito.any(ConfigContextEnum.class));
         Mockito.verify(baseConfigurationAccessor, Mockito.times(2)).createConfiguration(Mockito.anyString(), Mockito.any(ConfigContextEnum.class), Mockito.anyCollection());
         Mockito.verify(baseConfigurationAccessor, Mockito.times(3)).getConfigurationByDescriptorNameAndContext(Mockito.anyString(), Mockito.any(ConfigContextEnum.class));
     }
@@ -104,7 +108,8 @@ public class AlertStartupInitializerTest {
         final List<ProviderDescriptor> providerDescriptors = List.of();
         final List<ComponentDescriptor> componentDescriptors = List.of();
         final DescriptorMap descriptorMap = new DescriptorMap(channelDescriptors, providerDescriptors, componentDescriptors);
-        final AlertStartupInitializer initializer = new AlertStartupInitializer(descriptorMap, environment, baseDescriptorAccessor, baseConfigurationAccessor, modelConverter);
+        final FieldModelProcessor fieldModelProcessor = new FieldModelProcessor(baseDescriptorAccessor, baseConfigurationAccessor, descriptorMap, modelConverter, null);
+        final AlertStartupInitializer initializer = new AlertStartupInitializer(descriptorMap, environment, baseDescriptorAccessor, baseConfigurationAccessor, modelConverter, fieldModelProcessor);
         initializer.initializeConfigs();
         Mockito.verify(baseDescriptorAccessor, Mockito.times(2)).getFieldsForDescriptor(Mockito.anyString(), Mockito.any(ConfigContextEnum.class));
         Mockito.verify(baseConfigurationAccessor, Mockito.times(3)).getConfigurationByDescriptorNameAndContext(Mockito.anyString(), Mockito.any(ConfigContextEnum.class));
@@ -137,10 +142,11 @@ public class AlertStartupInitializerTest {
         final String value = "newValue";
         Mockito.when(environment.getProperty(Mockito.startsWith("ALERT_CHANNEL_"))).thenReturn(value);
 
-        final AlertStartupInitializer initializer = new AlertStartupInitializer(descriptorMap, environment, baseDescriptorAccessor, baseConfigurationAccessor, modelConverter);
+        final FieldModelProcessor fieldModelProcessor = new FieldModelProcessor(baseDescriptorAccessor, baseConfigurationAccessor, descriptorMap, modelConverter, null);
+        final AlertStartupInitializer initializer = new AlertStartupInitializer(descriptorMap, environment, baseDescriptorAccessor, baseConfigurationAccessor, modelConverter, fieldModelProcessor);
         initializer.initializeConfigs();
 
-        Mockito.verify(baseDescriptorAccessor, Mockito.times(2)).getFieldsForDescriptor(Mockito.anyString(), Mockito.any(ConfigContextEnum.class));
+        Mockito.verify(baseDescriptorAccessor, Mockito.times(3)).getFieldsForDescriptor(Mockito.anyString(), Mockito.any(ConfigContextEnum.class));
         Mockito.verify(baseConfigurationAccessor, Mockito.times(0)).createConfiguration(Mockito.anyString(), Mockito.any(ConfigContextEnum.class), Mockito.anyCollection());
         Mockito.verify(baseConfigurationAccessor, Mockito.times(3)).getConfigurationByDescriptorNameAndContext(Mockito.anyString(), Mockito.any(ConfigContextEnum.class));
         Mockito.verify(baseConfigurationAccessor).updateConfiguration(Mockito.anyLong(), Mockito.anyCollection());


### PR DESCRIPTION
Startup variables now call the save and update actions (Probably want this reworked in 4.1.0 as action api requires FieldModels).

our save and update endpoints now call the save and update actions before actually saving to the DB