### PR TITLE
Ldap prefix removal

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/component/settings/SettingsDescriptor.java
+++ b/src/main/java/com/synopsys/integration/alert/component/settings/SettingsDescriptor.java
@@ -61,7 +61,6 @@ public class SettingsDescriptor extends ComponentDescriptor {
     public static final String KEY_LDAP_GROUP_SEARCH_BASE = "settings.ldap.group.search.base";
     public static final String KEY_LDAP_GROUP_SEARCH_FILTER = "settings.ldap.group.search.filter";
     public static final String KEY_LDAP_GROUP_ROLE_ATTRIBUTE = "settings.ldap.group.role.attribute";
-    public static final String KEY_LDAP_ROLE_PREFIX = "settings.ldap.role.prefix";
     public static final String KEY_STARTUP_ENVIRONMENT_VARIABLE_OVERRIDE = "settings.startup.environment.variable.override";
 
     public static final String FIELD_ERROR_DEFAULT_USER_PWD = "Default admin user password missing";

--- a/src/main/java/com/synopsys/integration/alert/component/settings/SettingsUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/component/settings/SettingsUIConfig.java
@@ -72,10 +72,9 @@ public class SettingsUIConfig extends UIConfig {
         final ConfigField ldapGroupSearchBase = TextInputConfigField.create(SettingsDescriptor.KEY_LDAP_GROUP_SEARCH_BASE, "LDAP Group Search Base");
         final ConfigField ldapGroupSearchFilter = TextInputConfigField.create(SettingsDescriptor.KEY_LDAP_GROUP_SEARCH_FILTER, "LDAP Group Search Filter");
         final ConfigField ldapGroupRoleAttribute = TextInputConfigField.create(SettingsDescriptor.KEY_LDAP_GROUP_ROLE_ATTRIBUTE, "LDAP Group Role Attribute");
-        final ConfigField ldapRolePrefix = TextInputConfigField.create(SettingsDescriptor.KEY_LDAP_ROLE_PREFIX, "LDAP Role Prefix");
 
         return List.of(sysAdminEmail, defaultUserPassword, encryptionPassword, encryptionSalt, environmentVariableOverride, proxyHost, proxyPort, proxyUsername, proxyPassword, ldapEnabled, ldapServer, ldapManagerDn, ldapManagerPassword,
-            ldapAuthenticationType, ldapReferral, ldapUserSearchBase, ldapUserSearchFilter, ldapUserDNPatterns, ldapUserAttributes, ldapGroupSearchBase, ldapGroupSearchFilter, ldapGroupRoleAttribute, ldapRolePrefix);
+            ldapAuthenticationType, ldapReferral, ldapUserSearchBase, ldapUserSearchFilter, ldapUserDNPatterns, ldapUserAttributes, ldapGroupSearchBase, ldapGroupSearchFilter, ldapGroupRoleAttribute);
     }
 
     private Collection<String> validateProxyHost(final FieldValueModel fieldToValidate, final FieldModel fieldModel) {

--- a/src/main/java/com/synopsys/integration/alert/database/api/user/UserRole.java
+++ b/src/main/java/com/synopsys/integration/alert/database/api/user/UserRole.java
@@ -24,5 +24,7 @@
 package com.synopsys.integration.alert.database.api.user;
 
 public enum UserRole {
-    ADMIN
+    ALERT_ADMIN;
+
+    public static final String ALERT_ADMIN_TEXT = "ALERT_ADMIN";
 }

--- a/src/main/java/com/synopsys/integration/alert/web/security/HttpPathManager.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/HttpPathManager.java
@@ -31,14 +31,11 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
 import org.springframework.stereotype.Component;
 
+import com.synopsys.integration.alert.database.api.user.UserRole;
 import com.synopsys.integration.alert.web.controller.BaseController;
 
 @Component
 public class HttpPathManager {
-    private final List<String> allowedPaths;
-    private final List<String> csrfIgnoredPaths;
-    private final HttpSessionCsrfTokenRepository csrfTokenRepository;
-
     private static final String[] DEFAULT_PATHS = {
         "/",
         "/#",
@@ -56,6 +53,9 @@ public class HttpPathManager {
         BaseController.BASE_PATH + "/system/messages/latest",
         BaseController.BASE_PATH + "/system/setup/initial"
     };
+    private final List<String> allowedPaths;
+    private final List<String> csrfIgnoredPaths;
+    private final HttpSessionCsrfTokenRepository csrfTokenRepository;
 
     @Autowired
     public HttpPathManager(final HttpSessionCsrfTokenRepository csrfTokenRepository) {
@@ -101,7 +101,7 @@ public class HttpPathManager {
     public void completeHttpSecurity(final HttpSecurity http) throws Exception {
         http.csrf().csrfTokenRepository(csrfTokenRepository).ignoringAntMatchers(getCsrfIgnoredPaths())
             .and().authorizeRequests().antMatchers(getAllowedPaths()).permitAll()
-            .and().authorizeRequests().anyRequest().hasRole("ADMIN")
+            .and().authorizeRequests().anyRequest().hasRole(UserRole.ALERT_ADMIN.name())
             .and().logout().logoutSuccessUrl("/");
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/ldap/LdapManager.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/ldap/LdapManager.java
@@ -157,11 +157,12 @@ public class LdapManager {
         final String groupSearchBase = getFieldValueOrEmpty(configurationModel, SettingsDescriptor.KEY_LDAP_GROUP_SEARCH_BASE);
         final String groupSearchFilter = getFieldValueOrEmpty(configurationModel, SettingsDescriptor.KEY_LDAP_GROUP_SEARCH_FILTER);
         final String groupRoleAttribute = getFieldValueOrEmpty(configurationModel, SettingsDescriptor.KEY_LDAP_GROUP_ROLE_ATTRIBUTE);
-        final String rolePrefix = getFieldValueOrEmpty(configurationModel, SettingsDescriptor.KEY_LDAP_ROLE_PREFIX);
         final DefaultLdapAuthoritiesPopulator authoritiesPopulator = new DefaultLdapAuthoritiesPopulator(contextSource, groupSearchBase);
         authoritiesPopulator.setGroupSearchFilter(groupSearchFilter);
         authoritiesPopulator.setGroupRoleAttribute(groupRoleAttribute);
-        authoritiesPopulator.setRolePrefix(rolePrefix);
+        // expect the LDAP group name for the role to be ROLE_<ROLE_NAME> where ROLE_NAME defined in UserRoles
+        // Set the prefix to the empty string because the prefix is by default set to ROLE_ we don't want the populator to create ROLE_ROLE_<ROLE_NAME> due to the default prefix
+        authoritiesPopulator.setRolePrefix("");
         return authoritiesPopulator;
     }
 

--- a/src/main/js/component/settings/SettingsConfigurationForm.js
+++ b/src/main/js/component/settings/SettingsConfigurationForm.js
@@ -59,8 +59,7 @@ const fieldNames = [
     KEY_LDAP_USER_ATTRIBUTES,
     KEY_LDAP_GROUP_SEARCH_BASE,
     KEY_LDAP_GROUP_SEARCH_FILTER,
-    KEY_LDAP_GROUP_ROLE_ATTRIBUTE,
-    KEY_LDAP_ROLE_PREFIX
+    KEY_LDAP_GROUP_ROLE_ATTRIBUTE
 ];
 
 class SettingsConfigurationForm extends Component {
@@ -267,7 +266,7 @@ class SettingsConfigurationForm extends Component {
                                 title="LDAP Configuration"
                                 expanded={() => FieldModelUtilities.keysHaveValueOrIsSet(fieldModel, [KEY_LDAP_ENABLED, KEY_LDAP_SERVER, KEY_LDAP_MANAGER_DN, KEY_LDAP_MANAGER_PASSWORD,
                                     KEY_LDAP_AUTHENTICATION_TYPE, KEY_LDAP_REFERRAL, KEY_LDAP_USER_SEARCH_BASE, KEY_LDAP_USER_SEARCH_FILTER, KEY_LDAP_USER_DN_PATTERNS, KEY_LDAP_USER_ATTRIBUTES,
-                                    KEY_LDAP_GROUP_SEARCH_BASE, KEY_LDAP_GROUP_SEARCH_FILTER, KEY_LDAP_GROUP_ROLE_ATTRIBUTE, KEY_LDAP_ROLE_PREFIX])}
+                                    KEY_LDAP_GROUP_SEARCH_BASE, KEY_LDAP_GROUP_SEARCH_FILTER, KEY_LDAP_GROUP_ROLE_ATTRIBUTE])}
                             >
                                 <CheckboxInput
                                     id={KEY_LDAP_ENABLED}
@@ -392,15 +391,6 @@ class SettingsConfigurationForm extends Component {
                                     onChange={this.handleChange}
                                     errorName={FieldModelUtilities.createFieldModelErrorKey(KEY_LDAP_GROUP_ROLE_ATTRIBUTE)}
                                     errorValue={this.props.fieldErrors[KEY_LDAP_GROUP_ROLE_ATTRIBUTE]}
-                                />
-                                <TextInput
-                                    id={KEY_LDAP_ROLE_PREFIX}
-                                    label="Role Prefix"
-                                    name={KEY_LDAP_ROLE_PREFIX}
-                                    value={FieldModelUtilities.getFieldModelSingleValue(fieldModel, KEY_LDAP_ROLE_PREFIX)}
-                                    onChange={this.handleChange}
-                                    errorName={FieldModelUtilities.createFieldModelErrorKey(KEY_LDAP_ROLE_PREFIX)}
-                                    errorValue={this.props.fieldErrors[KEY_LDAP_ROLE_PREFIX]}
                                 />
                             </CollapsiblePane>
                         </div>

--- a/src/main/resources/db/changelog/alert/4.0.0/changelog-authentication.xml
+++ b/src/main/resources/db/changelog/alert/4.0.0/changelog-authentication.xml
@@ -58,7 +58,7 @@
     <changeSet author="psantos" id="1543502711058-4">
         <insert tableName="ROLES" schemaName="ALERT">
             <column name="id" value="1"/>
-            <column name="ROLENAME" value="ADMIN"/>
+            <column name="ROLENAME" value="ALERT_ADMIN"/>
         </insert>
     </changeSet>
     <changeSet author="psantos" id="1543502711058-5">

--- a/src/main/resources/db/changelog/alert/4.0.0/changelog-configuration-initialization.xml
+++ b/src/main/resources/db/changelog/alert/4.0.0/changelog-configuration-initialization.xml
@@ -396,9 +396,6 @@
         <sql dbms="h2" stripComments="true">
             CALL DEFINE_FIELD('settings.ldap.group.role.attribute', FALSE, 'component_settings', 'GLOBAL');
         </sql>
-        <sql dbms="h2" stripComments="true">
-            CALL DEFINE_FIELD('settings.ldap.role.prefix', FALSE, 'component_settings', 'GLOBAL');
-        </sql>
     </changeSet>
 
 

--- a/src/test/java/com/synopsys/integration/alert/audit/controller/AuditEntryControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/audit/controller/AuditEntryControllerTestIT.java
@@ -26,6 +26,7 @@ import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.database.api.configuration.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.database.api.configuration.model.ConfigurationJobModel;
 import com.synopsys.integration.alert.database.api.configuration.model.ConfigurationModel;
+import com.synopsys.integration.alert.database.api.user.UserRole;
 import com.synopsys.integration.alert.database.audit.AuditEntryEntity;
 import com.synopsys.integration.alert.database.audit.AuditEntryRepository;
 import com.synopsys.integration.alert.database.audit.AuditNotificationRepository;
@@ -75,16 +76,16 @@ public class AuditEntryControllerTestIT extends AlertIntegrationTest {
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUser(roles = UserRole.ALERT_ADMIN_TEXT)
     public void testGetConfig() throws Exception {
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(auditUrl)
-                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(UserRole.ALERT_ADMIN_TEXT))
                                                           .with(SecurityMockMvcRequestPostProcessors.csrf());
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk());
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUser(roles = UserRole.ALERT_ADMIN_TEXT)
     public void testGetConfigWithId() throws Exception {
         final MockAuditEntryEntity mockAuditEntryEntity = new MockAuditEntryEntity();
         AuditEntryEntity entity = mockAuditEntryEntity.createEntity();
@@ -98,25 +99,25 @@ public class AuditEntryControllerTestIT extends AlertIntegrationTest {
 
         final String getUrl = auditUrl + "/" + notificationContent.getId();
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(getUrl)
-                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(UserRole.ALERT_ADMIN_TEXT))
                                                           .with(SecurityMockMvcRequestPostProcessors.csrf());
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk());
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUser(roles = UserRole.ALERT_ADMIN_TEXT)
     public void testGetAuditInfoForJob() throws Exception {
         AuditEntryEntity entity = new MockAuditEntryEntity().createEntity();
         entity = auditEntryRepository.save(entity);
         final String getUrl = auditUrl + "/job/" + entity.getCommonConfigId();
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(getUrl)
-                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(UserRole.ALERT_ADMIN_TEXT))
                                                           .with(SecurityMockMvcRequestPostProcessors.csrf());
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk());
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUser(roles = UserRole.ALERT_ADMIN_TEXT)
     public void testPostConfig() throws Exception {
         final Collection<ConfigurationFieldModel> hipChatFields = MockConfigurationModelFactory.createHipChatDistributionFields();
         final ConfigurationModel configurationModel = baseConfigurationAccessor.createConfiguration(HipChatChannel.COMPONENT_NAME, ConfigContextEnum.DISTRIBUTION, hipChatFields);
@@ -133,7 +134,7 @@ public class AuditEntryControllerTestIT extends AlertIntegrationTest {
 
         final String resendUrl = auditUrl + "/resend/" + notificationEntity.getId() + "/";
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(resendUrl)
-                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(UserRole.ALERT_ADMIN_TEXT))
                                                           .with(SecurityMockMvcRequestPostProcessors.csrf());
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk());
     }

--- a/src/test/java/com/synopsys/integration/alert/database/api/user/UserAccessorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/database/api/user/UserAccessorTestIT.java
@@ -85,7 +85,7 @@ public class UserAccessorTestIT extends AlertIntegrationTest {
         assertTrue(userModel.getRoles().isEmpty());
 
         final String another_role = "ANOTHER_ROLE";
-        final String admin_role = "ADMIN";
+        final String admin_role = UserRole.ALERT_ADMIN_TEXT;
         final Set<String> roles = new LinkedHashSet<>(Arrays.asList(admin_role, another_role));
         final UserModel updatedModel = userAccessor.addOrUpdateUser(UserModel.of(userModel.getName(), userModel.getPassword(), userModel.getEmailAddress(), roles), true);
         assertEquals(userModel.getName(), updatedModel.getName());

--- a/src/test/java/com/synopsys/integration/alert/database/api/user/UserModelTest.java
+++ b/src/test/java/com/synopsys/integration/alert/database/api/user/UserModelTest.java
@@ -27,7 +27,7 @@ public class UserModelTest {
         assertEquals(expectedPassword, userModel.getPassword());
         assertEquals(expectedEmail, userModel.getEmailAddress());
         assertEquals(expectedRoles.size(), userModel.getRoles().size());
-        assertTrue(userModel.hasRole(UserRole.ADMIN.name()));
+        assertTrue(userModel.hasRole(UserRole.ALERT_ADMIN.name()));
         assertFalse(userModel.hasRole("UNKNOWN_ROLE"));
         assertFalse(userModel.isExpired());
         assertFalse(userModel.isLocked());
@@ -52,7 +52,7 @@ public class UserModelTest {
         assertEquals(expectedPassword, userModel.getPassword());
         assertEquals(expectedEmail, userModel.getEmailAddress());
         assertEquals(expectedRoles.size(), userModel.getRoles().size());
-        assertTrue(userModel.hasRole(UserRole.ADMIN.name()));
+        assertTrue(userModel.hasRole(UserRole.ALERT_ADMIN.name()));
         assertFalse(userModel.hasRole("UNKNOWN_ROLE"));
         assertTrue(userModel.isExpired());
         assertTrue(userModel.isLocked());

--- a/src/test/java/com/synopsys/integration/alert/web/actions/LoginActionsTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/web/actions/LoginActionsTestIT.java
@@ -30,6 +30,7 @@ import org.springframework.security.ldap.authentication.LdapAuthenticationProvid
 import com.synopsys.integration.alert.common.exception.AlertLDAPConfigurationException;
 import com.synopsys.integration.alert.database.api.user.UserAccessor;
 import com.synopsys.integration.alert.database.api.user.UserModel;
+import com.synopsys.integration.alert.database.api.user.UserRole;
 import com.synopsys.integration.alert.mock.model.MockLoginRestModel;
 import com.synopsys.integration.alert.util.AlertIntegrationTest;
 import com.synopsys.integration.alert.util.TestProperties;
@@ -90,7 +91,7 @@ public class LoginActionsTestIT extends AlertIntegrationTest {
         final Optional<UserModel> userModel = userAccessor.getUser(userName);
         assertTrue(userModel.isPresent());
         final UserModel model = userModel.get();
-        assertFalse(model.hasRole("ADMIN"));
+        assertFalse(model.hasRole(UserRole.ALERT_ADMIN_TEXT));
         assertTrue(model.getRoles().isEmpty());
 
         userAccessor.deleteUser(userName);

--- a/src/test/java/com/synopsys/integration/alert/web/config/GroupConfigControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/web/config/GroupConfigControllerTestIT.java
@@ -44,6 +44,7 @@ import com.synopsys.integration.alert.common.exception.AlertDatabaseConstraintEx
 import com.synopsys.integration.alert.database.api.configuration.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.database.api.configuration.model.ConfigurationJobModel;
 import com.synopsys.integration.alert.database.api.configuration.model.ConfigurationModel;
+import com.synopsys.integration.alert.database.api.user.UserRole;
 import com.synopsys.integration.alert.database.repository.configuration.DescriptorConfigRepository;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProvider;
 import com.synopsys.integration.alert.provider.blackduck.descriptor.BlackDuckDescriptor;
@@ -55,6 +56,7 @@ import com.synopsys.integration.alert.web.model.configuration.JobFieldModel;
 @Transactional
 public class GroupConfigControllerTestIT extends DatabaseConfiguredFieldTest {
     private final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(), MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
+    private final String url = JobConfigController.JOB_CONFIGURATION_PATH;
     @Autowired
     private DescriptorConfigRepository descriptorConfigRepository;
     @Autowired
@@ -63,22 +65,20 @@ public class GroupConfigControllerTestIT extends DatabaseConfiguredFieldTest {
     @Autowired
     private Gson gson;
 
-    private final String url = JobConfigController.JOB_CONFIGURATION_PATH;
-
     @BeforeEach
     public void setup() {
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).apply(SecurityMockMvcConfigurers.springSecurity()).build();
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUser(roles = UserRole.ALERT_ADMIN_TEXT)
     public void testGetConfig() throws Exception {
         final ConfigurationJobModel emptyConfigurationModel = addJob(HipChatChannel.COMPONENT_NAME, BlackDuckProvider.COMPONENT_NAME, Map.of());
         final String configId = String.valueOf(emptyConfigurationModel.getJobId());
 
         final String urlPath = url + "?context=" + ConfigContextEnum.DISTRIBUTION.name() + "&descriptorName=" + HipChatChannel.COMPONENT_NAME;
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(urlPath)
-                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(UserRole.ALERT_ADMIN_TEXT))
                                                           .with(SecurityMockMvcRequestPostProcessors.csrf());
 
         final MvcResult mvcResult = mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
@@ -96,14 +96,14 @@ public class GroupConfigControllerTestIT extends DatabaseConfiguredFieldTest {
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUser(roles = UserRole.ALERT_ADMIN_TEXT)
     public void testGetConfigById() throws Exception {
         final ConfigurationJobModel emptyConfigurationModel = addJob(HipChatChannel.COMPONENT_NAME, BlackDuckProvider.COMPONENT_NAME, Map.of());
         final String configId = String.valueOf(emptyConfigurationModel.getJobId());
 
         final String urlPath = url + "/" + configId;
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(urlPath)
-                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(UserRole.ALERT_ADMIN_TEXT))
                                                           .with(SecurityMockMvcRequestPostProcessors.csrf());
 
         final MvcResult mvcResult = mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
@@ -115,14 +115,14 @@ public class GroupConfigControllerTestIT extends DatabaseConfiguredFieldTest {
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUser(roles = UserRole.ALERT_ADMIN_TEXT)
     public void testDeleteConfig() throws Exception {
         final ConfigurationJobModel emptyConfigurationModel = addJob(HipChatChannel.COMPONENT_NAME, BlackDuckProvider.COMPONENT_NAME, Map.of());
         final String jobId = String.valueOf(emptyConfigurationModel.getJobId());
 
         final String urlPath = url + "/" + jobId;
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.delete(urlPath)
-                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(UserRole.ALERT_ADMIN_TEXT))
                                                           .with(SecurityMockMvcRequestPostProcessors.csrf());
 
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isAccepted());
@@ -135,7 +135,7 @@ public class GroupConfigControllerTestIT extends DatabaseConfiguredFieldTest {
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUser(roles = UserRole.ALERT_ADMIN_TEXT)
     public void testUpdateConfig() throws Exception {
         final JobFieldModel fieldModel = createTestJobFieldModel();
         final Map<String, Collection<String>> fieldValueModels = new HashMap<>();
@@ -146,7 +146,7 @@ public class GroupConfigControllerTestIT extends DatabaseConfiguredFieldTest {
         final String configId = String.valueOf(emptyConfigurationModel.getJobId());
         final String urlPath = url + "/" + configId;
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.put(urlPath)
-                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(UserRole.ALERT_ADMIN_TEXT))
                                                           .with(SecurityMockMvcRequestPostProcessors.csrf());
 
         fieldModel.setJobId(configId);
@@ -160,10 +160,10 @@ public class GroupConfigControllerTestIT extends DatabaseConfiguredFieldTest {
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUser(roles = UserRole.ALERT_ADMIN_TEXT)
     public void testSaveConfig() throws Exception {
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(url)
-                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(UserRole.ALERT_ADMIN_TEXT))
                                                           .with(SecurityMockMvcRequestPostProcessors.csrf());
 
         final JobFieldModel fieldModel = createTestJobFieldModel();
@@ -178,11 +178,11 @@ public class GroupConfigControllerTestIT extends DatabaseConfiguredFieldTest {
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUser(roles = UserRole.ALERT_ADMIN_TEXT)
     public void testValidateConfig() throws Exception {
         final String urlPath = url + "/validate";
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(urlPath)
-                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(UserRole.ALERT_ADMIN_TEXT))
                                                           .with(SecurityMockMvcRequestPostProcessors.csrf());
 
         final JobFieldModel fieldModel = createTestJobFieldModel();
@@ -195,12 +195,12 @@ public class GroupConfigControllerTestIT extends DatabaseConfiguredFieldTest {
 
     // FIXME Will need to add all configurations to properly run a test check for hipchat.
     //    @Test
-    //    @WithMockUser(roles = "ADMIN")
+    //    @WithMockUser(roles = UserRole.ALERT_ADMIN_TEXT)
     //    public void testTestConfig() throws Exception {
     //        registerDescriptor(hipChatDescriptor);
     //        final String urlPath = url + "/test";
     //        final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(urlPath)
-    //                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+    //                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(UserRole.ALERT_ADMIN_TEXT))
     //                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
     //
     //        final FieldModel fieldModel = createTestFieldModel();

--- a/src/test/java/com/synopsys/integration/alert/web/controller/AuthenticationControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/web/controller/AuthenticationControllerTestIT.java
@@ -32,6 +32,7 @@ import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.exception.AlertDatabaseConstraintException;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.component.settings.PasswordResetService;
+import com.synopsys.integration.alert.database.api.user.UserRole;
 import com.synopsys.integration.alert.mock.model.MockLoginRestModel;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
 import com.synopsys.integration.alert.util.AlertIntegrationTest;
@@ -62,7 +63,7 @@ public class AuthenticationControllerTestIT extends AlertIntegrationTest {
 
     @Test
     public void testLogout() throws Exception {
-        final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(logoutUrl).with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"));
+        final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(logoutUrl).with(SecurityMockMvcRequestPostProcessors.user("admin").roles(UserRole.ALERT_ADMIN_TEXT));
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isNoContent());
     }
 

--- a/src/test/java/com/synopsys/integration/alert/web/controller/HomeControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/web/controller/HomeControllerTestIT.java
@@ -22,6 +22,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import com.synopsys.integration.alert.database.api.user.UserRole;
 import com.synopsys.integration.alert.util.AlertIntegrationTest;
 
 public class HomeControllerTestIT extends AlertIntegrationTest {
@@ -42,13 +43,13 @@ public class HomeControllerTestIT extends AlertIntegrationTest {
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUser(roles = UserRole.ALERT_ADMIN_TEXT)
     public void testVerify() throws Exception {
         final HttpHeaders headers = new HttpHeaders();
         final MockHttpSession session = new MockHttpSession();
         final ServletContext servletContext = webApplicationContext.getServletContext();
 
-        final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(homeVerifyUrl).with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"));
+        final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(homeVerifyUrl).with(SecurityMockMvcRequestPostProcessors.user("admin").roles(UserRole.ALERT_ADMIN_TEXT));
         request.session(session);
         final HttpServletRequest httpServletRequest = request.buildRequest(servletContext);
         final CsrfToken csrfToken = csrfTokenRepository.generateToken(httpServletRequest);
@@ -58,32 +59,32 @@ public class HomeControllerTestIT extends AlertIntegrationTest {
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUser(roles = UserRole.ALERT_ADMIN_TEXT)
     public void testVerifyNoToken() throws Exception {
         final HttpHeaders headers = new HttpHeaders();
         headers.add("X-CSRF-TOKEN", UUID.randomUUID().toString());
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(homeVerifyUrl)
-                                                              .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
-                                                              .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(UserRole.ALERT_ADMIN_TEXT))
+                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
         request.headers(headers);
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isUnauthorized());
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUser(roles = UserRole.ALERT_ADMIN_TEXT)
     public void testVerifyMissingCSRFToken() throws Exception {
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(homeVerifyUrl)
-                                                              .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
-                                                              .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(UserRole.ALERT_ADMIN_TEXT))
+                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isUnauthorized());
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUser(roles = UserRole.ALERT_ADMIN_TEXT)
     public void testVerifyNullStringCSRFToken() throws Exception {
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(homeVerifyUrl)
-                                                              .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
-                                                              .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(UserRole.ALERT_ADMIN_TEXT))
+                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
         final HttpHeaders headers = new HttpHeaders();
         headers.add("X-CSRF-TOKEN", "null");
         request.headers(headers);

--- a/src/test/java/com/synopsys/integration/alert/web/controller/SystemControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/web/controller/SystemControllerTestIT.java
@@ -34,6 +34,7 @@ import com.synopsys.integration.alert.common.ContentConverter;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.component.settings.SettingsDescriptor;
+import com.synopsys.integration.alert.database.api.user.UserRole;
 import com.synopsys.integration.alert.database.system.SystemStatusUtility;
 import com.synopsys.integration.alert.util.AlertIntegrationTest;
 import com.synopsys.integration.alert.util.TestProperties;
@@ -70,10 +71,10 @@ public class SystemControllerTestIT extends AlertIntegrationTest {
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUser(roles = UserRole.ALERT_ADMIN_TEXT)
     public void testGetMessages() throws Exception {
         final MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(systemMessageBaseUrl)
-                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN"))
+                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(UserRole.ALERT_ADMIN_TEXT))
                                                           .with(SecurityMockMvcRequestPostProcessors.csrf());
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk());
     }

--- a/src/test/java/com/synopsys/integration/alert/web/security/authentication/ldap/LdapManagerTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/security/authentication/ldap/LdapManagerTest.java
@@ -33,7 +33,6 @@ public class LdapManagerTest {
     public static final String DEFAULT_GROUP_SEARCH_BASE = "groupSearchBase";
     public static final String DEFAULT_GROUP_SEARCH_FILTER = "groupSearchFilter";
     public static final String DEFAULT_GROUP_ROLE_ATTRIBUTE = "roleAttribute";
-    public static final String DEFAULT_ROLE_PREFIX = "ROLE_";
 
     private ConfigurationModel createConfigurationModel() {
         final ConfigurationModel configurationModel = new ConfigurationModel(1L, 1L, ConfigContextEnum.GLOBAL);
@@ -51,7 +50,6 @@ public class LdapManagerTest {
         final ConfigurationFieldModel groupSearchBaseField = ConfigurationFieldModel.create(SettingsDescriptor.KEY_LDAP_GROUP_SEARCH_BASE);
         final ConfigurationFieldModel groupSearchFilterField = ConfigurationFieldModel.create(SettingsDescriptor.KEY_LDAP_GROUP_SEARCH_FILTER);
         final ConfigurationFieldModel groupRoleAttributeField = ConfigurationFieldModel.create(SettingsDescriptor.KEY_LDAP_GROUP_ROLE_ATTRIBUTE);
-        final ConfigurationFieldModel rolePrefixField = ConfigurationFieldModel.create(SettingsDescriptor.KEY_LDAP_ROLE_PREFIX);
 
         enabledField.setFieldValue(DEFAULT_ENABLED);
         serverField.setFieldValue(DEFAULT_SERVER);
@@ -66,7 +64,6 @@ public class LdapManagerTest {
         groupSearchBaseField.setFieldValue(DEFAULT_GROUP_SEARCH_BASE);
         groupSearchFilterField.setFieldValue(DEFAULT_GROUP_SEARCH_FILTER);
         groupRoleAttributeField.setFieldValue(DEFAULT_GROUP_ROLE_ATTRIBUTE);
-        rolePrefixField.setFieldValue(DEFAULT_ROLE_PREFIX);
 
         configurationModel.put(enabledField);
         configurationModel.put(serverField);
@@ -81,7 +78,6 @@ public class LdapManagerTest {
         configurationModel.put(groupSearchBaseField);
         configurationModel.put(groupSearchFilterField);
         configurationModel.put(groupRoleAttributeField);
-        configurationModel.put(rolePrefixField);
 
         return configurationModel;
     }
@@ -107,7 +103,6 @@ public class LdapManagerTest {
         assertEquals(DEFAULT_GROUP_SEARCH_BASE, updatedProperties.getField(SettingsDescriptor.KEY_LDAP_GROUP_SEARCH_BASE).flatMap(field -> field.getFieldValue()).orElse(null));
         assertEquals(DEFAULT_GROUP_SEARCH_FILTER, updatedProperties.getField(SettingsDescriptor.KEY_LDAP_GROUP_SEARCH_FILTER).flatMap(field -> field.getFieldValue()).orElse(null));
         assertEquals(DEFAULT_GROUP_ROLE_ATTRIBUTE, updatedProperties.getField(SettingsDescriptor.KEY_LDAP_GROUP_ROLE_ATTRIBUTE).flatMap(field -> field.getFieldValue()).orElse(null));
-        assertEquals(DEFAULT_ROLE_PREFIX, updatedProperties.getField(SettingsDescriptor.KEY_LDAP_ROLE_PREFIX).flatMap(field -> field.getFieldValue()).orElse(null));
     }
 
     @Test


### PR DESCRIPTION
Remove the LDAP role prefix field value since it isn't used.  Changed the alert role to ALERT_ADMIN from ADMIN to make it Alert specific. ADMIN was too generic.