### PR TITLE
Returned empty config if no ID supplied

### DIFF
--- a/src/main/js/distribution/job/EmailJobConfiguration.js
+++ b/src/main/js/distribution/job/EmailJobConfiguration.js
@@ -36,8 +36,8 @@ class EmailJobConfiguration extends Component {
 
     componentDidMount() {
         const { jobId } = this.props;
+        this.props.getDistributionJob(jobId);
         if (jobId) {
-            this.props.getDistributionJob(jobId);
             this.loading = true;
         }
     }

--- a/src/main/js/distribution/job/HipChatJobConfiguration.js
+++ b/src/main/js/distribution/job/HipChatJobConfiguration.js
@@ -40,8 +40,8 @@ class HipChatJobConfiguration extends Component {
 
     componentDidMount() {
         const { jobId } = this.props;
+        this.props.getDistributionJob(jobId);
         if (jobId) {
-            this.props.getDistributionJob(jobId);
             this.loading = true;
         }
     }

--- a/src/main/js/distribution/job/SlackJobConfiguration.js
+++ b/src/main/js/distribution/job/SlackJobConfiguration.js
@@ -37,8 +37,8 @@ class SlackJobConfiguration extends Component {
 
     componentDidMount() {
         const { jobId } = this.props;
+        this.props.getDistributionJob(jobId);
         if (jobId) {
-            this.props.getDistributionJob(jobId);
             this.loading = true;
         }
     }

--- a/src/main/js/store/actions/distributionConfigs.js
+++ b/src/main/js/store/actions/distributionConfigs.js
@@ -127,7 +127,7 @@ export function getDistributionJob(jobId) {
                 }
             }).catch(console.error);
         } else {
-            dispatch(jobFetchError());
+            dispatch(jobFetched({}));
         }
     };
 }


### PR DESCRIPTION
This PR fixed an issue where old field errors remained when they should have been cleaned up when the page was closed.