### PR TITLE
fix add a check for the roles to make sure the user can use alert

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/web/actions/LoginActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/actions/LoginActions.java
@@ -33,11 +33,13 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.ldap.authentication.LdapAuthenticationProvider;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.common.exception.AlertLDAPConfigurationException;
+import com.synopsys.integration.alert.database.api.user.UserModel;
 import com.synopsys.integration.alert.database.api.user.UserRole;
 import com.synopsys.integration.alert.web.model.LoginConfig;
 import com.synopsys.integration.alert.web.security.authentication.ldap.LdapManager;
@@ -96,9 +98,9 @@ public class LoginActions {
     private boolean isAuthorized(final Authentication authentication) {
         EnumSet<UserRole> allowedRoles = EnumSet.allOf(UserRole.class);
         return authentication.getAuthorities().stream()
-                   .map(authority -> authority.getAuthority())
-                   .filter(role -> role.startsWith("ROLE_"))
-                   .map(role -> StringUtils.substringAfter(role, "ROLE_"))
+                   .map(GrantedAuthority::getAuthority)
+                   .filter(role -> role.startsWith(UserModel.ROLE_PREFIX))
+                   .map(role -> StringUtils.substringAfter(role, UserModel.ROLE_PREFIX))
                    .anyMatch(roleName -> allowedRoles.contains(UserRole.valueOf(roleName)));
     }
 

--- a/src/main/java/com/synopsys/integration/alert/web/actions/LoginActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/actions/LoginActions.java
@@ -23,6 +23,9 @@
  */
 package com.synopsys.integration.alert.web.actions;
 
+import java.util.EnumSet;
+
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,6 +38,7 @@ import org.springframework.security.ldap.authentication.LdapAuthenticationProvid
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.common.exception.AlertLDAPConfigurationException;
+import com.synopsys.integration.alert.database.api.user.UserRole;
 import com.synopsys.integration.alert.web.model.LoginConfig;
 import com.synopsys.integration.alert.web.security.authentication.ldap.LdapManager;
 
@@ -57,7 +61,7 @@ public class LoginActions {
             authentication = performDatabaseAuthentication(loginConfig);
         }
         SecurityContextHolder.getContext().setAuthentication(authentication);
-        return authentication.isAuthenticated();
+        return authentication.isAuthenticated() && isAuthorized(authentication);
     }
 
     private Authentication performDatabaseAuthentication(final LoginConfig loginConfig) {
@@ -87,6 +91,15 @@ public class LoginActions {
             result = pendingAuthentication;
         }
         return result;
+    }
+
+    private boolean isAuthorized(final Authentication authentication) {
+        EnumSet<UserRole> allowedRoles = EnumSet.allOf(UserRole.class);
+        return authentication.getAuthorities().stream()
+                   .map(authority -> authority.getAuthority())
+                   .filter(role -> role.startsWith("ROLE_"))
+                   .map(role -> StringUtils.substringAfter(role, "ROLE_"))
+                   .anyMatch(roleName -> allowedRoles.contains(UserRole.valueOf(roleName)));
     }
 
     private UsernamePasswordAuthenticationToken createUsernamePasswordAuthToken(final LoginConfig loginConfig) {

--- a/src/test/java/com/synopsys/integration/alert/web/actions/LoginActionsTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/web/actions/LoginActionsTestIT.java
@@ -87,7 +87,7 @@ public class LoginActionsTestIT extends AlertIntegrationTest {
         userAccessor.addUser(userName, mockLoginRestModel.getBlackDuckPassword(), "");
         final boolean userAuthenticated = loginActions.authenticateUser(mockLoginRestModel.createRestModel());
 
-        assertTrue(userAuthenticated);
+        assertFalse(userAuthenticated);
         final Optional<UserModel> userModel = userAccessor.getUser(userName);
         assertTrue(userModel.isPresent());
         final UserModel model = userModel.get();
@@ -109,7 +109,7 @@ public class LoginActionsTestIT extends AlertIntegrationTest {
 
         final LoginActions loginActions = new LoginActions(alertDatabaseAuthProvider, mockLdapManager);
         final boolean authenticated = loginActions.authenticateUser(mockLoginRestModel.createRestModel());
-        assertTrue(authenticated);
+        assertFalse(authenticated);
     }
 
     @Test


### PR DESCRIPTION
Add a check to make sure the user contains a role that alert recognizes during the login.  This authorization check is used to determine if the user can login to the application.