### PR TITLE
Added after save action to ActionApi

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/action/ChannelDistributionDescriptorActionApi.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/action/ChannelDistributionDescriptorActionApi.java
@@ -72,8 +72,8 @@ public abstract class ChannelDistributionDescriptorActionApi extends DescriptorA
     }
 
     @Override
-    public FieldModel saveConfig(final FieldModel fieldModel) {
-        return getProviderActionApi(fieldModel).map(descriptorActionApi -> descriptorActionApi.saveConfig(fieldModel)).orElse(fieldModel);
+    public FieldModel beforeSaveConfig(final FieldModel fieldModel) {
+        return getProviderActionApi(fieldModel).map(descriptorActionApi -> descriptorActionApi.beforeSaveConfig(fieldModel)).orElse(fieldModel);
     }
 
     @Override

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/action/DescriptorActionApi.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/action/DescriptorActionApi.java
@@ -106,7 +106,11 @@ public abstract class DescriptorActionApi {
         return fieldModel;
     }
 
-    public FieldModel saveConfig(final FieldModel fieldModel) {
+    public FieldModel beforeSaveConfig(final FieldModel fieldModel) {
+        return fieldModel;
+    }
+
+    public FieldModel afterSaveConfig(final FieldModel fieldModel) {
         return fieldModel;
     }
 

--- a/src/main/java/com/synopsys/integration/alert/component/scheduling/SchedulingDescriptorActionApi.java
+++ b/src/main/java/com/synopsys/integration/alert/component/scheduling/SchedulingDescriptorActionApi.java
@@ -59,11 +59,11 @@ public class SchedulingDescriptorActionApi extends NoTestActionApi {
 
     @Override
     public FieldModel updateConfig(final FieldModel fieldModel) {
-        return saveConfig(fieldModel);
+        return beforeSaveConfig(fieldModel);
     }
 
     @Override
-    public FieldModel saveConfig(final FieldModel fieldModel) {
+    public FieldModel beforeSaveConfig(final FieldModel fieldModel) {
         final String dailyDigestHourOfDay = fieldModel.getFieldValue(SchedulingDescriptor.KEY_DAILY_PROCESSOR_HOUR_OF_DAY).orElse("");
         final String purgeDataFrequencyDays = fieldModel.getFieldValue(SchedulingDescriptor.KEY_PURGE_DATA_FREQUENCY_DAYS).orElse("");
         final String dailyDigestCron = String.format(DailyTask.CRON_FORMAT, dailyDigestHourOfDay);

--- a/src/main/java/com/synopsys/integration/alert/component/settings/SettingsDescriptorActionApi.java
+++ b/src/main/java/com/synopsys/integration/alert/component/settings/SettingsDescriptorActionApi.java
@@ -68,11 +68,11 @@ public class SettingsDescriptorActionApi extends NoTestActionApi {
 
     @Override
     public FieldModel updateConfig(final FieldModel fieldModel) {
-        return saveConfig(fieldModel);
+        return beforeSaveConfig(fieldModel);
     }
 
     @Override
-    public FieldModel saveConfig(final FieldModel fieldModel) {
+    public FieldModel beforeSaveConfig(final FieldModel fieldModel) {
         saveDefaultAdminUserPassword(fieldModel);
         saveDefaultAdminUserEmail(fieldModel);
         saveEncryptionProperties(fieldModel);

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckProviderDescriptorActionApi.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckProviderDescriptorActionApi.java
@@ -109,12 +109,7 @@ public class BlackDuckProviderDescriptorActionApi extends DescriptorActionApi {
     }
 
     @Override
-    public FieldModel updateConfig(final FieldModel fieldModel) {
-        return saveConfig(fieldModel);
-    }
-
-    @Override
-    public FieldModel saveConfig(final FieldModel fieldModel) {
+    public FieldModel afterSaveConfig(final FieldModel fieldModel) {
         final boolean valid = systemValidator.validate();
         if (valid) {
             final Optional<String> nextRunTime = taskManager.getNextRunTime(BlackDuckAccumulator.TASK_NAME);
@@ -123,6 +118,6 @@ public class BlackDuckProviderDescriptorActionApi extends DescriptorActionApi {
                 taskManager.scheduleCronTask(ScheduledTask.EVERY_MINUTE_CRON_EXPRESSION, BlackDuckProjectSyncTask.TASK_NAME);
             }
         }
-        return super.saveConfig(fieldModel);
+        return super.afterSaveConfig(fieldModel);
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/provider/polaris/descriptor/PolarisGlobalDescriptorActionApi.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/polaris/descriptor/PolarisGlobalDescriptorActionApi.java
@@ -83,12 +83,12 @@ public class PolarisGlobalDescriptorActionApi extends DescriptorActionApi {
     }
 
     @Override
-    public FieldModel saveConfig(final FieldModel fieldModel) {
+    public FieldModel afterSaveConfig(final FieldModel fieldModel) {
         final Optional<AccessTokenPolarisHttpClient> polarisHttpClient = polarisProperties.createPolarisHttpClientSafely(logger);
         final Optional<String> nextRunTime = taskManager.getNextRunTime(BlackDuckAccumulator.TASK_NAME);
         if (polarisHttpClient.isPresent() && nextRunTime.isEmpty()) {
             taskManager.scheduleCronTask(ScheduledTask.EVERY_MINUTE_CRON_EXPRESSION, PolarisProjectSyncTask.TASK_NAME);
         }
-        return super.saveConfig(fieldModel);
+        return super.afterSaveConfig(fieldModel);
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/web/config/ConfigActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/config/ConfigActions.java
@@ -125,13 +125,14 @@ public class ConfigActions {
 
     public FieldModel saveConfig(final FieldModel fieldModel) throws AlertException, AlertFieldException {
         validateConfig(fieldModel, new HashMap<>());
-        final FieldModel modifiedFieldModel = fieldModelProcessor.performSaveAction(fieldModel);
+        final FieldModel modifiedFieldModel = fieldModelProcessor.performBeforeSaveAction(fieldModel);
         final String descriptorName = modifiedFieldModel.getDescriptorName();
         final String context = modifiedFieldModel.getContext();
         final Map<String, ConfigurationFieldModel> configurationFieldModelMap = modelConverter.convertFromFieldModel(modifiedFieldModel);
         final ConfigurationModel configuration = configurationAccessor.createConfiguration(descriptorName, EnumUtils.getEnum(ConfigContextEnum.class, context), configurationFieldModelMap.values());
         final FieldModel dbSavedModel = fieldModelProcessor.convertToFieldModel(configuration);
-        return dbSavedModel.fill(modifiedFieldModel);
+        final FieldModel afterSaveAction = fieldModelProcessor.performAfterSaveAction(dbSavedModel);
+        return dbSavedModel.fill(afterSaveAction);
     }
 
     public String validateConfig(final FieldModel fieldModel, final Map<String, String> fieldErrors) throws AlertFieldException {

--- a/src/main/java/com/synopsys/integration/alert/web/config/FieldModelProcessor.java
+++ b/src/main/java/com/synopsys/integration/alert/web/config/FieldModelProcessor.java
@@ -88,8 +88,12 @@ public class FieldModelProcessor {
         return retrieveDescriptorActionApi(fieldModel).map(actionApi -> actionApi.deleteConfig(fieldModel)).orElse(fieldModel);
     }
 
-    public FieldModel performSaveAction(final FieldModel fieldModel) {
-        return retrieveDescriptorActionApi(fieldModel).map(actionApi -> actionApi.saveConfig(fieldModel)).orElse(fieldModel);
+    public FieldModel performBeforeSaveAction(final FieldModel fieldModel) {
+        return retrieveDescriptorActionApi(fieldModel).map(actionApi -> actionApi.beforeSaveConfig(fieldModel)).orElse(fieldModel);
+    }
+
+    public FieldModel performAfterSaveAction(final FieldModel fieldModel) {
+        return retrieveDescriptorActionApi(fieldModel).map(actionApi -> actionApi.afterSaveConfig(fieldModel)).orElse(fieldModel);
     }
 
     public FieldModel performUpdateAction(final FieldModel fieldModel) {

--- a/src/main/java/com/synopsys/integration/alert/workflow/startup/AlertStartupInitializer.java
+++ b/src/main/java/com/synopsys/integration/alert/workflow/startup/AlertStartupInitializer.java
@@ -188,7 +188,7 @@ public class AlertStartupInitializer {
     private Collection<ConfigurationFieldModel> saveAction(final String descriptorName, final Collection<ConfigurationFieldModel> configurationFieldModels) throws AlertDatabaseConstraintException {
         final Map<String, FieldValueModel> fieldValueModelMap = fieldModelProcessor.convertToFieldValuesMap(configurationFieldModels);
         final FieldModel fieldModel = new FieldModel(descriptorName, ConfigContextEnum.GLOBAL.name(), fieldValueModelMap);
-        final FieldModel savedFieldModel = fieldModelProcessor.performSaveAction(fieldModel);
+        final FieldModel savedFieldModel = fieldModelProcessor.performBeforeSaveAction(fieldModel);
         return modelConverter.convertFromFieldModel(savedFieldModel).values();
     }
 

--- a/src/test/java/com/synopsys/integration/alert/component/scheduling/SchedulingDescriptorActionApiTest.java
+++ b/src/test/java/com/synopsys/integration/alert/component/scheduling/SchedulingDescriptorActionApiTest.java
@@ -237,7 +237,7 @@ public class SchedulingDescriptorActionApiTest {
         final FieldModel fieldModel = new FieldModel(SchedulingDescriptor.SCHEDULING_COMPONENT, ConfigContextEnum.GLOBAL.name(), new HashMap<>());
         fieldModel.putField(SchedulingDescriptor.KEY_DAILY_PROCESSOR_HOUR_OF_DAY, new FieldValueModel(List.of("2"), false));
         fieldModel.putField(SchedulingDescriptor.KEY_PURGE_DATA_FREQUENCY_DAYS, new FieldValueModel(List.of("6"), false));
-        actionApi.saveConfig(fieldModel);
+        actionApi.beforeSaveConfig(fieldModel);
         Mockito.verify(taskManager).scheduleCronTask(Mockito.anyString(), Mockito.eq(DailyTask.TASK_NAME));
         Mockito.verify(taskManager).scheduleCronTask(Mockito.anyString(), Mockito.eq(PurgeTask.TASK_NAME));
     }

--- a/src/test/java/com/synopsys/integration/alert/component/settings/SettingsDescriptorActionApiTest.java
+++ b/src/test/java/com/synopsys/integration/alert/component/settings/SettingsDescriptorActionApiTest.java
@@ -95,7 +95,7 @@ public class SettingsDescriptorActionApiTest {
         fieldModel.putField(SettingsDescriptor.KEY_ENCRYPTION_PWD, new FieldValueModel(List.of("valid_test_value"), false));
         fieldModel.putField(SettingsDescriptor.KEY_ENCRYPTION_GLOBAL_SALT, new FieldValueModel(List.of("valid_test_value"), false));
 
-        final FieldModel modelToSave = actionaApi.saveConfig(fieldModel);
+        final FieldModel modelToSave = actionaApi.beforeSaveConfig(fieldModel);
         assertFieldsMissing(modelToSave);
         Mockito.verify(userAccessor).changeUserPassword(Mockito.anyString(), Mockito.anyString());
         Mockito.verify(encryptionUtility).updatePasswordField(Mockito.anyString());
@@ -115,7 +115,7 @@ public class SettingsDescriptorActionApiTest {
         fieldModel.putField(SettingsDescriptor.KEY_ENCRYPTION_GLOBAL_SALT, new FieldValueModel(List.of(""), false));
 
         Mockito.doThrow(new IllegalArgumentException()).when(encryptionUtility).updatePasswordField(Mockito.anyString());
-        final FieldModel modelToSave = actionaApi.saveConfig(fieldModel);
+        final FieldModel modelToSave = actionaApi.beforeSaveConfig(fieldModel);
         assertFieldsMissing(modelToSave);
     }
 

--- a/src/test/java/com/synopsys/integration/alert/web/channel/handler/ChannelConfigHandlerTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/channel/handler/ChannelConfigHandlerTest.java
@@ -44,7 +44,7 @@ public class ChannelConfigHandlerTest {
     //
     //        final DescriptorActionApi descriptor = Mockito.mock(DescriptorActionApi.class);
     //        Mockito.when(configActions.doesConfigExist(Mockito.anyString(), Mockito.any())).thenReturn(false);
-    //        Mockito.when(configActions.saveConfig(Mockito.any(), Mockito.any())).thenReturn(new CommonDistributionConfigEntity());
+    //        Mockito.when(configActions.beforeSaveConfig(Mockito.any(), Mockito.any())).thenReturn(new CommonDistributionConfigEntity());
     //
     //        final CommonDistributionConfig restModel = mockCommonDistributionRestModel.createRestModel();
     //        final ResponseEntity<String> response = handler.postConfig(restModel, descriptor);


### PR DESCRIPTION
**Will merge after Gavin's Polaris branch**

This fixes the issue where we try to start tasks for providers before ever saving their data to the DB. I've added an after save method these providers can hook in to where they now start their tasks.

I want to change this functionality in the future to be event based. Our endpoints would instead fire of events based off of what action occurred and if anyone wants to do something custom, they would create their own handler.