### PR TITLE
Attempting to make the error message clearer

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckProperties.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckProperties.java
@@ -136,7 +136,7 @@ public class BlackDuckProperties extends ProviderProperties {
             final ConfigurationModel globalBlackDuckConfig = optionalGlobalBlackDuckConfig.get();
             final FieldAccessor fieldAccessor = new FieldAccessor(globalBlackDuckConfig.getCopyOfKeyToFieldMap());
 
-            final Integer timeout = fieldAccessor.getInteger(BlackDuckDescriptor.KEY_BLACKDUCK_TIMEOUT).orElse(300);
+            final Integer timeout = fieldAccessor.getInteger(BlackDuckDescriptor.KEY_BLACKDUCK_TIMEOUT).orElse(DEFAULT_TIMEOUT);
             final String apiKey = fieldAccessor.getString(BlackDuckDescriptor.KEY_BLACKDUCK_API_KEY).orElse(null);
             if (apiKey == null) {
                 throw new AlertException("Invalid global config settings. API Token is null.");

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckProperties.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckProperties.java
@@ -140,7 +140,15 @@ public class BlackDuckProperties extends ProviderProperties {
             final Integer timeout = fieldAccessor.getInteger(BlackDuckDescriptor.KEY_BLACKDUCK_TIMEOUT).orElse(null);
             final String apiKey = fieldAccessor.getString(BlackDuckDescriptor.KEY_BLACKDUCK_API_KEY).orElse(null);
             if (timeout == null || apiKey == null) {
-                throw new AlertException("Global config settings can not be null.");
+                final StringBuilder stringBuilder = new StringBuilder();
+                stringBuilder.append("Invalid global config settings.");
+                if (timeout == null) {
+                    stringBuilder.append(" Timeout is null.");
+                }
+                if (apiKey == null) {
+                    stringBuilder.append(" API Token is null.");
+                }
+                throw new AlertException(stringBuilder.toString());
             }
             return Optional.of(createBlackDuckServerConfig(logger, timeout, apiKey));
         }

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckProperties.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckProperties.java
@@ -136,18 +136,10 @@ public class BlackDuckProperties extends ProviderProperties {
             final ConfigurationModel globalBlackDuckConfig = optionalGlobalBlackDuckConfig.get();
             final FieldAccessor fieldAccessor = new FieldAccessor(globalBlackDuckConfig.getCopyOfKeyToFieldMap());
 
-            final Integer timeout = fieldAccessor.getInteger(BlackDuckDescriptor.KEY_BLACKDUCK_TIMEOUT).orElse(null);
+            final Integer timeout = fieldAccessor.getInteger(BlackDuckDescriptor.KEY_BLACKDUCK_TIMEOUT).orElse(300);
             final String apiKey = fieldAccessor.getString(BlackDuckDescriptor.KEY_BLACKDUCK_API_KEY).orElse(null);
-            if (timeout == null || apiKey == null) {
-                final StringBuilder stringBuilder = new StringBuilder();
-                stringBuilder.append("Invalid global config settings.");
-                if (timeout == null) {
-                    stringBuilder.append(" Timeout is null.");
-                }
-                if (apiKey == null) {
-                    stringBuilder.append(" API Token is null.");
-                }
-                throw new AlertException(stringBuilder.toString());
+            if (apiKey == null) {
+                throw new AlertException("Invalid global config settings. API Token is null.");
             }
             return Optional.of(createBlackDuckServerConfig(logger, timeout, apiKey));
         }


### PR DESCRIPTION
Right now if either the timeout or API token is null for the Black Duck provider. The error message just says the global config can not be null. 

This will hopefully clarify what fields are null in the Black Duck provider