### PR TITLE
Stop tasks on config delete

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckProviderDescriptorActionApi.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckProviderDescriptorActionApi.java
@@ -125,4 +125,11 @@ public class BlackDuckProviderDescriptorActionApi extends DescriptorActionApi {
         }
         return super.afterSaveConfig(fieldModel);
     }
+
+    @Override
+    public FieldModel deleteConfig(final FieldModel fieldModel) {
+        taskManager.unScheduleTask(BlackDuckAccumulator.TASK_NAME);
+        taskManager.unScheduleTask(BlackDuckProjectSyncTask.TASK_NAME);
+        return super.deleteConfig(fieldModel);
+    }
 }

--- a/src/main/java/com/synopsys/integration/alert/provider/polaris/descriptor/PolarisGlobalDescriptorActionApi.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/polaris/descriptor/PolarisGlobalDescriptorActionApi.java
@@ -109,4 +109,10 @@ public class PolarisGlobalDescriptorActionApi extends DescriptorActionApi {
         }
         return super.afterSaveConfig(fieldModel);
     }
+
+    @Override
+    public FieldModel deleteConfig(final FieldModel fieldModel) {
+        taskManager.unScheduleTask(PolarisProjectSyncTask.TASK_NAME);
+        return super.deleteConfig(fieldModel);
+    }
 }


### PR DESCRIPTION
Now that we have the option to delete global configurations, I stop the provider tasks when the configuration is deleted.