### PR TITLE
Temporary fix for License notifications

### DIFF
--- a/src/main/js/component/audit/Index.js
+++ b/src/main/js/component/audit/Index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { BootstrapTable, ButtonGroup, TableHeaderColumn } from 'react-bootstrap-table';
-import { getAuditData } from 'store/actions/audit';
+import { getAuditData, resendNotification } from 'store/actions/audit';
 import AutoRefresh from 'component/common/AutoRefresh';
 import DescriptorLabel from 'component/common/DescriptorLabel';
 import RefreshTableCellFormatter from 'component/common/RefreshTableCellFormatter';


### PR DESCRIPTION
License notifications do not have groups associated with them. Because of this, we need to check if the message is about licenses then add all the emails associated with the job.

This is meant to be temporary until we rework the way providers handle the Email channel.