### PR TITLE
Saml fallback

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/web/actions/LoginActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/actions/LoginActions.java
@@ -22,85 +22,28 @@
  */
 package com.synopsys.integration.alert.web.actions;
 
-import java.util.EnumSet;
-
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.ldap.authentication.LdapAuthenticationProvider;
 import org.springframework.stereotype.Component;
 
-import com.synopsys.integration.alert.common.exception.AlertLDAPConfigurationException;
-import com.synopsys.integration.alert.common.rest.model.UserModel;
-import com.synopsys.integration.alert.database.user.UserRole;
 import com.synopsys.integration.alert.web.model.LoginConfig;
-import com.synopsys.integration.alert.web.security.authentication.ldap.LdapManager;
+import com.synopsys.integration.alert.web.security.authentication.AlertAuthenticationProvider;
 
 @Component
 public class LoginActions {
-    private static final Logger logger = LoggerFactory.getLogger(LoginActions.class);
-    private final DaoAuthenticationProvider alertDatabaseAuthProvider;
-    private final LdapManager ldapManager;
+    private final AlertAuthenticationProvider authenticationProvider;
 
     @Autowired
-    public LoginActions(final DaoAuthenticationProvider alertDatabaseAuthProvider, final LdapManager ldapManager) {
-        this.alertDatabaseAuthProvider = alertDatabaseAuthProvider;
-        this.ldapManager = ldapManager;
+    public LoginActions(final AlertAuthenticationProvider authenticationProvider) {
+        this.authenticationProvider = authenticationProvider;
     }
 
     public boolean authenticateUser(final LoginConfig loginConfig) throws BadCredentialsException {
-        Authentication authentication;
-        authentication = performLdapAuthentication(loginConfig);
-        if (!authentication.isAuthenticated()) {
-            authentication = performDatabaseAuthentication(loginConfig);
-        }
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-        return authentication.isAuthenticated() && isAuthorized(authentication);
-    }
-
-    private Authentication performDatabaseAuthentication(final LoginConfig loginConfig) {
-        logger.info("Attempting database authentication...");
         final Authentication pendingAuthentication = createUsernamePasswordAuthToken(loginConfig);
-        return alertDatabaseAuthProvider.authenticate(pendingAuthentication);
-    }
-
-    private Authentication performLdapAuthentication(final LoginConfig loginConfig) {
-        logger.info("Checking ldap based authentication...");
-        final Authentication pendingAuthentication = createUsernamePasswordAuthToken(loginConfig);
-        Authentication result;
-        if (ldapManager.isLdapEnabled()) {
-            logger.info("LDAP authentication enabled");
-            try {
-                final LdapAuthenticationProvider authenticationProvider = ldapManager.getAuthenticationProvider();
-                result = authenticationProvider.authenticate(pendingAuthentication);
-            } catch (final AlertLDAPConfigurationException ex) {
-                logger.error("LDAP Configuration error", ex);
-                result = pendingAuthentication;
-            } catch (final Exception ex) {
-                logger.error("LDAP Authentication error", ex);
-                result = pendingAuthentication;
-            }
-        } else {
-            logger.info("LDAP authentication disabled");
-            result = pendingAuthentication;
-        }
-        return result;
-    }
-
-    private boolean isAuthorized(final Authentication authentication) {
-        final EnumSet<UserRole> allowedRoles = EnumSet.allOf(UserRole.class);
-        return authentication.getAuthorities().stream()
-                   .map(GrantedAuthority::getAuthority)
-                   .filter(role -> role.startsWith(UserModel.ROLE_PREFIX))
-                   .map(role -> StringUtils.substringAfter(role, UserModel.ROLE_PREFIX))
-                   .anyMatch(roleName -> allowedRoles.contains(UserRole.valueOf(roleName)));
+        final Authentication authentication = authenticationProvider.authenticate(pendingAuthentication);
+        return authentication.isAuthenticated() && !authentication.getAuthorities().isEmpty();
     }
 
     private UsernamePasswordAuthenticationToken createUsernamePasswordAuthToken(final LoginConfig loginConfig) {

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/AlertAuthenticationProvider.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/AlertAuthenticationProvider.java
@@ -1,0 +1,93 @@
+package com.synopsys.integration.alert.web.security.authentication;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.ldap.authentication.LdapAuthenticationProvider;
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.common.exception.AlertLDAPConfigurationException;
+import com.synopsys.integration.alert.common.rest.model.UserModel;
+import com.synopsys.integration.alert.database.user.UserRole;
+import com.synopsys.integration.alert.web.security.authentication.ldap.LdapManager;
+
+@Component
+public class AlertAuthenticationProvider implements AuthenticationProvider {
+    private static final Logger logger = LoggerFactory.getLogger(AlertAuthenticationProvider.class);
+    private final DaoAuthenticationProvider alertDatabaseAuthProvider;
+    private final LdapManager ldapManager;
+
+    @Autowired
+    public AlertAuthenticationProvider(final DaoAuthenticationProvider alertDatabaseAuthProvider, final LdapManager ldapManager) {
+        this.alertDatabaseAuthProvider = alertDatabaseAuthProvider;
+        this.ldapManager = ldapManager;
+    }
+
+    @Override
+    public Authentication authenticate(final Authentication authentication) throws AuthenticationException {
+        if (!supports(authentication.getClass())) {
+            throw new IllegalArgumentException("Only UsernamePasswordAuthenticationToken is supported, " + authentication.getClass() + " was attempted");
+        }
+        Authentication authenticationResult = performLdapAuthentication(authentication);
+        if (!authenticationResult.isAuthenticated()) {
+            authenticationResult = performDatabaseAuthentication(authentication);
+        }
+        final Collection<? extends GrantedAuthority> authorities = isAuthorized(authenticationResult) ? authenticationResult.getAuthorities() : List.of();
+        final UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(authenticationResult.getPrincipal(), authenticationResult.getCredentials(), authorities);
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        return authenticationToken;
+    }
+
+    @Override
+    public boolean supports(final Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+
+    private Authentication performDatabaseAuthentication(final Authentication pendingAuthentication) {
+        logger.info("Attempting database authentication...");
+        return alertDatabaseAuthProvider.authenticate(pendingAuthentication);
+    }
+
+    private Authentication performLdapAuthentication(final Authentication pendingAuthentication) {
+        logger.info("Checking ldap based authentication...");
+        Authentication result;
+        if (ldapManager.isLdapEnabled()) {
+            logger.info("LDAP authentication enabled");
+            try {
+                final LdapAuthenticationProvider authenticationProvider = ldapManager.getAuthenticationProvider();
+                result = authenticationProvider.authenticate(pendingAuthentication);
+            } catch (final AlertLDAPConfigurationException ex) {
+                logger.error("LDAP Configuration error", ex);
+                result = pendingAuthentication;
+            } catch (final Exception ex) {
+                logger.error("LDAP Authentication error", ex);
+                result = pendingAuthentication;
+            }
+        } else {
+            logger.info("LDAP authentication disabled");
+            result = pendingAuthentication;
+        }
+        return result;
+    }
+
+    private boolean isAuthorized(final Authentication authentication) {
+        final EnumSet<UserRole> allowedRoles = EnumSet.allOf(UserRole.class);
+        return authentication.getAuthorities().stream()
+                   .map(GrantedAuthority::getAuthority)
+                   .filter(role -> role.startsWith(UserModel.ROLE_PREFIX))
+                   .map(role -> StringUtils.substringAfter(role, UserModel.ROLE_PREFIX))
+                   .anyMatch(roleName -> allowedRoles.contains(UserRole.valueOf(roleName)));
+    }
+}

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/AlertAuthenticationProvider.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/AlertAuthenticationProvider.java
@@ -1,3 +1,25 @@
+/**
+ * blackduck-alert
+ *
+ * Copyright (c) 2019 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.synopsys.integration.alert.web.security.authentication;
 
 import java.util.Collection;

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/AlertAuthenticationProvider.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/AlertAuthenticationProvider.java
@@ -84,7 +84,7 @@ public class AlertAuthenticationProvider implements AuthenticationProvider {
 
     private Authentication performLdapAuthentication(final Authentication pendingAuthentication) {
         logger.info("Checking ldap based authentication...");
-        Authentication result;
+        Authentication result = pendingAuthentication;
         if (ldapManager.isLdapEnabled()) {
             logger.info("LDAP authentication enabled");
             try {
@@ -92,14 +92,11 @@ public class AlertAuthenticationProvider implements AuthenticationProvider {
                 result = authenticationProvider.authenticate(pendingAuthentication);
             } catch (final AlertLDAPConfigurationException ex) {
                 logger.error("LDAP Configuration error", ex);
-                result = pendingAuthentication;
             } catch (final Exception ex) {
                 logger.error("LDAP Authentication error", ex);
-                result = pendingAuthentication;
             }
         } else {
             logger.info("LDAP authentication disabled");
-            result = pendingAuthentication;
         }
         return result;
     }
@@ -110,6 +107,7 @@ public class AlertAuthenticationProvider implements AuthenticationProvider {
                    .map(GrantedAuthority::getAuthority)
                    .filter(role -> role.startsWith(UserModel.ROLE_PREFIX))
                    .map(role -> StringUtils.substringAfter(role, UserModel.ROLE_PREFIX))
-                   .anyMatch(roleName -> allowedRoles.contains(UserRole.valueOf(roleName)));
+                   .map(UserRole::valueOf)
+                   .anyMatch(allowedRoles::contains);
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/AlertSAMLEntryPoint.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/AlertSAMLEntryPoint.java
@@ -28,14 +28,11 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.saml.SAMLEntryPoint;
 
 public class AlertSAMLEntryPoint extends SAMLEntryPoint {
-    private final Logger logger = LoggerFactory.getLogger(AlertSAMLEntryPoint.class);
-
     private final SAMLContext samlContext;
 
     public AlertSAMLEntryPoint(final SAMLContext samlContext) {
@@ -54,6 +51,8 @@ public class AlertSAMLEntryPoint extends SAMLEntryPoint {
             super.commence(request, response, e);
             return;
         }
-        throw new ServletException(e);
+        if (e instanceof InsufficientAuthenticationException) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+        }
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SAMLAuthProvider.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SAMLAuthProvider.java
@@ -29,6 +29,7 @@ import org.springframework.security.saml.SAMLAuthenticationProvider;
 
 public class SAMLAuthProvider extends SAMLAuthenticationProvider {
 
+    @Override
     public Authentication authenticate(final Authentication authentication) throws AuthenticationException {
         final Authentication currentAuth = super.authenticate(authentication);
         if (currentAuth.isAuthenticated()) {


### PR DESCRIPTION
This branch was originally intended to fall back to our regular authentication scheme if SAML failed.  It couldn't be done as of now. 

However the authentication methods of the LoginActions were encapsulated into a AuthenticationProvider.  This makes it fit with Spring Security conventions and cleans up the code in case we need other authentication schemes from our login screen.