### PR TITLE
Bm auto test modals

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/Descriptor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/Descriptor.java
@@ -126,7 +126,7 @@ public abstract class Descriptor extends AlertSerializableModel {
         final String urlName = uiConfig.getUrlName();
         final String fontAwesomeIcon = uiConfig.getFontAwesomeIcon();
         final String description = uiConfig.getDescription();
-        return new DescriptorMetadata(label, urlName, getName(), description, context, fontAwesomeIcon, uiConfig.createFields(), getType());
+        return new DescriptorMetadata(label, urlName, getName(), description, context, fontAwesomeIcon, uiConfig.createFields(), uiConfig.createTestFields(), getType());
     }
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/Descriptor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/Descriptor.java
@@ -126,7 +126,7 @@ public abstract class Descriptor extends AlertSerializableModel {
         final String urlName = uiConfig.getUrlName();
         final String fontAwesomeIcon = uiConfig.getFontAwesomeIcon();
         final String description = uiConfig.getDescription();
-        return new DescriptorMetadata(label, urlName, getName(), description, context, fontAwesomeIcon, uiConfig.createFields(), uiConfig.createTestFields(), getType());
+        return new DescriptorMetadata(label, urlName, getName(), description, context, fontAwesomeIcon, uiConfig.createFields(), uiConfig.createTestLabel(), getType());
     }
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/DescriptorMetadata.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/DescriptorMetadata.java
@@ -39,15 +39,15 @@ public class DescriptorMetadata extends AlertSerializableModel {
     private final String fontAwesomeIcon;
     private final boolean automaticallyGenerateUI;
     private List<ConfigField> fields;
-    private List<ConfigField> testFields;
+    private String testFieldLabel;
 
     public DescriptorMetadata(final String label, final String urlName, final String name, final String description, final ConfigContextEnum context, final String fontAwesomeIcon, final List<ConfigField> fields,
-        final List<ConfigField> testFields, final DescriptorType type) {
-        this(label, urlName, name, description, type, context, fontAwesomeIcon, true, fields, testFields);
+        final String testFieldLabel, final DescriptorType type) {
+        this(label, urlName, name, description, type, context, fontAwesomeIcon, true, fields, testFieldLabel);
     }
 
     public DescriptorMetadata(final String label, final String urlName, final String name, final String description, final DescriptorType type, final ConfigContextEnum context, final String fontAwesomeIcon,
-        final boolean automaticallyGenerateUI, final List<ConfigField> fields, final List<ConfigField> testFields) {
+        final boolean automaticallyGenerateUI, final List<ConfigField> fields, final String testFieldLabel) {
         this.label = label;
         this.urlName = urlName;
         this.name = name;
@@ -57,7 +57,7 @@ public class DescriptorMetadata extends AlertSerializableModel {
         this.fontAwesomeIcon = fontAwesomeIcon;
         this.automaticallyGenerateUI = automaticallyGenerateUI;
         this.fields = fields;
-        this.testFields = testFields;
+        this.testFieldLabel = testFieldLabel;
     }
 
     public String getLabel() {
@@ -100,11 +100,11 @@ public class DescriptorMetadata extends AlertSerializableModel {
         this.fields = fields;
     }
 
-    public List<ConfigField> getTestFields() {
-        return testFields;
+    public String getTestFieldLabel() {
+        return testFieldLabel;
     }
 
-    public void setTestFields(final List<ConfigField> testFields) {
-        this.testFields = testFields;
+    public void setTestFieldLabel(final String testFieldLabel) {
+        this.testFieldLabel = testFieldLabel;
     }
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/DescriptorMetadata.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/DescriptorMetadata.java
@@ -39,13 +39,15 @@ public class DescriptorMetadata extends AlertSerializableModel {
     private final String fontAwesomeIcon;
     private final boolean automaticallyGenerateUI;
     private List<ConfigField> fields;
+    private List<ConfigField> testFields;
 
-    public DescriptorMetadata(final String label, final String urlName, final String name, final String description, final ConfigContextEnum context, final String fontAwesomeIcon, final List<ConfigField> fields, final DescriptorType type) {
-        this(label, urlName, name, description, type, context, fontAwesomeIcon, true, fields);
+    public DescriptorMetadata(final String label, final String urlName, final String name, final String description, final ConfigContextEnum context, final String fontAwesomeIcon, final List<ConfigField> fields,
+        final List<ConfigField> testFields, final DescriptorType type) {
+        this(label, urlName, name, description, type, context, fontAwesomeIcon, true, fields, testFields);
     }
 
     public DescriptorMetadata(final String label, final String urlName, final String name, final String description, final DescriptorType type, final ConfigContextEnum context, final String fontAwesomeIcon,
-        final boolean automaticallyGenerateUI, final List<ConfigField> fields) {
+        final boolean automaticallyGenerateUI, final List<ConfigField> fields, final List<ConfigField> testFields) {
         this.label = label;
         this.urlName = urlName;
         this.name = name;
@@ -55,6 +57,7 @@ public class DescriptorMetadata extends AlertSerializableModel {
         this.fontAwesomeIcon = fontAwesomeIcon;
         this.automaticallyGenerateUI = automaticallyGenerateUI;
         this.fields = fields;
+        this.testFields = testFields;
     }
 
     public String getLabel() {
@@ -95,5 +98,13 @@ public class DescriptorMetadata extends AlertSerializableModel {
 
     public void setFields(final List<ConfigField> fields) {
         this.fields = fields;
+    }
+
+    public List<ConfigField> getTestFields() {
+        return testFields;
+    }
+
+    public void setTestFields(final List<ConfigField> testFields) {
+        this.testFields = testFields;
     }
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/UIConfig.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/UIConfig.java
@@ -42,6 +42,10 @@ public abstract class UIConfig extends AlertSerializableModel {
 
     public abstract List<ConfigField> createFields();
 
+    public List<ConfigField> createTestFields() {
+        return List.of();
+    }
+
     public String getLabel() {
         return label;
     }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/UIConfig.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/UIConfig.java
@@ -42,8 +42,8 @@ public abstract class UIConfig extends AlertSerializableModel {
 
     public abstract List<ConfigField> createFields();
 
-    public List<ConfigField> createTestFields() {
-        return List.of();
+    public String createTestLabel() {
+        return "";
     }
 
     public String getLabel() {

--- a/src/main/java/com/synopsys/integration/alert/channel/email/descriptor/EmailGlobalUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/email/descriptor/EmailGlobalUIConfig.java
@@ -215,4 +215,9 @@ public class EmailGlobalUIConfig extends UIConfig {
             mailSmtpStartTlsRequired, mailSmtpProxyHost, mailSmtpProxyPort, mailSmtpSocksHost, mailSmtpSocksPort, mailSmtpMailExtension, mailSmtpUserSet, mailSmtpNoopStrict
         );
     }
+
+    @Override
+    public String createTestLabel() {
+        return "Email address";
+    }
 }

--- a/src/main/java/com/synopsys/integration/alert/channel/email/descriptor/EmailGlobalUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/email/descriptor/EmailGlobalUIConfig.java
@@ -134,6 +134,8 @@ public class EmailGlobalUIConfig extends UIConfig {
 
     private static final String ADVANCED_PANEL = "Advanced";
 
+    private static final String TEST_LABEL_ADDRESS = "Email address";
+
     public EmailGlobalUIConfig() {
         super(EmailDescriptor.EMAIL_LABEL, EmailDescriptor.EMAIL_DESCRIPTION, EmailDescriptor.EMAIL_URL, EmailDescriptor.EMAIL_ICON);
     }
@@ -218,6 +220,6 @@ public class EmailGlobalUIConfig extends UIConfig {
 
     @Override
     public String createTestLabel() {
-        return "Email address";
+        return TEST_LABEL_ADDRESS;
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/channel/hipchat/descriptor/HipChatGlobalDescriptorActionApi.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/hipchat/descriptor/HipChatGlobalDescriptorActionApi.java
@@ -95,7 +95,7 @@ public class HipChatGlobalDescriptorActionApi extends DescriptorActionApi {
             sendTestRequest(intHttpClient, configuredApiUrl, apiKey);
         } catch (final IntegrationException integrationException) {
             logger.error("Unable to create a response", integrationException);
-            throw new AlertException("Invalid API key: " + integrationException.getMessage());
+            throw new AlertException("Invalid HipChat configuration.");
         }
     }
 

--- a/src/main/java/com/synopsys/integration/alert/channel/hipchat/descriptor/HipChatGlobalUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/hipchat/descriptor/HipChatGlobalUIConfig.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.common.descriptor.config.field.ConfigField;
+import com.synopsys.integration.alert.common.descriptor.config.field.NumberConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.PasswordConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.TextInputConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.ui.UIConfig;
@@ -39,6 +40,10 @@ public class HipChatGlobalUIConfig extends UIConfig {
     private static final String HIP_CHAT_API_KEY_DESCRIPTION = "The API key of the user you want to use to authenticate with the HipChat server.";
     private static final String HIP_CHAT_HOST_SERVER_DESCRIPTION = "The URL for your HipChat server.";
 
+    private static final String KEY_TEST_HIP_CHAT = "channel.hipchat.test.key";
+    private static final String LABEL_TEST_ROOM_ID = "Room ID";
+    private static final String DESCRIPTION_TEST_ROOM_ID = "The Room ID to use for testing HipChat configuration.";
+
     public HipChatGlobalUIConfig() {
         super(HipChatDescriptor.HIP_CHAT_LABEL, HipChatDescriptor.HIP_CHAT_DESCRIPTION, HipChatDescriptor.HIP_CHAT_URL, HipChatDescriptor.HIP_CHAT_ICON);
     }
@@ -48,5 +53,10 @@ public class HipChatGlobalUIConfig extends UIConfig {
         final ConfigField apiKey = PasswordConfigField.createRequired(HipChatDescriptor.KEY_API_KEY, LABEL_API_KEY, HIP_CHAT_API_KEY_DESCRIPTION);
         final ConfigField hostServer = TextInputConfigField.createRequired(HipChatDescriptor.KEY_HOST_SERVER, LABEL_HOST_SERVER, HIP_CHAT_HOST_SERVER_DESCRIPTION);
         return List.of(apiKey, hostServer);
+    }
+
+    @Override
+    public List<ConfigField> createTestFields() {
+        return List.of(NumberConfigField.createRequired(KEY_TEST_HIP_CHAT, LABEL_TEST_ROOM_ID, DESCRIPTION_TEST_ROOM_ID));
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/channel/hipchat/descriptor/HipChatGlobalUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/hipchat/descriptor/HipChatGlobalUIConfig.java
@@ -27,7 +27,6 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.common.descriptor.config.field.ConfigField;
-import com.synopsys.integration.alert.common.descriptor.config.field.NumberConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.PasswordConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.TextInputConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.ui.UIConfig;
@@ -40,9 +39,7 @@ public class HipChatGlobalUIConfig extends UIConfig {
     private static final String HIP_CHAT_API_KEY_DESCRIPTION = "The API key of the user you want to use to authenticate with the HipChat server.";
     private static final String HIP_CHAT_HOST_SERVER_DESCRIPTION = "The URL for your HipChat server.";
 
-    private static final String KEY_TEST_HIP_CHAT = "channel.hipchat.test.key";
     private static final String LABEL_TEST_ROOM_ID = "Room ID";
-    private static final String DESCRIPTION_TEST_ROOM_ID = "The Room ID to use for testing HipChat configuration.";
 
     public HipChatGlobalUIConfig() {
         super(HipChatDescriptor.HIP_CHAT_LABEL, HipChatDescriptor.HIP_CHAT_DESCRIPTION, HipChatDescriptor.HIP_CHAT_URL, HipChatDescriptor.HIP_CHAT_ICON);
@@ -56,7 +53,7 @@ public class HipChatGlobalUIConfig extends UIConfig {
     }
 
     @Override
-    public List<ConfigField> createTestFields() {
-        return List.of(NumberConfigField.createRequired(KEY_TEST_HIP_CHAT, LABEL_TEST_ROOM_ID, DESCRIPTION_TEST_ROOM_ID));
+    public String createTestLabel() {
+        return LABEL_TEST_ROOM_ID;
     }
 }

--- a/src/main/js/component/common/ChannelTestModal.js
+++ b/src/main/js/component/common/ChannelTestModal.js
@@ -7,11 +7,14 @@ class ChannelTestModal extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            destination: ''
+            destination: '',
+            show: this.props.showTestModal
         };
 
         this.handleChange = this.handleChange.bind(this);
         this.handleSendTestMessage = this.handleSendTestMessage.bind(this);
+        this.handleCancel = this.handleCancel.bind(this);
+        this.handleHide = this.handleHide.bind(this);
     }
 
     handleChange(event) {
@@ -23,41 +26,57 @@ class ChannelTestModal extends Component {
     handleSendTestMessage(event) {
         event.preventDefault();
         event.stopPropagation();
-        this.props.sendTestMessage(this.state.destination);
+        const destination = this.state.destination;
+        this.props.sendTestMessage(destination);
+    }
+
+    handleCancel(event) {
+        event.preventDefault();
+        event.stopPropagation();
+        this.setState({
+            show: false
+        });
+    }
+
+    handleHide(event) {
+        event.preventDefault();
+        event.stopPropagation();
+        this.setState({
+            destination: ''
+        });
     }
 
     render() {
         // TODO figure out a way to toggle the spinner/ there is no point to toggling the spinner if the sendTestMessage is closing the modal
-        return (<Modal show={this.props.showTestModal} onHide={this.props.cancelTestModal}>
-            <Modal.Header closeButton>
-                <Modal.Title>Test Your Configuration</Modal.Title>
-            </Modal.Header>
-            <Modal.Body>
-                <TextInput id="destinationName" label={this.props.destinationName} name="destinationName" value={this.state.destination} onChange={this.handleChange} />
-            </Modal.Body>
-            <Modal.Footer>
-                <button id="testCancel" type="button" className="btn btn-link" onClick={this.props.cancelTestModal}>Cancel</button>
-                <button id="testSend" type="button" className="btn btn-primary" onClick={this.handleSendTestMessage}>Send Test Message</button>
-                {this.props.modalTesting &&
-                <div className="progressIcon">
-                    <span className="fa fa-spinner fa-pulse" aria-hidden="true" />
-                </div>
-                }
-            </Modal.Footer>
-        </Modal>);
+        return (
+            <Modal show={this.state.show} onHide={this.handleHide}>
+                <Modal.Header closeButton>
+                    <Modal.Title>Test Your Configuration</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <TextInput id="destinationName" label={this.props.destinationName} name="destinationName" value={this.state.destination} onChange={this.handleChange} />
+                </Modal.Body>
+                <Modal.Footer>
+                    <button id="testCancel" type="button" className="btn btn-link" onClick={this.handleCancel}>Cancel</button>
+                    <button id="testSend" type="button" className="btn btn-primary" onClick={this.handleSendTestMessage}>Send Test Message</button>
+                    {this.state.show &&
+                    <div className="progressIcon">
+                        <span className="fa fa-spinner fa-pulse" aria-hidden="true" />
+                    </div>
+                    }
+                </Modal.Footer>
+            </Modal>
+        );
     }
 }
 
 ChannelTestModal.propTypes = {
-    destinationName: PropTypes.string,
-    showTestModal: PropTypes.bool.isRequired,
-    modalTesting: PropTypes.bool.isRequired,
-    cancelTestModal: PropTypes.func.isRequired,
+    showTestModal: PropTypes.bool,
     sendTestMessage: PropTypes.func.isRequired
 };
 
 ChannelTestModal.defaultProps = {
-    destinationName: 'Destination'
-};
+    showTestModal: false
+}
 
 export default ChannelTestModal;

--- a/src/main/js/component/common/ChannelTestModal.js
+++ b/src/main/js/component/common/ChannelTestModal.js
@@ -28,6 +28,7 @@ class ChannelTestModal extends Component {
         const destination = this.state.destination;
         const fieldModel = this.props.fieldModel;
         this.props.sendTestMessage(fieldModel, destination);
+        this.handleHide();
     }
 
     handleHide() {

--- a/src/main/js/component/common/ChannelTestModal.js
+++ b/src/main/js/component/common/ChannelTestModal.js
@@ -13,7 +13,6 @@ class ChannelTestModal extends Component {
 
         this.handleChange = this.handleChange.bind(this);
         this.handleSendTestMessage = this.handleSendTestMessage.bind(this);
-        this.handleCancel = this.handleCancel.bind(this);
         this.handleHide = this.handleHide.bind(this);
     }
 
@@ -27,29 +26,21 @@ class ChannelTestModal extends Component {
         event.preventDefault();
         event.stopPropagation();
         const destination = this.state.destination;
-        this.props.sendTestMessage(destination);
+        const fieldModel = this.props.fieldModel;
+        this.props.sendTestMessage(fieldModel, destination);
     }
 
-    handleCancel(event) {
-        event.preventDefault();
-        event.stopPropagation();
-        this.setState({
-            show: false
-        });
-    }
-
-    handleHide(event) {
-        event.preventDefault();
-        event.stopPropagation();
+    handleHide() {
         this.setState({
             destination: ''
         });
+        this.props.handleCancel();
     }
 
     render() {
         // TODO figure out a way to toggle the spinner/ there is no point to toggling the spinner if the sendTestMessage is closing the modal
         return (
-            <Modal show={this.state.show} onHide={this.handleHide}>
+            <Modal show={this.props.showTestModal} onHide={this.handleHide}>
                 <Modal.Header closeButton>
                     <Modal.Title>Test Your Configuration</Modal.Title>
                 </Modal.Header>
@@ -57,7 +48,7 @@ class ChannelTestModal extends Component {
                     <TextInput id="destinationName" label={this.props.destinationName} name="destinationName" value={this.state.destination} onChange={this.handleChange} />
                 </Modal.Body>
                 <Modal.Footer>
-                    <button id="testCancel" type="button" className="btn btn-link" onClick={this.handleCancel}>Cancel</button>
+                    <button id="testCancel" type="button" className="btn btn-link" onClick={this.handleHide}>Cancel</button>
                     <button id="testSend" type="button" className="btn btn-primary" onClick={this.handleSendTestMessage}>Send Test Message</button>
                     {this.state.show &&
                     <div className="progressIcon">
@@ -72,7 +63,10 @@ class ChannelTestModal extends Component {
 
 ChannelTestModal.propTypes = {
     showTestModal: PropTypes.bool,
-    sendTestMessage: PropTypes.func.isRequired
+    sendTestMessage: PropTypes.func.isRequired,
+    handleCancel: PropTypes.func.isRequired,
+    destinationName: PropTypes.string.isRequired,
+    fieldModel: PropTypes.object.isRequired
 };
 
 ChannelTestModal.defaultProps = {

--- a/src/main/js/dynamic/GlobalConfiguration.js
+++ b/src/main/js/dynamic/GlobalConfiguration.js
@@ -10,7 +10,7 @@ import * as FieldModelUtilities from 'util/fieldModelUtilities';
 import * as DescriptorUtilities from 'util/descriptorUtilities';
 import * as FieldMapping from 'util/fieldMapping';
 import StatusMessage from 'field/StatusMessage';
-import ChannelTestModal from "../component/common/ChannelTestModal";
+import ChannelTestModal from 'component/common/ChannelTestModal';
 
 class GlobalConfiguration extends React.Component {
     constructor(props) {

--- a/src/main/js/dynamic/GlobalConfiguration.js
+++ b/src/main/js/dynamic/GlobalConfiguration.js
@@ -18,6 +18,7 @@ class GlobalConfiguration extends React.Component {
         this.handleChange = this.handleChange.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
         this.handleTest = this.handleTest.bind(this);
+        this.handleTestCancel = this.handleTestCancel.bind(this);
 
         const { fields, name } = this.props.descriptor;
         const fieldKeys = FieldMapping.retrieveKeys(fields);
@@ -26,7 +27,8 @@ class GlobalConfiguration extends React.Component {
             currentConfig: fieldModel,
             currentDescriptor: this.props.descriptor,
             currentKeys: fieldKeys,
-            showTest: false
+            showTest: false,
+            destinationName: ''
         }
         ;
     }
@@ -60,15 +62,22 @@ class GlobalConfiguration extends React.Component {
     }
 
     handleTest() {
-        const { testFields } = this.state.currentDescriptor;
-        if (Array.isArray(testFields) && testFields.length > 0) {
+        const { testFieldLabel } = this.state.currentDescriptor;
+        if (testFieldLabel) {
             this.setState({
-                showTest: true
+                showTest: true,
+                destinationName: testFieldLabel
             });
         } else {
             const fieldModel = this.state.currentConfig;
             this.props.testConfig(fieldModel, '');
         }
+    }
+
+    handleTestCancel() {
+        this.setState({
+            showTest: false
+        });
     }
 
     handleSubmit(event) {
@@ -89,6 +98,7 @@ class GlobalConfiguration extends React.Component {
             fontAwesomeIcon, label, description, fields, name
         } = this.state.currentDescriptor;
         const { errorMessage, actionMessage } = this.props;
+        const { currentConfig } = this.state
 
         return (
             <div>
@@ -97,10 +107,10 @@ class GlobalConfiguration extends React.Component {
 
                 <form className="form-horizontal" onSubmit={this.handleSubmit} noValidate={true}>
                     <div>
-                        <FieldsPanel descriptorFields={fields} currentConfig={this.state.currentConfig} fieldErrors={this.props.fieldErrors} handleChange={this.handleChange} />
+                        <FieldsPanel descriptorFields={fields} currentConfig={currentConfig} fieldErrors={this.props.fieldErrors} handleChange={this.handleChange} />
                     </div>
                     <ConfigButtons isFixed={false} includeSave includeTest type="submit" onTestClick={this.handleTest} />
-                    <ChannelTestModal sendTestMessage={this.props.testConfig} showTestModal={this.state.showTest} />
+                    <ChannelTestModal sendTestMessage={this.props.testConfig} showTestModal={this.state.showTest} handleCancel={this.handleTestCancel} destinationName={this.state.destinationName} fieldModel={currentConfig} />
                 </form>
             </div>
         );

--- a/src/main/js/dynamic/GlobalConfiguration.js
+++ b/src/main/js/dynamic/GlobalConfiguration.js
@@ -10,6 +10,7 @@ import * as FieldModelUtilities from 'util/fieldModelUtilities';
 import * as DescriptorUtilities from 'util/descriptorUtilities';
 import * as FieldMapping from 'util/fieldMapping';
 import StatusMessage from 'field/StatusMessage';
+import ChannelTestModal from "../component/common/ChannelTestModal";
 
 class GlobalConfiguration extends React.Component {
     constructor(props) {
@@ -17,14 +18,17 @@ class GlobalConfiguration extends React.Component {
         this.handleChange = this.handleChange.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
         this.handleTest = this.handleTest.bind(this);
+
         const { fields, name } = this.props.descriptor;
         const fieldKeys = FieldMapping.retrieveKeys(fields);
         const fieldModel = FieldModelUtilities.createEmptyFieldModelFromFieldObject(fieldKeys, DescriptorUtilities.CONTEXT_TYPE.GLOBAL, name);
         this.state = {
             currentConfig: fieldModel,
             currentDescriptor: this.props.descriptor,
-            currentKeys: fieldKeys
-        };
+            currentKeys: fieldKeys,
+            showTest: false
+        }
+        ;
     }
 
     componentDidMount() {
@@ -56,8 +60,15 @@ class GlobalConfiguration extends React.Component {
     }
 
     handleTest() {
-        const fieldModel = this.state.currentConfig;
-        this.props.testConfig(fieldModel);
+        const { testFields } = this.state.currentDescriptor;
+        if (Array.isArray(testFields) && testFields.length > 0) {
+            this.setState({
+                showTest: true
+            });
+        } else {
+            const fieldModel = this.state.currentConfig;
+            this.props.testConfig(fieldModel, '');
+        }
     }
 
     handleSubmit(event) {
@@ -78,6 +89,7 @@ class GlobalConfiguration extends React.Component {
             fontAwesomeIcon, label, description, fields, name
         } = this.state.currentDescriptor;
         const { errorMessage, actionMessage } = this.props;
+
         return (
             <div>
                 <ConfigurationLabel fontAwesomeIcon={fontAwesomeIcon} configurationName={label} description={description} />
@@ -88,6 +100,7 @@ class GlobalConfiguration extends React.Component {
                         <FieldsPanel descriptorFields={fields} currentConfig={this.state.currentConfig} fieldErrors={this.props.fieldErrors} handleChange={this.handleChange} />
                     </div>
                     <ConfigButtons isFixed={false} includeSave includeTest type="submit" onTestClick={this.handleTest} />
+                    <ChannelTestModal sendTestMessage={this.props.testConfig} showTestModal={this.state.showTest} />
                 </form>
             </div>
         );
@@ -130,7 +143,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
     getConfig: descriptorName => dispatch(getConfig(descriptorName)),
     updateConfig: config => dispatch(updateConfig(config)),
-    testConfig: config => dispatch(testConfig(config)),
+    testConfig: (config, destination) => dispatch(testConfig(config, destination)),
     deleteConfig: id => dispatch(deleteConfig(id))
 });
 


### PR DESCRIPTION
Added a new item to descriptor metadata that will autogenerate the test modal for global configurations. All you pass this new field is the label for the destination field that you want displayed. The modal should work exactly as before.

In the future, I would like to expand this feature to accept multiple field definitions so we can have a mini testing form, but that is not necessary at the moment.