### PR TITLE
Countdown field

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/CountdownConfigField.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/CountdownConfigField.java
@@ -1,16 +1,38 @@
+/**
+ * alert-common
+ *
+ * Copyright (c) 2019 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.synopsys.integration.alert.common.descriptor.config.field;
 
 import com.synopsys.integration.alert.common.enumeration.FieldType;
 
 public class CountdownConfigField extends ConfigField {
-    public Integer countdown;
+    public Long countdown;
 
-    public CountdownConfigField(final String key, final String label, final String description, final String panel, final Integer countdown) {
+    public CountdownConfigField(final String key, final String label, final String description, final String panel, final Long countdown) {
         super(key, label, description, FieldType.COUNTDOWN.getFieldTypeName(), false, false, panel);
         this.countdown = countdown;
     }
 
-    public static CountdownConfigField create(final String key, final String label, final String description, final Integer countdown) {
+    public static CountdownConfigField create(final String key, final String label, final String description, final Long countdown) {
         return new CountdownConfigField(key, label, description, "", countdown);
     }
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/CountdownConfigField.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/CountdownConfigField.java
@@ -1,0 +1,16 @@
+package com.synopsys.integration.alert.common.descriptor.config.field;
+
+import com.synopsys.integration.alert.common.enumeration.FieldType;
+
+public class CountdownConfigField extends ConfigField {
+    public Integer countdown;
+
+    public CountdownConfigField(final String key, final String label, final String description, final String panel, final Integer countdown) {
+        super(key, label, description, FieldType.COUNTDOWN.getFieldTypeName(), false, false, panel);
+        this.countdown = countdown;
+    }
+
+    public static CountdownConfigField create(final String key, final String label, final String description, final Integer countdown) {
+        return new CountdownConfigField(key, label, description, "", countdown);
+    }
+}

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/enumeration/FieldType.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/enumeration/FieldType.java
@@ -29,7 +29,8 @@ public enum FieldType {
     PASSWORD_INPUT("PasswordInput"),
     NUMBER_INPUT("NumberInput"),
     CHECKBOX_INPUT("CheckboxInput"),
-    READ_ONLY("ReadOnlyField");
+    READ_ONLY("ReadOnlyField"),
+    COUNTDOWN("CountdownField");
 
     private final String fieldTypeName;
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/task/ScheduledTask.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/task/ScheduledTask.java
@@ -42,6 +42,7 @@ public abstract class ScheduledTask implements Runnable {
     public static final String FORMAT_PATTERN = "MM/dd/yyy hh:mm a";
     public static final String STOP_SCHEDULE_EXPRESSION = "";
     public static final String EVERY_MINUTE_CRON_EXPRESSION = "0 0/1 * 1/1 * *";
+    public static final Long EVERY_MINUTE_SECONDS = 60L;
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final TaskScheduler taskScheduler;

--- a/src/main/java/com/synopsys/integration/alert/component/scheduling/SchedulingDescriptor.java
+++ b/src/main/java/com/synopsys/integration/alert/component/scheduling/SchedulingDescriptor.java
@@ -36,7 +36,8 @@ public class SchedulingDescriptor extends ComponentDescriptor {
     public static final String SCHEDULING_ICON = "clock-o";
     public static final String SCHEDULING_DESCRIPTION = "This page shows when the scheduled tasks will run next as well as allow you to configure the frequency of the tasks.";
 
-    public static final String KEY_ACCUMULATOR_NEXT_RUN = "scheduling.accumulator.next.run";
+    public static final String KEY_BLACKDUCK_NEXT_RUN = "scheduling.accumulator.next.run";
+    public static final String KEY_POLARIS_NEXT_RUN = "scheduling.polaris.next.run";
     public static final String KEY_DAILY_PROCESSOR_HOUR_OF_DAY = "scheduling.daily.processor.hour";
     public static final String KEY_DAILY_PROCESSOR_NEXT_RUN = "scheduling.daily.processor.next.run";
     public static final String KEY_PURGE_DATA_FREQUENCY_DAYS = "scheduling.purge.data.frequency";

--- a/src/main/java/com/synopsys/integration/alert/component/scheduling/SchedulingDescriptorActionApi.java
+++ b/src/main/java/com/synopsys/integration/alert/component/scheduling/SchedulingDescriptorActionApi.java
@@ -23,7 +23,6 @@
 package com.synopsys.integration.alert.component.scheduling;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,13 +32,12 @@ import com.synopsys.integration.alert.common.descriptor.action.NoTestActionApi;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
 import com.synopsys.integration.alert.common.workflow.task.TaskManager;
-import com.synopsys.integration.alert.provider.blackduck.tasks.BlackDuckAccumulator;
 import com.synopsys.integration.alert.workflow.scheduled.PurgeTask;
 import com.synopsys.integration.alert.workflow.scheduled.frequency.DailyTask;
+import com.synopsys.integration.alert.workflow.scheduled.frequency.OnDemandTask;
 
 @Component
 public class SchedulingDescriptorActionApi extends NoTestActionApi {
-
     private final TaskManager taskManager;
 
     @Autowired
@@ -49,8 +47,8 @@ public class SchedulingDescriptorActionApi extends NoTestActionApi {
 
     @Override
     public FieldModel readConfig(final FieldModel fieldModel) {
-        final Optional<Long> accumulatorNextRun = taskManager.getDifferenceToNextRun(BlackDuckAccumulator.TASK_NAME, TimeUnit.SECONDS);
-        fieldModel.putField(SchedulingDescriptor.KEY_ACCUMULATOR_NEXT_RUN, new FieldValueModel(List.of(accumulatorNextRun.map(String::valueOf).orElse("")), true));
+        final String accumulatorNextRun = taskManager.getDifferenceToNextRun(OnDemandTask.TASK_NAME, TimeUnit.SECONDS).map(String::valueOf).orElse("");
+        fieldModel.putField(SchedulingDescriptor.KEY_ACCUMULATOR_NEXT_RUN, new FieldValueModel(List.of(accumulatorNextRun), true));
         fieldModel.putField(SchedulingDescriptor.KEY_DAILY_PROCESSOR_NEXT_RUN, new FieldValueModel(List.of(taskManager.getNextRunTime(DailyTask.TASK_NAME).orElse("")), true));
         fieldModel.putField(SchedulingDescriptor.KEY_PURGE_DATA_NEXT_RUN, new FieldValueModel(List.of(taskManager.getNextRunTime(PurgeTask.TASK_NAME).orElse("")), true));
         return fieldModel;

--- a/src/main/java/com/synopsys/integration/alert/component/scheduling/SchedulingDescriptorActionApi.java
+++ b/src/main/java/com/synopsys/integration/alert/component/scheduling/SchedulingDescriptorActionApi.java
@@ -32,9 +32,10 @@ import com.synopsys.integration.alert.common.descriptor.action.NoTestActionApi;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
 import com.synopsys.integration.alert.common.workflow.task.TaskManager;
+import com.synopsys.integration.alert.provider.blackduck.tasks.BlackDuckAccumulator;
+import com.synopsys.integration.alert.provider.polaris.tasks.PolarisProjectSyncTask;
 import com.synopsys.integration.alert.workflow.scheduled.PurgeTask;
 import com.synopsys.integration.alert.workflow.scheduled.frequency.DailyTask;
-import com.synopsys.integration.alert.workflow.scheduled.frequency.OnDemandTask;
 
 @Component
 public class SchedulingDescriptorActionApi extends NoTestActionApi {
@@ -47,8 +48,11 @@ public class SchedulingDescriptorActionApi extends NoTestActionApi {
 
     @Override
     public FieldModel readConfig(final FieldModel fieldModel) {
-        final String accumulatorNextRun = taskManager.getDifferenceToNextRun(OnDemandTask.TASK_NAME, TimeUnit.SECONDS).map(String::valueOf).orElse("");
-        fieldModel.putField(SchedulingDescriptor.KEY_ACCUMULATOR_NEXT_RUN, new FieldValueModel(List.of(accumulatorNextRun), true));
+        final String blackDuckNextRun = taskManager.getDifferenceToNextRun(BlackDuckAccumulator.TASK_NAME, TimeUnit.SECONDS).map(String::valueOf).orElse("");
+        final String polarisNextRun = taskManager.getDifferenceToNextRun(PolarisProjectSyncTask.TASK_NAME, TimeUnit.SECONDS).map(String::valueOf).orElse("");
+
+        fieldModel.putField(SchedulingDescriptor.KEY_BLACKDUCK_NEXT_RUN, new FieldValueModel(List.of(blackDuckNextRun), true));
+        fieldModel.putField(SchedulingDescriptor.KEY_POLARIS_NEXT_RUN, new FieldValueModel(List.of(polarisNextRun), true));
         fieldModel.putField(SchedulingDescriptor.KEY_DAILY_PROCESSOR_NEXT_RUN, new FieldValueModel(List.of(taskManager.getNextRunTime(DailyTask.TASK_NAME).orElse("")), true));
         fieldModel.putField(SchedulingDescriptor.KEY_PURGE_DATA_NEXT_RUN, new FieldValueModel(List.of(taskManager.getNextRunTime(PurgeTask.TASK_NAME).orElse("")), true));
         return fieldModel;

--- a/src/main/java/com/synopsys/integration/alert/component/scheduling/SchedulingUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/component/scheduling/SchedulingUIConfig.java
@@ -23,6 +23,7 @@
 package com.synopsys.integration.alert.component.scheduling;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.stereotype.Component;
 
@@ -32,6 +33,7 @@ import com.synopsys.integration.alert.common.descriptor.config.field.LabelValueS
 import com.synopsys.integration.alert.common.descriptor.config.field.ReadOnlyConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.SelectConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.ui.UIConfig;
+import com.synopsys.integration.alert.workflow.scheduled.frequency.OnDemandTask;
 
 @Component
 public class SchedulingUIConfig extends UIConfig {
@@ -53,7 +55,8 @@ public class SchedulingUIConfig extends UIConfig {
 
     @Override
     public List<ConfigField> createFields() {
-        final ConfigField accumulatorNextRun = CountdownConfigField.create(SchedulingDescriptor.KEY_ACCUMULATOR_NEXT_RUN, LABEL_ACCUMULATOR_NEXT_RUN, ACCUMULATOR_NEXT_RUN_DESCRIPTION, 60);
+        final Long countdownMax = TimeUnit.MILLISECONDS.toSeconds(OnDemandTask.DEFAULT_INTERVAL_MILLISECONDS);
+        final ConfigField accumulatorNextRun = CountdownConfigField.create(SchedulingDescriptor.KEY_ACCUMULATOR_NEXT_RUN, LABEL_ACCUMULATOR_NEXT_RUN, ACCUMULATOR_NEXT_RUN_DESCRIPTION, countdownMax);
         final ConfigField digestHour = SelectConfigField.createRequired(SchedulingDescriptor.KEY_DAILY_PROCESSOR_HOUR_OF_DAY, LABEL_DAILY_DIGEST_HOUR_OF_DAY, SCHEDULING_DIGEST_HOUR_DESCRIPTION,
             createDigestHours());
         final ConfigField digestHourNextRun = ReadOnlyConfigField.create(SchedulingDescriptor.KEY_DAILY_PROCESSOR_NEXT_RUN, LABEL_DAILY_PROCESSOR_NEXT_RUN, DAILY_PROCESSOR_NEXT_RUN_DESCRIPTION);

--- a/src/main/java/com/synopsys/integration/alert/component/scheduling/SchedulingUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/component/scheduling/SchedulingUIConfig.java
@@ -23,7 +23,6 @@
 package com.synopsys.integration.alert.component.scheduling;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.springframework.stereotype.Component;
 
@@ -33,17 +32,19 @@ import com.synopsys.integration.alert.common.descriptor.config.field.LabelValueS
 import com.synopsys.integration.alert.common.descriptor.config.field.ReadOnlyConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.SelectConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.ui.UIConfig;
-import com.synopsys.integration.alert.workflow.scheduled.frequency.OnDemandTask;
+import com.synopsys.integration.alert.common.workflow.task.ScheduledTask;
 
 @Component
 public class SchedulingUIConfig extends UIConfig {
-    private static final String LABEL_ACCUMULATOR_NEXT_RUN = "Collecting Provider data in";
+    private static final String LABEL_BLACKDUCK_NEXT_RUN = "Collecting Black Duck data in";
+    private static final String LABEL_POLARIS_NEXT_RUN = "Collecting Polaris data in";
     private static final String LABEL_DAILY_DIGEST_HOUR_OF_DAY = "Daily digest hour of day";
     private static final String LABEL_DAILY_PROCESSOR_NEXT_RUN = "Daily Digest Cron Next Run";
     private static final String LABEL_PURGE_DATA_FREQUENCY_IN_DAYS = "Purge data frequency in days";
     private static final String LABEL_PURGE_DATA_NEXT_RUN = "Purge Cron Next Run";
 
-    private static final String ACCUMULATOR_NEXT_RUN_DESCRIPTION = "By default, Alert collects data every 60 seconds. This value indicates the number of seconds until the next time Alert pulls data from the Providers.";
+    private static final String ACCUMULATOR_NEXT_RUN_DESCRIPTION = "By default, Black Duck collects data every 60 seconds. This value indicates the number of seconds until the next time Black Duck pulls data.";
+    private static final String POLARIS_NEXT_RUN_DESCRIPTION = "By default, Polaris collects data every 60 seconds. This value indicates the number of seconds until the next time Polaris pulls data.";
     private static final String SCHEDULING_DIGEST_HOUR_DESCRIPTION = "Select the hour of the day to run the the daily digest distribution jobs.";
     private static final String DAILY_PROCESSOR_NEXT_RUN_DESCRIPTION = "This is the next time daily digest distribution jobs will run.";
     private static final String SCHEDULING_PURGE_FREQUENCY_DESCRIPTION = "Choose a frequency for cleaning up provider data; the default value is three days. When the purge runs, it deletes all data that is older than the selected value. EX: data older than 3 days will be deleted.";
@@ -55,15 +56,16 @@ public class SchedulingUIConfig extends UIConfig {
 
     @Override
     public List<ConfigField> createFields() {
-        final Long countdownMax = TimeUnit.MILLISECONDS.toSeconds(OnDemandTask.DEFAULT_INTERVAL_MILLISECONDS);
-        final ConfigField accumulatorNextRun = CountdownConfigField.create(SchedulingDescriptor.KEY_ACCUMULATOR_NEXT_RUN, LABEL_ACCUMULATOR_NEXT_RUN, ACCUMULATOR_NEXT_RUN_DESCRIPTION, countdownMax);
+        final Long countdownMax = ScheduledTask.EVERY_MINUTE_SECONDS;
+        final ConfigField blackDuckNextRun = CountdownConfigField.create(SchedulingDescriptor.KEY_BLACKDUCK_NEXT_RUN, LABEL_BLACKDUCK_NEXT_RUN, ACCUMULATOR_NEXT_RUN_DESCRIPTION, countdownMax);
+        final ConfigField polarisNextRun = CountdownConfigField.create(SchedulingDescriptor.KEY_POLARIS_NEXT_RUN, LABEL_POLARIS_NEXT_RUN, POLARIS_NEXT_RUN_DESCRIPTION, countdownMax);
         final ConfigField digestHour = SelectConfigField.createRequired(SchedulingDescriptor.KEY_DAILY_PROCESSOR_HOUR_OF_DAY, LABEL_DAILY_DIGEST_HOUR_OF_DAY, SCHEDULING_DIGEST_HOUR_DESCRIPTION,
             createDigestHours());
         final ConfigField digestHourNextRun = ReadOnlyConfigField.create(SchedulingDescriptor.KEY_DAILY_PROCESSOR_NEXT_RUN, LABEL_DAILY_PROCESSOR_NEXT_RUN, DAILY_PROCESSOR_NEXT_RUN_DESCRIPTION);
         final ConfigField purgeFrequency = SelectConfigField.createRequired(SchedulingDescriptor.KEY_PURGE_DATA_FREQUENCY_DAYS, LABEL_PURGE_DATA_FREQUENCY_IN_DAYS, SCHEDULING_PURGE_FREQUENCY_DESCRIPTION,
             createPurgeFrequency());
         final ConfigField purgeNextRun = ReadOnlyConfigField.create(SchedulingDescriptor.KEY_PURGE_DATA_NEXT_RUN, LABEL_PURGE_DATA_NEXT_RUN, PURGE_DATA_NEXT_RUN_DESCRIPTION);
-        return List.of(accumulatorNextRun, digestHour, digestHourNextRun, purgeFrequency, purgeNextRun);
+        return List.of(blackDuckNextRun, polarisNextRun, digestHour, digestHourNextRun, purgeFrequency, purgeNextRun);
     }
 
     private List<LabelValueSelectOption> createDigestHours() {

--- a/src/main/java/com/synopsys/integration/alert/component/scheduling/SchedulingUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/component/scheduling/SchedulingUIConfig.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.common.descriptor.config.field.ConfigField;
+import com.synopsys.integration.alert.common.descriptor.config.field.CountdownConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.LabelValueSelectOption;
 import com.synopsys.integration.alert.common.descriptor.config.field.ReadOnlyConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.SelectConfigField;
@@ -34,11 +35,13 @@ import com.synopsys.integration.alert.common.descriptor.config.ui.UIConfig;
 
 @Component
 public class SchedulingUIConfig extends UIConfig {
+    private static final String LABEL_ACCUMULATOR_NEXT_RUN = "Collecting Provider data in";
     private static final String LABEL_DAILY_DIGEST_HOUR_OF_DAY = "Daily digest hour of day";
     private static final String LABEL_DAILY_PROCESSOR_NEXT_RUN = "Daily Digest Cron Next Run";
     private static final String LABEL_PURGE_DATA_FREQUENCY_IN_DAYS = "Purge data frequency in days";
     private static final String LABEL_PURGE_DATA_NEXT_RUN = "Purge Cron Next Run";
 
+    private static final String ACCUMULATOR_NEXT_RUN_DESCRIPTION = "By default, Alert collects data every 60 seconds. This value indicates the number of seconds until the next time Alert pulls data from the Providers.";
     private static final String SCHEDULING_DIGEST_HOUR_DESCRIPTION = "Select the hour of the day to run the the daily digest distribution jobs.";
     private static final String DAILY_PROCESSOR_NEXT_RUN_DESCRIPTION = "This is the next time daily digest distribution jobs will run.";
     private static final String SCHEDULING_PURGE_FREQUENCY_DESCRIPTION = "Choose a frequency for cleaning up provider data; the default value is three days. When the purge runs, it deletes all data that is older than the selected value. EX: data older than 3 days will be deleted.";
@@ -50,13 +53,14 @@ public class SchedulingUIConfig extends UIConfig {
 
     @Override
     public List<ConfigField> createFields() {
+        final ConfigField accumulatorNextRun = CountdownConfigField.create(SchedulingDescriptor.KEY_ACCUMULATOR_NEXT_RUN, LABEL_ACCUMULATOR_NEXT_RUN, ACCUMULATOR_NEXT_RUN_DESCRIPTION, 60);
         final ConfigField digestHour = SelectConfigField.createRequired(SchedulingDescriptor.KEY_DAILY_PROCESSOR_HOUR_OF_DAY, LABEL_DAILY_DIGEST_HOUR_OF_DAY, SCHEDULING_DIGEST_HOUR_DESCRIPTION,
             createDigestHours());
         final ConfigField digestHourNextRun = ReadOnlyConfigField.create(SchedulingDescriptor.KEY_DAILY_PROCESSOR_NEXT_RUN, LABEL_DAILY_PROCESSOR_NEXT_RUN, DAILY_PROCESSOR_NEXT_RUN_DESCRIPTION);
         final ConfigField purgeFrequency = SelectConfigField.createRequired(SchedulingDescriptor.KEY_PURGE_DATA_FREQUENCY_DAYS, LABEL_PURGE_DATA_FREQUENCY_IN_DAYS, SCHEDULING_PURGE_FREQUENCY_DESCRIPTION,
             createPurgeFrequency());
         final ConfigField purgeNextRun = ReadOnlyConfigField.create(SchedulingDescriptor.KEY_PURGE_DATA_NEXT_RUN, LABEL_PURGE_DATA_NEXT_RUN, PURGE_DATA_NEXT_RUN_DESCRIPTION);
-        return List.of(digestHour, digestHourNextRun, purgeFrequency, purgeNextRun);
+        return List.of(accumulatorNextRun, digestHour, digestHourNextRun, purgeFrequency, purgeNextRun);
     }
 
     private List<LabelValueSelectOption> createDigestHours() {

--- a/src/main/java/com/synopsys/integration/alert/provider/polaris/descriptor/PolarisGlobalDescriptorActionApi.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/polaris/descriptor/PolarisGlobalDescriptorActionApi.java
@@ -37,7 +37,6 @@ import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.rest.model.TestConfigModel;
 import com.synopsys.integration.alert.common.workflow.task.ScheduledTask;
 import com.synopsys.integration.alert.common.workflow.task.TaskManager;
-import com.synopsys.integration.alert.provider.blackduck.tasks.BlackDuckAccumulator;
 import com.synopsys.integration.alert.provider.polaris.PolarisProperties;
 import com.synopsys.integration.alert.provider.polaris.tasks.PolarisProjectSyncTask;
 import com.synopsys.integration.builder.BuilderStatus;
@@ -103,7 +102,7 @@ public class PolarisGlobalDescriptorActionApi extends DescriptorActionApi {
     @Override
     public FieldModel afterSaveConfig(final FieldModel fieldModel) {
         final Optional<AccessTokenPolarisHttpClient> polarisHttpClient = polarisProperties.createPolarisHttpClientSafely(logger);
-        final Optional<String> nextRunTime = taskManager.getNextRunTime(BlackDuckAccumulator.TASK_NAME);
+        final Optional<String> nextRunTime = taskManager.getNextRunTime(PolarisProjectSyncTask.TASK_NAME);
         if (polarisHttpClient.isPresent() && nextRunTime.isEmpty()) {
             taskManager.scheduleCronTask(ScheduledTask.EVERY_MINUTE_CRON_EXPRESSION, PolarisProjectSyncTask.TASK_NAME);
         }

--- a/src/main/js/field/CounterField.js
+++ b/src/main/js/field/CounterField.js
@@ -20,13 +20,10 @@ class CounterField extends Component {
     }
 
     tickDown() {
-        console.log('tick down');
         const time = this.state.currentTime || this.props.value;
-        console.log(time);
         const parsedTime = parseInt(time, 10);
         if (!Number.isNaN(parsedTime)) {
             const nextTime = (parsedTime <= 0) ? this.props.countdown : (parsedTime - 1);
-            console.log(nextTime);
             this.setState({
                 currentTime: nextTime.toString()
             });

--- a/src/main/js/field/CounterField.js
+++ b/src/main/js/field/CounterField.js
@@ -1,0 +1,55 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import ReadOnlyField from 'field/ReadOnlyField';
+
+class CounterField extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            currentTime: this.props.value
+        };
+    }
+
+    componentDidMount() {
+        this.intervalId = setInterval(this.tickDown.bind(this), 1000);
+    }
+
+    componentWillUnmount() {
+        clearInterval(this.intervalId);
+    }
+
+    tickDown() {
+        console.log('tick down');
+        const time = this.state.currentTime || this.props.value;
+        console.log(time);
+        const parsedTime = parseInt(time, 10);
+        if (!Number.isNaN(parsedTime)) {
+            const nextTime = (parsedTime <= 0) ? this.props.countdown : (parsedTime - 1);
+            console.log(nextTime);
+            this.setState({
+                currentTime: nextTime.toString()
+            });
+        }
+    }
+
+    render() {
+        const updatedCount = Object.assign({}, this.props, { value: this.state.currentTime });
+        return (
+            <div>
+                <ReadOnlyField {...updatedCount} />
+            </div>
+        );
+    }
+}
+
+CounterField.propTypes = {
+    countdown: PropTypes.number.isRequired,
+    value: PropTypes.string
+};
+
+CounterField.defaultProps = {
+    value: '0'
+}
+
+export default CounterField;

--- a/src/main/js/util/fieldMapping.js
+++ b/src/main/js/util/fieldMapping.js
@@ -7,6 +7,7 @@ import NumberInput from 'field/input/NumberInput';
 import CheckboxInput from 'field/input/CheckboxInput';
 import ReadOnlyField from 'field/ReadOnlyField';
 import * as FieldModelUtilities from 'util/fieldModelUtilities';
+import CounterField from 'field/CounterField';
 
 export function buildTextInput(items) {
     return <TextInput {...items} />;
@@ -46,6 +47,14 @@ export function buildReadOnlyField(items) {
     return <ReadOnlyField {...items} />;
 }
 
+export function buildCounterField(items, field) {
+    const { countdown } = field;
+    const { value } = items;
+    const trimmedValue = (value.length > 0) && value[0];
+    Object.assign(items, { countdown, value: trimmedValue });
+    return <CounterField {...items} />;
+}
+
 export const FIELDS = {
     TextInput: buildTextInput,
     TextArea: buildTextArea,
@@ -53,7 +62,8 @@ export const FIELDS = {
     PasswordInput: buildPasswordInput,
     NumberInput: buildNumberInput,
     CheckboxInput: buildCheckboxInput,
-    ReadOnlyField: buildReadOnlyField
+    ReadOnlyField: buildReadOnlyField,
+    CountdownField: buildCounterField
 };
 
 export function getField(fieldType, props, field) {

--- a/src/main/resources/db/changelog-master.xml
+++ b/src/main/resources/db/changelog-master.xml
@@ -26,4 +26,5 @@
     <include file="changelog/alert/changelog-3.1.0.xml" relativeToChangelogFile="true"/>
     <include file="changelog/alert/4.0.0/changelog.xml" relativeToChangelogFile="true"/>
     <include file="changelog/alert/4.1.0/changelog.xml" relativeToChangelogFile="true"/>
+    <include file="changelog/alert/4.2.0/changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/alert/4.2.0/changelog-scheduling.xml
+++ b/src/main/resources/db/changelog/alert/4.2.0/changelog-scheduling.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+    <changeSet author="bmandel" id="1555523530598-1">
+        <sql dbms="h2" stripComments="true">
+            CALL DEFINE_FIELD('scheduling.polaris.next.run', FALSE, 'component_scheduling', 'GLOBAL');
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/alert/4.2.0/changelog.xml
+++ b/src/main/resources/db/changelog/alert/4.2.0/changelog.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+    <include file="changelog-scheduling.xml" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/src/test/java/com/synopsys/integration/alert/component/scheduling/SchedulingDescriptorActionApiTest.java
+++ b/src/test/java/com/synopsys/integration/alert/component/scheduling/SchedulingDescriptorActionApiTest.java
@@ -193,7 +193,7 @@ public class SchedulingDescriptorActionApiTest {
         final DescriptorActionApi actionApi = actionApiOptional.get();
         final FieldModel fieldModel = new FieldModel(SchedulingDescriptor.SCHEDULING_COMPONENT, ConfigContextEnum.GLOBAL.name(), new HashMap<>());
         final FieldModel actualFieldModel = actionApi.readConfig(fieldModel);
-        final Optional<String> accumulatorNextRun = actualFieldModel.getFieldValue(SchedulingDescriptor.KEY_ACCUMULATOR_NEXT_RUN);
+        final Optional<String> accumulatorNextRun = actualFieldModel.getFieldValue(SchedulingDescriptor.KEY_BLACKDUCK_NEXT_RUN);
         final Optional<String> dailyTaskNextRun = actualFieldModel.getFieldValue(SchedulingDescriptor.KEY_DAILY_PROCESSOR_NEXT_RUN);
         final Optional<String> purgeTaskNextRun = actualFieldModel.getFieldValue(SchedulingDescriptor.KEY_PURGE_DATA_NEXT_RUN);
 


### PR DESCRIPTION
To finish the scheduling page, I needed to add a countdown timer to match our accumulator. I did that and fixed the actual countdown value. Apparently we were counting down from the BD accumulator which ran after 60 seconds but the ondemand task runs every 10 seconds.

The only issue with this change is the countdown field takes a bit longer than all the other fields to display a value for some reason. That can be fixed some time in the future if necessary.