### PR TITLE
Delete BlackDuck Projects on delete

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckProviderDescriptorActionApi.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckProviderDescriptorActionApi.java
@@ -23,6 +23,7 @@
 package com.synopsys.integration.alert.provider.blackduck.descriptor;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
@@ -35,11 +36,14 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.common.descriptor.action.DescriptorActionApi;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldAccessor;
+import com.synopsys.integration.alert.common.persistence.accessor.ProviderDataAccessor;
+import com.synopsys.integration.alert.common.persistence.model.ProviderProject;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.rest.model.TestConfigModel;
 import com.synopsys.integration.alert.common.workflow.task.ScheduledTask;
 import com.synopsys.integration.alert.common.workflow.task.TaskManager;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
+import com.synopsys.integration.alert.provider.blackduck.BlackDuckProvider;
 import com.synopsys.integration.alert.provider.blackduck.tasks.BlackDuckAccumulator;
 import com.synopsys.integration.alert.provider.blackduck.tasks.BlackDuckProjectSyncTask;
 import com.synopsys.integration.alert.workflow.startup.SystemValidator;
@@ -61,12 +65,15 @@ public class BlackDuckProviderDescriptorActionApi extends DescriptorActionApi {
     private final BlackDuckProperties blackDuckProperties;
     private final SystemValidator systemValidator;
     private final TaskManager taskManager;
+    private final ProviderDataAccessor providerDataAccessor;
 
     @Autowired
-    public BlackDuckProviderDescriptorActionApi(final BlackDuckProperties blackDuckProperties, final SystemValidator systemValidator, final TaskManager taskManager) {
+    public BlackDuckProviderDescriptorActionApi(final BlackDuckProperties blackDuckProperties, final SystemValidator systemValidator, final TaskManager taskManager,
+        final ProviderDataAccessor providerDataAccessor) {
         this.blackDuckProperties = blackDuckProperties;
         this.systemValidator = systemValidator;
         this.taskManager = taskManager;
+        this.providerDataAccessor = providerDataAccessor;
     }
 
     @Override
@@ -130,6 +137,10 @@ public class BlackDuckProviderDescriptorActionApi extends DescriptorActionApi {
     public FieldModel deleteConfig(final FieldModel fieldModel) {
         taskManager.unScheduleTask(BlackDuckAccumulator.TASK_NAME);
         taskManager.unScheduleTask(BlackDuckProjectSyncTask.TASK_NAME);
+
+        final List<ProviderProject> blackDuckProjects = providerDataAccessor.findByProviderName(BlackDuckProvider.COMPONENT_NAME);
+        providerDataAccessor.deleteProjects(BlackDuckProvider.COMPONENT_NAME, blackDuckProjects);
+
         return super.deleteConfig(fieldModel);
     }
 }


### PR DESCRIPTION
Using DescriptorActionApi, I delete all projects associated with BlackDuck when a used deletes their one and only BD global config. This is what it looks like when you try testing with deleted projects.

![Screen Shot 2019-04-30 at 3 44 02 PM](https://user-images.githubusercontent.com/6484349/56989623-e684b500-6b60-11e9-9ecd-76d6b0b1040f.png)
