### PR TITLE
Fix(js): Adjust cancel button and remove the navigation headers for m…

### DIFF
--- a/src/main/css/app.scss
+++ b/src/main/css/app.scss
@@ -281,13 +281,22 @@ form.form-horizontal.loginForm {
 }
 
 .progressContainer {
+  display: inline-block;
   width: 30px;
   height: 30px;
+  margin: 0px;
+  border-radius: 3px;
+  border: 1px solid transparent;
 }
 
 .progressIcon {
   display: inline;
   margin: 0 10px;
+}
+
+.configButtonContainer {
+  display: block;
+  margin: 0px auto;
 }
 
 .missingBlackDuckData {
@@ -324,3 +333,4 @@ form.form-horizontal.loginForm {
 .pull-right {
   float: right;
 }
+

--- a/src/main/js/Navigation.js
+++ b/src/main/js/Navigation.js
@@ -13,7 +13,7 @@ class Navigation extends Component {
         this.createNavItemForDescriptors = this.createNavItemForDescriptors.bind(this);
     }
 
-    createNavItemForDescriptors(descriptorType, context, uriPrefix) {
+    createNavItemForDescriptors(descriptorType, context, uriPrefix, header) {
         const { descriptors } = this.props;
         if (!descriptors) {
             return null;
@@ -23,17 +23,24 @@ class Navigation extends Component {
             return null;
         }
 
-        return descriptorList.map(component =>
+        const contentList = descriptorList.map(component =>
             (<li key={component.name}>
                 <NavLink to={`${uriPrefix}${component.urlName}`} activeClassName="activeNav">
                     <FontAwesomeIcon icon={component.fontAwesomeIcon} fixedWidth /> {component.label}
                 </NavLink>
             </li>));
+
+        if (contentList && contentList.length > 0) {
+            contentList.unshift(<li className="navHeader">
+                {header}
+            </li>);
+        }
+        return contentList;
     }
 
     render() {
-        const channelGlobals = this.createNavItemForDescriptors(DescriptorUtilities.DESCRIPTOR_TYPE.CHANNEL, DescriptorUtilities.CONTEXT_TYPE.GLOBAL, '/alert/channels/');
-        const providers = this.createNavItemForDescriptors(DescriptorUtilities.DESCRIPTOR_TYPE.PROVIDER, DescriptorUtilities.CONTEXT_TYPE.GLOBAL, '/alert/providers/');
+        const channelGlobals = this.createNavItemForDescriptors(DescriptorUtilities.DESCRIPTOR_TYPE.CHANNEL, DescriptorUtilities.CONTEXT_TYPE.GLOBAL, '/alert/channels/', 'Channels');
+        const providers = this.createNavItemForDescriptors(DescriptorUtilities.DESCRIPTOR_TYPE.PROVIDER, DescriptorUtilities.CONTEXT_TYPE.GLOBAL, '/alert/providers/', 'Providers');
         const components = this.createNavItemForDescriptors(DescriptorUtilities.DESCRIPTOR_TYPE.COMPONENT, DescriptorUtilities.CONTEXT_TYPE.GLOBAL, '/alert/components/');
 
         return (
@@ -43,13 +50,7 @@ class Navigation extends Component {
                 </div>
                 <div className="navigationContent">
                     <ul>
-                        <li className="navHeader">
-                            Providers
-                        </li>
                         {providers}
-                        <li className="navHeader">
-                            Channels
-                        </li>
                         {channelGlobals}
                         <li className="navHeader">
                             Jobs

--- a/src/main/js/component/common/ConfigButtons.js
+++ b/src/main/js/component/common/ConfigButtons.js
@@ -16,7 +16,7 @@ class ConfigButtons extends Component {
                 <GeneralButton id="generalButton" onClick={onTestClick}>{testLabel}</GeneralButton>
             </div>);
         }
-        return <div></div>
+        return null;
     }
 
     createSaveButton() {
@@ -25,7 +25,7 @@ class ConfigButtons extends Component {
         if (includeSave) {
             return <SubmitButton id="submitButton">{submitLabel}</SubmitButton>
         }
-        return <div></div>
+        return null;
 
     }
 
@@ -35,38 +35,50 @@ class ConfigButtons extends Component {
         if (includeCancel) {
             return <CancelButton id="cancelButton" onClick={onCancelClick}>{cancelLabel}</CancelButton>
         }
-        return <div></div>
+        return null;
+    }
+
+    createButtonContent() {
+        const {
+            isFixed, performingAction
+        } = this.props;
+        const testButton = this.createTestButton();
+        const saveButton = this.createSaveButton();
+        const cancelButton = this.createCancelButton();
+        const buttonContainerClass = isFixed ? '' : 'configButtonContainer';
+        return (
+            <div className={buttonContainerClass}>
+                <div className="progressContainer">
+                    <div className="progressIcon">
+                        {performingAction &&
+                        <span className="fa fa-spinner fa-spin" aria-hidden="true" />
+                        }
+                    </div>
+                </div>
+                {testButton}
+                {saveButton}
+                {cancelButton}
+            </div>
+        );
     }
 
     render() {
         const {
-            isFixed, performingAction
+            isFixed
         } = this.props;
 
-        let fixedStyle = null;
+        let fixedStyle = '';
         if (isFixed) {
             fixedStyle = 'fixedButtonGroup';
         }
         const wrapperStyles = `${fixedStyle} d-inline-flex offset-sm-3 col-sm-8`;
-        const testButton = this.createTestButton();
-        const saveButton = this.createSaveButton();
-        const cancelButton = this.createCancelButton();
         return (
             <div className="form-group">
                 {isFixed &&
                 <div className="fixedButtonGroupBuffer" />
                 }
                 <div className={wrapperStyles}>
-                    <div className="progressContainer">
-                        <div className="progressIcon">
-                            {performingAction &&
-                            <span className="fa fa-spinner fa-spin" aria-hidden="true" />
-                            }
-                        </div>
-                    </div>
-                    {testButton}
-                    {saveButton}
-                    {cancelButton}
+                    {this.createButtonContent()}
                 </div>
             </div>
         );


### PR DESCRIPTION
Clean up where the cancel button is rendered when a user doesn't have permissions to test or save.

Remove the headers for Providers and Channels if the user cannot read the provider and channel global configuration.