### PR TITLE
Ps icon refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -914,15 +914,18 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.18.tgz",
       "integrity": "sha512-834DrzO2Ne3upCW+mJJPC/E6BsFcj+2Z1HmPIhbpbj8UaKmXWum4NClqLpUiMetugRlHuG4jbIHNdv2/lc3c1Q=="
     },
-    "@fortawesome/fontawesome-free": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.8.2.tgz",
-      "integrity": "sha512-E4fDUF4fbu9AxKpaQQqCN3XBnNzb/5e0Gvd9OaQsYkK574LVI57v/EqqPfIm/mC7jYbxaPNrhvT5AF+Yzwyizg=="
-    },
     "@fortawesome/fontawesome-svg-core": {
       "version": "1.2.18",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.18.tgz",
       "integrity": "sha512-1vyLWVQqxQ8q8bA2zgZcljk3RkeELlDJ757ymLk+ebK019AFgEFH5kTnR5OMN1SFsTwW1OHlFQO3VufdeCg/Gg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.18"
+      }
+    },
+    "@fortawesome/free-brands-svg-icons": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.8.2.tgz",
+      "integrity": "sha512-nhEWctDOP6f+Ka10LXAFoF+6mtWidC2iQgTBGRGgydmhBtcIEwyxWVx5wQHa86A1zAMi5TnipDAYQs2qn7DD6A==",
       "requires": {
         "@fortawesome/fontawesome-common-types": "^0.2.18"
       }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/blackducksoftware/blackduck-alert.git",
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^5.8.2",
     "@fortawesome/fontawesome-svg-core": "^1.2.18",
     "@fortawesome/free-solid-svg-icons": "^5.8.2",
+    "@fortawesome/free-brands-svg-icons": "^5.8.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "bootstrap": "^4.3.1",
     "enzyme": "^3.7.0",

--- a/src/main/css/app.scss
+++ b/src/main/css/app.scss
@@ -334,3 +334,7 @@ form.form-horizontal.loginForm {
   float: right;
 }
 
+.alert-icon {
+  padding: 3px;
+}
+

--- a/src/main/java/com/synopsys/integration/alert/channel/jira/descriptor/JiraDescriptor.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/jira/descriptor/JiraDescriptor.java
@@ -34,10 +34,11 @@ public class JiraDescriptor extends ChannelDescriptor {
     public static final String KEY_JIRA_USERNAME = "jira.user.name";
     public static final String KEY_JIRA_ACCESS_TOKEN = "jira.access.token";
 
-    public static final String JIRA_LABEL = "Jira";
+    public static final String JIRA_LABEL = "Jira Cloud";
     public static final String JIRA_URL = "jira";
-    public static final String JIRA_ICON = "fab,jira";
-    public static final String JIRA_DESCRIPTION = "This page allows you to configure the Jira server that Alert will send issue updates to.";
+    // brands are in the fab icon set use the / character to delimit the icon set.
+    public static final String JIRA_ICON = "fab/jira";
+    public static final String JIRA_DESCRIPTION = "This page allows you to configure the Jira Cloud instance that Alert will send issue updates to.";
 
     @Autowired
     public JiraDescriptor(final JiraGlobalUIConfig globalUIConfig, final JiraDistributionUIConfig distributionUIConfig) {

--- a/src/main/java/com/synopsys/integration/alert/channel/jira/descriptor/JiraDescriptor.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/jira/descriptor/JiraDescriptor.java
@@ -36,7 +36,7 @@ public class JiraDescriptor extends ChannelDescriptor {
 
     public static final String JIRA_LABEL = "Jira";
     public static final String JIRA_URL = "jira";
-    public static final String JIRA_ICON = "jira";
+    public static final String JIRA_ICON = "fab,jira";
     public static final String JIRA_DESCRIPTION = "This page allows you to configure the Jira server that Alert will send issue updates to.";
 
     @Autowired

--- a/src/main/java/com/synopsys/integration/alert/channel/slack/descriptor/SlackDescriptor.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/slack/descriptor/SlackDescriptor.java
@@ -36,7 +36,8 @@ public class SlackDescriptor extends ChannelDescriptor {
 
     public static final String SLACK_LABEL = "Slack";
     public static final String SLACK_URL = "slack";
-    public static final String SLACK_ICON = "fab,slack";
+    // brands are in the fab icon set use the / character to delimit the icon set.
+    public static final String SLACK_ICON = "fab/slack";
 
     @Autowired
     public SlackDescriptor(final SlackUIConfig slackUIConfig) {

--- a/src/main/java/com/synopsys/integration/alert/channel/slack/descriptor/SlackDescriptor.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/slack/descriptor/SlackDescriptor.java
@@ -36,7 +36,7 @@ public class SlackDescriptor extends ChannelDescriptor {
 
     public static final String SLACK_LABEL = "Slack";
     public static final String SLACK_URL = "slack";
-    public static final String SLACK_ICON = "slack";
+    public static final String SLACK_ICON = "fab,slack";
 
     @Autowired
     public SlackDescriptor(final SlackUIConfig slackUIConfig) {

--- a/src/main/js/App.js
+++ b/src/main/js/App.js
@@ -3,21 +3,17 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
-import '@fortawesome/fontawesome-free/scss/fontawesome.scss';
-import '@fortawesome/fontawesome-free/scss/v4-shims.scss';
-import '@fortawesome/fontawesome-free/js/all.js';
-import '@fortawesome/fontawesome-free/js/v4-shims.js';
-
 import MainPage from 'MainPage';
 import LoginPage from 'LoginPage';
 import AboutInfoFooter from 'component/AboutInfoFooter';
 import SetupPage from 'SetupPage';
 import { verifyLogin } from 'store/actions/session';
 import { getInitialSystemSetup } from 'store/actions/system';
-
+import * as IconUtility from 'util/iconUtility';
 import LogoutPage from 'LogoutPage';
 import '../css/main.scss';
 
+IconUtility.loadIconData();
 
 class App extends Component {
     componentDidMount() {

--- a/src/main/js/LoginPage.js
+++ b/src/main/js/LoginPage.js
@@ -8,6 +8,7 @@ import Header from 'component/common/Header';
 import { login } from 'store/actions/session';
 import { hideResetModal, sendPasswordResetEmail, showResetModal } from 'store/actions/system';
 import ResetPasswordModal from './component/common/ResetPasswordModal';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 class LoginPage extends Component {
     constructor(props) {
@@ -79,7 +80,7 @@ class LoginPage extends Component {
                                     <SubmitButton id="loginSubmit">Login</SubmitButton>
                                     <div className="progressIcon">
                                         {this.props.loggingIn &&
-                                        <span className="fa fa-spinner fa-spin" aria-hidden="true" />
+                                        <FontAwesomeIcon icon="spinner" className="alert-icon" size="lg" spin />
                                         }
                                         {!this.props.loggingIn &&
                                         <span>&nbsp;&nbsp;</span>

--- a/src/main/js/Navigation.js
+++ b/src/main/js/Navigation.js
@@ -2,10 +2,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { NavLink, withRouter } from 'react-router-dom';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Logo from 'component/common/Logo';
 import { confirmLogout } from 'store/actions/session';
 import * as DescriptorUtilities from 'util/descriptorUtilities';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 class Navigation extends Component {
     constructor(props) {
@@ -26,9 +26,10 @@ class Navigation extends Component {
         const contentList = descriptorList.map(component =>
             (<li key={component.name}>
                 <NavLink to={`${uriPrefix}${component.urlName}`} activeClassName="activeNav">
-                    <FontAwesomeIcon icon={component.fontAwesomeIcon} fixedWidth /> {component.label}
+                    <FontAwesomeIcon icon={component.fontAwesomeIcon} size="lg" fixedWidth /> {component.label}
                 </NavLink>
-            </li>));
+            </li>)
+        );
 
         if (contentList && contentList.length > 0) {
             contentList.unshift(<li className="navHeader">
@@ -57,14 +58,14 @@ class Navigation extends Component {
                         </li>
                         <li>
                             <NavLink to="/alert/jobs/distribution" activeClassName="activeNav">
-                                <FontAwesomeIcon icon="truck" fixedWidth /> Distribution
+                                <FontAwesomeIcon icon="truck" className="alert-icon" size="lg" fixedWidth /> Distribution
                             </NavLink>
                         </li>
                         <li className="divider" />
                         {components}
                         <li>
                             <NavLink to="/alert/general/about" activeClassName="activeNav">
-                                <FontAwesomeIcon icon="info" fixedWidth /> About
+                                <FontAwesomeIcon icon="info" className="alert-icon" size="lg" fixedWidth /> About
                             </NavLink>
                         </li>
                         <li className="logoutLink">
@@ -76,7 +77,7 @@ class Navigation extends Component {
                                     this.props.confirmLogout();
                                 }}
                             >
-                                <FontAwesomeIcon icon="sign-out-alt" fixedWidth /> Logout
+                                <FontAwesomeIcon icon="sign-out-alt" className="alert-icon" size="lg" fixedWidth /> Logout
                             </a>
                         </li>
                     </ul>

--- a/src/main/js/Navigation.js
+++ b/src/main/js/Navigation.js
@@ -6,6 +6,7 @@ import Logo from 'component/common/Logo';
 import { confirmLogout } from 'store/actions/session';
 import * as DescriptorUtilities from 'util/descriptorUtilities';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import * as IconUtility from 'util/iconUtility';
 
 class Navigation extends Component {
     constructor(props) {
@@ -26,7 +27,7 @@ class Navigation extends Component {
         const contentList = descriptorList.map(component =>
             (<li key={component.name}>
                 <NavLink to={`${uriPrefix}${component.urlName}`} activeClassName="activeNav">
-                    <FontAwesomeIcon icon={component.fontAwesomeIcon} size="lg" fixedWidth /> {component.label}
+                    <FontAwesomeIcon icon={IconUtility.createIconPath(component.fontAwesomeIcon)} size="lg" fixedWidth /> {component.label}
                 </NavLink>
             </li>)
         );

--- a/src/main/js/component/AboutInfo.js
+++ b/src/main/js/component/AboutInfo.js
@@ -6,6 +6,7 @@ import ReadOnlyField from 'field/ReadOnlyField';
 import { getAboutInfo } from 'store/actions/about';
 import * as DescriptorUtilities from 'util/descriptorUtilities';
 import ConfigurationLabel from 'component/common/ConfigurationLabel';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 class AboutInfo extends React.Component {
     componentDidMount() {
@@ -13,10 +14,8 @@ class AboutInfo extends React.Component {
     }
 
     iconColumnRenderer(cell) {
-        const altText = cell;
         const keyText = `aboutIconKey-${cell}`;
-        const classNameText = `fa fa-${cell}`;
-        return (<span key={keyText} alt={altText} className={classNameText} aria-hidden="true" />);
+        return (<FontAwesomeIcon key={keyText} icon={cell} className="alert-icon" size="lg" />);
     }
 
     createDescriptorTable(tableData) {

--- a/src/main/js/component/AboutInfo.js
+++ b/src/main/js/component/AboutInfo.js
@@ -7,6 +7,7 @@ import { getAboutInfo } from 'store/actions/about';
 import * as DescriptorUtilities from 'util/descriptorUtilities';
 import ConfigurationLabel from 'component/common/ConfigurationLabel';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import * as IconUtility from 'util/iconUtility';
 
 class AboutInfo extends React.Component {
     componentDidMount() {
@@ -15,7 +16,7 @@ class AboutInfo extends React.Component {
 
     iconColumnRenderer(cell) {
         const keyText = `aboutIconKey-${cell}`;
-        return (<FontAwesomeIcon key={keyText} icon={cell} className="alert-icon" size="lg" />);
+        return (<FontAwesomeIcon key={keyText} icon={IconUtility.createIconPath(cell)} className="alert-icon" size="lg" />);
     }
 
     createDescriptorTable(tableData) {

--- a/src/main/js/component/AboutInfoFooter.js
+++ b/src/main/js/component/AboutInfoFooter.js
@@ -10,6 +10,7 @@ import { getLatestMessages } from 'store/actions/system';
 import '../../css/footer.scss';
 import '../../css/messages.scss';
 import '../../css/logos.scss';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 
 class AboutInfoFooter extends React.Component {
@@ -46,9 +47,9 @@ class AboutInfoFooter extends React.Component {
     getFontAwesomeIcon() {
         const { latestMessages } = this.props;
         if (this.hasErrorMessages(latestMessages) || this.hasWarninigMessages(latestMessages)) {
-            return 'fa fa-exclamation-triangle';
+            return 'exclamation-triangle';
         }
-        return 'fa fa-check-circle';
+        return 'check-circle';
     }
 
     getIconColor() {
@@ -114,7 +115,7 @@ class AboutInfoFooter extends React.Component {
                     }}
                     onClick={this.handleOverlayButton}
                 >
-                    <div className={iconColor}><span className={iconClassName} /></div>
+                    <div className={iconColor}><FontAwesomeIcon icon={iconClassName} className="alert-icon" size="lg" /></div>
                 </div>
                 {overlayComponent}
             </div>

--- a/src/main/js/component/common/CollapsiblePane.js
+++ b/src/main/js/component/common/CollapsiblePane.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 class CollapsiblePane extends Component {
     constructor(props) {
@@ -26,14 +27,14 @@ class CollapsiblePane extends Component {
         }
 
         const contentClass = shouldExpand ? 'shown' : 'hidden';
-        const iconClass = shouldExpand ? 'fa-minus' : 'fa-plus';
+        const iconClass = shouldExpand ? 'minus' : 'plus';
         return (
             <div className="collapsiblePanel">
                 <button
                     type="button"
                     className="btn btn-link"
                     onClick={this.toggleDisplay}>
-                    <span className={`fa ${iconClass} icon`} aria-hidden="true" />
+                    <FontAwesomeIcon icon={iconClass} className='icon' size="lg" />
                     {this.props.title}
                 </button>
                 <div className={contentClass}>

--- a/src/main/js/component/common/ConfigButtons.js
+++ b/src/main/js/component/common/ConfigButtons.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import CancelButton from 'field/input/CancelButton';
 import SubmitButton from 'field/input/SubmitButton';
 import GeneralButton from 'field/input/GeneralButton';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 class ConfigButtons extends Component {
 
@@ -51,7 +52,7 @@ class ConfigButtons extends Component {
                 <div className="progressContainer">
                     <div className="progressIcon">
                         {performingAction &&
-                        <span className="fa fa-spinner fa-spin" aria-hidden="true" />
+                        <FontAwesomeIcon icon="spinner" className="alert-icon" size="lg" spin />
                         }
                     </div>
                 </div>

--- a/src/main/js/component/common/ConfigurationLabel.js
+++ b/src/main/js/component/common/ConfigurationLabel.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Tooltip from 'react-bootstrap/Tooltip';
 import Overlay from 'react-bootstrap/Overlay';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 class ConfigurationLabel extends Component {
     constructor(props) {
@@ -22,12 +22,14 @@ class ConfigurationLabel extends Component {
             descriptionField = (
                 <div className="d-inline-flex">
                     <span
-                        className="fa fa-question-circle configurationDescriptionIcon"
+                        className="configurationDescriptionIcon"
                         onClick={() => this.setState({ showDescription: !showDescription })}
                         ref={(icon) => {
                             this.target = icon;
                         }}
-                    />
+                    >
+                        <FontAwesomeIcon icon="question-circle" className="alert-icon" size="lg" />
+                    </span>
                     <Overlay
                         rootClose
                         placement="bottom"
@@ -47,7 +49,7 @@ class ConfigurationLabel extends Component {
         return (
             <div className="d-inline-flex col-sm-4">
                 <h1>
-                    <FontAwesomeIcon icon={fontAwesomeIcon} fixedWidth />
+                    <FontAwesomeIcon icon={fontAwesomeIcon} className="alert-icon" size="lg" fixedWidth />
                     {configurationName}
                     {descriptionField}
                 </h1>

--- a/src/main/js/component/common/ConfigurationLabel.js
+++ b/src/main/js/component/common/ConfigurationLabel.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Tooltip from 'react-bootstrap/Tooltip';
 import Overlay from 'react-bootstrap/Overlay';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import * as IconUtility from 'util/iconUtility';
 
 class ConfigurationLabel extends Component {
     constructor(props) {
@@ -49,7 +50,7 @@ class ConfigurationLabel extends Component {
         return (
             <div className="d-inline-flex col-sm-4">
                 <h1>
-                    <FontAwesomeIcon icon={fontAwesomeIcon} className="alert-icon" size="lg" fixedWidth />
+                    <FontAwesomeIcon icon={IconUtility.createIconPath(fontAwesomeIcon)} className="alert-icon" size="lg" fixedWidth />
                     {configurationName}
                     {descriptionField}
                 </h1>

--- a/src/main/js/component/common/DescriptorLabel.js
+++ b/src/main/js/component/common/DescriptorLabel.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import * as IconUtility from 'util/iconUtility';
 
 function DescriptorLabel(props) {
     const { descriptor, keyPrefix } = props;
@@ -8,7 +9,7 @@ function DescriptorLabel(props) {
     const cellText = descriptor.label;
     return (
         <div className="inline">
-            <FontAwesomeIcon key={elementKey} icon={descriptor.fontAwesomeIcon} className="alert-icon" size="lg" />
+            <FontAwesomeIcon key={elementKey} icon={IconUtility.createIconPath(descriptor.fontAwesomeIcon)} className="alert-icon" size="lg" />
             {cellText}
         </div>);
 }

--- a/src/main/js/component/common/DescriptorLabel.js
+++ b/src/main/js/component/common/DescriptorLabel.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 function DescriptorLabel(props) {
     const { descriptor, keyPrefix } = props;
-    const icon = `fa fa-${descriptor.fontAwesomeIcon} fa-fw`;
     const elementKey = `${keyPrefix}-${descriptor.label}`;
     const cellText = descriptor.label;
     return (
         <div className="inline">
-            <span key={elementKey} className={icon} aria-hidden="true" />
+            <FontAwesomeIcon key={elementKey} icon={descriptor.fontAwesomeIcon} className="alert-icon" size="lg" />
             {cellText}
         </div>);
 }

--- a/src/main/js/component/common/DescriptorOption.js
+++ b/src/main/js/component/common/DescriptorOption.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 function DescriptorOption(props) {
-    const fontAwesomeIcon = `fa fa-${props.icon} fa-fw`;
-    const formattedIcon = (<span key={`icon-${props.value}`} className={fontAwesomeIcon} aria-hidden="true" />);
+    const formattedIcon = (<FontAwesomeIcon key={`icon-${props.value}`} icon={props.icon} className="alert-icon" size="lg" />);
     const icon = props.icon != null ? formattedIcon : null;
     return (
         <div>

--- a/src/main/js/component/common/DescriptorOption.js
+++ b/src/main/js/component/common/DescriptorOption.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import * as IconUtility from 'util/iconUtility';
 
 function DescriptorOption(props) {
-    const formattedIcon = (<FontAwesomeIcon key={`icon-${props.value}`} icon={props.icon} className="alert-icon" size="lg" />);
+    const formattedIcon = (<FontAwesomeIcon key={`icon-${props.value}`} icon={IconUtility.createIconPath(props.icon)} className="alert-icon" size="lg" />);
     const icon = props.icon != null ? formattedIcon : null;
     return (
         <div>

--- a/src/main/js/component/common/EditTableCellFormatter.js
+++ b/src/main/js/component/common/EditTableCellFormatter.js
@@ -23,7 +23,7 @@ class EditTableCellFormatter extends Component {
         }
 
         return (
-            <button className={buttonClass} type="button" title={this.props.buttonText} onClick={this.onClick}><FontAwesomeIcon icon="pencil-alt" className="alert-icon" /></button>
+            <button className={buttonClass} type="button" title={this.props.buttonText} onClick={this.onClick}><FontAwesomeIcon icon="pencil-alt" className="alert-icon" size="lg" /></button>
         );
     }
 }

--- a/src/main/js/component/common/EditTableCellFormatter.js
+++ b/src/main/js/component/common/EditTableCellFormatter.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 class EditTableCellFormatter extends Component {
     constructor(props) {
@@ -22,7 +23,7 @@ class EditTableCellFormatter extends Component {
         }
 
         return (
-            <button className={buttonClass} type="button" title={this.props.buttonText} onClick={this.onClick}><span className="fa fa-pencil-alt" /></button>
+            <button className={buttonClass} type="button" title={this.props.buttonText} onClick={this.onClick}><FontAwesomeIcon icon="pencil-alt" className="alert-icon" /></button>
         );
     }
 }

--- a/src/main/js/component/common/NotificationTypeLegend.js
+++ b/src/main/js/component/common/NotificationTypeLegend.js
@@ -1,16 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-const policyViolationIcon = <span key="policyViolationIcon" alt="Policy Violation" className="fa fa-ban fa-fw policyViolation" aria-hidden="true" />;
-const policyViolationClearedIcon = <span key="policyViolationClearedIcon" alt="Policy Violation Cleared" className="fa fa-eraser fa-fw policyViolationCleared" aria-hidden="true" />;
-const policyViolationOverrideIcon = <span key="policyViolationOverrideIcon" alt="Policy Override" className="fa fa-exclamation-circle fa-fw policyViolationOverride" aria-hidden="true" />;
-const highVulnerabilityIcon = <span key="highVulnerabilityIcon" alt="High Vulnerability" className="fa fa-shield fa-fw highVulnerability" aria-hidden="true" />;
-const mediumVulnerabilityIcon = <span key="mediumVulnerabilityIcon" alt="Medium Vulnerability" className="fa fa-shield fa-fw mediumVulnerability" aria-hidden="true" />;
-const lowVulnerabilityIcon = <span key="lowVulnerabilityIcon" alt="Low Vulnerability" className="fa fa-shield fa-fw lowVulnerability" aria-hidden="true" />;
-const vulnerabilityIcon = <span key="vulnerabilityIcon" alt="Vulnerability" className="fa fa-shield fa-fw highVulnerability" aria-hidden="true" />;
-const issueCountIncreasedIcon = <span key="issueCountIncreasing" alt="Issue Count Increased" className="fa fa-angle-double-up fa-lg fa-fw issueCountIncreased" aria-hidden="true" />;
-const issueCountDecreasedIcon = <span key="issueCountDecreased" alt="Issue Count Decreased" className="fa fa-angle-double-down fa-lg fa-fw issueCountDecreased" aria-hidden="true" />;
+const policyViolationIcon = <span key="policyViolationIcon" alt="Policy Violation" className="fa-layers fa-fw policyViolation"><FontAwesomeIcon icon="ban" className="alert-icon" size="lg" /></span>;
+const policyViolationClearedIcon = <span key="policyViolationClearedIcon" alt="Policy Violation Cleared" className="fa-layers fa-fw policyViolationCleared"><FontAwesomeIcon icon="eraser" className="alert-icon" size="lg" /></span>;
+const policyViolationOverrideIcon = <span key="policyViolationOverrideIcon" alt="Policy Override" className="fa-layers fa-fw policyViolationOverride"><FontAwesomeIcon icon="exclamation-circle" className="alert-icon" size="lg" /></span>;
+const highVulnerabilityIcon = <span key="highVulnerabilityIcon" alt="High Vulnerability" className="fa-layers fa-fw highVulnerability"><FontAwesomeIcon icon="shield-alt" className="alert-icon" size="lg" /></span>;
+const mediumVulnerabilityIcon = <span key="mediumVulnerabilityIcon" alt="Medium Vulnerability" className="fa-layers fa-fw mediumVulnerability"><FontAwesomeIcon icon="shield-alt" className="alert-icon" size="lg" /></span>;
+const lowVulnerabilityIcon = <span key="lowVulnerabilityIcon" alt="Low Vulnerability" className="fa-layers fa-fw lowVulnerability"><FontAwesomeIcon icon="shield-alt" className="alert-icon" size="lg" /></span>;
+const vulnerabilityIcon = <span key="vulnerabilityIcon" alt="Vulnerability" className="fa-layers fa-fw highVulnerability"><FontAwesomeIcon icon="shield-alt" className="alert-icon" size="lg" /></span>;
+const issueCountIncreasedIcon = <span key="issueCountIncreasing" alt="Issue Count Increased" className="fa-layers fa-fw issueCountIncreased"><FontAwesomeIcon icon="angle-double-up" className="alert-icon" size="lg" /></span>;
+const issueCountDecreasedIcon = <span key="issueCountDecreased" alt="Issue Count Decreased" className="fa-layers fa-fw issueCountDecreased"><FontAwesomeIcon icon="angle-double-down" className="alert-icon" size="lg" /></span>;
 const licenseLimitIcon = <span key="licenseLimit" alt="License Limit" className="fa fa-database fa-fw licenseLimit" aria-hidden="true" />;
 
 const NotificationTypeLegend = ({

--- a/src/main/js/component/common/RefreshTableCellFormatter.js
+++ b/src/main/js/component/common/RefreshTableCellFormatter.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 const RefreshTableCellFormatter = ({ handleButtonClicked, currentRowSelected }) => (
     <button
@@ -11,7 +12,7 @@ const RefreshTableCellFormatter = ({ handleButtonClicked, currentRowSelected }) 
             handleButtonClicked(currentRowSelected);
         }}
     >
-        <span className="fa fa-sync" />
+        <FontAwesomeIcon icon="sync" className="alert-icon" size="lg" />
     </button>
 );
 

--- a/src/main/js/component/common/ResetPasswordModal.js
+++ b/src/main/js/component/common/ResetPasswordModal.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Modal } from 'react-bootstrap';
 import TextInput from 'field/input/TextInput';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 class ResetPasswordModal extends Component {
     constructor(props) {
@@ -39,7 +40,7 @@ class ResetPasswordModal extends Component {
                 <button id="testSend" type="button" className="btn btn-primary" onClick={this.handlePasswordReset}>Reset Password</button>
                 <div className="progressIcon">
                     {this.props.resettingPassword &&
-                    <span className="fa fa-spinner fa-spin" aria-hidden="true" />
+                    <FontAwesomeIcon icon="spinner" className="alert-icon" size="lg" spin />
                     }
                     {!this.props.resettingPassword &&
                     <span>&nbsp;&nbsp;</span>

--- a/src/main/js/component/common/SystemMessage.js
+++ b/src/main/js/component/common/SystemMessage.js
@@ -1,23 +1,34 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import '../../../css/messages.scss';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 class SystemMessage extends Component {
     getIcon() {
         const { severity } = this.props;
-        const errorIcon = 'fa fa-exclamation-triangle ';
+        const errorIcon = 'exclamation-triangle ';
         if (severity === 'ERROR') {
-            return `${errorIcon} errorStatus`;
+            return `${errorIcon}`;
         } else if (severity === 'WARNING') {
-            return `${errorIcon} warningStatus`;
+            return `${errorIcon}`;
         }
-        return 'fa fa-check-circle validStatus';
+        return 'check-circle';
+    }
+
+    getClassName() {
+        const { severity } = this.props;
+        if (severity === 'ERROR') {
+            return 'errorStatus';
+        } else if (severity === 'WARNING') {
+            return 'warningStatus';
+        }
+        return 'validStatus';
     }
 
     render() {
         const { createdAt, content, severity } = this.props;
         return (<div className="messageHeader">
-            <span className={this.getIcon()} aria-hidden="true" title={severity} /><span className="messageDate">{createdAt}</span>
+            <FontAwesomeIcon icon={this.getIcon()} className={`alert-icon ${this.getClassName()}`} size="lg" title={severity} /><span className="messageDate">{createdAt}</span>
             <div>{content}</div>
         </div>);
     }

--- a/src/main/js/distribution/Index.js
+++ b/src/main/js/distribution/Index.js
@@ -12,6 +12,7 @@ import JobDeleteModal from 'distribution/JobDeleteModal';
 import * as FieldModelUtilities from 'util/fieldModelUtilities';
 import ConfigurationLabel from 'component/common/ConfigurationLabel';
 import DistributionConfiguration from 'dynamic/DistributionConfiguration';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 /**
  * Selects className based on field value
@@ -188,7 +189,6 @@ class Index extends Component {
 
     createCustomButtonGroup(buttons) {
         const classes = 'btn btn-md btn-info react-bs-table-add-btn tableButton';
-        const fontAwesomeIcon = 'fa fa-sync fa-fw';
         const insertOnClick = buttons.insertBtn ? buttons.insertBtn.props.onClick : null;
         const deleteOnClick = buttons.deleteBtn ? buttons.deleteBtn.props.onClick : null;
         const reloadEntries = () => this.reloadJobs();
@@ -196,7 +196,7 @@ class Index extends Component {
         if (!this.props.autoRefresh) {
             refreshButton = (
                 <button type="button" tabIndex={0} className={classes} onClick={reloadEntries}>
-                    <span className={fontAwesomeIcon} aria-hidden="true" />Refresh
+                    <FontAwesomeIcon icon="sync" className="alert-icon" size="lg" />Refresh
                 </button>
             );
         }
@@ -204,13 +204,13 @@ class Index extends Component {
             <div>
                 {buttons.insertBtn
                 && <InsertButton className="addJobButton btn-md" onClick={insertOnClick}>
-                    <span className="fa fa-plus" />
+                    <FontAwesomeIcon icon="plus" className="alert-icon" size="lg" />
                     New
                 </InsertButton>
                 }
                 {buttons.deleteBtn
                 && <DeleteButton className="deleteJobButton btn-md" onClick={deleteOnClick}>
-                    <span className="fa fa-trash" />
+                    <FontAwesomeIcon icon="trash" className="alert-icon" size="lg" />
                     Delete
                 </DeleteButton>
                 }
@@ -364,7 +364,7 @@ class Index extends Component {
 
                 {this.props.inProgress &&
                 <div className="progressIcon">
-                    <span className="fa fa-spinner fa-spin" aria-hidden="true" />
+                    <FontAwesomeIcon icon="spinner" className="alert-icon" size="lg" spin />
                 </div>
                 }
 

--- a/src/main/js/distribution/ProjectConfiguration.js
+++ b/src/main/js/distribution/ProjectConfiguration.js
@@ -3,13 +3,19 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { BootstrapTable, TableHeaderColumn } from 'react-bootstrap-table';
 import { getProjects } from 'store/actions/projects';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 function assignClassName(row, rowIdx) {
     return 'tableRow';
 }
 
 function assignDataFormat(cell, row) {
-    const cellContent = (row.missing) ? <span className="missingBlackDuckData"><span className="fa fa-exclamation-triangle fa-fw" aria-hidden="true" />{cell}</span> : cell;
+    const cellContent = (row.missing) ? <span className="missingBlackDuckData">
+        <span className="fa-layers fa-fw">
+            <FontAwesomeIcon icon="exclamation-triangle" className="alert-icon" size="lg" />{cell}
+        </span> </span>
+        : cell;
+
 
     if (cell) {
         return <div title={cell.toString()}> {cellContent} </div>;
@@ -186,7 +192,10 @@ class ProjectConfiguration extends Component {
                 </BootstrapTable>
 
                 {this.props.fetching &&
-                <div className="progressIcon"><span className="fa fa-spinner fa-spin fa-fw" aria-hidden="true" />
+                <div className="progressIcon">
+                    <span className="fa-layers fa-fw">
+                        <FontAwesomeIcon icon="spinner" className="alert-icon" size="lg" spin />
+                    </span>
                 </div>}
 
                 {this.props.errorMsg && <p name="projectTableMessage">{this.props.errorMsg}</p>}

--- a/src/main/js/dynamic/ChannelTestModal.js
+++ b/src/main/js/dynamic/ChannelTestModal.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Modal } from 'react-bootstrap';
 import TextInput from 'field/input/TextInput';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 class ChannelTestModal extends Component {
     constructor(props) {
@@ -53,7 +54,7 @@ class ChannelTestModal extends Component {
                     <button id="testSend" type="button" className="btn btn-primary" onClick={this.handleSendTestMessage}>Send Test Message</button>
                     {this.state.show &&
                     <div className="progressIcon">
-                        <span className="fa fa-spinner fa-spin" aria-hidden="true" />
+                        <FontAwesomeIcon icon="spinner" className="alert-icon" size="lg" spin />
                     </div>
                     }
                 </Modal.Footer>

--- a/src/main/js/dynamic/loading/audit/AuditPage.js
+++ b/src/main/js/dynamic/loading/audit/AuditPage.js
@@ -12,6 +12,7 @@ import CheckboxInput from 'field/input/CheckboxInput';
 import * as DescriptorUtilities from 'util/descriptorUtilities';
 import { OPERATIONS } from 'util/descriptorUtilities';
 import ConfigurationLabel from 'component/common/ConfigurationLabel';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import '../../../../css/audit.scss';
 
@@ -282,7 +283,7 @@ class AuditPage extends Component {
             return (<RefreshTableCellFormatter handleButtonClicked={this.onResendClick} currentRowSelected={row}
                                                buttonText="Re-send" />);
         }
-        return (<div className="editJobButtonDisabled"><span className="fa fa-sync" /></div>);
+        return (<div className="editJobButtonDisabled"><FontAwesomeIcon icon="sync" className="alert-icon" size="lg" /></div>);
     }
 
     isResendAllowed() {
@@ -303,7 +304,10 @@ class AuditPage extends Component {
                 {!this.props.autoRefresh &&
                 <div role="button" tabIndex={0} className="btn btn-info react-bs-table-add-btn tableButton"
                      onClick={this.refreshAuditEntries}>
-                    <span className="fa fa-sync fa-fw" aria-hidden="true" /> Refresh
+                    <span>
+                        <FontAwesomeIcon icon="sync" className="alert-icon" size="lg" />
+                        Refresh
+                    </span>
                 </div>
                 }
             </ButtonGroup>
@@ -411,7 +415,9 @@ class AuditPage extends Component {
                     </BootstrapTable>
 
                     {this.props.inProgress && <div className="progressIcon">
-                        <span className="fa fa-spinner fa-spin fa-fw" aria-hidden="true" />
+                        <span className="fa-layers fa-fw">
+                            <FontAwesomeIcon icon="spinner" className="alert-icon" size="lg" spin />
+                        </span>
                     </div>}
 
                     <p name="message">{this.props.message}</p>

--- a/src/main/js/field/LabeledField.js
+++ b/src/main/js/field/LabeledField.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from 'react-bootstrap/Tooltip';
 import Overlay from 'react-bootstrap/Overlay';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 class LabeledField extends Component {
     constructor(props) {
@@ -22,12 +23,14 @@ class LabeledField extends Component {
         if (description) {
             descriptionField = (<div className="d-inline-flex">
                 <span
-                    className="fa fa-question-circle descriptionIcon"
+                    className="descriptionIcon"
                     onClick={() => this.setState({ showDescription: !showDescription })}
                     ref={(icon) => {
                         this.target = icon;
                     }}
-                />
+                >
+                    <FontAwesomeIcon icon="question-circle" className="alert-icon" size="lg" />
+                </span>
                 <Overlay
                     rootClose
                     placement="top"

--- a/src/main/js/util/iconUtility.js
+++ b/src/main/js/util/iconUtility.js
@@ -1,9 +1,16 @@
+// Because Font Awesome now has different icon sets we need to create an array that includes the icon set.
+// the default set is fas the solid icons.  Brands are in the fab set.
+// if the parameter to this function contains a '/' we construct an array from the string splitting on '/' to denote the icon set.
+// if the parameter to this function does not contain a '/' then we use the default icon set.
+// Format:
+// <FA_SET>/<ICON_NAME> = ['<FA_SET>', '<ICON_NAME>']
+// <ICON_NAME> = ['fas', '<ICON_NAME>]'
 export function createIconPath(iconPathData) {
     let path = null;
     if (iconPathData) {
         path = ['fas'];
-        if (iconPathData.includes(',')) {
-            path = iconPathData.split(',');
+        if (iconPathData.includes('/')) {
+            path = iconPathData.split('/');
         } else {
             path.push(iconPathData);
         }

--- a/src/main/js/util/iconUtility.js
+++ b/src/main/js/util/iconUtility.js
@@ -1,3 +1,11 @@
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { fas } from '@fortawesome/free-solid-svg-icons';
+import { fab } from '@fortawesome/free-brands-svg-icons';
+
+export function loadIconData() {
+    library.add(fas, fab);
+}
+
 // Because Font Awesome now has different icon sets we need to create an array that includes the icon set.
 // the default set is fas the solid icons.  Brands are in the fab set.
 // if the parameter to this function contains a '/' we construct an array from the string splitting on '/' to denote the icon set.

--- a/src/main/js/util/iconUtility.js
+++ b/src/main/js/util/iconUtility.js
@@ -1,0 +1,12 @@
+export function createIconPath(iconPathData) {
+    let path = null;
+    if (iconPathData) {
+        path = ['fas'];
+        if (iconPathData.includes(',')) {
+            path = iconPathData.split(',');
+        } else {
+            path.push(iconPathData);
+        }
+    }
+    return path;
+}


### PR DESCRIPTION
- Update the Font Awesome icon usage to the FontAwesomeIcon React component to make it consistent. 
- Change the icon paths for slack and jira to have the icon set name before the icon name i.e. 'fab/sack' and 'fab/jira' 
- Create a utility to construct the array that FontAwesomeIcon needs to load branded icons correctly.
- Created the alert-icon CSS class to add space between the FontAwesomeIcons and text elements.