### PR TITLE
Projects now associated with current user

### DIFF
--- a/alert-common/build.gradle
+++ b/alert-common/build.gradle
@@ -1,7 +1,7 @@
 ext.moduleName = 'com.synopsys.integration.alert.common'
 
 dependencies {
-    api 'com.blackducksoftware.integration:blackduck-common:42.3.0'
+    api 'com.blackducksoftware.integration:blackduck-common:43.0.0'
 
     api 'org.springframework.boot:spring-boot-starter-activemq'
     api 'org.springframework.security:spring-security-config'

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/tasks/BlackDuckProjectSyncTaskTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/tasks/BlackDuckProjectSyncTaskTest.java
@@ -5,16 +5,26 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
+import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
+import com.synopsys.integration.alert.common.persistence.model.ConfigurationJobModel;
+import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
+import com.synopsys.integration.alert.common.rest.model.CommonDistributionConfiguration;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProvider;
 import com.synopsys.integration.alert.provider.blackduck.mock.MockProviderDataAccessor;
 import com.synopsys.integration.blackduck.api.core.BlackDuckPathMultipleResponses;
+import com.synopsys.integration.blackduck.api.core.BlackDuckPathSingleResponse;
 import com.synopsys.integration.blackduck.api.generated.component.ResourceMetadata;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectView;
 import com.synopsys.integration.blackduck.api.generated.view.UserView;
@@ -28,7 +38,15 @@ public class BlackDuckProjectSyncTaskTest {
     @Test
     public void testRun() throws Exception {
         final BlackDuckProperties blackDuckProperties = Mockito.mock(BlackDuckProperties.class);
+        final ConfigurationAccessor configurationAccessor = Mockito.mock(ConfigurationAccessor.class);
         final MockProviderDataAccessor providerDataAccessor = new MockProviderDataAccessor();
+
+        final ConfigurationFieldModel configurationFieldModel = ConfigurationFieldModel.create(CommonDistributionConfiguration.KEY_CONFIGURED_PROJECT);
+        configurationFieldModel.setFieldValues(List.of("project", "project2"));
+        final ConfigurationModel configurationModel = new ConfigurationModel(1L, 1L, ConfigContextEnum.DISTRIBUTION);
+        configurationModel.put(configurationFieldModel);
+        final ConfigurationJobModel configurationJobModel = new ConfigurationJobModel(UUID.randomUUID(), Set.of(configurationModel));
+        Mockito.when(configurationAccessor.getAllJobs()).thenReturn(List.of(configurationJobModel));
 
         final String email1 = "user1@email.com";
         final String email2 = "user2@email.com";
@@ -50,6 +68,7 @@ public class BlackDuckProjectSyncTaskTest {
         final ProjectView projectView3 = createProjectView("project3", "description3", "projectUrl3");
 
         Mockito.when(hubService.getAllResponses(Mockito.any(BlackDuckPathMultipleResponses.class))).thenReturn(Arrays.asList(projectView, projectView2, projectView3));
+        Mockito.doReturn(null).when(hubService).getResponse(Mockito.any(BlackDuckPathSingleResponse.class));
 
         final UserView user1 = createUserView(email1, true);
         final UserView user2 = createUserView(email2, true);
@@ -59,8 +78,9 @@ public class BlackDuckProjectSyncTaskTest {
         Mockito.when(projectUsersService.getAllActiveUsersForProject(ArgumentMatchers.same(projectView))).thenReturn(new HashSet<>(Arrays.asList(user2, user4)));
         Mockito.when(projectUsersService.getAllActiveUsersForProject(ArgumentMatchers.same(projectView2))).thenReturn(new HashSet<>(Arrays.asList(user3)));
         Mockito.when(projectUsersService.getAllActiveUsersForProject(ArgumentMatchers.same(projectView3))).thenReturn(new HashSet<>(Arrays.asList(user1, user2, user3)));
+        Mockito.doNothing().when(projectUsersService).addUserToProject(Mockito.any(), Mockito.any(UserView.class));
 
-        final BlackDuckProjectSyncTask projectSyncTask = new BlackDuckProjectSyncTask(null, blackDuckProperties, providerDataAccessor);
+        final BlackDuckProjectSyncTask projectSyncTask = new BlackDuckProjectSyncTask(null, blackDuckProperties, providerDataAccessor, configurationAccessor);
         projectSyncTask.run();
 
         assertEquals(3, providerDataAccessor.findByProviderName(BlackDuckProvider.COMPONENT_NAME).size());


### PR DESCRIPTION
If a user sets up Alert and they are not associated with a project that is set in a distribution job, we will automatically add the user to the project.

Also updated to next version of blackduck common.