### PR TITLE
Fixed links to BlackDuck

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2074,7 +2074,7 @@
     },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
-      "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "dev": true,
       "requires": {
@@ -6702,7 +6702,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckCollector.java
@@ -1,0 +1,96 @@
+/**
+ * blackduck-alert
+ *
+ * Copyright (c) 2019 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.alert.provider.blackduck.collector;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.synopsys.integration.alert.common.provider.ProviderContentType;
+import com.synopsys.integration.alert.common.workflow.MessageContentCollector;
+import com.synopsys.integration.alert.common.workflow.filter.field.JsonExtractor;
+import com.synopsys.integration.alert.common.workflow.processor.MessageContentProcessor;
+import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
+import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionView;
+import com.synopsys.integration.blackduck.service.BlackDuckService;
+import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
+import com.synopsys.integration.blackduck.service.bucket.BlackDuckBucket;
+import com.synopsys.integration.blackduck.service.bucket.BlackDuckBucketService;
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.log.Slf4jIntLogger;
+
+// Created this class as a parent because of the ObjectFactory bean that is used with Collectors which destroys the bean after use. These services need to be destroyed after usage.
+public abstract class BlackDuckCollector extends MessageContentCollector {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Optional<BlackDuckBucketService> bucketService;
+    private final Optional<BlackDuckService> blackDuckService;
+    private final BlackDuckBucket blackDuckBucket;
+
+    public BlackDuckCollector(final JsonExtractor jsonExtractor, final List<MessageContentProcessor> messageContentProcessorList, final Collection<ProviderContentType> contentTypes, final BlackDuckProperties blackDuckProperties) {
+        super(jsonExtractor, messageContentProcessorList, contentTypes);
+
+        final Optional<BlackDuckServicesFactory> blackDuckServicesFactory = blackDuckProperties.createBlackDuckHttpClientAndLogErrors(logger)
+                                                                                .map(blackDuckHttpClient -> blackDuckProperties.createBlackDuckServicesFactory(blackDuckHttpClient, new Slf4jIntLogger(logger)));
+        blackDuckService = blackDuckServicesFactory.map(BlackDuckServicesFactory::createBlackDuckService);
+        bucketService = blackDuckServicesFactory.map(BlackDuckServicesFactory::createBlackDuckBucketService);
+        blackDuckBucket = new BlackDuckBucket();
+    }
+
+    public Optional<String> getProjectQueryLink(final String projectVersionUrl, final String link, final String componentName) {
+        final Optional<String> projectLink = getProjectLink(projectVersionUrl, link);
+        return projectLink.flatMap(optionalProjectLink -> getProjectQueryLink(optionalProjectLink, componentName));
+    }
+
+    public Optional<String> getProjectQueryLink(final String projectLink, final String componentName) {
+        return Optional.of(String.format("%s?q=componentName:%s", projectLink, componentName));
+    }
+
+    public Optional<String> getProjectLink(final String projectVersionUrl, final String link) {
+        if (blackDuckService.isPresent() && bucketService.isPresent()) {
+            try {
+                final ProjectVersionView projectVersionView = blackDuckService.get().getResponse(projectVersionUrl, ProjectVersionView.class);
+                bucketService.get().addToTheBucket(blackDuckBucket, projectVersionUrl, ProjectVersionView.class);
+                return projectVersionView.getFirstLink(link);
+            } catch (final IntegrationException e) {
+                logger.error("There was a problem retrieving the Project Version link.", e);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public Optional<BlackDuckBucketService> getBucketService() {
+        return bucketService;
+    }
+
+    public Optional<BlackDuckService> getBlackDuckService() {
+        return blackDuckService;
+    }
+
+    public BlackDuckBucket getBlackDuckBucket() {
+        return blackDuckBucket;
+    }
+}

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyCollector.java
@@ -34,15 +34,15 @@ import com.synopsys.integration.alert.common.message.model.CategoryItem;
 import com.synopsys.integration.alert.common.message.model.CategoryKey;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.common.provider.ProviderContentType;
-import com.synopsys.integration.alert.common.workflow.MessageContentCollector;
 import com.synopsys.integration.alert.common.workflow.filter.field.JsonExtractor;
 import com.synopsys.integration.alert.common.workflow.processor.MessageContentProcessor;
+import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
 
-public abstract class BlackDuckPolicyCollector extends MessageContentCollector {
+public abstract class BlackDuckPolicyCollector extends BlackDuckCollector {
     public static final String CATEGORY_TYPE = "policy";
 
-    public BlackDuckPolicyCollector(final JsonExtractor jsonExtractor, final List<MessageContentProcessor> messageContentProcessorList, final Collection<ProviderContentType> contentTypes) {
-        super(jsonExtractor, messageContentProcessorList, contentTypes);
+    public BlackDuckPolicyCollector(final JsonExtractor jsonExtractor, final List<MessageContentProcessor> messageContentProcessorList, final Collection<ProviderContentType> contentTypes, final BlackDuckProperties blackDuckProperties) {
+        super(jsonExtractor, messageContentProcessorList, contentTypes, blackDuckProperties);
     }
 
     protected void addApplicableItems(final SortedSet<CategoryItem> categoryItems, final Long notificationId, final Set<LinkableItem> policyItems, final ItemOperation operation, final Set<LinkableItem> applicableItems) {

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyOverrideCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyOverrideCollector.java
@@ -29,8 +29,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
@@ -47,31 +45,14 @@ import com.synopsys.integration.alert.common.workflow.processor.MessageContentPr
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
 import com.synopsys.integration.alert.provider.blackduck.descriptor.BlackDuckContent;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionView;
-import com.synopsys.integration.blackduck.service.BlackDuckService;
-import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
-import com.synopsys.integration.blackduck.service.bucket.BlackDuckBucket;
-import com.synopsys.integration.blackduck.service.bucket.BlackDuckBucketService;
-import com.synopsys.integration.exception.IntegrationException;
-import com.synopsys.integration.log.Slf4jIntLogger;
 
 @Component
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
 public class BlackDuckPolicyOverrideCollector extends BlackDuckPolicyCollector {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final Optional<BlackDuckBucketService> bucketService;
-    private final Optional<BlackDuckService> blackDuckService;
-    private final BlackDuckBucket blackDuckBucket;
 
     @Autowired
     public BlackDuckPolicyOverrideCollector(final JsonExtractor jsonExtractor, final List<MessageContentProcessor> messageContentProcessorList, final BlackDuckProperties blackDuckProperties) {
-        super(jsonExtractor, messageContentProcessorList, Arrays.asList(BlackDuckContent.POLICY_OVERRIDE));
-
-        final Optional<BlackDuckServicesFactory> blackDuckServicesFactory = blackDuckProperties.createBlackDuckHttpClientAndLogErrors(logger)
-                                                                                .map(blackDuckHttpClient -> blackDuckProperties.createBlackDuckServicesFactory(blackDuckHttpClient, new Slf4jIntLogger(logger)));
-
-        blackDuckService = blackDuckServicesFactory.map(BlackDuckServicesFactory::createBlackDuckService);
-        bucketService = blackDuckServicesFactory.map(BlackDuckServicesFactory::createBlackDuckBucketService);
-        blackDuckBucket = new BlackDuckBucket();
+        super(jsonExtractor, messageContentProcessorList, Arrays.asList(BlackDuckContent.POLICY_OVERRIDE), blackDuckProperties);
     }
 
     @Override
@@ -92,18 +73,8 @@ public class BlackDuckPolicyOverrideCollector extends BlackDuckPolicyCollector {
         final String projectVersionUrl = getFieldValueObjectsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_PROJECT_VERSION_NAME + JsonField.LABEL_URL_SUFFIX).stream().findFirst().orElse("");
         final String componentName = getFieldValueObjectsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_COMPONENT_NAME).stream().findFirst().orElse("");
 
-        Optional<LinkableItem> componentVersionItem = Optional.empty();
-        try {
-            if (blackDuckService.isPresent() && bucketService.isPresent()) {
-                final ProjectVersionView projectVersionView = blackDuckService.get().getResponse(projectVersionUrl, ProjectVersionView.class);
-                bucketService.get().addToTheBucket(blackDuckBucket, projectVersionUrl, ProjectVersionView.class);
-                final String vulnerableComponentLink = projectVersionView.getFirstLink(ProjectVersionView.COMPONENTS_LINK).orElse("");
-                final String projectVersionComponentLink = String.format("%s?q=componentName:%s", vulnerableComponentLink, componentName);
-                componentVersionItem = componentVersionName.map(name -> new LinkableItem(BlackDuckContent.LABEL_COMPONENT_VERSION_NAME, name, projectVersionComponentLink));
-            }
-        } catch (final IntegrationException e) {
-            logger.error("There was a problem retrieving the Project Version link.", e);
-        }
+        final String generatedLink = getProjectQueryLink(projectVersionUrl, ProjectVersionView.COMPONENTS_LINK, componentName).orElse(null);
+        final Optional<LinkableItem> componentVersionItem = componentVersionName.map(name -> new LinkableItem(BlackDuckContent.LABEL_COMPONENT_VERSION_NAME, name, generatedLink));
 
         final SortedSet<LinkableItem> applicableItems = new TreeSet<>();
         applicableItems.addAll(componentItems);

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyOverrideCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyOverrideCollector.java
@@ -70,7 +70,7 @@ public class BlackDuckPolicyOverrideCollector extends BlackDuckPolicyCollector {
         final Optional<String> componentVersionName = getFieldValueObjectsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_COMPONENT_VERSION_NAME).stream().findFirst();
         final String projectVersionUrl = getFieldValueObjectsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_PROJECT_VERSION_NAME + JsonField.LABEL_URL_SUFFIX).stream().findFirst().orElse("");
         final String componentName = getFieldValueObjectsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_COMPONENT_NAME).stream().findFirst().orElse("");
-        final String generatedLink = getProjectQueryLink(projectVersionUrl, ProjectVersionView.COMPONENTS_LINK, componentName).orElse(null);
+        final String generatedLink = getProjectComponentQueryLink(projectVersionUrl, ProjectVersionView.COMPONENTS_LINK, componentName).orElse(null);
 
         final Optional<LinkableItem> componentVersionItem = componentVersionName.map(name -> new LinkableItem(BlackDuckContent.LABEL_COMPONENT_VERSION_NAME, name, generatedLink));
         final String linkForComponentName = (componentVersionName.isPresent()) ? null : generatedLink;

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyOverrideCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyOverrideCollector.java
@@ -64,20 +64,20 @@ public class BlackDuckPolicyOverrideCollector extends BlackDuckPolicyCollector {
         final List<LinkableItem> policySeverity = getLinkableItemsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_POLICY_SEVERITY_NAME);
         policySeverity.forEach(severityItem -> severityItem.setSummarizable(true));
 
-        final List<LinkableItem> componentItems = getLinkableItemsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_COMPONENT_NAME);
-
         final Optional<LinkableItem> firstName = getLinkableItemsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_POLICY_OVERRIDE_FIRST_NAME).stream().findFirst();
         final Optional<LinkableItem> lastName = getLinkableItemsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_POLICY_OVERRIDE_LAST_NAME).stream().findFirst();
 
         final Optional<String> componentVersionName = getFieldValueObjectsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_COMPONENT_VERSION_NAME).stream().findFirst();
         final String projectVersionUrl = getFieldValueObjectsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_PROJECT_VERSION_NAME + JsonField.LABEL_URL_SUFFIX).stream().findFirst().orElse("");
         final String componentName = getFieldValueObjectsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_COMPONENT_NAME).stream().findFirst().orElse("");
-
         final String generatedLink = getProjectQueryLink(projectVersionUrl, ProjectVersionView.COMPONENTS_LINK, componentName).orElse(null);
+
         final Optional<LinkableItem> componentVersionItem = componentVersionName.map(name -> new LinkableItem(BlackDuckContent.LABEL_COMPONENT_VERSION_NAME, name, generatedLink));
+        final String linkForComponentName = (componentVersionName.isPresent()) ? null : generatedLink;
+        final LinkableItem componentItem = new LinkableItem(BlackDuckContent.LABEL_COMPONENT_NAME, componentName, linkForComponentName);
 
         final SortedSet<LinkableItem> applicableItems = new TreeSet<>();
-        applicableItems.addAll(componentItems);
+        applicableItems.add(componentItem);
         applicableItems.addAll(policySeverity);
         componentVersionItem.ifPresent(applicableItems::add);
 

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyOverrideCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyOverrideCollector.java
@@ -29,6 +29,8 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
@@ -42,16 +44,34 @@ import com.synopsys.integration.alert.common.workflow.filter.field.JsonExtractor
 import com.synopsys.integration.alert.common.workflow.filter.field.JsonField;
 import com.synopsys.integration.alert.common.workflow.filter.field.JsonFieldAccessor;
 import com.synopsys.integration.alert.common.workflow.processor.MessageContentProcessor;
+import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
 import com.synopsys.integration.alert.provider.blackduck.descriptor.BlackDuckContent;
+import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionView;
+import com.synopsys.integration.blackduck.service.BlackDuckService;
+import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
+import com.synopsys.integration.blackduck.service.bucket.BlackDuckBucket;
+import com.synopsys.integration.blackduck.service.bucket.BlackDuckBucketService;
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.log.Slf4jIntLogger;
 
 @Component
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
 public class BlackDuckPolicyOverrideCollector extends BlackDuckPolicyCollector {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Optional<BlackDuckBucketService> bucketService;
+    private final Optional<BlackDuckService> blackDuckService;
+    private final BlackDuckBucket blackDuckBucket;
 
     @Autowired
-    public BlackDuckPolicyOverrideCollector(final JsonExtractor jsonExtractor,
-        final List<MessageContentProcessor> messageContentProcessorList) {
+    public BlackDuckPolicyOverrideCollector(final JsonExtractor jsonExtractor, final List<MessageContentProcessor> messageContentProcessorList, final BlackDuckProperties blackDuckProperties) {
         super(jsonExtractor, messageContentProcessorList, Arrays.asList(BlackDuckContent.POLICY_OVERRIDE));
+
+        final Optional<BlackDuckServicesFactory> blackDuckServicesFactory = blackDuckProperties.createBlackDuckHttpClientAndLogErrors(logger)
+                                                                                .map(blackDuckHttpClient -> blackDuckProperties.createBlackDuckServicesFactory(blackDuckHttpClient, new Slf4jIntLogger(logger)));
+
+        blackDuckService = blackDuckServicesFactory.map(BlackDuckServicesFactory::createBlackDuckService);
+        bucketService = blackDuckServicesFactory.map(BlackDuckServicesFactory::createBlackDuckBucketService);
+        blackDuckBucket = new BlackDuckBucket();
     }
 
     @Override
@@ -64,15 +84,31 @@ public class BlackDuckPolicyOverrideCollector extends BlackDuckPolicyCollector {
         policySeverity.forEach(severityItem -> severityItem.setSummarizable(true));
 
         final List<LinkableItem> componentItems = getLinkableItemsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_COMPONENT_NAME);
-        final List<LinkableItem> componentVersionItems = getLinkableItemsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_COMPONENT_VERSION_NAME);
 
         final Optional<LinkableItem> firstName = getLinkableItemsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_POLICY_OVERRIDE_FIRST_NAME).stream().findFirst();
         final Optional<LinkableItem> lastName = getLinkableItemsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_POLICY_OVERRIDE_LAST_NAME).stream().findFirst();
 
+        final Optional<String> componentVersionName = getFieldValueObjectsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_COMPONENT_VERSION_NAME).stream().findFirst();
+        final String projectVersionUrl = getFieldValueObjectsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_PROJECT_VERSION_NAME + JsonField.LABEL_URL_SUFFIX).stream().findFirst().orElse("");
+        final String componentName = getFieldValueObjectsByLabel(jsonFieldAccessor, categoryFields, BlackDuckContent.LABEL_COMPONENT_NAME).stream().findFirst().orElse("");
+
+        Optional<LinkableItem> componentVersionItem = Optional.empty();
+        try {
+            if (blackDuckService.isPresent() && bucketService.isPresent()) {
+                final ProjectVersionView projectVersionView = blackDuckService.get().getResponse(projectVersionUrl, ProjectVersionView.class);
+                bucketService.get().addToTheBucket(blackDuckBucket, projectVersionUrl, ProjectVersionView.class);
+                final String vulnerableComponentLink = projectVersionView.getFirstLink(ProjectVersionView.COMPONENTS_LINK).orElse("");
+                final String projectVersionComponentLink = String.format("%s?q=componentName:%s", vulnerableComponentLink, componentName);
+                componentVersionItem = componentVersionName.map(name -> new LinkableItem(BlackDuckContent.LABEL_COMPONENT_VERSION_NAME, name, projectVersionComponentLink));
+            }
+        } catch (final IntegrationException e) {
+            logger.error("There was a problem retrieving the Project Version link.", e);
+        }
+
         final SortedSet<LinkableItem> applicableItems = new TreeSet<>();
         applicableItems.addAll(componentItems);
-        applicableItems.addAll(componentVersionItems);
         applicableItems.addAll(policySeverity);
+        componentVersionItem.ifPresent(applicableItems::add);
 
         if (firstName.isPresent() && lastName.isPresent()) {
             final String value = String.format("%s %s", firstName.get().getValue(), lastName.get().getValue());

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyViolationCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyViolationCollector.java
@@ -104,11 +104,11 @@ public class BlackDuckPolicyViolationCollector extends BlackDuckPolicyCollector 
                                              .findFirst()
                                              .orElse("");
 
-        final String projectVersionComponentLink = "";
+        String projectVersionComponentLink = "";
         try {
             final ProjectVersionView projectVersionView = blackDuckService.getResponse(projectVersionUrl, ProjectVersionView.class);
             bucketService.addToTheBucket(blackDuckBucket, projectVersionUrl, ProjectVersionView.class);
-            final String projectVersionComponentLinkprojectVersionComponentLink = projectVersionView.getFirstLink(ProjectVersionView.COMPONENTS_LINK).orElse("");
+            projectVersionComponentLink = projectVersionView.getFirstLink(ProjectVersionView.COMPONENTS_LINK).orElse("");
         } catch (final IntegrationException e) {
             logger.error("There was a problem retrieving the Project Version link.", e);
         }

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyViolationCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyViolationCollector.java
@@ -151,14 +151,15 @@ public class BlackDuckPolicyViolationCollector extends BlackDuckPolicyCollector 
     private BlackDuckPolicyLinkableItem createBlackDuckPolicyLinkableItem(final ComponentVersionStatus componentVersionStatus, final String projectVersionWithComponentLink) {
         final BlackDuckPolicyLinkableItem blackDuckPolicyLinkableItem = new BlackDuckPolicyLinkableItem();
 
-        final String componentName = componentVersionStatus.getComponentName();
-        if (StringUtils.isNotBlank(componentName)) {
-            blackDuckPolicyLinkableItem.addComponentNameItem(componentName, componentVersionStatus.getComponent());
-        }
-
         final String componentVersionName = componentVersionStatus.getComponentVersionName();
         if (StringUtils.isNotBlank(componentVersionName)) {
             blackDuckPolicyLinkableItem.addComponentVersionItem(componentVersionName, projectVersionWithComponentLink);
+        }
+
+        final String componentName = componentVersionStatus.getComponentName();
+        if (StringUtils.isNotBlank(componentName)) {
+            final String componentLink = (StringUtils.isBlank(componentVersionName)) ? projectVersionWithComponentLink : componentVersionStatus.getComponent();
+            blackDuckPolicyLinkableItem.addComponentNameItem(componentName, componentLink);
         }
 
         return blackDuckPolicyLinkableItem;

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyViolationCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyViolationCollector.java
@@ -124,7 +124,7 @@ public class BlackDuckPolicyViolationCollector extends BlackDuckPolicyCollector 
         final Optional<String> projectVersionUrl) {
         final Map<PolicyComponentMapping, BlackDuckPolicyLinkableItem> policyComponentToLinkableItemMapping = new HashMap<>();
         for (final ComponentVersionStatus componentVersionStatus : componentVersionStatuses) {
-            final String projectVersionLink = projectVersionUrl.flatMap(url -> getProjectQueryLink(url, componentVersionStatus.getComponentName())).orElse(null);
+            final String projectVersionLink = projectVersionUrl.flatMap(url -> getProjectComponentQueryLink(url, componentVersionStatus.getComponentName())).orElse(null);
             final PolicyComponentMapping policyComponentMapping = createPolicyComponentMapping(componentVersionStatus, policyItems);
             BlackDuckPolicyLinkableItem blackDuckPolicyLinkableItem = policyComponentToLinkableItemMapping.get(policyComponentMapping);
             if (blackDuckPolicyLinkableItem == null) {
@@ -158,7 +158,7 @@ public class BlackDuckPolicyViolationCollector extends BlackDuckPolicyCollector 
 
         final String componentName = componentVersionStatus.getComponentName();
         if (StringUtils.isNotBlank(componentName)) {
-            final String componentLink = (StringUtils.isBlank(componentVersionName)) ? projectVersionWithComponentLink : componentVersionStatus.getComponent();
+            final String componentLink = (StringUtils.isBlank(componentVersionName)) ? projectVersionWithComponentLink : null;
             blackDuckPolicyLinkableItem.addComponentNameItem(componentName, componentLink);
         }
 

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckVulnerabilityCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckVulnerabilityCollector.java
@@ -48,11 +48,13 @@ import com.synopsys.integration.alert.common.workflow.processor.MessageContentPr
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
 import com.synopsys.integration.alert.provider.blackduck.collector.item.VulnerabilityCategoryItem;
 import com.synopsys.integration.alert.provider.blackduck.descriptor.BlackDuckContent;
+import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionView;
 import com.synopsys.integration.blackduck.api.generated.view.VulnerabilityView;
 import com.synopsys.integration.blackduck.api.manual.component.VulnerabilitySourceQualifiedId;
-import com.synopsys.integration.blackduck.rest.BlackDuckHttpClient;
 import com.synopsys.integration.blackduck.service.BlackDuckService;
 import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
+import com.synopsys.integration.blackduck.service.bucket.BlackDuckBucket;
+import com.synopsys.integration.blackduck.service.bucket.BlackDuckBucketService;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.log.Slf4jIntLogger;
 
@@ -61,12 +63,20 @@ import com.synopsys.integration.log.Slf4jIntLogger;
 public class BlackDuckVulnerabilityCollector extends MessageContentCollector {
     public static final String CATEGORY_TYPE = "vulnerability";
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final BlackDuckProperties blackDuckProperties;
+    private final Optional<BlackDuckBucketService> bucketService;
+    private final Optional<BlackDuckService> blackDuckService;
+    private final BlackDuckBucket blackDuckBucket;
 
     @Autowired
     public BlackDuckVulnerabilityCollector(final JsonExtractor jsonExtractor, final List<MessageContentProcessor> messageContentProcessorList, final BlackDuckProperties blackDuckProperties) {
         super(jsonExtractor, messageContentProcessorList, Arrays.asList(BlackDuckContent.VULNERABILITY));
-        this.blackDuckProperties = blackDuckProperties;
+
+        final Optional<BlackDuckServicesFactory> blackDuckServicesFactory = blackDuckProperties.createBlackDuckHttpClientAndLogErrors(logger)
+                                                                                .map(blackDuckHttpClient -> blackDuckProperties.createBlackDuckServicesFactory(blackDuckHttpClient, new Slf4jIntLogger(logger)));
+
+        blackDuckService = blackDuckServicesFactory.map(BlackDuckServicesFactory::createBlackDuckService);
+        bucketService = blackDuckServicesFactory.map(BlackDuckServicesFactory::createBlackDuckBucketService);
+        blackDuckBucket = new BlackDuckBucket();
     }
 
     @Override
@@ -75,41 +85,41 @@ public class BlackDuckVulnerabilityCollector extends MessageContentCollector {
         final List<JsonField<VulnerabilitySourceQualifiedId>> vulnerabilityFields = getFieldsOfType(notificationFields, new TypeRef<VulnerabilitySourceQualifiedId>() {});
 
         final List<LinkableItem> componentItems = getLinkableItemsByLabel(jsonFieldAccessor, componentFields, BlackDuckContent.LABEL_COMPONENT_NAME);
-        final List<LinkableItem> componentVersionItems = getLinkableItemsByLabel(jsonFieldAccessor, componentFields, BlackDuckContent.LABEL_COMPONENT_VERSION_NAME);
 
         final LinkableItem componentItem = componentItems.stream().findFirst().orElse(null);
-        final Optional<LinkableItem> componentVersionItem = componentVersionItems.stream().findFirst();
 
         final List<VulnerabilitySourceQualifiedId> newVulnerabilityList = getFieldValueObjectsByLabel(jsonFieldAccessor, vulnerabilityFields, BlackDuckContent.LABEL_VULNERABILITY_NEW);
         final List<VulnerabilitySourceQualifiedId> updatedVulnerabilityList = getFieldValueObjectsByLabel(jsonFieldAccessor, vulnerabilityFields, BlackDuckContent.LABEL_VULNERABILITY_UPDATED);
         final List<VulnerabilitySourceQualifiedId> deletedVulnerabilityList = getFieldValueObjectsByLabel(jsonFieldAccessor, vulnerabilityFields, BlackDuckContent.LABEL_VULNERABILITY_DELETED);
-        final Optional<BlackDuckHttpClient> blackDuckHttpClientOptional = blackDuckProperties.createBlackDuckHttpClientAndLogErrors(logger);
-        if (blackDuckHttpClientOptional.isPresent()) {
-            try {
-                final BlackDuckHttpClient blackDuckHttpClient = blackDuckHttpClientOptional.get();
-                final BlackDuckServicesFactory blackDuckServicesFactory = blackDuckProperties.createBlackDuckServicesFactory(blackDuckHttpClient, new Slf4jIntLogger(logger));
-                final Optional<BlackDuckService> optionalBlackDuckService = Optional.of(blackDuckServicesFactory.createBlackDuckService());
 
-                addVulnerabilityItems(optionalBlackDuckService, categoryItems, notificationContent.getId(), ItemOperation.ADD,
-                    BlackDuckContent.LABEL_VULNERABILITY_NEW, componentItem, componentVersionItem, newVulnerabilityList);
+        final Optional<String> projectVersionName = getFieldValueObjectsByLabel(jsonFieldAccessor, componentFields, BlackDuckContent.LABEL_PROJECT_VERSION_NAME).stream().findFirst();
+        final String projectVersionUrl = getFieldValueObjectsByLabel(jsonFieldAccessor, componentFields, BlackDuckContent.LABEL_PROJECT_VERSION_NAME + JsonField.LABEL_URL_SUFFIX).stream().findFirst().orElse("");
+        final String componentName = getFieldValueObjectsByLabel(jsonFieldAccessor, componentFields, BlackDuckContent.LABEL_COMPONENT_NAME).stream().findFirst().orElse("");
 
-                addVulnerabilityItems(optionalBlackDuckService, categoryItems, notificationContent.getId(), ItemOperation.UPDATE,
-                    BlackDuckContent.LABEL_VULNERABILITY_UPDATED, componentItem, componentVersionItem, updatedVulnerabilityList);
-
-                addVulnerabilityItems(optionalBlackDuckService, categoryItems, notificationContent.getId(), ItemOperation.DELETE,
-                    BlackDuckContent.LABEL_VULNERABILITY_DELETED, componentItem, componentVersionItem, deletedVulnerabilityList);
-            } catch (final Exception ex) {
-                logger.error("Mishandled the expected type of a notification field", ex);
+        Optional<LinkableItem> componentVersionItem = Optional.empty();
+        try {
+            if (blackDuckService.isPresent() && bucketService.isPresent()) {
+                final ProjectVersionView projectVersionView = blackDuckService.get().getResponse(projectVersionUrl, ProjectVersionView.class);
+                bucketService.get().addToTheBucket(blackDuckBucket, projectVersionUrl, ProjectVersionView.class);
+                final String vulnerableComponentLink = projectVersionView.getFirstLink(ProjectVersionView.VULNERABLE_COMPONENTS_LINK).orElse("");
+                final String projectVersionComponentLink = String.format("%s?q=componentName:%s", vulnerableComponentLink, componentName);
+                componentVersionItem = projectVersionName.map(name -> new LinkableItem(BlackDuckContent.LABEL_PROJECT_VERSION_NAME, name, projectVersionComponentLink));
             }
-        } else {
-            addVulnerabilityItems(Optional.empty(), categoryItems, notificationContent.getId(), ItemOperation.ADD,
+        } catch (final IntegrationException e) {
+            logger.error("There was a problem retrieving the Project Version link.", e);
+        }
+
+        try {
+            addVulnerabilityItems(blackDuckService, categoryItems, notificationContent.getId(), ItemOperation.ADD,
                 BlackDuckContent.LABEL_VULNERABILITY_NEW, componentItem, componentVersionItem, newVulnerabilityList);
 
-            addVulnerabilityItems(Optional.empty(), categoryItems, notificationContent.getId(), ItemOperation.UPDATE,
+            addVulnerabilityItems(blackDuckService, categoryItems, notificationContent.getId(), ItemOperation.UPDATE,
                 BlackDuckContent.LABEL_VULNERABILITY_UPDATED, componentItem, componentVersionItem, updatedVulnerabilityList);
 
-            addVulnerabilityItems(Optional.empty(), categoryItems, notificationContent.getId(), ItemOperation.DELETE,
+            addVulnerabilityItems(blackDuckService, categoryItems, notificationContent.getId(), ItemOperation.DELETE,
                 BlackDuckContent.LABEL_VULNERABILITY_DELETED, componentItem, componentVersionItem, deletedVulnerabilityList);
+        } catch (final Exception ex) {
+            logger.error("Mishandled the expected type of a notification field", ex);
         }
     }
 

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckVulnerabilityCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckVulnerabilityCollector.java
@@ -81,7 +81,7 @@ public class BlackDuckVulnerabilityCollector extends BlackDuckCollector {
         final String projectVersionUrl = getFieldValueObjectsByLabel(jsonFieldAccessor, componentFields, BlackDuckContent.LABEL_PROJECT_VERSION_NAME + JsonField.LABEL_URL_SUFFIX).stream().findFirst().orElse("");
         final String componentName = getFieldValueObjectsByLabel(jsonFieldAccessor, componentFields, BlackDuckContent.LABEL_COMPONENT_NAME).stream().findFirst().orElse("");
 
-        final String projectQueryLink = getProjectQueryLink(projectVersionUrl, ProjectVersionView.VULNERABLE_COMPONENTS_LINK, componentName).orElse(null);
+        final String projectQueryLink = getProjectComponentQueryLink(projectVersionUrl, ProjectVersionView.VULNERABLE_COMPONENTS_LINK, componentName).orElse(null);
         final Optional<LinkableItem> componentVersionItem = projectVersionName.map(name -> new LinkableItem(BlackDuckContent.LABEL_PROJECT_VERSION_NAME, name, projectQueryLink));
 
         try {

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckVulnerabilityCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckVulnerabilityCollector.java
@@ -40,7 +40,6 @@ import com.synopsys.integration.alert.common.message.model.CategoryItem;
 import com.synopsys.integration.alert.common.message.model.CategoryKey;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.common.rest.model.AlertNotificationWrapper;
-import com.synopsys.integration.alert.common.workflow.MessageContentCollector;
 import com.synopsys.integration.alert.common.workflow.filter.field.JsonExtractor;
 import com.synopsys.integration.alert.common.workflow.filter.field.JsonField;
 import com.synopsys.integration.alert.common.workflow.filter.field.JsonFieldAccessor;
@@ -52,31 +51,17 @@ import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionView;
 import com.synopsys.integration.blackduck.api.generated.view.VulnerabilityView;
 import com.synopsys.integration.blackduck.api.manual.component.VulnerabilitySourceQualifiedId;
 import com.synopsys.integration.blackduck.service.BlackDuckService;
-import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
-import com.synopsys.integration.blackduck.service.bucket.BlackDuckBucket;
-import com.synopsys.integration.blackduck.service.bucket.BlackDuckBucketService;
 import com.synopsys.integration.exception.IntegrationException;
-import com.synopsys.integration.log.Slf4jIntLogger;
 
 @Component
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
-public class BlackDuckVulnerabilityCollector extends MessageContentCollector {
+public class BlackDuckVulnerabilityCollector extends BlackDuckCollector {
     public static final String CATEGORY_TYPE = "vulnerability";
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final Optional<BlackDuckBucketService> bucketService;
-    private final Optional<BlackDuckService> blackDuckService;
-    private final BlackDuckBucket blackDuckBucket;
 
     @Autowired
     public BlackDuckVulnerabilityCollector(final JsonExtractor jsonExtractor, final List<MessageContentProcessor> messageContentProcessorList, final BlackDuckProperties blackDuckProperties) {
-        super(jsonExtractor, messageContentProcessorList, Arrays.asList(BlackDuckContent.VULNERABILITY));
-
-        final Optional<BlackDuckServicesFactory> blackDuckServicesFactory = blackDuckProperties.createBlackDuckHttpClientAndLogErrors(logger)
-                                                                                .map(blackDuckHttpClient -> blackDuckProperties.createBlackDuckServicesFactory(blackDuckHttpClient, new Slf4jIntLogger(logger)));
-
-        blackDuckService = blackDuckServicesFactory.map(BlackDuckServicesFactory::createBlackDuckService);
-        bucketService = blackDuckServicesFactory.map(BlackDuckServicesFactory::createBlackDuckBucketService);
-        blackDuckBucket = new BlackDuckBucket();
+        super(jsonExtractor, messageContentProcessorList, Arrays.asList(BlackDuckContent.VULNERABILITY), blackDuckProperties);
     }
 
     @Override
@@ -85,10 +70,8 @@ public class BlackDuckVulnerabilityCollector extends MessageContentCollector {
         final List<JsonField<VulnerabilitySourceQualifiedId>> vulnerabilityFields = getFieldsOfType(notificationFields, new TypeRef<VulnerabilitySourceQualifiedId>() {});
 
         final List<LinkableItem> componentItems = getLinkableItemsByLabel(jsonFieldAccessor, componentFields, BlackDuckContent.LABEL_COMPONENT_NAME);
-        final List<LinkableItem> componentVersionItems = getLinkableItemsByLabel(jsonFieldAccessor, componentFields, BlackDuckContent.LABEL_COMPONENT_VERSION_NAME);
 
         final LinkableItem componentItem = componentItems.stream().findFirst().orElse(null);
-        Optional<LinkableItem> componentVersionItem = componentVersionItems.stream().findFirst();
 
         final List<VulnerabilitySourceQualifiedId> newVulnerabilityList = getFieldValueObjectsByLabel(jsonFieldAccessor, vulnerabilityFields, BlackDuckContent.LABEL_VULNERABILITY_NEW);
         final List<VulnerabilitySourceQualifiedId> updatedVulnerabilityList = getFieldValueObjectsByLabel(jsonFieldAccessor, vulnerabilityFields, BlackDuckContent.LABEL_VULNERABILITY_UPDATED);
@@ -98,33 +81,24 @@ public class BlackDuckVulnerabilityCollector extends MessageContentCollector {
         final String projectVersionUrl = getFieldValueObjectsByLabel(jsonFieldAccessor, componentFields, BlackDuckContent.LABEL_PROJECT_VERSION_NAME + JsonField.LABEL_URL_SUFFIX).stream().findFirst().orElse("");
         final String componentName = getFieldValueObjectsByLabel(jsonFieldAccessor, componentFields, BlackDuckContent.LABEL_COMPONENT_NAME).stream().findFirst().orElse("");
 
-        try {
-            if (blackDuckService.isPresent() && bucketService.isPresent()) {
-                final ProjectVersionView projectVersionView = blackDuckService.get().getResponse(projectVersionUrl, ProjectVersionView.class);
-                bucketService.get().addToTheBucket(blackDuckBucket, projectVersionUrl, ProjectVersionView.class);
-                final String vulnerableComponentLink = projectVersionView.getFirstLink(ProjectVersionView.VULNERABLE_COMPONENTS_LINK).orElse("");
-                final String projectVersionComponentLink = String.format("%s?q=componentName:%s", vulnerableComponentLink, componentName);
-                componentVersionItem = projectVersionName.map(name -> new LinkableItem(BlackDuckContent.LABEL_PROJECT_VERSION_NAME, name, projectVersionComponentLink));
-            }
-        } catch (final IntegrationException e) {
-            logger.error("There was a problem retrieving the Project Version link.", e);
-        }
+        final String projectQueryLink = getProjectQueryLink(projectVersionUrl, ProjectVersionView.VULNERABLE_COMPONENTS_LINK, componentName).orElse(null);
+        final Optional<LinkableItem> componentVersionItem = projectVersionName.map(name -> new LinkableItem(BlackDuckContent.LABEL_PROJECT_VERSION_NAME, name, projectQueryLink));
 
         try {
-            addVulnerabilityItems(blackDuckService, categoryItems, notificationContent.getId(), ItemOperation.ADD,
+            addVulnerabilityItems(categoryItems, notificationContent.getId(), ItemOperation.ADD,
                 BlackDuckContent.LABEL_VULNERABILITY_NEW, componentItem, componentVersionItem, newVulnerabilityList);
 
-            addVulnerabilityItems(blackDuckService, categoryItems, notificationContent.getId(), ItemOperation.UPDATE,
+            addVulnerabilityItems(categoryItems, notificationContent.getId(), ItemOperation.UPDATE,
                 BlackDuckContent.LABEL_VULNERABILITY_UPDATED, componentItem, componentVersionItem, updatedVulnerabilityList);
 
-            addVulnerabilityItems(blackDuckService, categoryItems, notificationContent.getId(), ItemOperation.DELETE,
+            addVulnerabilityItems(categoryItems, notificationContent.getId(), ItemOperation.DELETE,
                 BlackDuckContent.LABEL_VULNERABILITY_DELETED, componentItem, componentVersionItem, deletedVulnerabilityList);
         } catch (final Exception ex) {
             logger.error("Mishandled the expected type of a notification field", ex);
         }
     }
 
-    private void addVulnerabilityItems(final Optional<BlackDuckService> optionalBlackDuckService, final SortedSet<CategoryItem> categoryItems, final Long notificationId, final ItemOperation operation,
+    private void addVulnerabilityItems(final SortedSet<CategoryItem> categoryItems, final Long notificationId, final ItemOperation operation,
         final String vulnerabilityLabel, final LinkableItem componentItem, final Optional<LinkableItem> optionalComponentVersionItem, final List<VulnerabilitySourceQualifiedId> vulnerabilityList) {
         for (final VulnerabilitySourceQualifiedId vulnerabilityItem : vulnerabilityList) {
             final String vulnerabilityId = vulnerabilityItem.getVulnerabilityId();
@@ -136,7 +110,7 @@ public class BlackDuckVulnerabilityCollector extends MessageContentCollector {
             item.setCollapsible(true);
 
             final LinkableItem componentVersionItem = optionalComponentVersionItem.orElse(null);
-            final LinkableItem severityItem = getSeverity(optionalBlackDuckService, vulnerabilityUrl);
+            final LinkableItem severityItem = getSeverity(vulnerabilityUrl);
 
             String componentVersionUrl = "";
             if (optionalComponentVersionItem.isPresent()) {
@@ -150,11 +124,12 @@ public class BlackDuckVulnerabilityCollector extends MessageContentCollector {
         }
     }
 
-    private LinkableItem getSeverity(final Optional<BlackDuckService> optionalBlackDuckService, final String vulnerabilityUrl) {
+    private LinkableItem getSeverity(final String vulnerabilityUrl) {
         LinkableItem severityItem = new LinkableItem(BlackDuckContent.LABEL_VULNERABILITY_SEVERITY, "UNKNOWN");
-        if (optionalBlackDuckService.isPresent()) {
+        final Optional<BlackDuckService> blackDuckService = getBlackDuckService();
+        if (blackDuckService.isPresent()) {
             try {
-                final VulnerabilityView vulnerabilityView = optionalBlackDuckService.get().getResponse(vulnerabilityUrl, VulnerabilityView.class);
+                final VulnerabilityView vulnerabilityView = blackDuckService.get().getResponse(vulnerabilityUrl, VulnerabilityView.class);
                 final String severity = vulnerabilityView.getSeverity();
                 severityItem = new LinkableItem(BlackDuckContent.LABEL_VULNERABILITY_SEVERITY, severity);
             } catch (final IntegrationException ex) {

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckVulnerabilityCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckVulnerabilityCollector.java
@@ -85,8 +85,10 @@ public class BlackDuckVulnerabilityCollector extends MessageContentCollector {
         final List<JsonField<VulnerabilitySourceQualifiedId>> vulnerabilityFields = getFieldsOfType(notificationFields, new TypeRef<VulnerabilitySourceQualifiedId>() {});
 
         final List<LinkableItem> componentItems = getLinkableItemsByLabel(jsonFieldAccessor, componentFields, BlackDuckContent.LABEL_COMPONENT_NAME);
+        final List<LinkableItem> componentVersionItems = getLinkableItemsByLabel(jsonFieldAccessor, componentFields, BlackDuckContent.LABEL_COMPONENT_VERSION_NAME);
 
         final LinkableItem componentItem = componentItems.stream().findFirst().orElse(null);
+        Optional<LinkableItem> componentVersionItem = componentVersionItems.stream().findFirst();
 
         final List<VulnerabilitySourceQualifiedId> newVulnerabilityList = getFieldValueObjectsByLabel(jsonFieldAccessor, vulnerabilityFields, BlackDuckContent.LABEL_VULNERABILITY_NEW);
         final List<VulnerabilitySourceQualifiedId> updatedVulnerabilityList = getFieldValueObjectsByLabel(jsonFieldAccessor, vulnerabilityFields, BlackDuckContent.LABEL_VULNERABILITY_UPDATED);
@@ -96,7 +98,6 @@ public class BlackDuckVulnerabilityCollector extends MessageContentCollector {
         final String projectVersionUrl = getFieldValueObjectsByLabel(jsonFieldAccessor, componentFields, BlackDuckContent.LABEL_PROJECT_VERSION_NAME + JsonField.LABEL_URL_SUFFIX).stream().findFirst().orElse("");
         final String componentName = getFieldValueObjectsByLabel(jsonFieldAccessor, componentFields, BlackDuckContent.LABEL_COMPONENT_NAME).stream().findFirst().orElse("");
 
-        Optional<LinkableItem> componentVersionItem = Optional.empty();
         try {
             if (blackDuckService.isPresent() && bucketService.isPresent()) {
                 final ProjectVersionView projectVersionView = blackDuckService.get().getResponse(projectVersionUrl, ProjectVersionView.class);

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyOverrideMessageContentCollectorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyOverrideMessageContentCollectorTest.java
@@ -9,12 +9,14 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.SortedSet;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
 import org.springframework.core.io.ClassPathResource;
 
 import com.google.gson.Gson;
@@ -28,6 +30,7 @@ import com.synopsys.integration.alert.common.workflow.processor.DigestMessageCon
 import com.synopsys.integration.alert.common.workflow.processor.MessageContentCollapser;
 import com.synopsys.integration.alert.common.workflow.processor.MessageContentProcessor;
 import com.synopsys.integration.alert.database.notification.NotificationContent;
+import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProvider;
 import com.synopsys.integration.blackduck.api.generated.enumeration.NotificationType;
 
@@ -104,7 +107,9 @@ public class BlackDuckPolicyOverrideMessageContentCollectorTest {
     }
 
     private BlackDuckPolicyOverrideCollector createCollector() {
-        return new BlackDuckPolicyOverrideCollector(jsonExtractor, messageContentProcessorList);
+        final BlackDuckProperties blackDuckProperties = Mockito.mock(BlackDuckProperties.class);
+        Mockito.when(blackDuckProperties.createBlackDuckHttpClientAndLogErrors(Mockito.any(Logger.class))).thenReturn(Optional.empty());
+        return new BlackDuckPolicyOverrideCollector(jsonExtractor, messageContentProcessorList, blackDuckProperties);
     }
 
     private String getNotificationContentFromFile(final String notificationJsonFileName) throws Exception {

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyViolationMessageContentCollectorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckPolicyViolationMessageContentCollectorTest.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 
@@ -16,6 +17,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
 import org.springframework.core.io.ClassPathResource;
 
 import com.google.gson.Gson;
@@ -31,6 +33,7 @@ import com.synopsys.integration.alert.common.workflow.processor.DigestMessageCon
 import com.synopsys.integration.alert.common.workflow.processor.MessageContentCollapser;
 import com.synopsys.integration.alert.common.workflow.processor.MessageContentProcessor;
 import com.synopsys.integration.alert.database.notification.NotificationContent;
+import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProvider;
 import com.synopsys.integration.blackduck.api.generated.enumeration.NotificationType;
 
@@ -142,7 +145,9 @@ public class BlackDuckPolicyViolationMessageContentCollectorTest {
     }
 
     private BlackDuckPolicyViolationCollector createPolicyViolationCollector() {
-        return new BlackDuckPolicyViolationCollector(jsonExtractor, messageContentProcessorList);
+        final BlackDuckProperties blackDuckProperties = Mockito.mock(BlackDuckProperties.class);
+        Mockito.when(blackDuckProperties.createBlackDuckHttpClientAndLogErrors(Mockito.any(Logger.class))).thenReturn(Optional.empty());
+        return new BlackDuckPolicyViolationCollector(jsonExtractor, messageContentProcessorList, blackDuckProperties);
     }
 
     private String getNotificationContentFromFile(final String notificationJsonFileName) throws Exception {


### PR DESCRIPTION
Created a more appropriate link for BlackDuck policy and vulnerability components and their versions. Added a new Parent class that uses BlackDuck end points to properly update which URL should be hit.