### PR TITLE
Ps alert env var update

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/AlertProperties.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/AlertProperties.java
@@ -93,6 +93,9 @@ public class AlertProperties {
     @Value("${public.hub.webserver.port:}")
     private String publicWebserverPort;
 
+    @Value("${alert.hostname:}")
+    private String alertHostName;
+
     public String getAlertConfigHome() {
         return StringUtils.trimToNull(alertConfigHome);
     }
@@ -161,12 +164,18 @@ public class AlertProperties {
         return getOptionalString(keyStoreType);
     }
 
+    @Deprecated
     public Optional<String> getPublicWebserverHost() {
         return getOptionalString(publicWebserverHost);
     }
 
+    @Deprecated
     public Optional<String> getPublicWebserverPort() {
         return getOptionalString(publicWebserverPort);
+    }
+
+    public Optional<String> getAlertHostName() {
+        return getOptionalString(alertHostName);
     }
 
     private Optional<String> getOptionalString(final String value) {
@@ -178,8 +187,8 @@ public class AlertProperties {
 
     public Optional<String> getServerUrl() {
         try {
-            final String hostName = getPublicWebserverHost().orElse("localhost");
-            final String port = getPublicWebserverPort().orElse(getServerPort().orElse(""));
+            final String hostName = getAlertHostName().orElse(getPublicWebserverHost().orElse("localhost"));
+            final String port = getServerPort().orElse(getPublicWebserverPort().orElse(getServerPort().orElse("")));
             final String path = getContextPath().orElse("");
             String protocol = "http";
             if (getSslEnabled()) {

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/AlertProperties.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/AlertProperties.java
@@ -52,7 +52,7 @@ public class AlertProperties {
     private String loggingLevel;
 
     // SSL properties
-    @Value("${server.port:}")
+    @Value("${server.port:8443}")
     private String serverPort;
 
     @Value("${server.servlet.context-path:}")

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/AlertProperties.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/AlertProperties.java
@@ -52,7 +52,7 @@ public class AlertProperties {
     private String loggingLevel;
 
     // SSL properties
-    @Value("${server.port:8443}")
+    @Value("${server.port:}")
     private String serverPort;
 
     @Value("${server.servlet.context-path:}")

--- a/deployment/blackduck-alert.env
+++ b/deployment/blackduck-alert.env
@@ -1,9 +1,11 @@
 ALERT_SERVER_PORT=8443
 
+#PUBLIC_HUB_WEBSERVER_HOST is deprecated and should be replaced with the following.
 # The value is just the host name DO NOT include the
 # scheme i.e. http or https.
-PUBLIC_HUB_WEBSERVER_HOST=localhost
-PUBLIC_HUB_WEBSERVER_PORT=443
+ALERT_HOSTNAME=localhost
+
+#PUBLIC_HUB_WEBSERVER_PORT is decprecated and should be replaced with ALERT_SERVER_PORT
 
 # Encryption settings
 ALERT_ENCRYPTION_PASSWORD=

--- a/deployment/cm-alert.yml
+++ b/deployment/cm-alert.yml
@@ -4,10 +4,12 @@ metadata:
   name: blackduck-alert-config
 data:
   ALERT_SERVER_PORT: "8443"
+  #PUBLIC_HUB_WEBSERVER_HOST is deprecated and should be replaced with the following.
   # The value is just the host name DO NOT include the
   # scheme i.e. http or https.
-  PUBLIC_HUB_WEBSERVER_HOST: "localhost"
-  PUBLIC_HUB_WEBSERVER_PORT: "443"
+  ALERT_HOSTNAME: "localhost"
+
+  #PUBLIC_HUB_WEBSERVER_PORT is decprecated and should be replaced with ALERT_SERVER_PORT
 
   # Encryption settings:
   ALERT_ENCRYPTION_PASSWORD: ""

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@ logging.file=log/blackduck-alert.log
 logging.level.org.hibernate.SQL=ERROR
 logging.level.com.synopsys.integration=${ALERT_LOGGING_LEVEL:INFO}
 # Server
-server.port=${ALERT_SERVER_PORT:}
+server.port=${ALERT_SERVER_PORT:8443}
 server.servlet.session.timeout=${ALERT_SESSION_TIMEOUT:600}
 server.servlet.session.cookie.name=ALERT_SESSION_ID
 server.servlet.context-path=/alert

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@ logging.file=log/blackduck-alert.log
 logging.level.org.hibernate.SQL=ERROR
 logging.level.com.synopsys.integration=${ALERT_LOGGING_LEVEL:INFO}
 # Server
-server.port=${ALERT_SERVER_PORT:8080}
+server.port=${ALERT_SERVER_PORT:}
 server.servlet.session.timeout=${ALERT_SESSION_TIMEOUT:600}
 server.servlet.session.cookie.name=ALERT_SESSION_ID
 server.servlet.context-path=/alert


### PR DESCRIPTION
Remove the need for the PUBLIC_HUB_WEBSERVER_HOST and PUBLIC_HUB_WEBSERVER_PORT variables.

Use the ALERT_HOSTNAME and ALERT_SERVER_PORT environment variables.