### PR TITLE
Additional Email Addresses Only

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/channel/email/EmailAddressHandler.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/email/EmailAddressHandler.java
@@ -66,8 +66,11 @@ public class EmailAddressHandler {
         final Set<String> emailAddresses = new HashSet<>(allEmailAddresses);
         final Boolean projectOwnerOnly = originalAccessor.getBoolean(EmailDescriptor.KEY_PROJECT_OWNER_ONLY).orElse(false);
 
-        final Set<String> projectEmailAddresses = collectProviderEmailsFromProject(contentGroup.getCommonTopic().getValue(), projectOwnerOnly);
-        emailAddresses.addAll(projectEmailAddresses);
+        final boolean useOnlyAdditionalEmailAddresses = originalAccessor.getBoolean(EmailDescriptor.KEY_EMAIL_ADDITIONAL_ADDRESSES_ONLY).orElse(false);
+        if (!useOnlyAdditionalEmailAddresses) {
+            final Set<String> projectEmailAddresses = collectProviderEmailsFromProject(contentGroup.getCommonTopic().getValue(), projectOwnerOnly);
+            emailAddresses.addAll(projectEmailAddresses);
+        }
 
         final Set<String> additionalEmailAddresses = collectAdditionalEmailAddresses(originalAccessor);
         emailAddresses.addAll(additionalEmailAddresses);

--- a/src/main/java/com/synopsys/integration/alert/channel/email/descriptor/EmailDescriptor.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/email/descriptor/EmailDescriptor.java
@@ -34,6 +34,7 @@ public class EmailDescriptor extends ChannelDescriptor {
     public static final String KEY_PROJECT_OWNER_ONLY = "project.owner.only";
     public static final String KEY_EMAIL_ADDRESSES = "email.addresses";
     public static final String KEY_EMAIL_ADDITIONAL_ADDRESSES = "email.additional.addresses";
+    public static final String KEY_EMAIL_ADDITIONAL_ADDRESSES_ONLY = "email.additional.addresses.only";
 
     public static final String EMAIL_LABEL = "Email";
     public static final String EMAIL_URL = "email";

--- a/src/main/resources/db/changelog/alert/5.1.0/changelog-configuration-initialization.xml
+++ b/src/main/resources/db/changelog/alert/5.1.0/changelog-configuration-initialization.xml
@@ -6,5 +6,8 @@
         <sql dbms="h2" stripComments="true">
             CALL DEFINE_FIELD('email.additional.addresses', FALSE, 'channel_email', 'DISTRIBUTION');
         </sql>
+        <sql dbms="h2" stripComments="true">
+            CALL DEFINE_FIELD('email.additional.addresses.only', FALSE, 'channel_email', 'DISTRIBUTION');
+        </sql>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Add a checkbox to allow email jobs to only send to the 'Additional Email Addresses'.