### PR TITLE
Fix(deployment): Migrate 5.1.0 deployment fixes to 5.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM blackducksoftware/hub-docker-common:1.0.2 as docker-common
+FROM blackducksoftware/hub-docker-common:1.0.4 as docker-common
 FROM adoptopenjdk/openjdk11:alpine-slim
 
 ARG VERSION
@@ -22,6 +22,8 @@ ENV ALERT_IMAGES_DIR $ALERT_TAR_HOME/images
 
 ENV ALERT_MAX_HEAP_SIZE 2048m
 
+ENV BLACKDUCK_ALERT_OPTS="$BLACKDUCK_ALERT_OPTS -Djava.security.properties=${SECURITY_DIR}/java.security"
+
 RUN set -e \
     && mkdir -p $ALERT_HOME \
     && apk add --no-cache --virtual .blackduck-alert-run-deps \
@@ -31,16 +33,19 @@ RUN set -e \
     		bash \
     		zip \
     && addgroup -S alert \
-    && adduser -h "$ALERT_HOME" -g alert -s /sbin/nologin -G alert -S -D alert
+    && adduser -h "$ALERT_HOME" -g alert -s /sbin/nologin -G alert -S -D -H alert
 
-RUN mkdir -p -m 777 $SECURITY_DIR
+RUN mkdir -p -m 774 $CERTIFICATE_MANAGER_DIR
+RUN mkdir -p -m 774 $SECURITY_DIR
+RUN mkdir -p -m 774 $ALERT_CONFIG_HOME
+RUN mkdir -p -m 774 $ALERT_DATA_DIR
+RUN mkdir -p -m 774 $ALERT_DB_DIR
 
 COPY blackduck-alert-boot-$VERSION $ALERT_HOME/alert-tar
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY --from=docker-common healthcheck.sh /usr/local/bin/docker-healthcheck.sh
 COPY --from=docker-common certificate-manager.sh "$CERTIFICATE_MANAGER_DIR/certificate-manager.sh"
-
-EXPOSE 8080
+COPY --from=docker-common java.security "$SECURITY_DIR/java.security"
 
 ENTRYPOINT [ "docker-entrypoint.sh", "blackduck-alert" ]

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -18,10 +18,12 @@ services:
     env_file: [blackduck-alert.env]
     user: alert:root
     healthcheck:
-      test: [CMD, /usr/local/bin/docker-healthcheck.sh, 'https://localhost:8443/alert/api/about']
+      test: [CMD, /usr/local/bin/docker-healthcheck.sh, 'https://localhost:8443/alert/api/about',
+             /opt/blackduck/alert/security/root.crt, /opt/blackduck/alert/security/blackduck_system.crt,
+             /opt/blackduck/alert/security/blackduck_system.key]
       interval: 30s
-      timeout: 10s
-      retries: 5
+      timeout: 60s
+      retries: 15
     volumes: ['alert-db-volume:/opt/blackduck/alert/alert-config/data']
     mem_limit: 2560M
 volumes: {cert-volume: null, alert-db-volume: null }

--- a/deployment/docker-swarm/docker-compose.yml
+++ b/deployment/docker-swarm/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.6'
 services:
   cfssl:
     image: blackducksoftware/blackduck-cfssl:1.0.0
@@ -22,10 +22,13 @@ services:
     env_file: [blackduck-alert.env]
     user: alert:root
     healthcheck:
-      test: [CMD, /usr/local/bin/docker-healthcheck.sh, 'https://localhost:8443/alert/api/about']
+      test: [CMD, /usr/local/bin/docker-healthcheck.sh, 'https://localhost:8443/alert/api/about',
+             /opt/blackduck/alert/security/root.crt, /opt/blackduck/alert/security/blackduck_system.crt,
+             /opt/blackduck/alert/security/blackduck_system.key]
       interval: 30s
-      timeout: 10s
-      retries: 5
+      timeout: 60s
+      retries: 15
+      start_period: 7200s
     volumes: ['alert-db-volume:/opt/blackduck/alert/alert-config/data']
     deploy:
       mode: replicated

--- a/deployment/kubernetes/hub/3-alert.yml
+++ b/deployment/kubernetes/hub/3-alert.yml
@@ -1,67 +1,70 @@
 kind: List
 apiVersion: v1
 items:
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: alert
-  spec:
-    selector:
-      matchLabels:
-        app: alert
-        tier: alert
-    replicas: 1
-    template:
-      metadata:
-        name: alert
-        labels:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: alert
+    spec:
+      selector:
+        matchLabels:
           app: alert
           tier: alert
-      spec:
-        volumes:
-        # NOTE: replace the emptyDir volume with a persistent volume or all the data will be lost when the pod is destroyed.
-        - emptyDir: {}
-          name: dir-alert
-        containers:
-        - image: blackducksoftware/blackduck-alert:VERSION_TOKEN
+      replicas: 1
+      template:
+        metadata:
           name: alert
-          livenessProbe:
-            exec:
-              command:
-              - /usr/local/bin/docker-healthcheck.sh
-              - 'https://localhost:8443/alert/api/about'
-            initialDelaySeconds: 240
-            timeoutSeconds: 10
-            periodSeconds: 30
-            failureThreshold: 5
-          imagePullPolicy: Always
-          resources:
-            requests:
-              memory: 2560M
-            limits:
-              memory: 2560M
-          envFrom:
-          - configMapRef:
-              name: hub-config
-          - configMapRef:
-              name: blackduck-alert-config
-          volumeMounts:
-          - mountPath: /opt/blackduck/alert/alert-config
-            name: dir-alert
-          ports:
-          - containerPort: 8443
-            protocol: TCP
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: alert
-  spec:
-    ports:
-    - name: 8443-tcp
-      protocol: TCP
-      port: 8443
-      targetPort: 8443
-    selector:
-      app: alert
-  status:
-    loadBalancer: {}
+          labels:
+            app: alert
+            tier: alert
+        spec:
+          volumes:
+            # NOTE: replace the emptyDir volume with a persistent volume or all the data will be lost when the pod is destroyed.
+            - emptyDir: {}
+              name: dir-alert
+          containers:
+            - image: blackducksoftware/blackduck-alert:VERSION_TOKEN
+              name: alert
+              livenessProbe:
+                exec:
+                  command:
+                    - /usr/local/bin/docker-healthcheck.sh
+                    - 'https://localhost:8443/alert/api/about'
+                    - /opt/blackduck/alert/security/root.crt
+                    - /opt/blackduck/alert/security/blackduck_system.crt
+                    - /opt/blackduck/alert/security/blackduck_system.key
+                initialDelaySeconds: 240
+                timeoutSeconds: 60
+                periodSeconds: 30
+                failureThreshold: 15
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  memory: 2560M
+                limits:
+                  memory: 2560M
+              envFrom:
+                - configMapRef:
+                    name: hub-config
+                - configMapRef:
+                    name: blackduck-alert-config
+              volumeMounts:
+                - mountPath: /opt/blackduck/alert/alert-config
+                  name: dir-alert
+              ports:
+                - containerPort: 8443
+                  protocol: TCP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: alert
+    spec:
+      ports:
+        - name: 8443-tcp
+          protocol: TCP
+          port: 8443
+          targetPort: 8443
+      selector:
+        app: alert
+    status:
+      loadBalancer: {}

--- a/deployment/kubernetes/standalone/3-alert.yml
+++ b/deployment/kubernetes/standalone/3-alert.yml
@@ -1,66 +1,69 @@
 kind: List
 apiVersion: v1
 items:
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: alert
-  spec:
-    selector:
-      matchLabels:
-        app: alert
-        tier: alert
-    replicas: 1
-    template:
-      metadata:
-        name: alert
-        labels:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: alert
+    spec:
+      selector:
+        matchLabels:
           app: alert
           tier: alert
-      spec:
-        volumes:
-        # NOTE: replace the emptyDir volume with a persistent volume or all the data will be lost when the pod is destroyed.
-        - emptyDir: {}
-          name: dir-alert
-        containers:
-        - image: blackducksoftware/blackduck-alert:VERSION_TOKEN
+      replicas: 1
+      template:
+        metadata:
           name: alert
-          livenessProbe:
-            exec:
-              command:
-              - /usr/local/bin/docker-healthcheck.sh
-              - 'https://localhost:8443/alert/api/about'
-            initialDelaySeconds: 240
-            timeoutSeconds: 10
-            periodSeconds: 30
-            failureThreshold: 5
-          imagePullPolicy: Always
-          resources:
-            requests:
-              memory: 2560M
-            limits:
-              memory: 2560M
-          envFrom:
-          - configMapRef:
-              name: blackduck-alert-config
-          volumeMounts:
-          - mountPath: /opt/blackduck/alert/alert-config
-            name: dir-alert
-          ports:
-          - containerPort: 8443
-            protocol: TCP
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: alert
-  spec:
-    ports:
-    - name: 8443-tcp
-      protocol: TCP
-      port: 8443
-      targetPort: 8443
-    selector:
-      app: alert
-    type: LoadBalancer
-  status:
-    loadBalancer: {}
+          labels:
+            app: alert
+            tier: alert
+        spec:
+          volumes:
+            # NOTE: replace the emptyDir volume with a persistent volume or all the data will be lost when the pod is destroyed.
+            - emptyDir: {}
+              name: dir-alert
+          containers:
+            - image: blackducksoftware/blackduck-alert:VERSION_TOKEN
+              name: alert
+              livenessProbe:
+                exec:
+                  command:
+                    - /usr/local/bin/docker-healthcheck.sh
+                    - 'https://localhost:8443/alert/api/about'
+                    - /opt/blackduck/alert/security/root.crt
+                    - /opt/blackduck/alert/security/blackduck_system.crt
+                    - /opt/blackduck/alert/security/blackduck_system.key
+                initialDelaySeconds: 240
+                timeoutSeconds: 60
+                periodSeconds: 30
+                failureThreshold: 15
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  memory: 2560M
+                limits:
+                  memory: 2560M
+              envFrom:
+                - configMapRef:
+                    name: blackduck-alert-config
+              volumeMounts:
+                - mountPath: /opt/blackduck/alert/alert-config
+                  name: dir-alert
+              ports:
+                - containerPort: 8443
+                  protocol: TCP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: alert
+    spec:
+      ports:
+        - name: 8443-tcp
+          protocol: TCP
+          port: 8443
+          targetPort: 8443
+      selector:
+        app: alert
+      type: LoadBalancer
+    status:
+      loadBalancer: {}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -230,9 +230,9 @@ importBlackDuckSystemCertificateIntoKeystore() {
     exitCode=$?
     if [ $exitCode -eq 0 ];
     then
-        echo "Successfully imported BlackDuck system certificate into Java truststore."
+        echo "Successfully imported BlackDuck system certificate into Java keystore."
     else
-        echo "Unable to import BlackDuck system certificate into Java truststore (Code: $exitCode)."
+        echo "Unable to import BlackDuck system certificate into Java keystore (Code: $exitCode)."
         exit $exitCode
     fi
 }


### PR DESCRIPTION
Backport of 5.1.0 deployment file changes.

See https://github.com/blackducksoftware/blackduck-alert/pull/549 for analogous changes.

There is one file different in Kubernetes that is different because the healthcheck was not implemented in master for 5.1.0.  This PR fixes that issue.