### PR TITLE
Jira Component Version link fix

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/channel/jira/util/JiraIssueFormatHelper.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/jira/util/JiraIssueFormatHelper.java
@@ -129,7 +129,7 @@ public class JiraIssueFormatHelper {
             componentSection.append("\n");
             componentSection.append(subComponent.getName());
             componentSection.append(": ");
-            componentSection.append(subComponent.getValue());
+            componentSection.append(createValueString(subComponent));
         });
 
         componentSection.append("\n");


### PR DESCRIPTION
Fixed an issue with Jira component versions not properly linking back to BlackDuck like we do in other channels.