### PR TITLE
Get cvss3 severity from Black Duck if it exists

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckVulnerabilityCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckVulnerabilityCollector.java
@@ -36,6 +36,8 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.jayway.jsonpath.TypeRef;
 import com.synopsys.integration.alert.common.enumeration.ComponentItemPriority;
 import com.synopsys.integration.alert.common.enumeration.ItemOperation;
@@ -166,6 +168,10 @@ public class BlackDuckVulnerabilityCollector extends BlackDuckCollector {
             getBucketService().addToTheBucket(getBlackDuckBucket(), vulnerabilityUrl, VulnerabilityView.class);
             VulnerabilityView vulnerabilityView = getBlackDuckBucket().get(vulnerabilityUrl, VulnerabilityView.class);
             String severity = vulnerabilityView.getSeverity();
+            Optional<String> cvss3Severity = getCvss3Severity(vulnerabilityView);
+            if (cvss3Severity.isPresent()) {
+                severity = cvss3Severity.get();
+            }
             severityItem = new LinkableItem(BlackDuckContent.LABEL_VULNERABILITY_SEVERITY, severity);
         } catch (Exception e) {
             logger.debug("Error fetching vulnerability view", e);
@@ -174,6 +180,21 @@ public class BlackDuckVulnerabilityCollector extends BlackDuckCollector {
         severityItem.setSummarizable(true);
         severityItem.setPartOfKey(true);
         return severityItem;
+    }
+
+    private Optional<String> getCvss3Severity(VulnerabilityView vulnerabilityView) {
+        Boolean useCvss3 = vulnerabilityView.getUseCvss3();
+        if (null != useCvss3 && useCvss3) {
+            JsonObject vulnJsonObject = vulnerabilityView.getJsonElement().getAsJsonObject();
+            JsonElement cvss3 = vulnJsonObject.get("cvss3");
+            if (null != cvss3) {
+                JsonElement cvss3Severity = cvss3.getAsJsonObject().get("severity");
+                if (null != cvss3Severity) {
+                    return Optional.of(cvss3Severity.getAsString());
+                }
+            }
+        }
+        return Optional.empty();
     }
 
 }

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckVulnerabilityCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckVulnerabilityCollector.java
@@ -36,8 +36,6 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import com.jayway.jsonpath.TypeRef;
 import com.synopsys.integration.alert.common.enumeration.ComponentItemPriority;
 import com.synopsys.integration.alert.common.enumeration.ItemOperation;
@@ -53,7 +51,6 @@ import com.synopsys.integration.alert.provider.blackduck.collector.util.BlackDuc
 import com.synopsys.integration.alert.provider.blackduck.descriptor.BlackDuckContent;
 import com.synopsys.integration.blackduck.api.generated.view.ComponentVersionView;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionView;
-import com.synopsys.integration.blackduck.api.generated.view.VulnerabilityView;
 import com.synopsys.integration.blackduck.api.manual.component.VulnerabilitySourceQualifiedId;
 
 @Component
@@ -160,41 +157,6 @@ public class BlackDuckVulnerabilityCollector extends BlackDuckCollector {
             }
         }
         return items;
-    }
-
-    private LinkableItem getSeverity(String vulnerabilityUrl) {
-        LinkableItem severityItem = new LinkableItem(BlackDuckContent.LABEL_VULNERABILITY_SEVERITY, "UNKNOWN");
-        try {
-            getBucketService().addToTheBucket(getBlackDuckBucket(), vulnerabilityUrl, VulnerabilityView.class);
-            VulnerabilityView vulnerabilityView = getBlackDuckBucket().get(vulnerabilityUrl, VulnerabilityView.class);
-            String severity = vulnerabilityView.getSeverity();
-            Optional<String> cvss3Severity = getCvss3Severity(vulnerabilityView);
-            if (cvss3Severity.isPresent()) {
-                severity = cvss3Severity.get();
-            }
-            severityItem = new LinkableItem(BlackDuckContent.LABEL_VULNERABILITY_SEVERITY, severity);
-        } catch (Exception e) {
-            logger.debug("Error fetching vulnerability view", e);
-        }
-
-        severityItem.setSummarizable(true);
-        severityItem.setPartOfKey(true);
-        return severityItem;
-    }
-
-    private Optional<String> getCvss3Severity(VulnerabilityView vulnerabilityView) {
-        Boolean useCvss3 = vulnerabilityView.getUseCvss3();
-        if (null != useCvss3 && useCvss3) {
-            JsonObject vulnJsonObject = vulnerabilityView.getJsonElement().getAsJsonObject();
-            JsonElement cvss3 = vulnJsonObject.get("cvss3");
-            if (null != cvss3) {
-                JsonElement cvss3Severity = cvss3.getAsJsonObject().get("severity");
-                if (null != cvss3Severity) {
-                    return Optional.of(cvss3Severity.getAsString());
-                }
-            }
-        }
-        return Optional.empty();
     }
 
 }


### PR DESCRIPTION
I also added this in a previous commit on master. Before, it was the same without the if-statement.
```java
    public static final ComponentItemPriority findPriority(String priority) {
        String upperCasePriority = priority.toUpperCase();
        if ("CRITICAL".equals(upperCasePriority) || "BLOCKER".equals(upperCasePriority)) {
            return HIGHEST;
        }

        try {
            return ComponentItemPriority.valueOf(upperCasePriority);
        } catch (IllegalArgumentException ex) {
            // couldn't find the enum value default to STANDARD
            return NONE;
        }
    }
```