### PR TITLE
Ps encryption read fix

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/AlertProperties.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/AlertProperties.java
@@ -39,6 +39,9 @@ public class AlertProperties {
     @Value("${alert.images.dir:}")
     private String alertImagesDir;
 
+    @Value("${alert.secrets.dir:/run/secrets}")
+    private String alertSecretsDir;
+
     @Value("${alert.trust.cert:}")
     private Boolean alertTrustCertificate;
 
@@ -114,6 +117,10 @@ public class AlertProperties {
             return imagesDirectory + "/synopsys.png";
         }
         return System.getProperties().getProperty("user.dir") + "/src/main/resources/email/images/synopsys.png";
+    }
+
+    public String getAlertSecretsDir() {
+        return StringUtils.trimToNull(alertSecretsDir);
     }
 
     public Boolean getH2ConsoleEnabled() {

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/util/FilePersistenceUtil.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/util/FilePersistenceUtil.java
@@ -48,7 +48,7 @@ public class FilePersistenceUtil {
             dataDirectory = String.format("%s/data", alertProperties.getAlertConfigHome());
         }
         this.parentDataDirectory = new File(dataDirectory);
-        this.secretsDirectory = new File("/run/secrets");
+        this.secretsDirectory = new File(alertProperties.getAlertSecretsDir());
     }
 
     public void writeToFile(final String fileName, final String content) throws IOException {

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/security/EncryptionUtility.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/security/EncryptionUtility.java
@@ -22,6 +22,7 @@
  */
 package com.synopsys.integration.alert.common.security;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Optional;
 
@@ -163,14 +164,18 @@ public class EncryptionUtility {
     private Optional<String> readGlobalSaltFromSecretsFile() {
         try {
             return Optional.ofNullable(filePersistenceUtil.readFromSecretsFile(SECRETS_ENCRYPTION_SALT));
+        } catch (FileNotFoundException ex) {
+            // ignore so we can attempt the old file.
         } catch (final IOException ex) {
-            logger.debug("New global salt file not found ", ex);
+            logger.debug("Error getting new global salt file.", ex);
         }
 
         try {
             return Optional.ofNullable(filePersistenceUtil.readFromSecretsFile(SECRETS_ENCRYPTION_SALT_OLD));
+        } catch (FileNotFoundException ex) {
+            // ignore if not found.
         } catch (final IOException ex) {
-            logger.debug("Old global salt file not found ", ex);
+            logger.debug("Error getting old global salt file.", ex);
         }
 
         return Optional.empty();

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/security/EncryptionUtility.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/security/EncryptionUtility.java
@@ -44,6 +44,8 @@ public class EncryptionUtility {
     private static final String DATA_FILE_NAME = "alert_encryption_data.json";
     private static final String SECRETS_ENCRYPTION_PASSWORD = "ALERT_ENCRYPTION_PASSWORD";
     private static final String SECRETS_ENCRYPTION_SALT = "ALERT_ENCRYPTION_GLOBAL_SALT";
+    // TODO: In 6.x remove the old salt variable.
+    private static final String SECRETS_ENCRYPTION_SALT_OLD = "ALERT_ENCRYPTION_SALT";
     private final AlertProperties alertProperties;
     private final FilePersistenceUtil filePersistenceUtil;
 
@@ -162,8 +164,16 @@ public class EncryptionUtility {
         try {
             return Optional.ofNullable(filePersistenceUtil.readFromSecretsFile(SECRETS_ENCRYPTION_SALT));
         } catch (final IOException ex) {
-            return Optional.empty();
+            logger.debug("New global salt file not found ", ex);
         }
+
+        try {
+            return Optional.ofNullable(filePersistenceUtil.readFromSecretsFile(SECRETS_ENCRYPTION_SALT_OLD));
+        } catch (final IOException ex) {
+            logger.debug("Old global salt file not found ", ex);
+        }
+
+        return Optional.empty();
     }
 
     private String readGlobalSaltFromVolumeDataFile() {

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/security/EncryptionUtility.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/security/EncryptionUtility.java
@@ -165,11 +165,13 @@ public class EncryptionUtility {
         try {
             return Optional.ofNullable(filePersistenceUtil.readFromSecretsFile(SECRETS_ENCRYPTION_SALT));
         } catch (FileNotFoundException ex) {
+            // TODO in 6.x remove this catch block
             // ignore so we can attempt the old file.
         } catch (final IOException ex) {
             logger.debug("Error getting new global salt file.", ex);
         }
 
+        // TODO remove in 6.x
         try {
             return Optional.ofNullable(filePersistenceUtil.readFromSecretsFile(SECRETS_ENCRYPTION_SALT_OLD));
         } catch (FileNotFoundException ex) {

--- a/src/test/java/com/synopsys/integration/alert/util/TestAlertProperties.java
+++ b/src/test/java/com/synopsys/integration/alert/util/TestAlertProperties.java
@@ -8,6 +8,7 @@ public class TestAlertProperties extends AlertProperties {
     private String alertConfigHome;
     private String alertTemplatesDir;
     private String alertImagesDir;
+    private String alertSecretsDir;
     private Boolean alertTrustCertificate;
     private String alertProxyHost;
     private String alertProxyPort;
@@ -16,6 +17,7 @@ public class TestAlertProperties extends AlertProperties {
     private Boolean sslEnabled = false;
 
     public TestAlertProperties() {
+        this.alertSecretsDir = "./testDB/run/secrets";
     }
 
     @Override
@@ -61,5 +63,14 @@ public class TestAlertProperties extends AlertProperties {
 
     public void setSslEnabled(final Boolean sslEnabled) {
         this.sslEnabled = sslEnabled;
+    }
+
+    @Override
+    public String getAlertSecretsDir() {
+        return this.alertSecretsDir;
+    }
+
+    public void setAlertSecretsDir(final String alertSecretsDir) {
+        this.alertSecretsDir = alertSecretsDir;
     }
 }


### PR DESCRIPTION
Try to read the new salt secret first otherwise attempt to read the old secret file name.

Added unit tests to the encryption utility class.