### PR TITLE
Ps changelock fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,9 +121,13 @@ bootJar {
 distributions {
     boot {
         contents {
-            from("$project.buildDir/libs") {
+            from("$project.buildDir/libs/liquibase") {
+                include 'h2*.jar'
                 include 'liquibase-core*.jar'
-                into 'lib'
+                include 'logback-*.jar'
+                include 'slf4j-api*.jar'
+                include 'snakeyaml*.jar'
+                into 'lib/liquibase'
             }
             from('src/main/resources/db/release-locks-changelog.xml') { into 'changelogs' }
             from('src/main/resources/email/images/') { into 'images/' }
@@ -133,8 +137,13 @@ distributions {
 }
 
 task copyToLib(type: Copy, dependsOn: [compileJava]) {
+    from findJar('h2')
     from findJar('liquibase')
-    into "${project.buildDir}/libs"
+    from findJar('logback-classic')
+    from findJar('logback-core')
+    from findJar('slf4j-api')
+    from findJar('snakeyaml')
+    into "${project.buildDir}/libs/liquibase"
 }
 
 def findJar(prefix) {

--- a/build.gradle
+++ b/build.gradle
@@ -121,11 +121,25 @@ bootJar {
 distributions {
     boot {
         contents {
+            from("$project.buildDir/libs/liquibase-core-3.6.3.jar") { into 'lib' }
             from('src/main/resources/email/images/') { into 'images/' }
             from('src/main/resources/email/templates/') { into 'templates/email' }
         }
     }
 }
+
+task copyToLib(type: Copy, dependsOn: [compileJava]) {
+    from findJar('liquibase')
+    into "${project.buildDir}/libs"
+}
+
+def findJar(prefix) {
+    configurations.runtimeClasspath.filter {
+        it.name.startsWith(prefix)
+    }
+}
+
+tasks.compileJava.finalizedBy(tasks.copyToLib)
 
 // run alert locally
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
@@ -139,7 +153,6 @@ gradle.taskGraph.whenReady { graph ->
         test.enabled = false
     }
 }
-
 
 task createKeystore(type: Exec) {
     doFirst {

--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,10 @@ bootJar {
 distributions {
     boot {
         contents {
-            from("$project.buildDir/libs/liquibase-core-3.6.3.jar") { into 'lib' }
+            from("$project.buildDir/libs") {
+                include 'liquibase-core*.jar'
+                into 'lib'
+            }
             from('src/main/resources/email/images/') { into 'images/' }
             from('src/main/resources/email/templates/') { into 'templates/email' }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,7 @@ distributions {
                 include 'liquibase-core*.jar'
                 into 'lib'
             }
+            from('src/main/resources/db/release-locks-changelog.xml') { into 'changelogs' }
             from('src/main/resources/email/images/') { into 'images/' }
             from('src/main/resources/email/templates/') { into 'templates/email' }
         }

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,6 +4,7 @@ certificateManagerDir=/opt/blackduck/alert/bin
 securityDir=/opt/blackduck/alert/security
 alertHome=/opt/blackduck/alert
 alertConfigHome=$alertHome/alert-config
+alertDatabaseDir=$alertConfigHome/data/alertdb
 
 serverCertName=$APPLICATION_NAME-server
 
@@ -347,6 +348,18 @@ checkVolumeDirectories() {
   fi
 }
 
+liquibaseChangelockReset() {
+  echo "Begin releasing liquibase changeloglock."
+  $JAVA_HOME/bin/java -jar $alertHome/alert-tar/lib/liquibase-core-3.6.3.jar \
+  --url=$alertDatabaseDir \
+  --username=sa \
+  --password= \
+  --driver=org.h2.Driver \
+  --changeLogFile= $alertHome/alert-tar/changelogs/release-locks-changelog.xml \
+  releaseLocks
+  echo "End releasing liquibase changeloglock."
+}
+
 checkVolumeDirectories
 
 if [ ! -f "$certificateManagerDir/certificate-manager.sh" ];
@@ -373,6 +386,7 @@ else
   importBlackDuckWebServerCertificate
   importDockerHubServerCertificate
   createDataBackUp
+  liquibaseChangelockReset
 
   if [ -f "$truststoreFile" ];
   then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -350,12 +350,13 @@ checkVolumeDirectories() {
 
 liquibaseChangelockReset() {
   echo "Begin releasing liquibase changeloglock."
-  $JAVA_HOME/bin/java -jar $alertHome/alert-tar/lib/liquibase-core-3.6.3.jar \
-  --url=$alertDatabaseDir \
-  --username=sa \
-  --password= \
-  --driver=org.h2.Driver \
-  --changeLogFile= $alertHome/alert-tar/changelogs/release-locks-changelog.xml \
+  $JAVA_HOME/bin/java -cp "/opt/blackduck/alert/alert-tar/lib/liquibase/*" \
+  liquibase.integration.commandline.Main \
+  --url="jdbc:h2:file:$alertDatabaseDir" \
+  --username="sa" \
+  --password="" \
+  --driver="org.h2.Driver" \
+  --changeLogFile="$alertHome/alert-tar/changelogs/release-locks-changelog.xml" \
   releaseLocks
   echo "End releasing liquibase changeloglock."
 }

--- a/src/main/resources/db/release-locks-changelog.xml
+++ b/src/main/resources/db/release-locks-changelog.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+</databaseChangeLog>


### PR DESCRIPTION
A patch where upon startup of Alert liquibase will release the changelocks on the database.

A new changelocks directory is created with an empty changeset.
The jar files for the liquibase command line are copied into the lib/ directory of the deployment.
The entrypoint script executes the liquibase command line to release the locks on the database.
