### PR TITLE
Fix(settings): Remove the admin email and password settings.

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/component/settings/descriptor/SettingsDescriptor.java
+++ b/src/main/java/com/synopsys/integration/alert/component/settings/descriptor/SettingsDescriptor.java
@@ -34,6 +34,7 @@ public class SettingsDescriptor extends ComponentDescriptor {
     public static final String SETTINGS_DESCRIPTION = "This page allows you to configure the admin settings.";
 
     // Values not stored in the database, but keys must be registered
+    //TODO deprecate these fields in 5.3.0 and remove them in 6.0.0.
     public static final String KEY_DEFAULT_SYSTEM_ADMIN_EMAIL = "settings.user.default.admin.email";
     public static final String KEY_DEFAULT_SYSTEM_ADMIN_PWD = "settings.user.default.admin.password";
     public static final String KEY_ENCRYPTION_PWD = "settings.encryption.password";

--- a/src/main/java/com/synopsys/integration/alert/component/settings/descriptor/SettingsUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/component/settings/descriptor/SettingsUIConfig.java
@@ -89,13 +89,6 @@ public class SettingsUIConfig extends UIConfig {
     }
 
     private List<ConfigField> createDefaultSettingsPanel() {
-
-        ConfigField sysAdminEmail = new TextInputConfigField(SettingsDescriptor.KEY_DEFAULT_SYSTEM_ADMIN_EMAIL, LABEL_DEFAULT_SYSTEM_ADMINISTRATOR_EMAIL, SETTINGS_ADMIN_EMAIL_DESCRIPTION)
-                                        .applyRequired(true)
-                                        .applyHeader(SETTINGS_HEADER_ADMINISTRATOR);
-        ConfigField defaultUserPassword = new PasswordConfigField(SettingsDescriptor.KEY_DEFAULT_SYSTEM_ADMIN_PWD, LABEL_DEFAULT_SYSTEM_ADMINISTRATOR_PASSWORD, SETTINGS_USER_PASSWORD_DESCRIPTION, encryptionConfigValidator)
-                                              .applyRequired(true)
-                                              .applyHeader(SETTINGS_HEADER_ADMINISTRATOR);
         ConfigField encryptionPassword = new PasswordConfigField(SettingsDescriptor.KEY_ENCRYPTION_PWD, LABEL_ENCRYPTION_PASSWORD, SETTINGS_ENCRYPTION_PASSWORD_DESCRIPTION, encryptionFieldValidator)
                                              .applyRequired(true)
                                              .applyValidationFunctions(this::minimumEncryptionFieldLength)
@@ -105,7 +98,7 @@ public class SettingsUIConfig extends UIConfig {
                                          .applyValidationFunctions(this::minimumEncryptionFieldLength)
                                          .applyHeader(SETTINGS_HEADER_ENCRYPTION);
         ConfigField environmentVariableOverride = new CheckboxConfigField(SettingsDescriptor.KEY_STARTUP_ENVIRONMENT_VARIABLE_OVERRIDE, LABEL_STARTUP_ENVIRONMENT_VARIABLE_OVERRIDE, SETTINGS_ENVIRONMENT_VARIABLE_OVERRIDE_DESCRIPTION);
-        return List.of(sysAdminEmail, defaultUserPassword, encryptionPassword, encryptionSalt, environmentVariableOverride);
+        return List.of(encryptionPassword, encryptionSalt, environmentVariableOverride);
     }
 
     private List<ConfigField> createProxyPanel() {

--- a/src/test/java/com/synopsys/integration/alert/component/settings/SettingsGlobalApiActionTest.java
+++ b/src/test/java/com/synopsys/integration/alert/component/settings/SettingsGlobalApiActionTest.java
@@ -159,7 +159,6 @@ public class SettingsGlobalApiActionTest {
         fieldValidationAction.validateConfig(configFieldMap, fieldModel, fieldErrors);
 
         assertFalse(fieldErrors.isEmpty());
-        assertEquals(ConfigField.REQUIRED_FIELD_MISSING, fieldErrors.get(SettingsDescriptor.KEY_DEFAULT_SYSTEM_ADMIN_PWD));
         assertEquals(ConfigField.REQUIRED_FIELD_MISSING, fieldErrors.get(SettingsDescriptor.KEY_ENCRYPTION_PWD));
         assertEquals(ConfigField.REQUIRED_FIELD_MISSING, fieldErrors.get(SettingsDescriptor.KEY_ENCRYPTION_GLOBAL_SALT));
 
@@ -168,7 +167,6 @@ public class SettingsGlobalApiActionTest {
         fieldValidationAction.validateConfig(configFieldMap, fieldModel, fieldErrors);
 
         assertFalse(fieldErrors.isEmpty());
-        assertEquals(ConfigField.REQUIRED_FIELD_MISSING, fieldErrors.get(SettingsDescriptor.KEY_DEFAULT_SYSTEM_ADMIN_PWD));
         assertEquals(ConfigField.REQUIRED_FIELD_MISSING, fieldErrors.get(SettingsDescriptor.KEY_ENCRYPTION_PWD));
         assertEquals(ConfigField.REQUIRED_FIELD_MISSING, fieldErrors.get(SettingsDescriptor.KEY_ENCRYPTION_GLOBAL_SALT));
     }
@@ -185,7 +183,6 @@ public class SettingsGlobalApiActionTest {
         fieldValidationAction.validateConfig(configFieldMap, fieldModel, fieldErrors);
 
         assertFalse(fieldErrors.isEmpty());
-        assertEquals(ConfigField.REQUIRED_FIELD_MISSING, fieldErrors.get(SettingsDescriptor.KEY_DEFAULT_SYSTEM_ADMIN_PWD));
         assertEquals(ConfigField.REQUIRED_FIELD_MISSING, fieldErrors.get(SettingsDescriptor.KEY_ENCRYPTION_PWD));
         assertEquals(ConfigField.REQUIRED_FIELD_MISSING, fieldErrors.get(SettingsDescriptor.KEY_ENCRYPTION_GLOBAL_SALT));
     }


### PR DESCRIPTION
Remove the UI components for setting the default user email and password since it can now be done through the user management screen.