### PR TITLE
Ps external user roles

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/UserModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/UserModel.java
@@ -43,8 +43,9 @@ public class UserModel extends AlertSerializableModel {
     private final boolean locked;
     private final boolean passwordExpired;
     private final boolean enabled;
+    private final boolean external;
 
-    private UserModel(Long id, String name, String password, String emailAddress, Set<UserRoleModel> roles, boolean expired, boolean locked, boolean passwordExpired, boolean enabled) {
+    private UserModel(Long id, String name, String password, String emailAddress, Set<UserRoleModel> roles, boolean expired, boolean locked, boolean passwordExpired, boolean enabled, boolean external) {
         this.id = id;
         this.name = name;
         this.password = password;
@@ -54,6 +55,7 @@ public class UserModel extends AlertSerializableModel {
         this.locked = locked;
         this.passwordExpired = passwordExpired;
         this.enabled = enabled;
+        this.external = external;
         if (null == roles || roles.isEmpty()) {
             this.roleNames = Set.of();
         } else {
@@ -61,12 +63,12 @@ public class UserModel extends AlertSerializableModel {
         }
     }
 
-    public static UserModel newUser(String userName, String password, String emailAddress, Set<UserRoleModel> roles) {
-        return existingUser(null, userName, password, emailAddress, roles);
+    public static UserModel newUser(String userName, String password, String emailAddress, boolean external, Set<UserRoleModel> roles) {
+        return existingUser(null, userName, password, emailAddress, external, roles);
     }
 
-    public static UserModel existingUser(Long id, String userName, String password, String emailAddress, Set<UserRoleModel> roles) {
-        return new UserModel(id, userName, password, emailAddress, roles, false, false, false, true);
+    public static UserModel existingUser(Long id, String userName, String password, String emailAddress, boolean external, Set<UserRoleModel> roles) {
+        return new UserModel(id, userName, password, emailAddress, roles, false, false, false, true, external);
     }
 
     public Long getId() {
@@ -122,4 +124,7 @@ public class UserModel extends AlertSerializableModel {
         return roleNames;
     }
 
+    public boolean isExternal() {
+        return external;
+    }
 }

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultUserAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultUserAccessor.java
@@ -78,7 +78,7 @@ public class DefaultUserAccessor implements UserAccessor {
 
     @Override
     public UserModel addUser(String userName, String password, String emailAddress) throws AlertDatabaseConstraintException {
-        return addUser(UserModel.newUser(userName, password, emailAddress, Collections.emptySet()), false);
+        return addUser(UserModel.newUser(userName, password, emailAddress, false, Collections.emptySet()), false);
     }
 
     @Override
@@ -204,7 +204,7 @@ public class DefaultUserAccessor implements UserAccessor {
         List<UserRoleRelation> roleRelations = userRoleRepository.findAllByUserId(user.getId());
         List<Long> roleIdsForUser = roleRelations.stream().map(UserRoleRelation::getRoleId).collect(Collectors.toList());
         Set<UserRoleModel> roles = authorizationUtility.getRoles(roleIdsForUser);
-        return UserModel.existingUser(user.getId(), user.getUserName(), user.getPassword(), user.getEmailAddress(), roles);
+        return UserModel.existingUser(user.getId(), user.getUserName(), user.getPassword(), user.getEmailAddress(), user.isExternal(), roles);
     }
 
 }

--- a/src/main/java/com/synopsys/integration/alert/web/model/UserConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/web/model/UserConfig.java
@@ -36,11 +36,12 @@ public class UserConfig extends Config {
     private boolean passwordExpired;
     private boolean enabled;
     private boolean passwordSet;
+    private boolean external;
 
     public UserConfig() {
     }
 
-    public UserConfig(String id, String username, String password, String emailAddress, Set<String> roleNames, boolean expired, boolean locked, boolean passwordExpired, boolean enabled, boolean passwordSet) {
+    public UserConfig(String id, String username, String password, String emailAddress, Set<String> roleNames, boolean expired, boolean locked, boolean passwordExpired, boolean enabled, boolean passwordSet, boolean external) {
         super(id);
         this.username = username;
         this.password = password;
@@ -51,6 +52,7 @@ public class UserConfig extends Config {
         this.passwordExpired = passwordExpired;
         this.enabled = enabled;
         this.passwordSet = passwordSet;
+        this.external = external;
     }
 
     public String getUsername() {
@@ -87,5 +89,9 @@ public class UserConfig extends Config {
 
     public boolean isPasswordSet() {
         return passwordSet;
+    }
+
+    public boolean isExternal() {
+        return external;
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/UserManagementAuthoritiesPopulator.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/UserManagementAuthoritiesPopulator.java
@@ -72,6 +72,7 @@ public class UserManagementAuthoritiesPopulator {
     }
 
     public Set<String> addAdditionalRoleNames(String userName, Set<String> existingRoles, boolean appendRolePrefix) {
+        // TODO remove in 6.0.0 the createRolesMapping method.
         Map<String, String> roleMap = createRolesMapping(appendRolePrefix);
         Set<String> rolesFromDB = getRolesFromDatabase(userName, appendRolePrefix);
         Set<String> roles = new LinkedHashSet<>();
@@ -98,7 +99,7 @@ public class UserManagementAuthoritiesPopulator {
         return defaultName;
     }
 
-    @Deprecated
+    // TODO remove in 6.0.0
     private Map<String, String> createRolesMapping(boolean appendRolePrefix) {
         Map<String, String> roleMapping = new HashMap<>(DefaultUserRole.values().length);
         try {
@@ -127,12 +128,12 @@ public class UserManagementAuthoritiesPopulator {
         return newRoleNames;
     }
 
-    @Deprecated
+    // TODO remove in 6.0.0
     private String createRoleWithPrefix(DefaultUserRole alertRole) {
         return UserModel.ROLE_PREFIX + alertRole.name();
     }
 
-    @Deprecated
+    // TODO remove in 6.0.0
     private ConfigurationModel getCurrentConfiguration() throws AlertException {
         return configurationAccessor.getConfigurationsByDescriptorKey(AuthenticationDescriptorKey)
                    .stream()
@@ -140,7 +141,7 @@ public class UserManagementAuthoritiesPopulator {
                    .orElseThrow(() -> new AlertException("Settings configuration missing"));
     }
 
-    @Deprecated
+    // TODO remove in 6.0.0
     private Optional<String> getFieldValue(ConfigurationModel configurationModel, String fieldKey) {
         return configurationModel.getField(fieldKey).flatMap(ConfigurationFieldModel::getFieldValue);
     }

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/event/AuthenticationEventManager.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/event/AuthenticationEventManager.java
@@ -93,7 +93,7 @@ public class AuthenticationEventManager {
                                             .map(UserRoleModel::of)
                                             .collect(Collectors.toSet());
 
-        UserModel userModel = UserModel.newUser(username, null, emailAddress, alertRoles);
+        UserModel userModel = UserModel.newUser(username, null, emailAddress, true, alertRoles);
         AlertAuthenticationEvent authEvent = new AlertAuthenticationEvent(userModel);
         eventManager.sendEvent(authEvent);
     }

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/ldap/MappingLdapAuthoritiesPopulator.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/ldap/MappingLdapAuthoritiesPopulator.java
@@ -39,7 +39,7 @@ public class MappingLdapAuthoritiesPopulator extends DefaultLdapAuthoritiesPopul
     }
 
     @Override
-    public Set<GrantedAuthority> getGroupMembershipRoles(String userDn, String username) {
-        return authoritiesPopulator.addAdditionalRoles(super.getGroupMembershipRoles(userDn, username));
+    public Set<GrantedAuthority> getGroupMembershipRoles(String userDn, String userName) {
+        return authoritiesPopulator.addAdditionalRoles(userName, super.getGroupMembershipRoles(userDn, userName));
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/UserDetailsService.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/UserDetailsService.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang.StringUtils;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.saml.SAMLCredential;
 import org.springframework.security.saml.userdetails.SAMLUserDetailsService;
@@ -44,13 +45,13 @@ public class UserDetailsService implements SAMLUserDetailsService {
 
     @Override
     public Object loadUserBySAML(SAMLCredential credential) throws UsernameNotFoundException {
-        String userName = credential.getAttributeAsString("Name");
-        String emailAddress = credential.getAttributeAsString("Email");
+        String userName = credential.getNameID().getValue();
+        String emailAddress = StringUtils.contains(userName, "@") ? userName : null;
         String[] alertRoles = credential.getAttributeAsStringArray(authoritiesPopulator.getSAMLRoleAttributeName("AlertRoles"));
         Set<UserRoleModel> roles = Set.of();
 
         if (alertRoles != null) {
-            Set<String> roleNames = authoritiesPopulator.addAdditionalRoleNames(Arrays.stream(alertRoles).collect(Collectors.toSet()), false);
+            Set<String> roleNames = authoritiesPopulator.addAdditionalRoleNames(userName, Arrays.stream(alertRoles).collect(Collectors.toSet()), false);
             roles = roleNames.stream()
                         .map(UserRoleModel::of)
                         .collect(Collectors.toSet());

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/UserDetailsService.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/UserDetailsService.java
@@ -56,7 +56,7 @@ public class UserDetailsService implements SAMLUserDetailsService {
                         .collect(Collectors.toSet());
         }
 
-        UserModel userModel = UserModel.newUser(userName, "", emailAddress, roles);
+        UserModel userModel = UserModel.newUser(userName, "", emailAddress, true, roles);
         return new UserPrincipal(userModel);
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/web/user/UserActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/user/UserActions.java
@@ -101,7 +101,7 @@ public class UserActions {
             if (!fieldErrors.isEmpty()) {
                 throw new AlertFieldException(fieldErrors);
             }
-            UserModel newUserModel = UserModel.existingUser(existingUser.getId(), userName, password, emailAddress, existingUser.getRoles());
+            UserModel newUserModel = UserModel.existingUser(existingUser.getId(), userName, password, emailAddress, existingUser.isExternal(), existingUser.getRoles());
             userAccessor.updateUser(newUserModel, passwordMissing);
 
             Set<String> configuredRoleNames = userConfig.getRoleNames();
@@ -123,6 +123,9 @@ public class UserActions {
 
     private UserConfig convertToCustomUserRoleModel(UserModel userModel) {
         // converting to an object to return to the client; remove the password field.
+        // also if the user is external the password is set
+        boolean external = userModel.isExternal();
+        boolean passwordSet = StringUtils.isNotBlank(userModel.getPassword()) || external;
         return new UserConfig(
             userModel.getId().toString(),
             userModel.getName(),
@@ -133,7 +136,8 @@ public class UserActions {
             userModel.isLocked(),
             userModel.isPasswordExpired(),
             userModel.isEnabled(),
-            StringUtils.isNotBlank(userModel.getPassword()));
+            passwordSet,
+            external);
     }
 
     private void validateCreationRequiredFields(UserConfig userConfig) throws AlertFieldException {

--- a/src/main/js/dynamic/loaded/users/UserTable.js
+++ b/src/main/js/dynamic/loaded/users/UserTable.js
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import { clearUserFieldErrors, createNewUser, deleteUser, fetchUsers, updateUser } from 'store/actions/users';
 import DynamicSelectInput from 'field/input/DynamicSelect';
 import { fetchRoles } from 'store/actions/roles';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 class UserTable extends Component {
     constructor(props) {
@@ -36,6 +37,12 @@ class UserTable extends Component {
                 header: 'id',
                 headerLabel: 'Id',
                 isKey: true,
+                hidden: true
+            },
+            {
+                header: 'external',
+                headerLabel: 'External',
+                isKey: false,
                 hidden: true
             },
             {
@@ -123,12 +130,30 @@ class UserTable extends Component {
         const emailKey = 'emailAddress';
         const roleNames = 'roleNames';
         const passwordSetKey = 'passwordSet';
+        const externalKey = 'external'
+        const external = user[externalKey];
+        const externalNote = (
+            <div className="form-group">
+                <label className="col-sm-3 col-form-label text-right warningStatus" />
+                <div className="d-inline-flex">
+                    <span className="warningStatus">
+                        <FontAwesomeIcon icon="exclamation-triangle" className="alert-icon" size="lg" />
+                    </span>
+                </div>
+                <div className="d-inline-flex p-2 col-sm-8 warningStatus">
+                    This user is managed by a system external to Alert. Only roles can be assigned.
+                </div>
+            </div>
+        );
         return (
             <div>
-                <TextInput name={usernameKey} label="Username" description="The users username." required={true} onChange={this.handleChange} value={user[usernameKey]} errorName={usernameKey} errorValue={fieldErrors[usernameKey]} />
-                <PasswordInput name={passwordKey} label="Password" description="The users password." required={true} onChange={this.handleChange} value={user[passwordKey]} isSet={user[passwordSetKey]} errorName={passwordKey}
+                {external && externalNote}
+                <TextInput name={usernameKey} label="Username" description="The users username." readOnly={external} required={!external} onChange={this.handleChange} value={user[usernameKey]} errorName={usernameKey}
+                           errorValue={fieldErrors[usernameKey]} />
+                <PasswordInput name={passwordKey} label="Password" description="The users password." readOnly={external} required={!external} onChange={this.handleChange} value={user[passwordKey]} isSet={user[passwordSetKey]}
+                               errorName={passwordKey}
                                errorValue={fieldErrors[passwordKey]} />
-                <TextInput name={emailKey} label="Email" description="The users email." required={true} onChange={this.handleChange} value={user[emailKey]} errorName={emailKey} errorValue={fieldErrors[emailKey]} />
+                <TextInput name={emailKey} label="Email" description="The users email." readOnly={external} required={!external} onChange={this.handleChange} value={user[emailKey]} errorName={emailKey} errorValue={fieldErrors[emailKey]} />
                 <DynamicSelectInput
                     name={roleNames}
                     id={roleNames}

--- a/src/test/java/com/synopsys/integration/alert/component/settings/PasswordResetServiceTest.java
+++ b/src/test/java/com/synopsys/integration/alert/component/settings/PasswordResetServiceTest.java
@@ -55,7 +55,7 @@ public class PasswordResetServiceTest {
     @Test
     public void resetPasswordNoUserEmailTest() {
         String username = "username";
-        UserModel userModel = UserModel.newUser(username, "", null, Set.of());
+        UserModel userModel = UserModel.newUser(username, "", null, false, Set.of());
         DefaultUserAccessor userAccessor = Mockito.mock(DefaultUserAccessor.class);
         Mockito.when(userAccessor.getUser(Mockito.eq(username))).thenReturn(Optional.of(userModel));
 
@@ -72,7 +72,7 @@ public class PasswordResetServiceTest {
     @Test
     public void resetPasswordNoEmailConfigurationTest() throws AlertDatabaseConstraintException {
         String username = "username";
-        UserModel userModel = UserModel.newUser(username, "", "noreply@synopsys.com", Set.of());
+        UserModel userModel = UserModel.newUser(username, "", "noreply@synopsys.com", false, Set.of());
         DefaultUserAccessor userAccessor = Mockito.mock(DefaultUserAccessor.class);
         Mockito.when(userAccessor.getUser(Mockito.eq(username))).thenReturn(Optional.of(userModel));
 
@@ -108,7 +108,7 @@ public class PasswordResetServiceTest {
         addConfigurationFieldToMap(keyToFieldMap, EmailPropertyKeys.JAVAMAIL_PORT_KEY.getPropertyKey(), testProperties.getProperty(TestPropertyKey.TEST_EMAIL_SMTP_PORT));
 
         String username = "username";
-        UserModel userModel = UserModel.newUser(username, "", "noreply@synopsys.com", Set.of());
+        UserModel userModel = UserModel.newUser(username, "", "noreply@synopsys.com", false, Set.of());
         DefaultUserAccessor userAccessor = Mockito.mock(DefaultUserAccessor.class);
         Mockito.when(userAccessor.getUser(Mockito.eq(username))).thenReturn(Optional.of(userModel));
         Mockito.when(userAccessor.changeUserPassword(Mockito.eq(username), Mockito.anyString())).thenReturn(true);
@@ -128,7 +128,7 @@ public class PasswordResetServiceTest {
     @Test
     public void resetPasswordInvalidEmailConfigTest() throws AlertException {
         String username = "username";
-        UserModel userModel = UserModel.newUser(username, "", "noreply@synopsys.com", Set.of());
+        UserModel userModel = UserModel.newUser(username, "", "noreply@synopsys.com", false, Set.of());
         DefaultUserAccessor userAccessor = Mockito.mock(DefaultUserAccessor.class);
         Mockito.when(userAccessor.getUser(Mockito.eq(username))).thenReturn(Optional.of(userModel));
         Mockito.when(userAccessor.changeUserPassword(Mockito.eq(username), Mockito.anyString())).thenReturn(true);

--- a/src/test/java/com/synopsys/integration/alert/component/settings/SettingsGlobalApiActionTest.java
+++ b/src/test/java/com/synopsys/integration/alert/component/settings/SettingsGlobalApiActionTest.java
@@ -64,7 +64,7 @@ public class SettingsGlobalApiActionTest {
         SettingsValidator settingsValidator = Mockito.mock(SettingsValidator.class);
         SettingsGlobalApiAction actionaApi = new SettingsGlobalApiAction(encryptionUtility, userAccessor, settingsValidator);
 
-        UserModel userModel = UserModel.existingUser(UserAccessor.DEFAULT_ADMIN_USER_ID, "example", null, null, Set.of());
+        UserModel userModel = UserModel.existingUser(UserAccessor.DEFAULT_ADMIN_USER_ID, "example", null, null, false, Set.of());
         Mockito.when(userAccessor.getUser(UserAccessor.DEFAULT_ADMIN_USER_ID)).thenReturn(Optional.of(userModel));
 
         FieldModel fieldModel = new FieldModel(SETTINGS_DESCRIPTOR_KEY.getUniversalKey(), ConfigContextEnum.GLOBAL.name(), new HashMap<>());
@@ -86,7 +86,7 @@ public class SettingsGlobalApiActionTest {
         SettingsValidator settingsValidator = Mockito.mock(SettingsValidator.class);
         SettingsGlobalApiAction actionaApi = new SettingsGlobalApiAction(encryptionUtility, userAccessor, settingsValidator);
 
-        UserModel userModel = UserModel.existingUser(UserAccessor.DEFAULT_ADMIN_USER_ID, "example", null, null, Set.of());
+        UserModel userModel = UserModel.existingUser(UserAccessor.DEFAULT_ADMIN_USER_ID, "example", null, null, false, Set.of());
         Mockito.when(userAccessor.getUser(UserAccessor.DEFAULT_ADMIN_USER_ID)).thenReturn(Optional.of(userModel));
 
         FieldModel fieldModel = new FieldModel(SETTINGS_DESCRIPTOR_KEY.getUniversalKey(), ConfigContextEnum.GLOBAL.name(), new HashMap<>());

--- a/src/test/java/com/synopsys/integration/alert/database/api/user/UserAccessorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/database/api/user/UserAccessorTestIT.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -17,6 +18,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.synopsys.integration.alert.common.enumeration.DefaultUserRole;
 import com.synopsys.integration.alert.common.exception.AlertDatabaseConstraintException;
 import com.synopsys.integration.alert.common.exception.AlertForbiddenOperationException;
 import com.synopsys.integration.alert.common.persistence.accessor.UserAccessor;
@@ -161,5 +163,67 @@ public class UserAccessorTestIT extends AlertIntegrationTest {
         userAccessor.deleteUser(userName);
 
         assertFalse(userAccessor.changeUserEmailAddress("bad_user_name", "new_test_email"));
+    }
+
+    @Test
+    public void testExternalUserUpdateRoles() throws AlertDatabaseConstraintException, AlertForbiddenOperationException {
+        String userName = "testUser";
+        String password = "testPassword";
+        String email = "testEmail";
+        UserModel userModel = UserModel.newUser(userName, password, email, true, Collections.emptySet());
+        userModel = userAccessor.addExternalUser(userModel);
+        UserRoleModel userRole = UserRoleModel.of(DefaultUserRole.ALERT_ADMIN.name());
+        Set<UserRoleModel> roles = Set.of(userRole);
+        UserModel existingUser = UserModel.existingUser(userModel.getId(), userName, null, email, true, roles);
+        UserModel updatedUser = userAccessor.updateUser(existingUser, true);
+
+        assertEquals(roles.stream().map(UserRoleModel::getName).collect(Collectors.toSet()), updatedUser.getRoles().stream().map(UserRoleModel::getName).collect(Collectors.toSet()));
+        userAccessor.deleteUser(userName);
+    }
+
+    @Test
+    public void testExternalUserUpdateNameException() throws AlertDatabaseConstraintException, AlertForbiddenOperationException {
+        String userName = "testUser";
+        String password = "testPassword";
+        String email = "testEmail";
+        UserModel userModel = UserModel.newUser(userName, password, email, true, Collections.emptySet());
+        userModel = userAccessor.addExternalUser(userModel);
+        UserModel updatedUser = UserModel.existingUser(userModel.getId(), userName + "_updated", null, email, true, Collections.emptySet());
+        testUserUpdateException(updatedUser);
+        userAccessor.deleteUser(userName);
+    }
+
+    @Test
+    public void testExternalUserUpdateEmailException() throws AlertDatabaseConstraintException, AlertForbiddenOperationException {
+        String userName = "testUser";
+        String password = "testPassword";
+        String email = "testEmail";
+        UserModel userModel = UserModel.newUser(userName, password, email, true, Collections.emptySet());
+        userModel = userAccessor.addExternalUser(userModel);
+        UserModel updatedUser = UserModel.existingUser(userModel.getId(), userName, null, email + "_updated", true, Collections.emptySet());
+        testUserUpdateException(updatedUser);
+        userAccessor.deleteUser(userName);
+    }
+
+    @Test
+    public void testExternalUserUpdatePasswordException() throws AlertDatabaseConstraintException, AlertForbiddenOperationException {
+        String userName = "testUser";
+        String password = "testPassword";
+        String email = "testEmail";
+        UserModel userModel = UserModel.newUser(userName, password, email, true, Collections.emptySet());
+        userModel = userAccessor.addExternalUser(userModel);
+        UserModel updatedUser = UserModel.existingUser(userModel.getId(), userName, password, email, true, Collections.emptySet());
+        testUserUpdateException(updatedUser);
+        userAccessor.deleteUser(userName);
+    }
+
+    private void testUserUpdateException(UserModel updatedUser) {
+        String exceptionMessage = "An external user cannot change its credentials.";
+        try {
+            userAccessor.updateUser(updatedUser, true);
+            fail();
+        } catch (AlertDatabaseConstraintException ex) {
+            assertTrue(ex.getMessage().contains(exceptionMessage));
+        }
     }
 }

--- a/src/test/java/com/synopsys/integration/alert/database/api/user/UserAccessorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/database/api/user/UserAccessorTestIT.java
@@ -95,7 +95,7 @@ public class UserAccessorTestIT extends AlertIntegrationTest {
         String admin_role = AlertIntegrationTest.ROLE_ALERT_ADMIN;
         Set<String> roleNames = new LinkedHashSet<>(Arrays.asList(admin_role, another_role));
         Set<UserRoleModel> roles = roleNames.stream().map(UserRoleModel::of).collect(Collectors.toSet());
-        UserModel updatedModel = userAccessor.updateUser(UserModel.existingUser(userModel.getId(), userModel.getName(), userModel.getPassword(), userModel.getEmailAddress(), roles), true);
+        UserModel updatedModel = userAccessor.updateUser(UserModel.existingUser(userModel.getId(), userModel.getName(), userModel.getPassword(), userModel.getEmailAddress(), false, roles), true);
         assertEquals(userModel.getName(), updatedModel.getName());
         assertEquals(userModel.getEmailAddress(), updatedModel.getEmailAddress());
         assertEquals(userModel.getPassword(), updatedModel.getPassword());
@@ -103,6 +103,7 @@ public class UserAccessorTestIT extends AlertIntegrationTest {
 
         assertFalse(updatedModel.hasRole(another_role));
         assertTrue(updatedModel.hasRole(admin_role));
+        assertFalse(updatedModel.isExternal());
         userAccessor.deleteUser(userName);
     }
 

--- a/src/test/java/com/synopsys/integration/alert/database/api/user/UserModelTest.java
+++ b/src/test/java/com/synopsys/integration/alert/database/api/user/UserModelTest.java
@@ -25,7 +25,7 @@ public class UserModelTest {
         String expectedEmail = "expectedEmail";
         Set<String> roleNames = new LinkedHashSet<>(Arrays.asList(DefaultUserRole.values()).stream().map(DefaultUserRole::name).collect(Collectors.toList()));
         Set<UserRoleModel> expectedRoles = roleNames.stream().map(UserRoleModel::of).collect(Collectors.toSet());
-        UserModel userModel = UserModel.newUser(expectedUserName, expectedPassword, expectedEmail, expectedRoles);
+        UserModel userModel = UserModel.newUser(expectedUserName, expectedPassword, expectedEmail, false, expectedRoles);
 
         assertEquals(expectedUserName, userModel.getName());
         assertEquals(expectedPassword, userModel.getPassword());
@@ -37,6 +37,7 @@ public class UserModelTest {
         assertFalse(userModel.isLocked());
         assertFalse(userModel.isPasswordExpired());
         assertTrue(userModel.isEnabled());
+        assertFalse(userModel.isExternal());
     }
 
     @Test
@@ -46,7 +47,7 @@ public class UserModelTest {
         String expectedEmail = "expectedEmail";
         Set<String> roleNames = null;
         Set<UserRoleModel> expectedRoles = null;
-        UserModel userModel = UserModel.newUser(expectedUserName, expectedPassword, expectedEmail, expectedRoles);
+        UserModel userModel = UserModel.newUser(expectedUserName, expectedPassword, expectedEmail, false, expectedRoles);
 
         assertEquals(expectedUserName, userModel.getName());
         assertEquals(expectedPassword, userModel.getPassword());
@@ -58,6 +59,7 @@ public class UserModelTest {
         assertFalse(userModel.isLocked());
         assertFalse(userModel.isPasswordExpired());
         assertTrue(userModel.isEnabled());
+        assertFalse(userModel.isExternal());
     }
 
     @Test
@@ -66,7 +68,7 @@ public class UserModelTest {
         String expectedPassword = "expectedPassword";
         String expectedEmail = "expectedEmail";
         Set<UserRoleModel> expectedRoles = new LinkedHashSet<>();
-        UserModel userModel = UserModel.newUser(expectedUserName, expectedPassword, expectedEmail, expectedRoles);
+        UserModel userModel = UserModel.newUser(expectedUserName, expectedPassword, expectedEmail, false, expectedRoles);
 
         assertEquals(expectedUserName, userModel.getName());
         assertEquals(expectedPassword, userModel.getPassword());
@@ -78,5 +80,6 @@ public class UserModelTest {
         assertFalse(userModel.isLocked());
         assertFalse(userModel.isPasswordExpired());
         assertTrue(userModel.isEnabled());
+        assertFalse(userModel.isExternal());
     }
 }

--- a/src/test/java/com/synopsys/integration/alert/web/security/authentication/saml/UserDetailsServiceTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/security/authentication/saml/UserDetailsServiceTest.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.opensaml.saml2.core.NameID;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.saml.SAMLCredential;
 
@@ -46,6 +47,9 @@ public class UserDetailsServiceTest {
     public void testValidCredential() {
         SAMLCredential credential = Mockito.mock(SAMLCredential.class);
 
+        NameID nameId = Mockito.mock(NameID.class);
+        Mockito.when(nameId.getValue()).thenReturn(USER_NAME);
+        Mockito.when(credential.getNameID()).thenReturn(nameId);
         Mockito.when(credential.getAttributeAsString("Name")).thenReturn(USER_NAME);
         Mockito.when(credential.getAttributeAsString("Email")).thenReturn(EMAIL);
         Mockito.when(credential.getAttributeAsStringArray("AlertRoles")).thenReturn(VALID_ROLES);
@@ -67,6 +71,9 @@ public class UserDetailsServiceTest {
     public void testNullRoleArray() {
         SAMLCredential credential = Mockito.mock(SAMLCredential.class);
 
+        NameID nameId = Mockito.mock(NameID.class);
+        Mockito.when(nameId.getValue()).thenReturn(USER_NAME);
+        Mockito.when(credential.getNameID()).thenReturn(nameId);
         Mockito.when(credential.getAttributeAsString("Name")).thenReturn(USER_NAME);
         Mockito.when(credential.getAttributeAsString("Email")).thenReturn(EMAIL);
         Mockito.when(credential.getAttributeAsStringArray("AlertRoles")).thenReturn(null);
@@ -86,6 +93,9 @@ public class UserDetailsServiceTest {
     public void testEmptyRoleArray() {
         SAMLCredential credential = Mockito.mock(SAMLCredential.class);
         String[] roles = new String[0];
+        NameID nameId = Mockito.mock(NameID.class);
+        Mockito.when(nameId.getValue()).thenReturn(USER_NAME);
+        Mockito.when(credential.getNameID()).thenReturn(nameId);
         Mockito.when(credential.getAttributeAsString("Name")).thenReturn(USER_NAME);
         Mockito.when(credential.getAttributeAsString("Email")).thenReturn(EMAIL);
         Mockito.when(credential.getAttributeAsStringArray("AlertRoles")).thenReturn(roles);


### PR DESCRIPTION
Allow the assignment of internal roles to external users.
Change the UI to make the fields in user management readonly for external users.
Allow an external user to be deleted since only roles can be modified.  when the user logs in they will be re-added to Alert.

I will have a different PR to remove the external boolean to be a more descriptive if the user has logged in via SAML or LDAP.  This is the initial change to add internal roles to external users.