### PR TITLE
Ps role permission fix

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/PermissionMatrixModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/PermissionMatrixModel.java
@@ -61,7 +61,8 @@ public class PermissionMatrixModel extends AlertSerializableModel {
 
     public boolean isReadOnly(PermissionKey permissionKey) {
         if (!permissions.containsKey(permissionKey)) {
-            return false;
+            // if the permission key isn't listed here be the most restrictive and assume read only.
+            return true;
         }
 
         Integer operations = permissions.get(permissionKey);

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/PermissionMatrixModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/PermissionMatrixModel.java
@@ -61,7 +61,6 @@ public class PermissionMatrixModel extends AlertSerializableModel {
 
     public boolean isReadOnly(PermissionKey permissionKey) {
         if (!permissions.containsKey(permissionKey)) {
-            // if the permission key isn't listed here be the most restrictive and assume read only.
             return true;
         }
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/security/authorization/AuthorizationManager.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/security/authorization/AuthorizationManager.java
@@ -77,7 +77,9 @@ public class AuthorizationManager {
         Collection<String> roleNames = getCurrentUserRoleNames();
         return roleNames.stream()
                    .filter(this::isAlertRole)
-                   .allMatch(name -> permissionCache.containsKey(name) && permissionCache.get(name).isReadOnly(permissionKey));
+                   .filter(permissionCache::containsKey)
+                   .map(permissionCache::get)
+                   .allMatch(permissions -> permissions.isReadOnly(permissionKey));
     }
 
     public final boolean anyReadPermission(Collection<String> contexts, Collection<String> descriptorNames) {

--- a/src/main/java/com/synopsys/integration/alert/web/user/UserActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/user/UserActions.java
@@ -41,6 +41,7 @@ import com.synopsys.integration.alert.common.exception.AlertForbiddenOperationEx
 import com.synopsys.integration.alert.common.persistence.accessor.UserAccessor;
 import com.synopsys.integration.alert.common.persistence.model.UserModel;
 import com.synopsys.integration.alert.common.persistence.model.UserRoleModel;
+import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
 import com.synopsys.integration.alert.web.model.UserConfig;
 
 @Component
@@ -52,10 +53,12 @@ public class UserActions {
     private static final int DEFAULT_PASSWORD_LENGTH = 8;
     private UserAccessor userAccessor;
     private AuthorizationUtility authorizationUtility;
+    private AuthorizationManager authorizationManager;
 
-    public UserActions(UserAccessor userAccessor, AuthorizationUtility authorizationUtility) {
+    public UserActions(UserAccessor userAccessor, AuthorizationUtility authorizationUtility, AuthorizationManager authorizationManager) {
         this.userAccessor = userAccessor;
         this.authorizationUtility = authorizationUtility;
+        this.authorizationManager = authorizationManager;
     }
 
     public Collection<UserConfig> getUsers() {
@@ -110,6 +113,7 @@ public class UserActions {
                                                           .filter(role -> configuredRoleNames.contains(role.getName()))
                                                           .collect(Collectors.toList());
                 authorizationUtility.updateUserRoles(userModel.get().getId(), roleNames);
+                authorizationManager.loadPermissionsIntoCache();
             }
         }
         return userAccessor.getUser(userId)


### PR DESCRIPTION
Always assume readonly in the isReadOnly methods.
Always load the cache when the user roles are updated.