### PR TITLE
Ps scheduling fix

### DIFF
--- a/src/main/js/field/FieldsPanel.js
+++ b/src/main/js/field/FieldsPanel.js
@@ -140,7 +140,8 @@ class FieldsPanel extends React.Component {
         fields.forEach((field) => {
             const fieldKey = field.key;
             if (!this.state.hiddenFieldKeys.includes(fieldKey)) {
-                const newField = FieldMapping.createField(field, currentConfigCopy, fieldErrors[fieldKey], this.handleChange);
+                const fieldError = fieldErrors ? fieldErrors[fieldKey] : null;
+                const newField = FieldMapping.createField(field, currentConfigCopy, fieldError, this.handleChange);
                 createdFields.push(newField);
             }
         });

--- a/src/main/resources/db/changelog/alert/5.2.0/changelog-authentication-permissions.xml
+++ b/src/main/resources/db/changelog/alert/5.2.0/changelog-authentication-permissions.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+    <changeSet author="psantos" id="2020-01-13-09-28-38-298">
+        <sql dbms="h2" stripComments="true">
+            CALL ASSIGN_ROLE_PERMISSION_ACCESS('ALERT_ADMIN', 'component_scheduling', 'global', 'CREATE');
+            CALL ASSIGN_ROLE_PERMISSION_ACCESS('ALERT_ADMIN', 'component_scheduling', 'global', 'DELETE');
+            CALL ASSIGN_ROLE_PERMISSION_ACCESS('ALERT_JOB_MANAGER', 'component_scheduling', 'global', 'CREATE');
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/alert/5.2.0/changelog.xml
+++ b/src/main/resources/db/changelog/alert/5.2.0/changelog.xml
@@ -3,6 +3,7 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
     <include file="changelog-migrate-field-stored-procedure.xml" relativeToChangelogFile="true"/>
     <include file="changelog-authentication-component.xml" relativeToChangelogFile="true"/>
+    <include file="changelog-authentication-permissions.xml" relativeToChangelogFile="true"/>
     <include file="changelog-configuration-timestamp.xml" relativeToChangelogFile="true"/>
     <include file="changelog-jira-server.xml" relativeToChangelogFile="true"/>
     <include file="changelog-default-users.xml" relativeToChangelogFile="true"/>


### PR DESCRIPTION
Add the permissions to create and delete the scheduling component.  In previous versions every descriptor had an empty configuration created for it.  Because the configuration is missing a POST request would be sent from the UI to create the scheduling configuration.  This requires the 'create' permission.