### PR TITLE
Ps project name increase

### DIFF
--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProviderDataAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProviderDataAccessor.java
@@ -42,7 +42,6 @@ import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.common.descriptor.DescriptorKey;
-
 import com.synopsys.integration.alert.common.exception.AlertDatabaseConstraintException;
 import com.synopsys.integration.alert.common.persistence.accessor.ProviderDataAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ProviderProject;
@@ -62,6 +61,7 @@ public class DefaultProviderDataAccessor implements ProviderDataAccessor {
     public static final Integer DEFAULT_LIMIT = 100;
 
     private static final int MAX_DESCRIPTION_LENGTH = 250;
+    private static final int MAX_PROJECT_NAME_LENGTH = 507;
 
     private final Logger logger = LoggerFactory.getLogger(DefaultProviderDataAccessor.class);
     private final ProviderProjectRepository providerProjectRepository;
@@ -225,8 +225,9 @@ public class DefaultProviderDataAccessor implements ProviderDataAccessor {
     }
 
     private ProviderProjectEntity convertToProjectEntity(DescriptorKey descriptorKey, ProviderProject providerProject) {
+        String trimmedProjectName = StringUtils.abbreviate(providerProject.getName(), MAX_PROJECT_NAME_LENGTH);
         String trimmedDescription = StringUtils.abbreviate(providerProject.getDescription(), MAX_DESCRIPTION_LENGTH);
-        return new ProviderProjectEntity(providerProject.getName(), trimmedDescription, providerProject.getHref(), providerProject.getProjectOwnerEmail(), descriptorKey.getUniversalKey());
+        return new ProviderProjectEntity(trimmedProjectName, trimmedDescription, providerProject.getHref(), providerProject.getProjectOwnerEmail(), descriptorKey.getUniversalKey());
     }
 
     private ProviderUserModel convertToUserModel(ProviderUserEntity providerUserEntity) {

--- a/src/main/resources/db/changelog/alert/5.2.0/changelog-migrate-provider-projects.xml
+++ b/src/main/resources/db/changelog/alert/5.2.0/changelog-migrate-provider-projects.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+       <changeSet id="2020-01-23-07-16-34-518" author="psantos">
+           <modifyDataType schemaName="PROVIDER_PROJECTS" tableName="AUDIT_ENTRIES" columnName="NAME" newDataType="VARCHAR(512)"/>
+       </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/alert/5.2.0/changelog-migrate-provider-projects.xml
+++ b/src/main/resources/db/changelog/alert/5.2.0/changelog-migrate-provider-projects.xml
@@ -2,6 +2,6 @@
 <databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
        <changeSet id="2020-01-23-07-16-34-518" author="psantos">
-           <modifyDataType schemaName="PROVIDER_PROJECTS" tableName="AUDIT_ENTRIES" columnName="NAME" newDataType="VARCHAR(512)"/>
+           <modifyDataType schemaName="ALERT" tableName="PROVIDER_PROJECTS" columnName="NAME" newDataType="VARCHAR(512)"/>
        </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/alert/5.2.0/changelog.xml
+++ b/src/main/resources/db/changelog/alert/5.2.0/changelog.xml
@@ -2,6 +2,7 @@
 <databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
     <include file="changelog-migrate-field-stored-procedure.xml" relativeToChangelogFile="true"/>
+    <include file="changelog-migrate-provider-projects.xml" relativeToChangelogFile="true"/>
     <include file="changelog-authentication-component.xml" relativeToChangelogFile="true"/>
     <include file="changelog-authentication-permissions.xml" relativeToChangelogFile="true"/>
     <include file="changelog-configuration-timestamp.xml" relativeToChangelogFile="true"/>


### PR DESCRIPTION
Fix for the project name column issue.  Increase the size to 512 which will handle the current issue where the largest project name is 367 characters long.  Although the length is arbitrary and alert may run into the same issue in the future.  This will provide enough of a buffer to avoid running into the issue again for some time.