### PR TITLE
Handle email channel FIXME related to multiple providers.

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/event/ContentEvent.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/event/ContentEvent.java
@@ -25,12 +25,13 @@ package com.synopsys.integration.alert.common.event;
 import com.synopsys.integration.alert.common.message.model.MessageContentGroup;
 
 public class ContentEvent extends AlertEvent {
+    private static final long serialVersionUID = -4226565845990359050L;
     private final String createdAt;
     private final String provider;
     private final String formatType;
     private final MessageContentGroup contentGroup;
 
-    public ContentEvent(final String destination, final String createdAt, final String provider, final String formatType, final MessageContentGroup contentGroup) {
+    public ContentEvent(String destination, String createdAt, String provider, String formatType, MessageContentGroup contentGroup) {
         super(destination);
         this.createdAt = createdAt;
         this.provider = provider;

--- a/src/main/java/com/synopsys/integration/alert/channel/email/EmailChannel.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/email/EmailChannel.java
@@ -86,8 +86,7 @@ public class EmailChannel extends NamedDistributionChannel {
             throw new AlertException("ERROR: Missing global config.");
         }
 
-        // FIXME this should update addresses based on Provider event.getProvider()
-        FieldAccessor updatedFieldAccessor = emailAddressHandler.updateEmailAddresses(event.getContent(), fieldAccessor);
+        FieldAccessor updatedFieldAccessor = emailAddressHandler.updateEmailAddresses(event.getProvider(), event.getContent(), fieldAccessor);
 
         Set<String> emailAddresses = new HashSet<>(updatedFieldAccessor.getAllStrings(EmailDescriptor.KEY_EMAIL_ADDRESSES));
         EmailProperties emailProperties = new EmailProperties(updatedFieldAccessor);


### PR DESCRIPTION
The two remaining FIXME comments are from previous versions of Alert and need to be re-evaluated.  To avoid more changes beyond the multiple provider configuration feature I have left those FIXME comments to be addressed later.