### PR TITLE
Helm Chart: Have the resources in Values.yaml match the k8s format

### DIFF
--- a/deployment/helm/templates/alert-cfssl.yaml
+++ b/deployment/helm/templates/alert-cfssl.yaml
@@ -43,10 +43,7 @@ spec:
             - containerPort: 8888
               protocol: TCP
           resources:
-            limits:
-              memory: {{ .Values.cfssl.limitMemory }}
-            requests:
-              memory: {{ .Values.cfssl.requestMemory }}
+            {{- toYaml .Values.cfssl.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /etc/cfssl
               name: dir-cfssl

--- a/deployment/helm/templates/alert.yaml
+++ b/deployment/helm/templates/alert.yaml
@@ -55,10 +55,7 @@ spec:
           - containerPort: 8443
             protocol: TCP
         resources:
-          limits:
-            memory: {{ .Values.alert.limitMemory }}
-          requests:
-            memory: {{ .Values.alert.requestMemory }}
+          {{- toYaml .Values.alert.resources | nindent 12 }}
         volumeMounts:
         - mountPath: /opt/blackduck/alert/alert-config
           name: dir-alert

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -5,8 +5,11 @@
 # alert - configurations for the Alert Pod
 alert:
   image: "docker.io/blackducksoftware/blackduck-alert:VERSION_TOKEN"
-  limitMemory: "2560M"
-  requestMemory: "2560M"
+  resources:
+    limits:
+      memory: "2560M"
+    requests:
+      memory: "2560M"
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -17,8 +20,11 @@ deployAlertWithBlackDuck: false
 enableStandalone: true
 cfssl:
   image: "docker.io/blackducksoftware/blackduck-cfssl:1.0.0"
-  limitMemory: "640M"
-  requestMemory: "640M"
+  resources:
+    limits:
+      memory: "640M"
+    requests:
+      memory: "640M"
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -7,9 +7,9 @@ alert:
   image: "docker.io/blackducksoftware/blackduck-alert:VERSION_TOKEN"
   resources:
     limits:
-      memory: "2560M"
+      memory: "2560Mi"
     requests:
-      memory: "2560M"
+      memory: "2560Mi"
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -22,9 +22,9 @@ cfssl:
   image: "docker.io/blackducksoftware/blackduck-cfssl:1.0.0"
   resources:
     limits:
-      memory: "640M"
+      memory: "640Mi"
     requests:
-      memory: "640M"
+      memory: "640Mi"
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
# PR Overview:

**Link to github issue (if applicable):**

* N/A

**If nothing above, what is your reason for this pull request:**

* The User can specify any k8s resource configurations in the Values.yaml

**Changes proposed in this pull request:**

* Have the format for taking in resources in the Values.yaml file match the format of k8s objects. Then pass the values directly into the deployment manifest for Alert and Cfssl