### PR TITLE
provider config select

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/channel/ChannelDistributionTestAction.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/channel/ChannelDistributionTestAction.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import java.util.UUID;
 
 import com.synopsys.integration.alert.common.action.TestAction;
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.descriptor.config.ui.ChannelDistributionUIConfig;
 import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderDistributionUIConfig;
 import com.synopsys.integration.alert.common.enumeration.ItemOperation;
@@ -55,10 +56,10 @@ public abstract class ChannelDistributionTestAction extends TestAction {
         ProviderMessageContent messageContent = createTestNotificationContent(fieldAccessor, ItemOperation.ADD, UUID.randomUUID().toString());
 
         String channelName = fieldAccessor.getStringOrEmpty(ChannelDistributionUIConfig.KEY_CHANNEL_NAME);
-        String providerName = fieldAccessor.getStringOrEmpty(ChannelDistributionUIConfig.KEY_PROVIDER_NAME);
+        String providerConfigName = fieldAccessor.getStringOrEmpty(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME);
         String formatType = fieldAccessor.getStringOrEmpty(ProviderDistributionUIConfig.KEY_FORMAT_TYPE);
 
-        return new DistributionEvent(configId, channelName, RestConstants.formatDate(new Date()), providerName, formatType, MessageContentGroup.singleton(messageContent), fieldAccessor);
+        return new DistributionEvent(configId, channelName, RestConstants.formatDate(new Date()), providerConfigName, formatType, MessageContentGroup.singleton(messageContent), fieldAccessor);
     }
 
     public DistributionChannel getDistributionChannel() {

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/ProviderDescriptor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/ProviderDescriptor.java
@@ -28,6 +28,15 @@ import com.synopsys.integration.alert.common.enumeration.DescriptorType;
 import com.synopsys.integration.alert.common.provider.ProviderKey;
 
 public abstract class ProviderDescriptor extends Descriptor {
+    public static final String KEY_COMMON_PROVIDER_PREFIX = "provider.common.";
+    public static final String KEY_PROVIDER_CONFIG_NAME = KEY_COMMON_PROVIDER_PREFIX + "config.name";
+    public static final String KEY_PROVIDER_CONFIG_ENABLED = KEY_COMMON_PROVIDER_PREFIX + "config.enabled";
+    public static final String LABEL_PROVIDER_CONFIG_ENABLED = "Enabled";
+    public static final String LABEL_PROVIDER_CONFIG_NAME = "Configuration Name";
+    public static final String DESCRIPTION_PROVIDER_CONFIG_ENABLED =
+        "If selected, this provider configuration will be able to pull data into Alert and available to configure with distribution jobs, otherwise, it will not be available for those usages.";
+    public static final String DESCRIPTION_PROVIDER_CONFIG_NAME = "The name of this provider configuration. Must be unique.";
+
     public ProviderDescriptor(ProviderKey providerKey, ProviderGlobalUIConfig providerUiConfig, UIConfig distributionUIConfig) {
         super(providerKey, DescriptorType.PROVIDER);
         addGlobalUiConfig(providerUiConfig);

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderConfigSelectCustomEndpoint.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderConfigSelectCustomEndpoint.java
@@ -1,8 +1,8 @@
 package com.synopsys.integration.alert.common.descriptor.config.ui;
 
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -39,16 +39,14 @@ public class ProviderConfigSelectCustomEndpoint extends SelectCustomEndpoint {
         String providerName = fieldModel.getDescriptorName();
         Optional<DescriptorKey> descriptorKey = descriptorMap.getDescriptorKey(providerName);
         if (descriptorKey.isPresent()) {
-            List<LabelValueSelectOption> options = new LinkedList<>();
             List<ConfigurationModel> configurationModels = configurationAccessor.getConfigurationByDescriptorKeyAndContext(descriptorKey.get(), ConfigContextEnum.GLOBAL);
-            for (ConfigurationModel configurationModel : configurationModels) {
-                FieldAccessor accessor = new FieldAccessor(configurationModel.getCopyOfKeyToFieldMap());
-                Optional<String> configName = accessor.getString(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME);
-                if (configName.isPresent()) {
-                    options.add(new LabelValueSelectOption(configName.get()));
-                }
-            }
-            return options;
+            return configurationModels.stream()
+                       .map(ConfigurationModel::getCopyOfKeyToFieldMap)
+                       .map(FieldAccessor::new)
+                       .map(accessor -> accessor.getString(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME))
+                       .flatMap(Optional::stream)
+                       .map(LabelValueSelectOption::new)
+                       .collect(Collectors.toList());
         }
         return List.of();
     }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderConfigSelectCustomEndpoint.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderConfigSelectCustomEndpoint.java
@@ -1,3 +1,25 @@
+/**
+ * alert-common
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.synopsys.integration.alert.common.descriptor.config.ui;
 
 import java.util.List;

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderConfigSelectCustomEndpoint.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderConfigSelectCustomEndpoint.java
@@ -4,7 +4,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -37,8 +36,8 @@ public class ProviderConfigSelectCustomEndpoint extends SelectCustomEndpoint {
 
     @Override
     protected List<LabelValueSelectOption> createData(FieldModel fieldModel) throws AlertException {
-        Optional<String> providerName = fieldModel.getFieldValue(ChannelDistributionUIConfig.KEY_PROVIDER_NAME);
-        Optional<DescriptorKey> descriptorKey = descriptorMap.getDescriptorKey(providerName.orElse(StringUtils.EMPTY));
+        String providerName = fieldModel.getDescriptorName();
+        Optional<DescriptorKey> descriptorKey = descriptorMap.getDescriptorKey(providerName);
         if (descriptorKey.isPresent()) {
             List<LabelValueSelectOption> options = new LinkedList<>();
             List<ConfigurationModel> configurationModels = configurationAccessor.getConfigurationByDescriptorKeyAndContext(descriptorKey.get(), ConfigContextEnum.GLOBAL);

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderConfigSelectCustomEndpoint.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderConfigSelectCustomEndpoint.java
@@ -1,0 +1,56 @@
+package com.synopsys.integration.alert.common.descriptor.config.ui;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.common.action.CustomEndpointManager;
+import com.synopsys.integration.alert.common.descriptor.DescriptorKey;
+import com.synopsys.integration.alert.common.descriptor.DescriptorMap;
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
+import com.synopsys.integration.alert.common.descriptor.config.field.LabelValueSelectOption;
+import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.SelectCustomEndpoint;
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.exception.AlertException;
+import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
+import com.synopsys.integration.alert.common.persistence.accessor.FieldAccessor;
+import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
+import com.synopsys.integration.alert.common.rest.ResponseFactory;
+import com.synopsys.integration.alert.common.rest.model.FieldModel;
+
+@Component
+public class ProviderConfigSelectCustomEndpoint extends SelectCustomEndpoint {
+    private final ConfigurationAccessor configurationAccessor;
+    private final DescriptorMap descriptorMap;
+
+    @Autowired
+    public ProviderConfigSelectCustomEndpoint(CustomEndpointManager customEndpointManager, ResponseFactory responseFactory, Gson gson, ConfigurationAccessor configurationAccessor, DescriptorMap descriptorMap) throws AlertException {
+        super(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME, customEndpointManager, responseFactory, gson);
+        this.configurationAccessor = configurationAccessor;
+        this.descriptorMap = descriptorMap;
+    }
+
+    @Override
+    protected List<LabelValueSelectOption> createData(FieldModel fieldModel) throws AlertException {
+        Optional<String> providerName = fieldModel.getFieldValue(ChannelDistributionUIConfig.KEY_PROVIDER_NAME);
+        Optional<DescriptorKey> descriptorKey = descriptorMap.getDescriptorKey(providerName.orElse(StringUtils.EMPTY));
+        if (descriptorKey.isPresent()) {
+            List<LabelValueSelectOption> options = new LinkedList<>();
+            List<ConfigurationModel> configurationModels = configurationAccessor.getConfigurationByDescriptorKeyAndContext(descriptorKey.get(), ConfigContextEnum.GLOBAL);
+            for (ConfigurationModel configurationModel : configurationModels) {
+                FieldAccessor accessor = new FieldAccessor(configurationModel.getCopyOfKeyToFieldMap());
+                Optional<String> configName = accessor.getString(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME);
+                if (configName.isPresent()) {
+                    options.add(new LabelValueSelectOption(configName.get()));
+                }
+            }
+            return options;
+        }
+        return List.of();
+    }
+}

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderDistributionCustomEndpoint.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderDistributionCustomEndpoint.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Component;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.common.action.CustomEndpointManager;
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.table.TableSelectCustomEndpoint;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.common.persistence.accessor.ProviderDataAccessor;
@@ -65,7 +66,7 @@ public class ProviderDistributionCustomEndpoint extends TableSelectCustomEndpoin
 
     @Override
     protected List<?> createData(FieldModel fieldModel) throws AlertException {
-        String providerConfigName = fieldModel.getFieldValue(ProviderGlobalUIConfig.KEY_PROVIDER_CONFIG_NAME).orElse("");
+        String providerConfigName = fieldModel.getFieldValue(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME).orElse("");
         return providerDataAccessor.getProjectsByProviderConfigName(providerConfigName);
     }
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderDistributionUIConfig.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderDistributionUIConfig.java
@@ -106,6 +106,7 @@ public abstract class ProviderDistributionUIConfig extends UIConfig {
                                             .applyColumn(new TableSelectColumn("name", "Project Name", true, true))
                                             .applyColumn(new TableSelectColumn("description", "Project Description", false, false))
                                             .applyRequestedDataFieldKey(ChannelDistributionUIConfig.KEY_PROVIDER_NAME)
+                                            .applyRequestedDataFieldKey(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME)
                                             .applyValidationFunctions(this::validateConfiguredProject);
 
         List<ConfigField> configFields = List.of(providerConfigField, notificationTypesField, formatField, filterByProject, projectNamePattern, configuredProject);

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderDistributionUIConfig.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderDistributionUIConfig.java
@@ -76,9 +76,9 @@ public abstract class ProviderDistributionUIConfig extends UIConfig {
 
     @Override
     public List<ConfigField> createFields() {
-        ConfigField providerConfigField = new EndpointSelectField(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME, ProviderDescriptor.LABEL_PROVIDER_CONFIG_NAME, ProviderDescriptor.DESCRIPTION_PROVIDER_CONFIG_NAME)
-                                              .applyClearable(false)
-                                              .applyRequired(true);
+        ConfigField providerConfigNameField = new EndpointSelectField(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME, ProviderDescriptor.LABEL_PROVIDER_CONFIG_NAME, ProviderDescriptor.DESCRIPTION_PROVIDER_CONFIG_NAME)
+                                                  .applyClearable(false)
+                                                  .applyRequired(true);
         List<LabelValueSelectOption> notificationTypeOptions = providerContent.getContentTypes()
                                                                    .stream()
                                                                    .map(this::convertToLabelValueOption)
@@ -109,7 +109,7 @@ public abstract class ProviderDistributionUIConfig extends UIConfig {
                                             .applyRequestedDataFieldKey(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME)
                                             .applyValidationFunctions(this::validateConfiguredProject);
 
-        List<ConfigField> configFields = List.of(providerConfigField, notificationTypesField, formatField, filterByProject, projectNamePattern, configuredProject);
+        List<ConfigField> configFields = List.of(providerConfigNameField, notificationTypesField, formatField, filterByProject, projectNamePattern, configuredProject);
         List<ConfigField> providerDistributionFields = createProviderDistributionFields();
         return Stream.concat(configFields.stream(), providerDistributionFields.stream()).collect(Collectors.toList());
     }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderDistributionUIConfig.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderDistributionUIConfig.java
@@ -33,11 +33,13 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.WordUtils;
 
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.descriptor.config.field.ConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.HideCheckboxConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.LabelValueSelectOption;
 import com.synopsys.integration.alert.common.descriptor.config.field.SelectConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.TextInputConfigField;
+import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.EndpointSelectField;
 import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.table.EndpointTableSelectField;
 import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.table.TableSelectColumn;
 import com.synopsys.integration.alert.common.enumeration.FormatType;
@@ -74,6 +76,9 @@ public abstract class ProviderDistributionUIConfig extends UIConfig {
 
     @Override
     public List<ConfigField> createFields() {
+        ConfigField providerConfigField = new EndpointSelectField(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME, ProviderDescriptor.LABEL_PROVIDER_CONFIG_NAME, ProviderDescriptor.DESCRIPTION_PROVIDER_CONFIG_NAME)
+                                              .applyClearable(false)
+                                              .applyRequired(true);
         List<LabelValueSelectOption> notificationTypeOptions = providerContent.getContentTypes()
                                                                    .stream()
                                                                    .map(this::convertToLabelValueOption)
@@ -103,7 +108,7 @@ public abstract class ProviderDistributionUIConfig extends UIConfig {
                                             .applyRequestedDataFieldKey(ChannelDistributionUIConfig.KEY_PROVIDER_NAME)
                                             .applyValidationFunctions(this::validateConfiguredProject);
 
-        List<ConfigField> configFields = List.of(notificationTypesField, formatField, filterByProject, projectNamePattern, configuredProject);
+        List<ConfigField> configFields = List.of(providerConfigField, notificationTypesField, formatField, filterByProject, projectNamePattern, configuredProject);
         List<ConfigField> providerDistributionFields = createProviderDistributionFields();
         return Stream.concat(configFields.stream(), providerDistributionFields.stream()).collect(Collectors.toList());
     }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderGlobalUIConfig.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderGlobalUIConfig.java
@@ -26,22 +26,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Streams;
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.descriptor.config.field.CheckboxConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.ConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.TextInputConfigField;
 import com.synopsys.integration.alert.common.provider.ProviderKey;
 
 public abstract class ProviderGlobalUIConfig extends UIConfig {
-    public static final String KEY_COMMON_PROVIDER_PREFIX = "provider.common.";
-    public static final String KEY_PROVIDER_CONFIG_ENABLED = KEY_COMMON_PROVIDER_PREFIX + "config.enabled";
-    public static final String KEY_PROVIDER_CONFIG_NAME = KEY_COMMON_PROVIDER_PREFIX + "config.name";
-
-    public static final String LABEL_PROVIDER_CONFIG_ENABLED = "Enabled";
-    public static final String LABEL_PROVIDER_CONFIG_NAME = "Configuration Name";
-
-    public static final String DESCRIPTION_PROVIDER_CONFIG_ENABLED =
-        "If selected, this provider configuration will be able to pull data into Alert and available to configure with distribution jobs, otherwise, it will not be available for those usages.";
-    public static final String DESCRIPTION_PROVIDER_CONFIG_NAME = "The name of this provider configuration. Must be unique.";
 
     private final ProviderKey providerKey;
 
@@ -52,8 +43,9 @@ public abstract class ProviderGlobalUIConfig extends UIConfig {
 
     @Override
     public final List<ConfigField> createFields() {
-        ConfigField providerConfigEnabled = new CheckboxConfigField(KEY_PROVIDER_CONFIG_ENABLED, LABEL_PROVIDER_CONFIG_ENABLED, DESCRIPTION_PROVIDER_CONFIG_ENABLED).applyDefaultValue(Boolean.TRUE.toString());
-        ConfigField providerConfigName = new TextInputConfigField(KEY_PROVIDER_CONFIG_NAME, LABEL_PROVIDER_CONFIG_NAME, DESCRIPTION_PROVIDER_CONFIG_NAME).applyRequired(true);
+        ConfigField providerConfigEnabled = new CheckboxConfigField(ProviderDescriptor.KEY_PROVIDER_CONFIG_ENABLED, ProviderDescriptor.LABEL_PROVIDER_CONFIG_ENABLED, ProviderDescriptor.DESCRIPTION_PROVIDER_CONFIG_ENABLED)
+                                                .applyDefaultValue(Boolean.TRUE.toString());
+        ConfigField providerConfigName = new TextInputConfigField(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME, ProviderDescriptor.LABEL_PROVIDER_CONFIG_NAME, ProviderDescriptor.DESCRIPTION_PROVIDER_CONFIG_NAME).applyRequired(true);
 
         List<ConfigField> providerCommonGlobalFields = List.of(providerConfigEnabled, providerConfigName);
         List<ConfigField> providerGlobalFields = createProviderGlobalFields();

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/event/ContentEvent.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/event/ContentEvent.java
@@ -25,16 +25,16 @@ package com.synopsys.integration.alert.common.event;
 import com.synopsys.integration.alert.common.message.model.MessageContentGroup;
 
 public class ContentEvent extends AlertEvent {
-    private static final long serialVersionUID = -4226565845990359050L;
+    private static final long serialVersionUID = 8592125218004089822L;
     private final String createdAt;
-    private final String provider;
+    private final String providerConfigName;
     private final String formatType;
     private final MessageContentGroup contentGroup;
 
-    public ContentEvent(String destination, String createdAt, String provider, String formatType, MessageContentGroup contentGroup) {
+    public ContentEvent(String destination, String createdAt, String providerConfigName, String formatType, MessageContentGroup contentGroup) {
         super(destination);
         this.createdAt = createdAt;
-        this.provider = provider;
+        this.providerConfigName = providerConfigName;
         this.formatType = formatType;
         this.contentGroup = contentGroup;
     }
@@ -43,8 +43,8 @@ public class ContentEvent extends AlertEvent {
         return createdAt;
     }
 
-    public String getProvider() {
-        return provider;
+    public String getProviderConfigName() {
+        return providerConfigName;
     }
 
     public String getFormatType() {

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/event/DistributionEvent.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/event/DistributionEvent.java
@@ -31,12 +31,13 @@ import com.synopsys.integration.alert.common.message.model.MessageContentGroup;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldAccessor;
 
 public class DistributionEvent extends ContentEvent {
+    private static final long serialVersionUID = -2067819359358348281L;
     private final FieldAccessor fieldAccessor;
     private final String configId;
     private Map<Long, Long> notificationIdToAuditId;
 
-    public DistributionEvent(String configId, String destination, String createdAt, String provider, String formatType, MessageContentGroup contentGroup, FieldAccessor fieldAccessor) {
-        super(destination, createdAt, provider, formatType, contentGroup);
+    public DistributionEvent(String configId, String destination, String createdAt, String providerConfigName, String formatType, MessageContentGroup contentGroup, FieldAccessor fieldAccessor) {
+        super(destination, createdAt, providerConfigName, formatType, contentGroup);
         this.fieldAccessor = fieldAccessor;
         this.configId = configId;
     }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/ConfigurationJobModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/ConfigurationJobModel.java
@@ -27,15 +27,16 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.descriptor.config.ui.ChannelDistributionUIConfig;
 import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderDistributionUIConfig;
-import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderGlobalUIConfig;
 import com.synopsys.integration.alert.common.enumeration.FormatType;
 import com.synopsys.integration.alert.common.enumeration.FrequencyType;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldAccessor;
 import com.synopsys.integration.alert.common.rest.model.AlertSerializableModel;
 
 public class ConfigurationJobModel extends AlertSerializableModel {
+    private static final long serialVersionUID = 4714533679724412017L;
     private final UUID jobId;
     private final Set<ConfigurationModel> configurations;
     private final FieldAccessor fieldAccessor;
@@ -76,7 +77,7 @@ public class ConfigurationJobModel extends AlertSerializableModel {
     }
 
     public String getProviderConfigName() {
-        return getFieldAccessor().getStringOrNull(ProviderGlobalUIConfig.KEY_PROVIDER_CONFIG_NAME);
+        return getFieldAccessor().getStringOrNull(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME);
     }
 
     public FrequencyType getFrequencyType() {

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/provider/Provider.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/provider/Provider.java
@@ -51,7 +51,7 @@ public abstract class Provider<T extends ProviderProperties> {
 
     public abstract ProviderNotificationClassMap getNotificationClassMap();
 
-    public abstract ProviderMessageContentCollector createMessageContentCollector();
+    public abstract ProviderMessageContentCollector createMessageContentCollector(T providerProperties);
 
     public ProviderContent getProviderContent() {
         return providerContent;

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/provider/ProviderProperties.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/provider/ProviderProperties.java
@@ -22,7 +22,7 @@
  */
 package com.synopsys.integration.alert.common.provider;
 
-import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderGlobalUIConfig;
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldAccessor;
 
 public abstract class ProviderProperties {
@@ -33,8 +33,8 @@ public abstract class ProviderProperties {
 
     public ProviderProperties(Long configId, FieldAccessor fieldAccessor) {
         this.configId = configId;
-        this.configEnabled = fieldAccessor.getBooleanOrFalse(ProviderGlobalUIConfig.KEY_PROVIDER_CONFIG_ENABLED);
-        this.configName = fieldAccessor.getString(ProviderGlobalUIConfig.KEY_PROVIDER_CONFIG_NAME).orElse("UNKNOWN CONFIGURATION");
+        this.configEnabled = fieldAccessor.getBooleanOrFalse(ProviderDescriptor.KEY_PROVIDER_CONFIG_ENABLED);
+        this.configName = fieldAccessor.getString(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME).orElse("UNKNOWN CONFIGURATION");
     }
 
     public Long getConfigId() {

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/provider/lifecycle/ProviderLifecycleManager.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/provider/lifecycle/ProviderLifecycleManager.java
@@ -75,7 +75,7 @@ public class ProviderLifecycleManager {
         List<ProviderTask> acceptedTasks = new ArrayList<>();
 
         ProviderProperties providerProperties = provider.createProperties(providerConfig);
-        if (providerProperties.isConfigEnabled()) {
+        if (!providerProperties.isConfigEnabled()) {
             throw new AlertException(String.format("The provider configuration '%s' cannot have tasks scheduled while it is disabled.", providerProperties.getConfigName()));
         }
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/processor/NotificationProcessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/processor/NotificationProcessor.java
@@ -92,7 +92,7 @@ public class NotificationProcessor {
         List<AlertNotificationModel> filteredNotifications = filterNotificationsByProviderFields(job, distributionFilter, notificationsByType);
 
         if (!filteredNotifications.isEmpty()) {
-            ProviderMessageContentCollector messageContentCollector = provider.createMessageContentCollector();
+            ProviderMessageContentCollector messageContentCollector = provider.createMessageContentCollector(providerProperties);
             return createDistributionEventsForNotifications(messageContentCollector, job, distributionFilter.getCache(), filteredNotifications);
         }
         return List.of();

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/processor/NotificationToDistributionEventConverter.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/processor/NotificationToDistributionEventConverter.java
@@ -86,7 +86,7 @@ public class NotificationToDistributionEventConverter {
     }
 
     private DistributionEvent createChannelEvent(ConfigurationJobModel job, MessageContentGroup contentGroup) {
-        return new DistributionEvent(job.getJobId().toString(), job.getChannelName(), RestConstants.formatDate(new Date()), job.getProviderName(), job.getFormatType().name(), contentGroup, job.getFieldAccessor());
+        return new DistributionEvent(job.getJobId().toString(), job.getChannelName(), RestConstants.formatDate(new Date()), job.getProviderConfigName(), job.getFormatType().name(), contentGroup, job.getFieldAccessor());
     }
 
 }

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultAuditUtility.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultAuditUtility.java
@@ -49,8 +49,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.common.ContentConverter;
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.descriptor.accessor.AuditUtility;
-import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderGlobalUIConfig;
 import com.synopsys.integration.alert.common.enumeration.AuditEntryStatus;
 import com.synopsys.integration.alert.common.exception.AlertDatabaseConstraintException;
 import com.synopsys.integration.alert.common.message.model.ComponentItem;
@@ -363,7 +363,7 @@ public class DefaultAuditUtility implements AuditUtility {
                              .stream()
                              .map(ConfigurationModel::getCopyOfFieldList)
                              .flatMap(List::stream)
-                             .filter(field -> field.getFieldKey().equals(ProviderGlobalUIConfig.KEY_PROVIDER_CONFIG_NAME))
+                             .filter(field -> field.getFieldKey().equals(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME))
                              .map(ConfigurationFieldModel::getFieldValue)
                              .flatMap(Optional::stream)
                              .findFirst()

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultConfigurationAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultConfigurationAccessor.java
@@ -176,8 +176,7 @@ public class DefaultConfigurationAccessor implements ConfigurationAccessor {
                                            .collect(Collectors.toList());
         if (!providerConfigIds.isEmpty()) {
             for (Long configId : providerConfigIds) {
-                Optional<ConfigurationModel> configurationModel = getConfigurationById(configId);
-                Optional<ConfigurationModel> globalModel = configurationModel
+                Optional<ConfigurationModel> globalModel = getConfigurationById(configId)
                                                                .filter(model -> model.getDescriptorContext() == ConfigContextEnum.GLOBAL);
                 if (globalModel.isPresent()) {
                     return globalModel;

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultConfigurationAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultConfigurationAccessor.java
@@ -39,7 +39,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.common.descriptor.DescriptorKey;
-import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderGlobalUIConfig;
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.enumeration.DescriptorType;
 import com.synopsys.integration.alert.common.enumeration.FrequencyType;
@@ -167,9 +167,9 @@ public class DefaultConfigurationAccessor implements ConfigurationAccessor {
         if (StringUtils.isBlank(providerConfigName)) {
             throw new AlertDatabaseConstraintException("The provider configuration name cannot be null");
         }
-        Long fieldId = definedFieldRepository.findFirstByKey(ProviderGlobalUIConfig.KEY_PROVIDER_CONFIG_NAME)
+        Long fieldId = definedFieldRepository.findFirstByKey(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME)
                            .map(DefinedFieldEntity::getId)
-                           .orElseThrow(() -> new AlertDatabaseConstraintException(String.format("The key '%s' is not registered in the database", ProviderGlobalUIConfig.KEY_PROVIDER_CONFIG_NAME)));
+                           .orElseThrow(() -> new AlertDatabaseConstraintException(String.format("The key '%s' is not registered in the database", ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME)));
         Optional<Long> optionalProviderConfigId = fieldValueRepository.findAllByFieldIdAndValue(fieldId, providerConfigName)
                                                       .stream()
                                                       .map(FieldValueEntity::getConfigId)

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultNotificationManager.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultNotificationManager.java
@@ -43,7 +43,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderGlobalUIConfig;
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.event.EventManager;
 import com.synopsys.integration.alert.common.event.NotificationEvent;
 import com.synopsys.integration.alert.common.exception.AlertDatabaseConstraintException;
@@ -217,7 +217,7 @@ public class DefaultNotificationManager implements NotificationManager {
         if (null != providerConfigId) {
             try {
                 providerConfigName = configurationAccessor.getConfigurationById(providerConfigId)
-                                         .flatMap(field -> field.getField(ProviderGlobalUIConfig.KEY_PROVIDER_CONFIG_NAME))
+                                         .flatMap(field -> field.getField(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME))
                                          .flatMap(ConfigurationFieldModel::getFieldValue)
                                          .orElse(providerConfigName);
             } catch (AlertDatabaseConstraintException e) {

--- a/src/main/java/com/synopsys/integration/alert/channel/email/EmailAddressHandler.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/email/EmailAddressHandler.java
@@ -59,7 +59,7 @@ public class EmailAddressHandler {
         this.providerDataAccessor = providerDataAccessor;
     }
 
-    public FieldAccessor updateEmailAddresses(String eventProviderConfigName, MessageContentGroup contentGroup, FieldAccessor originalAccessor) {
+    public FieldAccessor updateEmailAddresses(String providerConfigName, MessageContentGroup contentGroup, FieldAccessor originalAccessor) {
         Collection<String> allEmailAddresses = originalAccessor.getAllStrings(EmailDescriptor.KEY_EMAIL_ADDRESSES);
         Set<String> emailAddresses = new HashSet<>(allEmailAddresses);
 
@@ -67,17 +67,17 @@ public class EmailAddressHandler {
         boolean useOnlyAdditionalEmailAddresses = originalAccessor.getBoolean(EmailDescriptor.KEY_EMAIL_ADDITIONAL_ADDRESSES_ONLY).orElse(false);
 
         if (!useOnlyAdditionalEmailAddresses) {
-            Set<String> projectEmailAddresses = collectProviderEmailsFromProject(eventProviderConfigName, contentGroup.getCommonTopic().getValue(), projectOwnerOnly);
+            Set<String> projectEmailAddresses = collectProviderEmailsFromProject(providerConfigName, contentGroup.getCommonTopic().getValue(), projectOwnerOnly);
             emailAddresses.addAll(projectEmailAddresses);
         }
 
         if (emailAddresses.isEmpty()) {
             // Temporary fix for license notifications
-            Set<String> licenseNotificationEmails = systemWideNotificationCheck(contentGroup.getSubContent(), originalAccessor, eventProviderConfigName, projectOwnerOnly);
+            Set<String> licenseNotificationEmails = systemWideNotificationCheck(contentGroup.getSubContent(), originalAccessor, providerConfigName, projectOwnerOnly);
             emailAddresses.addAll(licenseNotificationEmails);
         }
 
-        Set<String> additionalEmailAddresses = collectAdditionalEmailAddresses(eventProviderConfigName, originalAccessor);
+        Set<String> additionalEmailAddresses = collectAdditionalEmailAddresses(providerConfigName, originalAccessor);
         emailAddresses.addAll(additionalEmailAddresses);
 
         Map<String, ConfigurationFieldModel> fieldMap = new HashMap<>();

--- a/src/main/java/com/synopsys/integration/alert/channel/email/EmailChannel.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/email/EmailChannel.java
@@ -85,8 +85,7 @@ public class EmailChannel extends NamedDistributionChannel {
         if (host.isEmpty() || from.isEmpty()) {
             throw new AlertException("ERROR: Missing global config.");
         }
-
-        FieldAccessor updatedFieldAccessor = emailAddressHandler.updateEmailAddresses(event.getProvider(), event.getContent(), fieldAccessor);
+        FieldAccessor updatedFieldAccessor = emailAddressHandler.updateEmailAddresses(event.getProviderConfigName(), event.getContent(), fieldAccessor);
 
         Set<String> emailAddresses = new HashSet<>(updatedFieldAccessor.getAllStrings(EmailDescriptor.KEY_EMAIL_ADDRESSES));
         EmailProperties emailProperties = new EmailProperties(updatedFieldAccessor);

--- a/src/main/java/com/synopsys/integration/alert/channel/email/actions/EmailActionHelper.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/email/actions/EmailActionHelper.java
@@ -34,8 +34,8 @@ import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.channel.email.EmailAddressHandler;
 import com.synopsys.integration.alert.channel.email.descriptor.EmailDescriptor;
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderDistributionUIConfig;
-import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderGlobalUIConfig;
 import com.synopsys.integration.alert.common.exception.AlertFieldException;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.ProviderDataAccessor;
@@ -60,7 +60,7 @@ public class EmailActionHelper {
         }
 
         Boolean filterByProject = fieldAccessor.getBooleanOrFalse(ProviderDistributionUIConfig.KEY_FILTER_BY_PROJECT);
-        String providerConfigName = fieldAccessor.getString(ProviderGlobalUIConfig.KEY_PROVIDER_CONFIG_NAME).orElse("");
+        String providerConfigName = fieldAccessor.getString(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME).orElse("");
         Boolean onlyAdditionalEmails = fieldAccessor.getBooleanOrFalse(EmailDescriptor.KEY_EMAIL_ADDITIONAL_ADDRESSES_ONLY);
 
         if (StringUtils.isNotBlank(providerConfigName) && !onlyAdditionalEmails) {

--- a/src/main/java/com/synopsys/integration/alert/channel/email/web/EmailCustomEndpoint.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/email/web/EmailCustomEndpoint.java
@@ -35,7 +35,7 @@ import org.springframework.stereotype.Component;
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.channel.email.descriptor.EmailDescriptor;
 import com.synopsys.integration.alert.common.action.CustomEndpointManager;
-import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderGlobalUIConfig;
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.common.persistence.accessor.ProviderDataAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ProviderUserModel;
@@ -60,7 +60,7 @@ public class EmailCustomEndpoint {
     }
 
     public ResponseEntity<String> createEmailOptions(FieldModel fieldModel) {
-        String providerConfigName = fieldModel.getFieldValue(ProviderGlobalUIConfig.KEY_PROVIDER_CONFIG_NAME).orElse("");
+        String providerConfigName = fieldModel.getFieldValue(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME).orElse("");
 
         if (StringUtils.isBlank(providerConfigName)) {
             logger.debug("Received provider user email data request with a blank provider config name");

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckProvider.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckProvider.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -36,7 +35,7 @@ import com.synopsys.integration.alert.common.provider.lifecycle.ProviderTask;
 import com.synopsys.integration.alert.common.provider.notification.ProviderDistributionFilter;
 import com.synopsys.integration.alert.common.provider.notification.ProviderNotificationClassMap;
 import com.synopsys.integration.alert.common.workflow.processor.ProviderMessageContentCollector;
-import com.synopsys.integration.alert.provider.blackduck.collector.BlackDuckMessageContentCollector;
+import com.synopsys.integration.alert.provider.blackduck.collector.MessageContentCollectorFactory;
 import com.synopsys.integration.alert.provider.blackduck.descriptor.BlackDuckContent;
 import com.synopsys.integration.alert.provider.blackduck.factories.BlackDuckPropertiesFactory;
 import com.synopsys.integration.alert.provider.blackduck.factories.BlackDuckTaskFactory;
@@ -55,13 +54,13 @@ import com.synopsys.integration.blackduck.api.manual.view.VulnerabilityNotificat
 @Component
 public class BlackDuckProvider extends Provider<BlackDuckProperties> {
     private final DistributionFilterFactory distributionFilterFactory;
-    private final ObjectFactory<BlackDuckMessageContentCollector> messageContentCollectorFactory;
+    private final MessageContentCollectorFactory messageContentCollectorFactory;
     private final BlackDuckPropertiesFactory propertiesFactory;
     private final BlackDuckValidator validator;
     private final BlackDuckTaskFactory taskFactory;
 
     @Autowired
-    public BlackDuckProvider(BlackDuckProviderKey blackDuckProviderKey, BlackDuckContent blackDuckContent, DistributionFilterFactory distributionFilterFactory, ObjectFactory<BlackDuckMessageContentCollector> messageContentCollectorFactory,
+    public BlackDuckProvider(BlackDuckProviderKey blackDuckProviderKey, BlackDuckContent blackDuckContent, DistributionFilterFactory distributionFilterFactory, MessageContentCollectorFactory messageContentCollectorFactory,
         BlackDuckPropertiesFactory propertiesFactory, BlackDuckValidator validator, BlackDuckTaskFactory taskFactory) {
         super(blackDuckProviderKey, blackDuckContent);
         this.distributionFilterFactory = distributionFilterFactory;
@@ -87,8 +86,8 @@ public class BlackDuckProvider extends Provider<BlackDuckProperties> {
     }
 
     @Override
-    public ProviderMessageContentCollector createMessageContentCollector() {
-        return messageContentCollectorFactory.getObject();
+    public ProviderMessageContentCollector createMessageContentCollector(BlackDuckProperties blackDuckProperties) {
+        return messageContentCollectorFactory.createCollector(blackDuckProperties);
     }
 
     @Override

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/actions/BlackDuckDistributionTestAction.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/actions/BlackDuckDistributionTestAction.java
@@ -30,8 +30,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.common.action.TestAction;
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderDistributionUIConfig;
-import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderGlobalUIConfig;
 import com.synopsys.integration.alert.common.exception.AlertFieldException;
 import com.synopsys.integration.alert.common.message.model.MessageResult;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldAccessor;
@@ -50,14 +50,14 @@ public class BlackDuckDistributionTestAction extends TestAction {
 
     @Override
     public MessageResult testConfig(String configId, String description, FieldAccessor fieldAccessor) throws IntegrationException {
-        Optional<String> optionalProviderConfigName = fieldAccessor.getString(ProviderGlobalUIConfig.KEY_PROVIDER_CONFIG_NAME);
+        Optional<String> optionalProviderConfigName = fieldAccessor.getString(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME);
         if (optionalProviderConfigName.isPresent()) {
             Optional<String> projectNamePattern = fieldAccessor.getString(ProviderDistributionUIConfig.KEY_PROJECT_NAME_PATTERN);
             if (projectNamePattern.isPresent()) {
                 validatePatternMatchesProject(optionalProviderConfigName.get(), projectNamePattern.get());
             }
         } else {
-            throw AlertFieldException.singleFieldError(ProviderGlobalUIConfig.KEY_PROVIDER_CONFIG_NAME, "A provider configuration is required");
+            throw AlertFieldException.singleFieldError(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME, "A provider configuration is required");
         }
         return new MessageResult("Successfully tested BlackDuck provider fields");
     }

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/actions/BlackDuckGlobalApiAction.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/actions/BlackDuckGlobalApiAction.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.common.action.ApiAction;
-import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderGlobalUIConfig;
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.common.persistence.accessor.ProviderDataAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
@@ -70,7 +70,7 @@ public class BlackDuckGlobalApiAction extends ApiAction {
     @Override
     public void afterDeleteAction(FieldModel fieldModel) {
         Map<String, FieldValueModel> keyToValues = fieldModel.getKeyToValues();
-        FieldValueModel fieldValueModel = keyToValues.get(ProviderGlobalUIConfig.KEY_PROVIDER_CONFIG_NAME);
+        FieldValueModel fieldValueModel = keyToValues.get(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME);
         String blackDuckGlobalConfigName = fieldValueModel.getValue().orElse("");
 
         Long configId = Long.parseLong(Objects.requireNonNullElse(fieldModel.getId(), "-1"));

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/actions/BlackDuckGlobalTestAction.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/actions/BlackDuckGlobalTestAction.java
@@ -67,7 +67,11 @@ public class BlackDuckGlobalTestAction extends TestAction {
         Long parsedConfigurationId = ProviderProperties.UNKNOWN_CONFIG_ID;
 
         if (StringUtils.isNotBlank(configId)) {
-            parsedConfigurationId = Long.valueOf(configId);
+            try {
+                parsedConfigurationId = Long.valueOf(configId);
+            } catch (NumberFormatException ex) {
+                throw new AlertException("Configuration id not valid.");
+            }
         }
 
         BlackDuckProperties blackDuckProperties = blackDuckPropertiesFactory.createProperties(parsedConfigurationId, fieldAccessor);

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/actions/BlackDuckGlobalTestAction.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/actions/BlackDuckGlobalTestAction.java
@@ -34,6 +34,7 @@ import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.common.exception.AlertFieldException;
 import com.synopsys.integration.alert.common.message.model.MessageResult;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldAccessor;
+import com.synopsys.integration.alert.common.provider.ProviderProperties;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
 import com.synopsys.integration.alert.provider.blackduck.descriptor.BlackDuckDescriptor;
 import com.synopsys.integration.alert.provider.blackduck.factories.BlackDuckPropertiesFactory;
@@ -63,7 +64,13 @@ public class BlackDuckGlobalTestAction extends TestAction {
         String apiToken = fieldAccessor.getStringOrEmpty(BlackDuckDescriptor.KEY_BLACKDUCK_API_KEY);
         String url = fieldAccessor.getStringOrEmpty(BlackDuckDescriptor.KEY_BLACKDUCK_URL);
         String timeout = fieldAccessor.getStringOrEmpty(BlackDuckDescriptor.KEY_BLACKDUCK_TIMEOUT);
-        BlackDuckProperties blackDuckProperties = blackDuckPropertiesFactory.createProperties(Long.valueOf(configId), fieldAccessor);
+        Long parsedConfigurationId = ProviderProperties.UNKNOWN_CONFIG_ID;
+
+        if (StringUtils.isNotBlank(configId)) {
+            parsedConfigurationId = Long.valueOf(configId);
+        }
+
+        BlackDuckProperties blackDuckProperties = blackDuckPropertiesFactory.createProperties(parsedConfigurationId, fieldAccessor);
         BlackDuckServerConfigBuilder blackDuckServerConfigBuilder = blackDuckProperties.createServerConfigBuilderWithoutAuthentication(intLogger, NumberUtils.toInt(timeout, 300));
         blackDuckServerConfigBuilder.setApiToken(apiToken);
         blackDuckServerConfigBuilder.setUrl(url);

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckMessageContentCollector.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/BlackDuckMessageContentCollector.java
@@ -29,10 +29,6 @@ import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.common.message.model.CommonMessageData;
@@ -49,8 +45,6 @@ import com.synopsys.integration.blackduck.rest.BlackDuckHttpClient;
 import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
 import com.synopsys.integration.blackduck.service.bucket.BlackDuckBucket;
 
-@Component
-@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class BlackDuckMessageContentCollector extends ProviderMessageContentCollector {
     private final Logger logger = LoggerFactory.getLogger(BlackDuckMessageContentCollector.class);
 
@@ -58,7 +52,6 @@ public class BlackDuckMessageContentCollector extends ProviderMessageContentColl
     private Map<String, BlackDuckMessageBuilder> messageBuilderMap;
     private BlackDuckBucket blackDuckBucket;
 
-    @Autowired
     public BlackDuckMessageContentCollector(BlackDuckProperties blackDuckProperties, List<MessageContentFormatter> messageContentProcessors, List<BlackDuckMessageBuilder> messageBuilders) {
         super(messageContentProcessors);
         this.blackDuckProperties = blackDuckProperties;

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/MessageContentCollectorFactory.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/MessageContentCollectorFactory.java
@@ -1,0 +1,46 @@
+/**
+ * blackduck-alert
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.alert.provider.blackduck.collector;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.common.workflow.formatter.MessageContentFormatter;
+import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
+import com.synopsys.integration.alert.provider.blackduck.collector.builder.BlackDuckMessageBuilder;
+
+@Component
+public class MessageContentCollectorFactory {
+    private final List<MessageContentFormatter> messageContentProcessors;
+    private final List<BlackDuckMessageBuilder> messageBuilders;
+
+    public MessageContentCollectorFactory(List<MessageContentFormatter> messageContentProcessors, List<BlackDuckMessageBuilder> messageBuilders) {
+        this.messageContentProcessors = messageContentProcessors;
+        this.messageBuilders = messageBuilders;
+    }
+
+    public BlackDuckMessageContentCollector createCollector(BlackDuckProperties properties) {
+        return new BlackDuckMessageContentCollector(properties, messageContentProcessors, messageBuilders);
+    }
+}

--- a/src/test/java/com/synopsys/integration/alert/channel/email/EmailChannelChannelDescriptorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/email/EmailChannelChannelDescriptorTestIT.java
@@ -27,7 +27,7 @@ import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.action.TestAction;
 import com.synopsys.integration.alert.common.channel.template.FreemarkerTemplatingService;
 import com.synopsys.integration.alert.common.descriptor.ChannelDescriptor;
-import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderGlobalUIConfig;
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.email.MessageContentGroupCsvCreator;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.enumeration.EmailPropertyKeys;
@@ -94,9 +94,9 @@ public class EmailChannelChannelDescriptorTestIT extends ChannelDescriptorTest {
 
     @BeforeEach
     public void testSetup() throws Exception {
-        ConfigurationFieldModel nameField = ConfigurationFieldModel.create(ProviderGlobalUIConfig.KEY_PROVIDER_CONFIG_NAME);
+        ConfigurationFieldModel nameField = ConfigurationFieldModel.create(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME);
         nameField.setFieldValue(EMAIL_TEST_PROVIDER_CONFIG_NAME);
-        ConfigurationFieldModel enabledField = ConfigurationFieldModel.create(ProviderGlobalUIConfig.KEY_PROVIDER_CONFIG_ENABLED);
+        ConfigurationFieldModel enabledField = ConfigurationFieldModel.create(ProviderDescriptor.KEY_PROVIDER_CONFIG_ENABLED);
         enabledField.setFieldValue("true");
         providerConfig = configurationAccessor.createConfiguration(new BlackDuckProviderKey(), ConfigContextEnum.GLOBAL, List.of(nameField, enabledField));
         Long providerConfigId = providerConfig.getConfigurationId();

--- a/src/test/java/com/synopsys/integration/alert/common/event/ContentEventTest.java
+++ b/src/test/java/com/synopsys/integration/alert/common/event/ContentEventTest.java
@@ -22,7 +22,7 @@ public class ContentEventTest {
     @Test
     public void getProviderTest() {
         ContentEvent event = new ContentEvent(TOPIC, CREATED_AT, PROVIDER, null, null);
-        assertEquals(PROVIDER, event.getProvider());
+        assertEquals(PROVIDER, event.getProviderConfigName());
     }
 
     @Test

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/actions/BlackDuckGlobalApiActionTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/actions/BlackDuckGlobalApiActionTest.java
@@ -38,7 +38,7 @@ public class BlackDuckGlobalApiActionTest {
     private void runApiActionTest(ThrowingBiFunction<BlackDuckGlobalApiAction, FieldModel, FieldModel, AlertException> apiAction) throws AlertException {
         TaskManager taskManager = new TaskManager();
         BlackDuckProperties properties = Mockito.mock(BlackDuckProperties.class);
-        Mockito.when(properties.isConfigEnabled()).thenReturn(false);
+        Mockito.when(properties.isConfigEnabled()).thenReturn(true);
         FieldModel fieldModel = Mockito.mock(FieldModel.class);
         Mockito.when(fieldModel.getFieldValue(Mockito.eq(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME))).thenReturn(Optional.of("Test Provider Config"));
 

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/actions/BlackDuckGlobalApiActionTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/actions/BlackDuckGlobalApiActionTest.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.ProviderDataAccessor;
@@ -38,6 +39,8 @@ public class BlackDuckGlobalApiActionTest {
         TaskManager taskManager = new TaskManager();
         BlackDuckProperties properties = Mockito.mock(BlackDuckProperties.class);
         Mockito.when(properties.isConfigEnabled()).thenReturn(false);
+        FieldModel fieldModel = Mockito.mock(FieldModel.class);
+        Mockito.when(fieldModel.getFieldValue(Mockito.eq(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME))).thenReturn(Optional.of("Test Provider Config"));
 
         BlackDuckAccumulator blackDuckAccumulator = Mockito.mock(BlackDuckAccumulator.class);
         Mockito.when(blackDuckAccumulator.getTaskName()).thenReturn("accumulator-task");
@@ -74,7 +77,7 @@ public class BlackDuckGlobalApiActionTest {
         assertTrue(initialAccumulatorNextRunTime.isEmpty());
         assertTrue(initialSyncNextRunTime.isEmpty());
 
-        apiAction.apply(blackDuckGlobalApiAction, null);
+        apiAction.apply(blackDuckGlobalApiAction, fieldModel);
         Optional<String> accumulatorNextRunTime = taskManager.getNextRunTime(blackDuckAccumulator.getTaskName());
         Optional<String> syncNextRunTime = taskManager.getNextRunTime(blackDuckDataSyncTask.getTaskName());
 

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/actions/BlackDuckGlobalApiActionTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/actions/BlackDuckGlobalApiActionTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.synopsys.integration.alert.common.exception.AlertException;
+import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.ProviderDataAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
 import com.synopsys.integration.alert.common.persistence.util.ConfigurationFieldModelConverter;
@@ -49,6 +50,9 @@ public class BlackDuckGlobalApiActionTest {
         Mockito.when(configurationModel.getConfigurationId()).thenReturn(-1L);
         Mockito.when(configurationModel.getDescriptorId()).thenReturn(-1L);
 
+        ConfigurationAccessor configurationAccessor = Mockito.mock(ConfigurationAccessor.class);
+        Mockito.when(configurationAccessor.getProviderConfigurationByName(Mockito.anyString())).thenReturn(Optional.of(configurationModel));
+
         BlackDuckProvider blackDuckProvider = Mockito.mock(BlackDuckProvider.class);
         Mockito.when(blackDuckProvider.validate(configurationModel)).thenReturn(true);
         Mockito.when(blackDuckProvider.createProperties(configurationModel)).thenReturn(properties);
@@ -62,7 +66,7 @@ public class BlackDuckGlobalApiActionTest {
         Mockito.when(fieldModelConverter.convertToConfigurationModel(Mockito.any())).thenReturn(configurationModel);
 
         ProviderLifecycleManager providerLifecycleManager = new ProviderLifecycleManager(List.of(blackDuckProvider), taskManager, null);
-        BlackDuckGlobalApiAction blackDuckGlobalApiAction = new BlackDuckGlobalApiAction(blackDuckProvider, providerLifecycleManager, providerDataAccessor, fieldModelConverter);
+        BlackDuckGlobalApiAction blackDuckGlobalApiAction = new BlackDuckGlobalApiAction(blackDuckProvider, providerLifecycleManager, providerDataAccessor, fieldModelConverter, configurationAccessor);
 
         Optional<String> initialAccumulatorNextRunTime = taskManager.getNextRunTime(blackDuckAccumulator.getTaskName());
         Optional<String> initialSyncNextRunTime = taskManager.getNextRunTime(blackDuckDataSyncTask.getTaskName());

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckDescriptorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckDescriptorTest.java
@@ -27,6 +27,6 @@ public class BlackDuckDescriptorTest {
         assertEquals(5, fields.size());
 
         fields = descriptor.getAllDefinedFields(ConfigContextEnum.DISTRIBUTION);
-        assertEquals(7, fields.size());
+        assertEquals(8, fields.size());
     }
 }

--- a/src/test/java/com/synopsys/integration/alert/web/config/JobConfigControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/web/config/JobConfigControllerTestIT.java
@@ -36,6 +36,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.synopsys.integration.alert.channel.slack.SlackChannelKey;
 import com.synopsys.integration.alert.channel.slack.descriptor.SlackDescriptor;
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.descriptor.config.ui.ChannelDistributionUIConfig;
 import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderDistributionUIConfig;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
@@ -85,8 +86,8 @@ public class JobConfigControllerTestIT extends DatabaseConfiguredFieldTest {
 
         String urlPath = url + "?context=" + ConfigContextEnum.DISTRIBUTION.name() + "&descriptorName=" + slackChannelKey.getUniversalKey();
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(urlPath)
-                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTest.ROLE_ALERT_ADMIN))
-                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                    .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTest.ROLE_ALERT_ADMIN))
+                                                    .with(SecurityMockMvcRequestPostProcessors.csrf());
 
         MvcResult mvcResult = mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
         String response = mvcResult.getResponse().getContentAsString();
@@ -108,8 +109,8 @@ public class JobConfigControllerTestIT extends DatabaseConfiguredFieldTest {
 
         String urlPath = url + "/" + configId;
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(urlPath)
-                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTest.ROLE_ALERT_ADMIN))
-                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                    .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTest.ROLE_ALERT_ADMIN))
+                                                    .with(SecurityMockMvcRequestPostProcessors.csrf());
 
         MvcResult mvcResult = mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
         String response = mvcResult.getResponse().getContentAsString();
@@ -129,8 +130,8 @@ public class JobConfigControllerTestIT extends DatabaseConfiguredFieldTest {
             BlackDuckDescriptor.KEY_BLACKDUCK_API_KEY, List.of("BLACKDUCK_API")));
         String urlPath = url + "/" + jobId;
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.delete(urlPath)
-                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTest.ROLE_ALERT_ADMIN))
-                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                    .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTest.ROLE_ALERT_ADMIN))
+                                                    .with(SecurityMockMvcRequestPostProcessors.csrf());
 
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isAccepted());
         descriptorConfigRepository.flush();
@@ -156,8 +157,8 @@ public class JobConfigControllerTestIT extends DatabaseConfiguredFieldTest {
         String configId = String.valueOf(emptyConfigurationModel.getJobId());
         String urlPath = url + "/" + configId;
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.put(urlPath)
-                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTest.ROLE_ALERT_ADMIN))
-                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                    .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTest.ROLE_ALERT_ADMIN))
+                                                    .with(SecurityMockMvcRequestPostProcessors.csrf());
 
         fieldModel.setJobId(configId);
 
@@ -176,8 +177,8 @@ public class JobConfigControllerTestIT extends DatabaseConfiguredFieldTest {
             BlackDuckDescriptor.KEY_BLACKDUCK_URL, List.of("BLACKDUCK_URL"),
             BlackDuckDescriptor.KEY_BLACKDUCK_API_KEY, List.of("BLACKDUCK_API")));
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(url)
-                                                          .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTest.ROLE_ALERT_ADMIN))
-                                                          .with(SecurityMockMvcRequestPostProcessors.csrf());
+                                                    .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTest.ROLE_ALERT_ADMIN))
+                                                    .with(SecurityMockMvcRequestPostProcessors.csrf());
 
         JobFieldModel fieldModel = createTestJobFieldModel(null, null);
 
@@ -213,6 +214,7 @@ public class JobConfigControllerTestIT extends DatabaseConfiguredFieldTest {
         String descriptorName = slackChannelKey.getUniversalKey();
         String context = ConfigContextEnum.DISTRIBUTION.name();
 
+        FieldValueModel providerConfig = new FieldValueModel(List.of("Default Black Duck Config"), true);
         FieldValueModel slackChannelName = new FieldValueModel(List.of("channelName"), true);
         FieldValueModel frequency = new FieldValueModel(List.of(FrequencyType.DAILY.name()), true);
         FieldValueModel name = new FieldValueModel(List.of("name"), true);
@@ -224,6 +226,7 @@ public class JobConfigControllerTestIT extends DatabaseConfiguredFieldTest {
             SlackDescriptor.KEY_WEBHOOK, webhook,
             ChannelDistributionUIConfig.KEY_NAME, name,
             ChannelDistributionUIConfig.KEY_PROVIDER_NAME, provider,
+            ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME, providerConfig,
             ChannelDistributionUIConfig.KEY_CHANNEL_NAME, channel,
             ChannelDistributionUIConfig.KEY_FREQUENCY, frequency);
         FieldModel fieldModel = new FieldModel(descriptorName, context, fields);
@@ -239,8 +242,11 @@ public class JobConfigControllerTestIT extends DatabaseConfiguredFieldTest {
         FieldValueModel filterByProject = new FieldValueModel(List.of("false"), true);
         FieldValueModel projectNames = new FieldValueModel(List.of("project"), true);
 
-        Map<String, FieldValueModel> bdFields = Map.of(ProviderDistributionUIConfig.KEY_NOTIFICATION_TYPES, notificationType, ProviderDistributionUIConfig.KEY_FORMAT_TYPE,
-            formatType, ProviderDistributionUIConfig.KEY_FILTER_BY_PROJECT, filterByProject, ProviderDistributionUIConfig.KEY_CONFIGURED_PROJECT, projectNames);
+        Map<String, FieldValueModel> bdFields = Map.of(ProviderDistributionUIConfig.KEY_NOTIFICATION_TYPES, notificationType,
+            ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME, providerConfig,
+            ProviderDistributionUIConfig.KEY_FORMAT_TYPE, formatType,
+            ProviderDistributionUIConfig.KEY_FILTER_BY_PROJECT, filterByProject,
+            ProviderDistributionUIConfig.KEY_CONFIGURED_PROJECT, projectNames);
         FieldModel bdFieldModel = new FieldModel(bdDescriptorName, bdContext, bdFields);
         if (StringUtils.isNotBlank(providerId)) {
             bdFieldModel.setId(providerId);


### PR DESCRIPTION
1. Adds the provider config select field to the distribution UI.  
2. Fixes the backend code to be able to send messages to the channels. 
3. Fixes the email address lookup to use the provider config name.