### PR TITLE
[WIP] Helm Chart: Fix configuring volumes for certificates and keystore

### DIFF
--- a/deployment/helm/templates/alert.yaml
+++ b/deployment/helm/templates/alert.yaml
@@ -25,16 +25,10 @@ spec:
       name: {{ .Release.Name }}-alert
     spec:
       containers:
-      {{- if .Values.enableCertificateSecret }}
       - env:
         - name: RUN_SECRETS_DIR
-          valueFrom:
-            fieldRef:
-                fieldPath: metadata.name
+          value: /tmp/secrets
         envFrom:
-      {{- else }}
-      - envFrom:
-      {{- end }}
         - configMapRef:
             name: {{ .Release.Name }}-alert-environs
         - secretRef:
@@ -62,15 +56,17 @@ spec:
         volumeMounts:
         - mountPath: /opt/blackduck/alert/alert-config
           name: dir-alert
-        {{- if .Values.enableCertificateSecret }}
+        {{- if .Values.webserverCustomCertificatesSecretName }}
         - mountPath: /tmp/secrets/WEBSERVER_CUSTOM_CERT_FILE
           name: certificate
           subPath: WEBSERVER_CUSTOM_CERT_FILE
         - mountPath: /tmp/secrets/WEBSERVER_CUSTOM_KEY_FILE
           name: certificate
           subPath: WEBSERVER_CUSTOM_KEY_FILE
+        {{- end }}
+        {{- if .Values.javaKeystoreSecretName }}
         - mountPath: /tmp/secrets/cacerts
-          name: certificate
+          name: java-keystore
           subPath: cacerts
         {{- end }}
       dnsPolicy: ClusterFirst
@@ -95,11 +91,17 @@ spec:
       - emptyDir: {}
         name: dir-alert
       {{- end }}
-      {{- if .Values.enableCertificateSecret }}
+      {{- if.Values.webserverCustomCertificatesSecretName }}
       - name: certificate
         secret:
           defaultMode: 292
-          secretName: {{ (required "must provide --set certificateSecretName=\"\"" .Values.certificateSecretName) }}
+          secretName: {{ .Values.webserverCustomCertificatesSecretName }}
+      {{- end }}
+      {{- if .Values.javaKeystoreSecretName }}
+      - name: java-keystore
+        secret:
+          defaultMode: 292
+          secretName: {{ .Values.javaKeystoreSecretName }}
       {{- end }}
 ---
 

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -52,4 +52,5 @@ secretEnvirons: []
 setEncryptionSecretData: false
 
 # Alert's certificate information
-enableCertificateSecret: false
+webserverCustomCertificatesSecretName: "" # kubectl create secret generic <name>-alert-certificate -n <namespace> --from-file=WEBSERVER_CUSTOM_CERT_FILE=tls.crt --from-file=WEBSERVER_CUSTOM_KEY_FILE=tls.key
+javaKeystoreSecretName: ""                # kubectl create secret generic <name>-alert-certificate -n <namespace> --from-file=cacerts  


### PR DESCRIPTION
# Pull Request template

**Link to github issue (if applicable):**

* N/A

**If nothing above, what is your reason for this pull request:**

* The synopsysctl bug fixed by the following PR needs to be fixed in the Alert Helm Chart (https://github.com/blackducksoftware/synopsys-operator/pull/1268)
* The customer should first create secrets for their certificates and then pass the secret name to the helm chart

**Changes proposed in this pull request:**

* Set the correct value for the RUN_SECRETS_DIR environ
* Add Helm values for certificates and java-keystore