### PR TITLE
ldap validation fix

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/web/user/UserActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/user/UserActions.java
@@ -50,9 +50,9 @@ import com.synopsys.integration.alert.web.model.UserConfig;
 @Component
 @Transactional
 public class UserActions {
-    private static final String FIELD_KEY_USER_MGMT_USERNAME = "username";
-    private static final String FIELD_KEY_USER_MGMT_PASSWORD = "password";
-    private static final String FIELD_KEY_USER_MGMT_EMAILADDRESS = "emailAddress";
+    public static final String FIELD_KEY_USER_MGMT_USERNAME = "username";
+    public static final String FIELD_KEY_USER_MGMT_PASSWORD = "password";
+    public static final String FIELD_KEY_USER_MGMT_EMAILADDRESS = "emailAddress";
     private static final int DEFAULT_PASSWORD_LENGTH = 8;
     private UserAccessor userAccessor;
     private AuthorizationUtility authorizationUtility;
@@ -103,7 +103,9 @@ public class UserActions {
             Map<String, String> fieldErrors = new HashMap<>();
 
             validateUserExistsById(fieldErrors, userId, userName);
-            validateRequiredField(FIELD_KEY_USER_MGMT_EMAILADDRESS, fieldErrors, emailAddress);
+            if (!existingUser.isExternal()) {
+                validateRequiredField(FIELD_KEY_USER_MGMT_EMAILADDRESS, fieldErrors, emailAddress);
+            }
             if (!userConfig.isPasswordSet() || !passwordMissing) {
                 validatePasswordLength(fieldErrors, password);
             }

--- a/src/test/java/com/synopsys/integration/alert/web/user/UserActionTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/user/UserActionTest.java
@@ -1,0 +1,85 @@
+package com.synopsys.integration.alert.web.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.synopsys.integration.alert.common.descriptor.accessor.AuthorizationUtility;
+import com.synopsys.integration.alert.common.enumeration.AuthenticationType;
+import com.synopsys.integration.alert.common.exception.AlertFieldException;
+import com.synopsys.integration.alert.common.persistence.accessor.AuthenticationTypeAccessor;
+import com.synopsys.integration.alert.common.persistence.accessor.UserAccessor;
+import com.synopsys.integration.alert.common.persistence.model.UserModel;
+import com.synopsys.integration.alert.common.persistence.model.UserRoleModel;
+import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
+import com.synopsys.integration.alert.web.model.UserConfig;
+
+public class UserActionTest {
+
+    @Test
+    public void testInternalUserNoEmailValidation() throws Exception {
+        Long id = 1L;
+        String name = "user";
+        String password = "password";
+        Set<UserRoleModel> roles = Set.of();
+        AuthenticationType authenticationType = AuthenticationType.DATABASE;
+
+        UserModel userModel = UserModel.existingUser(id, name, password, null, authenticationType, roles, true);
+
+        UserAccessor userAccessor = Mockito.mock(UserAccessor.class);
+        Mockito.when(userAccessor.getUser(Mockito.anyLong())).thenReturn(Optional.of(userModel));
+        AuthorizationUtility authorizationUtility = Mockito.mock(AuthorizationUtility.class);
+        AuthorizationManager authorizationManager = Mockito.mock(AuthorizationManager.class);
+        AuthenticationTypeAccessor authenticationTypeAccessor = Mockito.mock(AuthenticationTypeAccessor.class);
+
+        Set<String> roleNames = roles
+                                    .stream()
+                                    .map(UserRoleModel::getName)
+                                    .collect(Collectors.toSet());
+        UserConfig userConfig = new UserConfig(id.toString(), name, "newPassword", null, roleNames, false, false, false, true, false, authenticationType.name(), true);
+        UserActions userActions = new UserActions(userAccessor, authorizationUtility, authorizationManager, authenticationTypeAccessor);
+        try {
+            UserConfig newConfig = userActions.updateUser(id, userConfig);
+            fail("Email adress is missing and should be validated.");
+        } catch (AlertFieldException ex) {
+            assertTrue(ex.getFieldErrors().containsKey(UserActions.FIELD_KEY_USER_MGMT_EMAILADDRESS));
+        }
+    }
+
+    @Test
+    public void testExternalUserNoEmailValidation() throws Exception {
+        Long id = 1L;
+        String name = "user";
+        String password = "password";
+        Set<UserRoleModel> roles = Set.of();
+        AuthenticationType authenticationType = AuthenticationType.LDAP;
+
+        UserModel userModel = UserModel.existingUser(id, name, password, null, authenticationType, roles, true);
+
+        UserAccessor userAccessor = Mockito.mock(UserAccessor.class);
+        Mockito.when(userAccessor.getUser(Mockito.anyLong())).thenReturn(Optional.of(userModel));
+        AuthorizationUtility authorizationUtility = Mockito.mock(AuthorizationUtility.class);
+        AuthorizationManager authorizationManager = Mockito.mock(AuthorizationManager.class);
+        AuthenticationTypeAccessor authenticationTypeAccessor = Mockito.mock(AuthenticationTypeAccessor.class);
+
+        Set<String> roleNames = roles
+                                    .stream()
+                                    .map(UserRoleModel::getName)
+                                    .collect(Collectors.toSet());
+        UserConfig userConfig = new UserConfig(id.toString(), name, "newPassword", null, roleNames, false, false, false, true, false, authenticationType.name(), true);
+        UserActions userActions = new UserActions(userAccessor, authorizationUtility, authorizationManager, authenticationTypeAccessor);
+        UserConfig newConfig = userActions.updateUser(id, userConfig);
+        assertEquals(String.valueOf(id), newConfig.getId());
+        assertEquals(name, newConfig.getUsername());
+        assertNull(newConfig.getPassword());
+        assertNull(newConfig.getEmailAddress());
+    }
+}


### PR DESCRIPTION
If the user is an external user skip validating the email address on update because LDAP and SAML manage the email address.