### PR TITLE
Use returned auth object from super.authenticate.

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SAMLAuthProvider.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SAMLAuthProvider.java
@@ -45,7 +45,7 @@ public class SAMLAuthProvider extends SAMLAuthenticationProvider {
         Authentication currentAuth = super.authenticate(authentication);
         logger.debug("User authenticated: {}", currentAuth.isAuthenticated());
         if (currentAuth.isAuthenticated()) {
-            authenticationEventManager.sendAuthenticationEvent(authentication, AuthenticationType.SAML);
+            authenticationEventManager.sendAuthenticationEvent(currentAuth, AuthenticationType.SAML);
             SecurityContextHolder.getContext().setAuthentication(currentAuth);
         }
         return currentAuth;


### PR DESCRIPTION
Sending the SAML auth event was using the wrong authentication object.  Use the populated Authentication object from the super.authenticate call.  It will have the granted authorities populated.