### PR TITLE
 table select event propagation

### DIFF
--- a/src/main/js/field/input/TableSelectInput.js
+++ b/src/main/js/field/input/TableSelectInput.js
@@ -305,7 +305,9 @@ class TableSelectInput extends Component {
             </div>);
     }
 
-    selectOnClick() {
+    selectOnClick(event) {
+        event.preventDefault();
+        event.stopPropagation();
         this.retrieveTableData();
         this.setState({ showTable: true })
     }


### PR DESCRIPTION
The event of the click of the select button is propagating to the ok button on the table. This closes it immediately in firefox.  Stop the event propagation when the select button is clicked.