### PR TITLE
Helm Chart: Add field to start/stop an alert instance

### DIFF
--- a/deployment/helm/templates/alert-cfssl.yaml
+++ b/deployment/helm/templates/alert-cfssl.yaml
@@ -8,7 +8,11 @@ metadata:
   name: {{ .Release.Name }}-alert-cfssl
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  {{- if eq .Values.status "Running" }} 
+  replicas: 1 
+  {{- else }} 
+  replicas: 0 
+  {{- end }}
   selector:
     matchLabels:
       app: alert

--- a/deployment/helm/templates/alert.yaml
+++ b/deployment/helm/templates/alert.yaml
@@ -7,7 +7,11 @@ metadata:
   name: {{ .Release.Name }}-alert
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  {{- if eq .Values.status "Running" }} 
+  replicas: 1 
+  {{- else }} 
+  replicas: 0 
+  {{- end }}
   selector:
     matchLabels:
       app: alert

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -35,6 +35,9 @@ pvcSize: "5G"
 storageClassName: ""
 volumeName: ""
 
+# Used to start or stop the alert instance. Set to "Running" to start, or "Stopped" to stop
+status: Running
+
 # Expose Alert's User Interface
 exposeui: true
 exposedServiceType: NodePort # ClusterIP | NodePort | LoadBalancer


### PR DESCRIPTION
# Pull Request template

**Link to github issue (if applicable):**

* N/A
* JIRA Ticket: https://jira-sig.internal.synopsys.com/browse/CLOUD-663

**If nothing above, what is your reason for this pull request:**

* The user should be able to start/stop an alert instance with the Helm Chart. (ex: they need to manage their storage)

**Changes proposed in this pull request:**

* Add a status field in the Helm Chart's Values.yaml
* If the status is not "Running" then scale down all pods to 0
