### PR TITLE
Helm Chart: Ability to specify a persistent volume claim name

### DIFF
--- a/deployment/helm/templates/alert.yaml
+++ b/deployment/helm/templates/alert.yaml
@@ -83,7 +83,7 @@ spec:
       {{- if .Values.enablePersistentStorage }}
       - name: dir-alert
         persistentVolumeClaim:
-          claimName: {{ .Release.Name }}-alert-pvc
+          claimName: {{if .Values.persistentVolumeClaimName}} {{.Values.persistentVolumeClaimName}} {{else}} {{ .Release.Name }}-alert-pvc {{end}}
       {{- else }}
       - emptyDir: {}
         name: dir-alert
@@ -122,7 +122,7 @@ spec:
   type: ClusterIP
 ---
 
-{{- if .Values.enablePersistentStorage -}}
+{{- if and .Values.enablePersistentStorage (not .Values.persistentVolumeClaimName) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -31,6 +31,7 @@ cfssl:
 
 # Storage configurations
 enablePersistentStorage: false
+persistentVolumeClaimName: ""
 pvcSize: "5G"
 storageClassName: ""
 volumeName: ""


### PR DESCRIPTION
# Pull Request template

**Link to github issue (if applicable):**

* N/A

**If nothing above, what is your reason for this pull request:**

* The user should be able to create their own Persistent Volume Claim that the Alert instance can use for storage. 

**Changes proposed in this pull request:**

* Add persistentVolumeClaimName field to Values.yaml
* If persistentVolumeClaimName is set then don't create the PVC and use the specified value for the name
