### PR TITLE
Helm Chart: Values.environs are passed through a map

### DIFF
--- a/deployment/helm/templates/_helpers.tpl
+++ b/deployment/helm/templates/_helpers.tpl
@@ -2,3 +2,12 @@
 {{/*
 _helpers.tpl - create helper functions for templating here...
 */}}
+
+{{- define "alert.encryptionSecretEnvirons" -}}
+{{ if not (hasKey .Values.secretEnvirons "ALERT_ENCRYPTION_PASSWORD") -}}
+ALERT_ENCRYPTION_PASSWORD: {{ required "must provide --set alertEncryptionPassword=\"\"" .Values.alertEncryptionPassword }}
+{{- end }}
+{{ if not (hasKey .Values.secretEnvirons "ALERT_ENCRYPTION_GLOBAL_SALT") -}}
+ALERT_ENCRYPTION_GLOBAL_SALT: {{ required "must provide --set alertEncryptionGlobalSalt=\"\"" .Values.alertEncryptionGlobalSalt }}
+{{- end }}
+{{- end -}}

--- a/deployment/helm/templates/alert-environ-configmap.yaml
+++ b/deployment/helm/templates/alert-environ-configmap.yaml
@@ -12,9 +12,8 @@ data:
   HUB_CFSSL_HOST: {{ .Release.Name }}-alert-cfssl
   {{- end }}
   {{- end }}
-  {{- range $key, $value := .Values.environs }}
-  {{- $parts := splitn ":" 2 $value }}
-  {{ $parts._0 }}: {{ $parts._1 }}
+  {{- if .Values.environs }}
+  {{ .Values.environs | toYaml | trimSuffix "\n" }}
   {{- end }}
 metadata:
   labels:

--- a/deployment/helm/templates/alert-environ-secret.yaml
+++ b/deployment/helm/templates/alert-environ-secret.yaml
@@ -2,12 +2,10 @@ apiVersion: v1
 kind: Secret
 data:
   {{- if .Values.setEncryptionSecretData -}}
-  ALERT_ENCRYPTION_PASSWORD: {{ required "must provide --set alertEncryptionPassword=\"\"" .Values.alertEncryptionPassword }}
-  ALERT_ENCRYPTION_GLOBAL_SALT: {{ required "must provide --set alertEncryptionGlobalSalt=\"\"" .Values.alertEncryptionGlobalSalt }}
+  {{- include "alert.encryptionSecretEnvirons" . | nindent 2 }}
   {{- end }}
-  {{- range $key, $value := .Values.secretEnvirons }}
-  {{- $parts := splitn ":" 2 $value }}
-  {{ $parts._0 }}: {{ $parts._1 }}
+  {{- if .Values.secretEnvirons }}
+  {{ .Values.secretEnvirons | toYaml | trimSuffix "\n" | nindent 2 }}
   {{- end }}
 metadata:
   labels:

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -39,23 +39,22 @@ volumeName: ""
 exposeui: true
 exposedServiceType: NodePort # ClusterIP | NodePort | LoadBalancer
 
-# environs is a list of *additional* environs to add to the Alert's ConfigMap
+# environs is a map of *additional* environs to add to the Alert's ConfigMap
 # The follwing environs are already set in the ConfigMap
 # at /templates/alert-environ-resources.yaml (go there to set them):
-#   - HUB_WEBAPP_HOST
-#   - HUB_CFSSL_HOST
-#   - ALERT_SERVER_PORT
-# Format: array of strings delimited by commas; each string has the format "KEY:VALUE" e.g. ["HUB_WEBAPP_HOST:localhost", "ALERT_SERVER_PORT:443"]
-environs: []
+#   HUB_WEBAPP_HOST
+#   HUB_CFSSL_HOST
+#   ALERT_SERVER_PORT
+# if you are setting the value using set flag in helm command, do --set environs.* = ""; i.e.: --set environs.ALERT_CHANNEL_EMAIL_MAIL_SMTP_HOST="email@synopsys.com"
+environs: {}
 
-# secretEnvirons is a list of environs to add to the Alert's Secret
-# The follwing environs are handled by setting .Values.setEncryptionSecretData:
-#   - ALERT_ENCRYPTION_PASSWORD
-#   - ALERT_ENCRYPTION_GLOBAL_SALT
-# Format: array of strings delimited by commas; each string has the format "KEY:VALUE" e.g. ["KEY:VALUE", "KEY:VALUE"]
-secretEnvirons: []
+# secretEnvirons is a map of environs to add to the Alert's Secret
+# if you are setting the value using set flag in helm command, do --set secretEnvirons.* = ""; i.e.: --set secretEnvirons.ALERT_CHANNEL_EMAIL_MAIL_SMTP_HOST="email@synopsys.com"
+secretEnvirons: {}
 
-# If true, requires the user to set alertEncryptionPassword and alertEncryptionGlobalSalt
+# If true, requires the user to set...
+#   the value alertEncryptionPassword or the secretEnviron ALERT_ENCRYPTION_PASSWORD
+#   the value alertEncryptionGlobalSalt or the secretEnviron ALERT_ENCRYPTION_GLOBAL_SALT
 setEncryptionSecretData: false
 
 # Alert's certificate information


### PR DESCRIPTION

# Pull Request template

**Link to github issue (if applicable):**

* N/A
* JIRA Ticket: https://jira-sig.internal.synopsys.com/browse/CLOUD-664

**If nothing above, what is your reason for this pull request:**

* This is done to match the conventions in the Black Duck Helm Chart (which uses a map)

**Changes proposed in this pull request:**

* Change the Values.environs field to be a map
* Modify how they are transcribed into the ConfigMap and Secret
