### PR TITLE
Helm Chart: Ability to configure Alert's port

### DIFF
--- a/deployment/helm/templates/alert.yaml
+++ b/deployment/helm/templates/alert.yaml
@@ -46,7 +46,7 @@ spec:
           timeoutSeconds: 10
         name: blackduck-alert
         ports:
-          - containerPort: 8443
+          - containerPort: {{ .Values.alert.port }}
             protocol: TCP
         resources:
           {{- toYaml .Values.alert.resources | nindent 12 }}
@@ -112,10 +112,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
-    - name: port-8443
-      port: 8443
+    - name: port-{{ .Values.alert.port }}
+      port: {{ .Values.alert.port }}
       protocol: TCP
-      targetPort: 8443
+      targetPort: {{ .Values.alert.port }}
   selector:
     app: alert
     name: {{ .Release.Name }}
@@ -157,10 +157,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
-    - name: port-8443
-      port: 8443
+    - name: port-{{ .Values.alert.port }}
+      port: {{ .Values.alert.port }}
       protocol: TCP
-      targetPort: 8443
+      targetPort: {{ .Values.alert.port }}
   selector:
     app: alert
     name: {{ .Release.Name }}

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -5,6 +5,7 @@
 # alert - configurations for the Alert Pod
 alert:
   image: "docker.io/blackducksoftware/blackduck-alert:VERSION_TOKEN"
+  port: 8443
   resources:
     limits:
       memory: "2560Mi"


### PR DESCRIPTION
# Pull Request template

**Link to github issue (if applicable):**

* N/A

**If nothing above, what is your reason for this pull request:**

* The Helm Chart should allow Alert's port to be configured

**Changes proposed in this pull request:**

* Add a port value in Values.yaml
* Use the port value in the Alert's Deployment, Services, and ConfigMap (ALERT_SERVER_PORT)