### PR TITLE
Helm Chart: Use separate fields for registry and imageTag like BlackDuck

### DIFF
--- a/deployment/helm/templates/alert-cfssl.yaml
+++ b/deployment/helm/templates/alert-cfssl.yaml
@@ -32,7 +32,11 @@ spec:
         - envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-alert-environs
-          image: {{ .Values.cfssl.image }}
+          {{- if .Values.cfssl.registry }}
+          image: {{ .Values.cfssl.registry }}/blackduck-cfssl:{{ .Values.cfssl.imageTag }}
+          {{- else }}
+          image: {{ .Values.registry }}/blackduck-cfssl:{{ .Values.cfssl.imageTag }} 
+          {{- end }}
           livenessProbe:
             exec:
               command:

--- a/deployment/helm/templates/alert.yaml
+++ b/deployment/helm/templates/alert.yaml
@@ -37,7 +37,11 @@ spec:
             name: {{ .Release.Name }}-alert-environs
         - secretRef:
             name: {{ .Release.Name }}-alert-environs-secret
-        image: {{ .Values.alert.image }}
+        {{- if .Values.alert.registry }}
+        image: {{ .Values.alert.registry }}/blackduck-alert:{{ .Values.alert.imageTag }}
+        {{- else }}
+        image: {{ .Values.registry }}/blackduck-alert:{{ .Values.alert.imageTag }} 
+        {{- end }}
         imagePullPolicy: Always
         livenessProbe:
           exec:

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -2,9 +2,12 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+registry: "docker.io/blackducksoftware"
+
 # alert - configurations for the Alert Pod
 alert:
-  image: "docker.io/blackducksoftware/blackduck-alert:VERSION_TOKEN"
+  imageTag: VERSION_TOKEN
+  registry: "" # override the docker registry at container level
   port: 8443
   resources:
     limits:
@@ -20,7 +23,8 @@ deployAlertWithBlackDuck: false
 # enableStandalone deploys a cfssl instance with Alert
 enableStandalone: true
 cfssl:
-  image: "docker.io/blackducksoftware/blackduck-cfssl:1.0.0"
+  imageTag: 1.0.0
+  registry: "" # override the docker registry at container level
   resources:
     limits:
       memory: "640Mi"


### PR DESCRIPTION
# Pull Request template

**Link to github issue (if applicable):**

* N/A

**If nothing above, what is your reason for this pull request:**

* The Helm Chart should be able to allow users to easily configure the imageTag and registry for their images

**Changes proposed in this pull request:**

* Create a global registry field in Values.yaml
* Create a registry field for alert and cfssl (overrides the global if set)
* Create an imageTag for alert and cfssl
* The image is constructed using the above values in alert.yaml and cfssl.yaml