### PR TITLE
Helm Chart: Bug - secret values aren't encoded

### DIFF
--- a/deployment/helm/templates/_helpers.tpl
+++ b/deployment/helm/templates/_helpers.tpl
@@ -5,9 +5,9 @@ _helpers.tpl - create helper functions for templating here...
 
 {{- define "alert.encryptionSecretEnvirons" -}}
 {{ if not (hasKey .Values.secretEnvirons "ALERT_ENCRYPTION_PASSWORD") -}}
-ALERT_ENCRYPTION_PASSWORD: {{ required "must provide --set alertEncryptionPassword=\"\"" .Values.alertEncryptionPassword }}
+ALERT_ENCRYPTION_PASSWORD: {{ required "must provide --set alertEncryptionPassword=\"\"" .Values.alertEncryptionPassword | b64enc }}
 {{- end }}
 {{ if not (hasKey .Values.secretEnvirons "ALERT_ENCRYPTION_GLOBAL_SALT") -}}
-ALERT_ENCRYPTION_GLOBAL_SALT: {{ required "must provide --set alertEncryptionGlobalSalt=\"\"" .Values.alertEncryptionGlobalSalt }}
+ALERT_ENCRYPTION_GLOBAL_SALT: {{ required "must provide --set alertEncryptionGlobalSalt=\"\"" .Values.alertEncryptionGlobalSalt | b64enc }}
 {{- end }}
 {{- end -}}

--- a/deployment/helm/templates/alert-environ-secret.yaml
+++ b/deployment/helm/templates/alert-environ-secret.yaml
@@ -5,7 +5,9 @@ data:
   {{- include "alert.encryptionSecretEnvirons" . | nindent 2 }}
   {{- end }}
   {{- if .Values.secretEnvirons }}
-  {{ .Values.secretEnvirons | toYaml | trimSuffix "\n" | nindent 2 }}
+  {{- range $key, $value := .Values.secretEnvirons }}
+  {{ $key }}: {{ $value | b64enc }}
+  {{- end }}
   {{- end }}
 metadata:
   labels:


### PR DESCRIPTION
# Pull Request template

**Link to github issue (if applicable):**

* N/A

**If nothing above, what is your reason for this pull request:**

* The values in a k8s Secret should be base64 encoded

**Changes proposed in this pull request:**

* Change the function in _helpers.tpl to encode the values from secretEnvirons
* Change the templating in alert-environ-secret.yaml to loop through each environ and encode the data