### PR TITLE
Helm Chart: Set imagePullSecrets for Alert and Cfssl images

### DIFF
--- a/deployment/helm/templates/_helpers.tpl
+++ b/deployment/helm/templates/_helpers.tpl
@@ -11,3 +11,13 @@ ALERT_ENCRYPTION_PASSWORD: {{ required "must provide --set alertEncryptionPasswo
 ALERT_ENCRYPTION_GLOBAL_SALT: {{ required "must provide --set alertEncryptionGlobalSalt=\"\"" .Values.alertEncryptionGlobalSalt }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Image pull secrets to pull the image
+*/}}
+{{- define "alert.imagePullSecrets" -}}
+{{- with .Values.imagePullSecrets -}}
+imagePullSecrets:
+{{- toYaml . | nindent 0 -}}
+{{- end -}}
+{{- end -}}

--- a/deployment/helm/templates/alert-cfssl.yaml
+++ b/deployment/helm/templates/alert-cfssl.yaml
@@ -52,6 +52,7 @@ spec:
             - mountPath: /etc/cfssl
               name: dir-cfssl
       dnsPolicy: ClusterFirst
+      {{- include "alert.imagePullSecrets" . | nindent 6 -}}
       {{- with .Values.cfssl.nodeSelector }}
       nodeSelector:
       {{ toYaml . | indent 2 }}

--- a/deployment/helm/templates/alert.yaml
+++ b/deployment/helm/templates/alert.yaml
@@ -71,6 +71,7 @@ spec:
           subPath: cacerts
         {{- end }}
       dnsPolicy: ClusterFirst
+      {{- include "alert.imagePullSecrets" . | nindent 6 -}}
       {{- with .Values.alert.nodeSelector }}
       nodeSelector:
       {{ toYaml . | indent 2 }}

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -16,6 +16,7 @@ alert:
 
 # Set if Alert will be deployed with a Black Duck instance
 deployAlertWithBlackDuck: false
+
 # enableStandalone deploys a cfssl instance with Alert
 enableStandalone: true
 cfssl:
@@ -35,6 +36,12 @@ persistentVolumeClaimName: ""
 pvcSize: "5G"
 storageClassName: ""
 volumeName: ""
+
+# image pull secret to download the images (mostly applicable for air gapped customers)
+# Format: a list of objects (key: value). Example:
+# imagePullSecrets
+# - name: registryName
+imagePullSecrets: []
 
 # Used to start or stop the alert instance. Set to "Running" to start, or "Stopped" to stop
 status: Running


### PR DESCRIPTION
# Pull Request template

**Link to github issue (if applicable):**

* N/A

**If nothing above, what is your reason for this pull request:**

* The Alert Helm Chart should allow the user to specify imagePullSecrets for pulling images from private registries

**Changes proposed in this pull request:**

* Add an imagePullSecrets field to Values.yaml
* Put the imagePullSecrets into the Deployments for Alert and Cfssl