### PR TITLE
Check id field to allow edits.

### DIFF
--- a/src/main/js/dynamic/loaded/users/PermissionTable.js
+++ b/src/main/js/dynamic/loaded/users/PermissionTable.js
@@ -237,11 +237,13 @@ class PermissionTable extends Component {
             });
             return false;
         }
-        const existingPermission = data.find(permission =>
+        const duplicates = data.filter(permission =>
             permission[PERMISSIONS_TABLE.DESCRIPTOR_NAME] === permissionsData[PERMISSIONS_TABLE.DESCRIPTOR_NAME] &&
-            permission[PERMISSIONS_TABLE.CONTEXT] === permissionsData[PERMISSIONS_TABLE.CONTEXT]
+            permission[PERMISSIONS_TABLE.CONTEXT] === permissionsData[PERMISSIONS_TABLE.CONTEXT] &&
+            permission.id !== permissionsData.id
         );
-        if (existingPermission && existingPermission.id !== permissionsData.id) {
+
+        if (duplicates && duplicates.length > 0) {
             await this.setState({
                 errorMessage: `Can't add a duplicate permission. A permission already exists for Descriptor:${permissionsData[PERMISSIONS_TABLE.DESCRIPTOR_NAME]} and Context:${permissionsData[PERMISSIONS_TABLE.CONTEXT]}`,
                 saveInProgress: false

--- a/src/main/js/dynamic/loaded/users/PermissionTable.js
+++ b/src/main/js/dynamic/loaded/users/PermissionTable.js
@@ -237,11 +237,11 @@ class PermissionTable extends Component {
             });
             return false;
         }
-        const duplicate = data.find(permission =>
+        const existingPermission = data.find(permission =>
             permission[PERMISSIONS_TABLE.DESCRIPTOR_NAME] === permissionsData[PERMISSIONS_TABLE.DESCRIPTOR_NAME] &&
             permission[PERMISSIONS_TABLE.CONTEXT] === permissionsData[PERMISSIONS_TABLE.CONTEXT]
         );
-        if (duplicate) {
+        if (existingPermission && existingPermission.id !== permissionsData.id) {
             await this.setState({
                 errorMessage: `Can't add a duplicate permission. A permission already exists for Descriptor:${permissionsData[PERMISSIONS_TABLE.DESCRIPTOR_NAME]} and Context:${permissionsData[PERMISSIONS_TABLE.CONTEXT]}`,
                 saveInProgress: false


### PR DESCRIPTION
If the id is the same for the permission we are editing and the list of permissions from the same descriptor and context allow the update of the permissions.  If the IDs are different report the duplicate error.