### PR TITLE
Helm Chart: Add VERSION_TOKEN to the appVersion in Chart.yaml

### DIFF
--- a/deployment/helm/Chart.yaml
+++ b/deployment/helm/Chart.yaml
@@ -18,6 +18,6 @@ version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should match
 # the version of Alert
-appVersion: 5.1.0
+appVersion: VERSION_TOKEN
 
 


### PR DESCRIPTION
# Pull Request template

**Link to github issue (if applicable):**

* N/A
* JIRA: https://jira-sig.internal.synopsys.com/browse/IALERT-1678

**If nothing above, what is your reason for this pull request:**

* N/A

**Changes proposed in this pull request:**

* change appVersion to VERSION_TOKEN in Chart.yaml
