### PR TITLE
Helm Chart: Remove repetitive 'alert' in names of resources

### DIFF
--- a/deployment/helm/templates/alert-cfssl.yaml
+++ b/deployment/helm/templates/alert-cfssl.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: alert
     name: {{ .Release.Name }}
-  name: {{ .Release.Name }}-alert-cfssl
+  name: {{ .Release.Name }}-cfssl
   namespace: {{ .Release.Namespace }}
 spec:
   {{- if eq .Values.status "Running" }} 
@@ -26,12 +26,12 @@ spec:
         name: {{ .Release.Name }}
       annotations:
         checksum/alert-environ-resources: {{ include (print $.Template.BasePath "/alert-environ-configmap.yaml") . | sha256sum }}
-      name: {{ .Release.Name }}-alert-cfssl
+      name: {{ .Release.Name }}-cfssl
     spec:
       containers:
         - envFrom:
             - configMapRef:
-                name: {{ .Release.Name }}-alert-environs
+                name: {{ .Release.Name }}-environs
           {{- if .Values.cfssl.registry }}
           image: {{ .Values.cfssl.registry }}/blackduck-cfssl:{{ .Values.cfssl.imageTag }}
           {{- else }}
@@ -80,7 +80,7 @@ metadata:
   labels:
     app: alert
     name: {{ .Release.Name }}
-  name: {{ .Release.Name }}-alert-cfssl
+  name: {{ .Release.Name }}-cfssl
   namespace: {{ .Release.Namespace }}
 spec:
   ports:

--- a/deployment/helm/templates/alert-environ-configmap.yaml
+++ b/deployment/helm/templates/alert-environ-configmap.yaml
@@ -9,7 +9,7 @@ data:
   ALERT_HOSTNAME: localhost
   ALERT_SERVER_PORT: "8443"
   {{- if .Values.enableStandalone }}
-  HUB_CFSSL_HOST: {{ .Release.Name }}-alert-cfssl
+  HUB_CFSSL_HOST: {{ .Release.Name }}-cfssl
   {{- end }}
   {{- end }}
   {{- if .Values.environs }}
@@ -19,6 +19,6 @@ metadata:
   labels:
     app: alert
     name: {{ .Release.Name }}
-  name: {{ .Release.Name }}-alert-environs
+  name: {{ .Release.Name }}-environs
   namespace: {{ .Release.Namespace }}
 ---

--- a/deployment/helm/templates/alert-environ-secret.yaml
+++ b/deployment/helm/templates/alert-environ-secret.yaml
@@ -13,7 +13,7 @@ metadata:
   labels:
     app: alert
     name: {{ .Release.Name }}
-  name: {{ .Release.Name }}-alert-environs-secret
+  name: {{ .Release.Name }}-environs-secret
   namespace: {{ .Release.Namespace }}
 type: Opaque
 ---

--- a/deployment/helm/templates/alert.yaml
+++ b/deployment/helm/templates/alert.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: alert
     name: {{ .Release.Name }} 
-  name: {{ .Release.Name }}-alert
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 spec:
   {{- if eq .Values.status "Running" }} 
@@ -26,7 +26,7 @@ spec:
       annotations:
         checksum/alert-environ-configmap: {{ include (print $.Template.BasePath "/alert-environ-configmap.yaml") . | sha256sum }}
         checksum/alert-environ-secret: {{ include (print $.Template.BasePath "/alert-environ-secret.yaml") . | sha256sum }}
-      name: {{ .Release.Name }}-alert
+      name: {{ .Release.Name }}
     spec:
       containers:
       - env:
@@ -34,9 +34,9 @@ spec:
           value: /tmp/secrets
         envFrom:
         - configMapRef:
-            name: {{ .Release.Name }}-alert-environs
+            name: {{ .Release.Name }}-environs
         - secretRef:
-            name: {{ .Release.Name }}-alert-environs-secret
+            name: {{ .Release.Name }}-environs-secret
         {{- if .Values.alert.registry }}
         image: {{ .Values.alert.registry }}/blackduck-alert:{{ .Values.alert.imageTag }}
         {{- else }}
@@ -117,7 +117,7 @@ metadata:
   labels:
     app: alert
     name: {{ .Release.Name }}
-  name: {{ .Release.Name }}-alert
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
@@ -138,7 +138,7 @@ metadata:
   labels:
     app: alert
     name: {{ .Release.Name }}
-  name: {{ .Release.Name }}-alert-pvc
+  name: {{ .Release.Name }}-pvc
   namespace: {{ .Release.Namespace }}
 spec:
   {{ if .Values.storageClassName -}}
@@ -162,7 +162,7 @@ metadata:
   labels:
     app: alert
     name: {{ .Release.Name }}
-  name: {{ .Release.Name }}-alert-exposed
+  name: {{ .Release.Name }}-exposed
   namespace: {{ .Release.Namespace }}
 spec:
   ports:


### PR DESCRIPTION
# Pull Request template

**Link to github issue (if applicable):**

* N/A
* JIRA: https://jira-sig.internal.synopsys.com/browse/IALERT-1677

**If nothing above, what is your reason for this pull request:**

* N/A

**Changes proposed in this pull request:**

* Remove the "-alert" from all resource names