### PR TITLE
Helm Chart: Add Routes and set enable PersistentStorage by default

### DIFF
--- a/deployment/helm/templates/alert.yaml
+++ b/deployment/helm/templates/alert.yaml
@@ -111,26 +111,6 @@ spec:
       {{- end }}
 ---
 
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: alert
-    name: {{ .Release.Name }}
-  name: {{ .Release.Name }}-alert
-  namespace: {{ .Release.Namespace }}
-spec:
-  ports:
-    - name: port-{{ .Values.alert.port }}
-      port: {{ .Values.alert.port }}
-      protocol: TCP
-      targetPort: {{ .Values.alert.port }}
-  selector:
-    app: alert
-    name: {{ .Release.Name }}
-  type: ClusterIP
----
-
 {{- if and .Values.enablePersistentStorage (not .Values.persistentVolumeClaimName) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -155,7 +135,46 @@ spec:
 ---
 {{- end }}
 
-{{ if .Values.exposeui -}}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: alert
+    name: {{ .Release.Name }}
+  name: {{ .Release.Name }}-alert
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+    - name: port-{{ .Values.alert.port }}
+      port: {{ .Values.alert.port }}
+      protocol: TCP
+      targetPort: {{ .Values.alert.port }}
+  selector:
+    app: alert
+    name: {{ .Release.Name }}
+  type: ClusterIP
+---
+
+{{ if and .Values.exposeui (eq .Values.exposedServiceType "OpenShift" ) -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: alert
+    component: route
+    name: {{ .Release.Name }}
+  name: {{ .Release.Name }}-alert
+  namespace: {{ .Release.Namespace }}
+spec:
+  port:
+    targetPort: port-{{ .Values.alert.port }}
+  tls:
+    termination: passthrough
+  to:
+    kind: Service
+    name: {{ .Release.Name }}-alert
+  wildcardPolicy: None
+{{ else if .Values.exposeui }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -50,7 +50,7 @@ status: Running
 
 # Expose Alert's User Interface
 exposeui: true
-exposedServiceType: NodePort # ClusterIP | NodePort | LoadBalancer
+exposedServiceType: NodePort # NodePort | LoadBalancer | OpenShift
 
 # environs is a map of *additional* environs to add to the Alert's ConfigMap
 # The follwing environs are already set in the ConfigMap

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -36,7 +36,7 @@ cfssl:
   affinity: {}
 
 # Storage configurations
-enablePersistentStorage: false
+enablePersistentStorage: true
 persistentVolumeClaimName: ""
 pvcSize: "5G"
 storageClassName: ""


### PR DESCRIPTION
# Pull Request template

**Link to github issue (if applicable):**

* N/A
* JIRA: https://jira-sig.internal.synopsys.com/browse/IALERT-1681

**If nothing above, what is your reason for this pull request:**

1. Customers should be able to deploy with Routes if they are in openshift
2. Customers should always be deploying their resources with persistent storage. This is also how the Black Duck Helm Chart is implemented. 

**Changes proposed in this pull request:**

* Add the Route manifest for the Route Resource
* Add logic to enable/disable the route, or use a service for k8s
* Change the default "enablePersistentStorage" to be true