### PR TITLE
Helm Chart: Make security contexts configurable in the helm chart

### DIFF
--- a/deployment/helm/synopsys-alert/templates/_helpers.tpl
+++ b/deployment/helm/synopsys-alert/templates/_helpers.tpl
@@ -3,32 +3,32 @@
 _helpers.tpl - create helper functions for templating here...
 */}}
 
-{{- define "alert.encryptionSecretEnvirons" }}
+{{- define "alert.encryptionSecretEnvirons" -}}
 {{- if not (hasKey .Values.secretEnvirons "ALERT_ENCRYPTION_PASSWORD") }}
-ALERT_ENCRYPTION_PASSWORD: {{ required "must provide --set alertEncryptionPassword=\"\"" .Values.alertEncryptionPassword | b64enc }}
+ALERT_ENCRYPTION_PASSWORD: {{ required "must provide --set alertEncryptionPassword=\"\"" .Values.alertEncryptionPassword | quote | b64enc }}
 {{- end }}
 {{- if not (hasKey .Values.secretEnvirons "ALERT_ENCRYPTION_GLOBAL_SALT") }}
-ALERT_ENCRYPTION_GLOBAL_SALT: {{ required "must provide --set alertEncryptionGlobalSalt=\"\"" .Values.alertEncryptionGlobalSalt | b64enc }}
+ALERT_ENCRYPTION_GLOBAL_SALT: {{ required "must provide --set alertEncryptionGlobalSalt=\"\"" .Values.alertEncryptionGlobalSalt | quote | b64enc }}
 {{- end }}
 {{- end -}}
 
 {{/*
 Image pull secrets to pull the image
 */}}
-{{- define "alert.imagePullSecrets" }}
+{{- define "alert.imagePullSecrets" -}}
 {{- if .Values.imagePullSecrets }}
 imagePullSecrets:
 {{- range .Values.imagePullSecrets }}
 - name: {{ . }}
 {{- end }}
 {{- end }}
-{{- end }}
+{{- end -}}
 
 {{/*
 Environs for Alert Config Map
 */}}
-{{- define "alert.environs" }}
+{{- define "alert.environs" -}}
 {{- range $key, $value := .Values.environs }}
 {{ $key }}: {{ $value | quote }}
 {{- end }}
-{{- end }}
+{{- end -}}

--- a/deployment/helm/synopsys-alert/templates/_helpers.tpl
+++ b/deployment/helm/synopsys-alert/templates/_helpers.tpl
@@ -3,11 +3,11 @@
 _helpers.tpl - create helper functions for templating here...
 */}}
 
-{{- define "alert.encryptionSecretEnvirons" -}}
-{{ if not (hasKey .Values.secretEnvirons "ALERT_ENCRYPTION_PASSWORD") -}}
+{{- define "alert.encryptionSecretEnvirons" }}
+{{- if not (hasKey .Values.secretEnvirons "ALERT_ENCRYPTION_PASSWORD") }}
 ALERT_ENCRYPTION_PASSWORD: {{ required "must provide --set alertEncryptionPassword=\"\"" .Values.alertEncryptionPassword | b64enc }}
 {{- end }}
-{{ if not (hasKey .Values.secretEnvirons "ALERT_ENCRYPTION_GLOBAL_SALT") -}}
+{{- if not (hasKey .Values.secretEnvirons "ALERT_ENCRYPTION_GLOBAL_SALT") }}
 ALERT_ENCRYPTION_GLOBAL_SALT: {{ required "must provide --set alertEncryptionGlobalSalt=\"\"" .Values.alertEncryptionGlobalSalt | b64enc }}
 {{- end }}
 {{- end -}}
@@ -15,11 +15,20 @@ ALERT_ENCRYPTION_GLOBAL_SALT: {{ required "must provide --set alertEncryptionGlo
 {{/*
 Image pull secrets to pull the image
 */}}
-{{- define "alert.imagePullSecrets" -}}
-{{- if .Values.imagePullSecrets -}}
+{{- define "alert.imagePullSecrets" }}
+{{- if .Values.imagePullSecrets }}
 imagePullSecrets:
 {{- range .Values.imagePullSecrets }}
 - name: {{ . }}
 {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Environs for Alert Config Map
+*/}}
+{{- define "alert.environs" }}
+{{- range $key, $value := .Values.environs }}
+{{ $key }}: {{ $value | quote }}
 {{- end }}
 {{- end }}

--- a/deployment/helm/synopsys-alert/templates/alert-cfssl.yaml
+++ b/deployment/helm/synopsys-alert/templates/alert-cfssl.yaml
@@ -55,6 +55,10 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.cfssl.resources | nindent 12 }}
+          {{- with .Values.cfssl.securityContext }}
+          securityContext:
+{{ toYaml . | indent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /etc/cfssl
               name: dir-cfssl
@@ -71,6 +75,10 @@ spec:
       {{- with .Values.cfssl.tolerations }}
       tolerations:
       {{ toYaml . | indent 2 }}
+      {{- end }}
+      {{- with .Values.cfssl.podSecurityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
       {{- end }}
       volumes:
         - emptyDir: {}

--- a/deployment/helm/synopsys-alert/templates/alert-environ-configmap.yaml
+++ b/deployment/helm/synopsys-alert/templates/alert-environ-configmap.yaml
@@ -10,8 +10,8 @@ data:
   ALERT_SERVER_PORT: "8443"
   {{- if .Values.enableStandalone }}
   HUB_CFSSL_HOST: {{ .Release.Name }}-cfssl
-  {{- end }}
-  {{- end }}
+  {{- end -}}
+  {{- end -}}
   {{- if .Values.environs }}
   {{- include "alert.environs" . | nindent 2 }}
   {{- end }}

--- a/deployment/helm/synopsys-alert/templates/alert-environ-configmap.yaml
+++ b/deployment/helm/synopsys-alert/templates/alert-environ-configmap.yaml
@@ -13,7 +13,7 @@ data:
   {{- end }}
   {{- end }}
   {{- if .Values.environs }}
-  {{- .Values.environs | toYaml | nindent 2 | trimSuffix "\n" }}
+  {{- include "alert.environs" . | nindent 2 }}
   {{- end }}
 metadata:
   labels:

--- a/deployment/helm/synopsys-alert/templates/alert-environ-configmap.yaml
+++ b/deployment/helm/synopsys-alert/templates/alert-environ-configmap.yaml
@@ -3,8 +3,8 @@ kind: ConfigMap
 data:
   {{- if .Values.deployAlertWithBlackDuck }}
   ALERT_HOSTNAME: localhost
-  HUB_WEBAPP_HOST: {{ .Release.Name }}-blackduck-webapp.{{ .Release.Namespace }}.svc
-  HUB_CFSSL_HOST: {{ .Release.Name }}-blackduck-cfssl
+  HUB_WEBAPP_HOST: {{ required "must --set blackDuckName" .Values.blackDuckName }}-blackduck-webapp.{{ required "must --set blackDuckNamespace" .Values.blackDuckNamespace }}.svc
+  HUB_CFSSL_HOST: {{ .Values.blackDuckName }}-blackduck-cfssl.{{ .Values.blackDuckNamespace }}.svc
   {{- else }}
   ALERT_HOSTNAME: localhost
   ALERT_SERVER_PORT: "8443"

--- a/deployment/helm/synopsys-alert/templates/alert-environ-secret.yaml
+++ b/deployment/helm/synopsys-alert/templates/alert-environ-secret.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Secret
 data:
-  {{- if .Values.setEncryptionSecretData -}}
+  {{- if .Values.setEncryptionSecretData }}
   {{- include "alert.encryptionSecretEnvirons" . | nindent 2 }}
   {{- end }}
   {{- if .Values.secretEnvirons }}
   {{- range $key, $value := .Values.secretEnvirons }}
-  {{ $key }}: {{ $value | b64enc }}
+  {{ $key }}: {{ $value | quote | b64enc }}
   {{- end }}
   {{- end }}
 metadata:

--- a/deployment/helm/synopsys-alert/templates/alert.yaml
+++ b/deployment/helm/synopsys-alert/templates/alert.yaml
@@ -103,7 +103,7 @@ spec:
       {{- if .Values.enablePersistentStorage }}
       - name: dir-alert
         persistentVolumeClaim:
-          claimName: {{if .Values.persistentVolumeClaimName}} {{.Values.persistentVolumeClaimName}} {{else}} {{ .Release.Name }}-pvc {{end}}
+          claimName: {{if .Values.alert.persistentVolumeClaimName}} {{.Values.alert.persistentVolumeClaimName}} {{else}} {{ .Release.Name }}-pvc {{end}}
       {{- else }}
       - emptyDir: {}
         name: dir-alert
@@ -144,7 +144,7 @@ spec:
   type: ClusterIP
 ---
 
-{{- if and .Values.enablePersistentStorage (not .Values.persistentVolumeClaimName) }}
+{{- if and .Values.enablePersistentStorage (not .Values.alert.persistentVolumeClaimName) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -155,17 +155,19 @@ metadata:
   name: {{ .Release.Name }}-pvc
   namespace: {{ .Release.Namespace }}
 spec:
-  {{ if .Values.storageClassName -}}
-  storageClassName: {{ .Values.storageClassName }}
-  {{ end -}}
-  {{ if .Values.volumeName -}}
-  volumeName: {{ .Values.volumeName }}
+  {{- if .Values.alert.storageClass }}
+  storageClassName: {{ .Values.alert.storageClass }}
+  {{- else if .Values.storageClass }}
+  storageClassName: {{ .Values.storageClass }}
+  {{- end}}
+  {{ if .Values.alert.volumeName -}}
+  volumeName: {{ .Values.alert.volumeName }}
   {{ end -}}
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: {{ .Values.pvcSize }}
+      storage: {{ .Values.alert.claimSize }}
 ---
 {{- end }}
 

--- a/deployment/helm/synopsys-alert/templates/alert.yaml
+++ b/deployment/helm/synopsys-alert/templates/alert.yaml
@@ -61,6 +61,10 @@ spec:
             protocol: TCP
         resources:
           {{- toYaml .Values.alert.resources | nindent 12 }}
+        {{- with .Values.alert.securityContext }}
+        securityContext:
+{{ toYaml . | indent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /opt/blackduck/alert/alert-config
           name: dir-alert
@@ -90,6 +94,10 @@ spec:
       {{- with .Values.alert.tolerations }}
       tolerations:
       {{ toYaml . | indent 2 }}
+      {{- end }}
+      {{- with .Values.alert.podSecurityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
       {{- end }}
       volumes:
       {{- if .Values.enablePersistentStorage }}

--- a/deployment/helm/synopsys-alert/values.yaml
+++ b/deployment/helm/synopsys-alert/values.yaml
@@ -79,3 +79,5 @@ javaKeystoreSecretName: ""                # kubectl create secret generic <name>
 
 # Set if Alert will be deployed with a Black Duck instance
 deployAlertWithBlackDuck: false
+blackDuckName: ""       # If true, you must provide the ReleaseName of the Black Duck instance
+blackDuckNamespace: ""  # If true, you must provide the Namspace of the Black Duck instance

--- a/deployment/helm/synopsys-alert/values.yaml
+++ b/deployment/helm/synopsys-alert/values.yaml
@@ -17,7 +17,9 @@ alert:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-
+  securityContext: {}
+  podSecurityContext: {}
+    
 # Set if Alert will be deployed with a Black Duck instance
 deployAlertWithBlackDuck: false
 
@@ -34,6 +36,8 @@ cfssl:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  securityContext: {}
+  podSecurityContext: {}
 
 # Storage configurations
 enablePersistentStorage: true

--- a/deployment/helm/synopsys-alert/values.yaml
+++ b/deployment/helm/synopsys-alert/values.yaml
@@ -4,6 +4,10 @@
 
 registry: "docker.io/blackducksoftware"
 
+# Storage configurations
+enablePersistentStorage: true
+storageClass: # it will apply to all PVC's storage class but it can be override at container level
+
 # alert - configurations for the Alert Pod
 alert:
   imageTag: VERSION_TOKEN
@@ -14,17 +18,19 @@ alert:
       memory: "2560Mi"
     requests:
       memory: "2560Mi"
+  persistentVolumeClaimName: ""
+  claimSize: "5G"
+  storageClass: ""
+  volumeName: ""
   nodeSelector: {}
   tolerations: []
   affinity: {}
   securityContext: {}
   podSecurityContext: {}
-    
-# Set if Alert will be deployed with a Black Duck instance
-deployAlertWithBlackDuck: false
 
 # enableStandalone deploys a cfssl instance with Alert
 enableStandalone: true
+# cfssl - configurations for the cfssl Pod
 cfssl:
   imageTag: 1.0.0
   registry: "" # override the docker registry at container level
@@ -38,13 +44,6 @@ cfssl:
   affinity: {}
   securityContext: {}
   podSecurityContext: {}
-
-# Storage configurations
-enablePersistentStorage: true
-persistentVolumeClaimName: ""
-pvcSize: "5G"
-storageClassName: ""
-volumeName: ""
 
 # image pull secret to download images (mostly applicable for air gapped customers)
 imagePullSecrets: [] # array of strings delimited by comma
@@ -77,3 +76,6 @@ setEncryptionSecretData: false
 # Alert's certificate information
 webserverCustomCertificatesSecretName: "" # kubectl create secret generic <name>-alert-certificate -n <namespace> --from-file=WEBSERVER_CUSTOM_CERT_FILE=tls.crt --from-file=WEBSERVER_CUSTOM_KEY_FILE=tls.key
 javaKeystoreSecretName: ""                # kubectl create secret generic <name>-alert-certificate -n <namespace> --from-file=cacerts  
+
+# Set if Alert will be deployed with a Black Duck instance
+deployAlertWithBlackDuck: false


### PR DESCRIPTION
# Pull Request template

**Link to github issue (if applicable):**

* GitHub: N/A
* Progress on JIRA: https://jira-sig.internal.synopsys.com/browse/IALERT-1590
* Progress on JIRA: https://jira-sig.internal.synopsys.com/browse/CLOUD-592

**If nothing above, what is your reason for this pull request:**

* The Helm Chart should be able to set Security Contexts so customers can run as non-root. Synopsysctl will need to use this ability from the Helm Chart.

**Changes proposed in this pull request:**

* Add podSecurityContext and securityContext in Values.yaml for Alert and Cfssl
* Configure podSecurityContext and securityContext in the Deployments for Alert and Cfssl