### PR TITLE
upgrade fix

### DIFF
--- a/alert-database/src/main/resources/liquibase/6.0.0/notification-migration-procedures.xml
+++ b/alert-database/src/main/resources/liquibase/6.0.0/notification-migration-procedures.xml
@@ -11,7 +11,7 @@
                     into result
                     from ALERT.DESCRIPTOR_CONFIGS
                     where DESCRIPTOR_ID = GET_DESCRIPTOR_ID($1)
-                    and GET_CONTEXT_ID('GLOBAL')
+                    and CONTEXT_ID = GET_CONTEXT_ID('GLOBAL')
                     LIMIT 1;
                     RETURN result;
                 END;

--- a/alert-database/src/main/resources/liquibase/6.0.0/notifications.xml
+++ b/alert-database/src/main/resources/liquibase/6.0.0/notifications.xml
@@ -8,10 +8,28 @@
             </not>
         </preConditions>
         <addColumn schemaName="alert" tableName="raw_notification_content">
-            <column name="provider_config_id" type="BIGINT" valueComputed="GET_PROVIDER_CONFIG_ID('provider_blackduck')">
+            <column name="provider_config_id" type="BIGINT" value="-1">
                 <constraints nullable="false"/>
             </column>
         </addColumn>
+    </changeSet>
+    <!-- https://liquibase.jira.com/browse/CORE-3028
+         The previous changeset won't run because the addition of the table with valueComputed results in a
+         ALTER TABLE ADD COLUMN 'provider_config_id' BIGINT NOT NULL statement to get executed.  This fails
+         because the column has a default value of NULL but the constraint doesn't allow that.
+         Use the value attribute in the previous changeset adding the provider_config_id column to set a non null value.
+         Then update the column with the computed value for the provider id.
+    -->
+    <changeSet id="2020-04-17-14-14-03-123" author="psantos">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <sqlCheck expectedResult="0">select count(*) from alert.raw_notification_content where provider_config_id = -1</sqlCheck>
+            </not>
+        </preConditions>
+        <update schemaName="alert" tableName="raw_notification_content">
+            <column name="provider_config_id" type="BIGINT" valueComputed="GET_PROVIDER_CONFIG_ID('provider_blackduck')"/>
+            <where>provider_config_id = -1</where>
+        </update>
     </changeSet>
     <changeSet author="gavink" id="2020-02-11-09-21-42-238">
         <preConditions>

--- a/alert-database/src/main/resources/liquibase/6.0.0/notifications.xml
+++ b/alert-database/src/main/resources/liquibase/6.0.0/notifications.xml
@@ -9,6 +9,7 @@
         </preConditions>
         <addColumn schemaName="alert" tableName="raw_notification_content">
             <column name="provider_config_id" type="BIGINT" valueComputed="GET_PROVIDER_CONFIG_ID('provider_blackduck')">
+                <constraints nullable="false"/>
             </column>
         </addColumn>
     </changeSet>

--- a/alert-database/src/main/resources/liquibase/6.0.0/notifications.xml
+++ b/alert-database/src/main/resources/liquibase/6.0.0/notifications.xml
@@ -9,7 +9,6 @@
         </preConditions>
         <addColumn schemaName="alert" tableName="raw_notification_content">
             <column name="provider_config_id" type="BIGINT" valueComputed="GET_PROVIDER_CONFIG_ID('provider_blackduck')">
-                <constraints nullable="false"/>
             </column>
         </addColumn>
     </changeSet>

--- a/alert-database/src/main/resources/liquibase/6.0.0/notifications.xml
+++ b/alert-database/src/main/resources/liquibase/6.0.0/notifications.xml
@@ -8,28 +8,9 @@
             </not>
         </preConditions>
         <addColumn schemaName="alert" tableName="raw_notification_content">
-            <column name="provider_config_id" type="BIGINT" value="-1">
-                <constraints nullable="false"/>
+            <column name="provider_config_id" type="BIGINT" valueComputed="GET_PROVIDER_CONFIG_ID('provider_blackduck')">
             </column>
         </addColumn>
-    </changeSet>
-    <!-- https://liquibase.jira.com/browse/CORE-3028
-         The previous changeset won't run because the addition of the table with valueComputed results in a
-         ALTER TABLE ADD COLUMN 'provider_config_id' BIGINT NOT NULL statement to get executed.  This fails
-         because the column has a default value of NULL but the constraint doesn't allow that.
-         Use the value attribute in the previous changeset adding the provider_config_id column to set a non null value.
-         Then update the column with the computed value for the provider id.
-    -->
-    <changeSet id="2020-04-17-14-14-03-123" author="psantos">
-        <preConditions onFail="MARK_RAN">
-            <not>
-                <sqlCheck expectedResult="0">select count(*) from alert.raw_notification_content where provider_config_id = -1</sqlCheck>
-            </not>
-        </preConditions>
-        <update schemaName="alert" tableName="raw_notification_content">
-            <column name="provider_config_id" type="BIGINT" valueComputed="GET_PROVIDER_CONFIG_ID('provider_blackduck')"/>
-            <where>provider_config_id = -1</where>
-        </update>
     </changeSet>
     <changeSet author="gavink" id="2020-02-11-09-21-42-238">
         <preConditions>

--- a/alert-database/src/main/resources/liquibase/6.0.0/notifications.xml
+++ b/alert-database/src/main/resources/liquibase/6.0.0/notifications.xml
@@ -8,9 +8,7 @@
             </not>
         </preConditions>
         <addColumn schemaName="alert" tableName="raw_notification_content">
-            <column name="provider_config_id" type="BIGINT" valueComputed="GET_PROVIDER_CONFIG_ID('provider_blackduck')">
-                <constraints nullable="false"/>
-            </column>
+            <column name="provider_config_id" type="BIGINT" valueComputed="GET_PROVIDER_CONFIG_ID('provider_blackduck')"/>
         </addColumn>
     </changeSet>
     <changeSet author="gavink" id="2020-02-11-09-21-42-238">

--- a/alert-database/src/main/resources/liquibase/6.0.0/notifications.xml
+++ b/alert-database/src/main/resources/liquibase/6.0.0/notifications.xml
@@ -11,6 +11,14 @@
             <column name="provider_config_id" type="BIGINT" valueComputed="GET_PROVIDER_CONFIG_ID('provider_blackduck')"/>
         </addColumn>
     </changeSet>
+    <changeSet author="psantos" id="2020-04-20-06-44-21-289">
+        <addNotNullConstraint
+                schemaName="alert"
+                tableName="raw_notification_content"
+                columnName="provider_config_id"
+                columnDataType="BIGINT"
+        />
+    </changeSet>
     <changeSet author="gavink" id="2020-02-11-09-21-42-238">
         <preConditions>
             <not>


### PR DESCRIPTION
Fix the procedure to get the provider configuration id.

Remove the not null constraint on the provider_config_id column.  Because valueComputed is used the first statement that liquibase issues is 
ALTER TABLE raw_notification_content ADD COLUMN 'provider_config_id' NOT NULL;
But there is no default value defined so NULL is used but the column can't be null.
May be related to this liquibase bug which has similar behavior:
https://liquibase.jira.com/browse/CORE-3028