### PR TITLE
Read the provider config to get the missing data.

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/channel/email/descriptor/EmailDistributionUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/email/descriptor/EmailDistributionUIConfig.java
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.channel.email.EmailChannelKey;
 import com.synopsys.integration.alert.channel.email.template.EmailAttachmentFormat;
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.descriptor.config.field.CheckboxConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.ConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.LabelValueSelectOption;
@@ -69,7 +70,8 @@ public class EmailDistributionUIConfig extends ChannelDistributionUIConfig {
         ConfigField additionalEmailAddresses = new EndpointTableSelectField(EmailDescriptor.KEY_EMAIL_ADDITIONAL_ADDRESSES, LABEL_ADDITIONAL_ADDRESSES, DESCRIPTION_ADDITIONAL_ADDRESSES)
                                                    .applyColumn(new TableSelectColumn("emailAddress", "Email Address", true, true))
                                                    .applySearchable(true)
-                                                   .applyRequestedDataFieldKey(ChannelDistributionUIConfig.KEY_PROVIDER_NAME);
+                                                   .applyRequestedDataFieldKey(ChannelDistributionUIConfig.KEY_PROVIDER_NAME)
+                                                   .applyRequestedDataFieldKey(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME);
         ConfigField additionalEmailAddressesOnly = new CheckboxConfigField(EmailDescriptor.KEY_EMAIL_ADDITIONAL_ADDRESSES_ONLY, LABEL_ADDITIONAL_ADDRESSES_ONLY, DESCRIPTION_ADDITIONAL_ADDRESSES_ONLY)
                                                        .applyValidationFunctions(this::validateAdditionalEmailAddressesOnly)
                                                        .applyDisallowedRelatedField(EmailDescriptor.KEY_PROJECT_OWNER_ONLY);

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckDistributionUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckDistributionUIConfig.java
@@ -27,10 +27,12 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.descriptor.config.field.ConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.EndpointSelectField;
 import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.table.EndpointTableSelectField;
 import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.table.TableSelectColumn;
+import com.synopsys.integration.alert.common.descriptor.config.ui.ChannelDistributionUIConfig;
 import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderDistributionUIConfig;
 
 @Component
@@ -55,11 +57,15 @@ public class BlackDuckDistributionUIConfig extends ProviderDistributionUIConfig 
                                                        .applyColumn(new TableSelectColumn("name", "Name", true, true))
                                                        .applyPaged(true)
                                                        .applyRequestedDataFieldKey(ProviderDistributionUIConfig.KEY_NOTIFICATION_TYPES)
+                                                       .applyRequestedDataFieldKey(ChannelDistributionUIConfig.KEY_PROVIDER_NAME)
+                                                       .applyRequestedDataFieldKey(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME)
                                                        .applyPanel(PANEL_NOTIFICATION_FILTERING);
 
         ConfigField vulnerabilityNotificationTypeFilter = new EndpointSelectField(BlackDuckDescriptor.KEY_BLACKDUCK_VULNERABILITY_NOTIFICATION_TYPE_FILTER, LABEL_BALCKDUCK_VULNERABILITY_NOTIFICATION_TYPE_FILTER,
             DESCRIPTION_BLACKDUCK_VULNERABILITY_NOTIFICATION_TYPE_FILTER)
                                                               .applyRequestedDataFieldKey(ProviderDistributionUIConfig.KEY_NOTIFICATION_TYPES)
+                                                              .applyRequestedDataFieldKey(ChannelDistributionUIConfig.KEY_PROVIDER_NAME)
+                                                              .applyRequestedDataFieldKey(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME)
                                                               .applyMultiSelect(true)
                                                               .applyClearable(true)
                                                               .applyPanel(PANEL_NOTIFICATION_FILTERING);

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckDistributionUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckDistributionUIConfig.java
@@ -64,8 +64,6 @@ public class BlackDuckDistributionUIConfig extends ProviderDistributionUIConfig 
         ConfigField vulnerabilityNotificationTypeFilter = new EndpointSelectField(BlackDuckDescriptor.KEY_BLACKDUCK_VULNERABILITY_NOTIFICATION_TYPE_FILTER, LABEL_BALCKDUCK_VULNERABILITY_NOTIFICATION_TYPE_FILTER,
             DESCRIPTION_BLACKDUCK_VULNERABILITY_NOTIFICATION_TYPE_FILTER)
                                                               .applyRequestedDataFieldKey(ProviderDistributionUIConfig.KEY_NOTIFICATION_TYPES)
-                                                              .applyRequestedDataFieldKey(ChannelDistributionUIConfig.KEY_PROVIDER_NAME)
-                                                              .applyRequestedDataFieldKey(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME)
                                                               .applyMultiSelect(true)
                                                               .applyClearable(true)
                                                               .applyPanel(PANEL_NOTIFICATION_FILTERING);


### PR DESCRIPTION
Allow the provider config name to be included in the field model.  Read the configuration from the database to create the options for the field.