### PR TITLE
change PVC claim size representation from G to Gi

### DIFF
--- a/deployment/helm/synopsys-alert/values.yaml
+++ b/deployment/helm/synopsys-alert/values.yaml
@@ -16,10 +16,8 @@ alert:
   resources:
     limits:
       memory: "2560Mi"
-    requests:
-      memory: "2560Mi"
   persistentVolumeClaimName: ""
-  claimSize: "5G"
+  claimSize: "5Gi"
   storageClass: ""
   volumeName: ""
   nodeSelector: {}
@@ -36,8 +34,6 @@ cfssl:
   registry: "" # override the docker registry at container level
   resources:
     limits:
-      memory: "640Mi"
-    requests:
       memory: "640Mi"
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
# Pull Request template
Resolves: 
* change PVC claim size representation from G to Gi
* If you specify limits alone on kubernetes container resources, then internally Kubernetes will set requests as same as limits and hence removed requests from resources in order to remove the duplicates.