### PR TITLE
Database task management fixes

### DIFF
--- a/alert-database/src/main/resources/liquibase/6.0.0/changelog.xml
+++ b/alert-database/src/main/resources/liquibase/6.0.0/changelog.xml
@@ -3,6 +3,7 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
     <include file="init-config-db.xml" relativeToChangelogFile="true"/>
     <include file="init-auth-db.xml" relativeToChangelogFile="true"/>
+    <include file="component-tasks.xml" relativeToChangelogFile="true"/>
     <include file="settings-fields.xml" relativeToChangelogFile="true"/>
     <include file="notification-migration-procedures.xml" relativeToChangelogFile="true"/>
     <include file="notifications.xml" relativeToChangelogFile="true"/>

--- a/alert-database/src/main/resources/liquibase/6.0.0/component-tasks.xml
+++ b/alert-database/src/main/resources/liquibase/6.0.0/component-tasks.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+    <changeSet author="psantos" id="2020-05-04-14-09-12-649" >
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from ALERT.REGISTERED_DESCRIPTORS where NAME = 'component_tasks'</sqlCheck>
+        </preConditions>
+        <insert schemaName="ALERT" tableName="REGISTERED_DESCRIPTORS">
+            <column name="TYPE_ID" valueComputed="GET_DESCRIPTOR_TYPE_ID('COMPONENT')"/>
+            <column name="NAME">component_tasks</column>
+        </insert>
+    </changeSet>
+    <changeSet author="psantos" id="2020-05-04-14-41-58-554">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from ALERT.PERMISSION_MATRIX where DESCRIPTOR_ID = GET_DESCRIPTOR_ID('component_tasks')</sqlCheck>
+        </preConditions>
+        <insert tableName="PERMISSION_MATRIX" schemaName="ALERT">
+            <column name="ROLE_ID" valueComputed="GET_ROLE_ID('ALERT_ADMIN')"/>
+             <column name="OPERATIONS">255</column>
+            <column name="DESCRIPTOR_ID" valueComputed="GET_DESCRIPTOR_ID('component_tasks')"/>
+            <column name="CONTEXT_ID" valueComputed="GET_CONTEXT_ID('GLOBAL')"/>
+        </insert>
+        <insert tableName="PERMISSION_MATRIX" schemaName="ALERT">
+            <column name="ROLE_ID" valueComputed="GET_ROLE_ID('ALERT_JOB_MANAGER')"/>
+             <column name="OPERATIONS">4</column>
+            <column name="DESCRIPTOR_ID" valueComputed="GET_DESCRIPTOR_ID('component_tasks')"/>
+            <column name="CONTEXT_ID" valueComputed="GET_CONTEXT_ID('GLOBAL')"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/alert-database/src/main/resources/liquibase/6.0.0/init-auth-db.xml
+++ b/alert-database/src/main/resources/liquibase/6.0.0/init-auth-db.xml
@@ -233,12 +233,6 @@
             <column name="DESCRIPTOR_ID" valueComputed="GET_DESCRIPTOR_ID('component_users')"/>
             <column name="CONTEXT_ID" valueComputed="GET_CONTEXT_ID('GLOBAL')"/>
         </insert>
-        <insert tableName="PERMISSION_MATRIX" schemaName="ALERT">
-            <column name="ROLE_ID" valueComputed="GET_ROLE_ID('ALERT_ADMIN')"/>
-             <column name="OPERATIONS">255</column>
-            <column name="DESCRIPTOR_ID" valueComputed="GET_DESCRIPTOR_ID('component_tasks')"/>
-            <column name="CONTEXT_ID" valueComputed="GET_CONTEXT_ID('GLOBAL')"/>
-        </insert>
         <insert schemaName="ALERT" tableName="PERMISSION_MATRIX">
             <column name="ROLE_ID" valueComputed="GET_ROLE_ID('ALERT_JOB_MANAGER')"/>
             <column name="OPERATIONS">4</column>
@@ -323,12 +317,6 @@
             <column name="DESCRIPTOR_ID" valueComputed="GET_DESCRIPTOR_ID('channel_jira_server')"/>
             <column name="CONTEXT_ID" valueComputed="GET_CONTEXT_ID('DISTRIBUTION')"/>
         </insert>
-        <insert tableName="PERMISSION_MATRIX" schemaName="ALERT">
-            <column name="ROLE_ID" valueComputed="GET_ROLE_ID('ALERT_JOB_MANAGER')"/>
-             <column name="OPERATIONS">4</column>
-            <column name="DESCRIPTOR_ID" valueComputed="GET_DESCRIPTOR_ID('component_tasks')"/>
-            <column name="CONTEXT_ID" valueComputed="GET_CONTEXT_ID('GLOBAL')"/>
-        </insert>
         <insert schemaName="ALERT" tableName="PERMISSION_MATRIX">
             <column name="ROLE_ID" valueComputed="GET_ROLE_ID('ALERT_USER')"/>
             <column name="OPERATIONS">4</column>
@@ -375,6 +363,20 @@
             <column name="ROLE_ID" valueComputed="GET_ROLE_ID('ALERT_JOB_MANAGER')"/>
             <column name="OPERATIONS">0</column>
             <column name="DESCRIPTOR_ID" valueComputed="GET_DESCRIPTOR_ID('component_certificates')"/>
+            <column name="CONTEXT_ID" valueComputed="GET_CONTEXT_ID('GLOBAL')"/>
+        </insert>
+    </changeSet>
+    <changeSet author="psantos" id="2020-05-04-14-41-58-554">
+        <insert tableName="PERMISSION_MATRIX" schemaName="ALERT">
+            <column name="ROLE_ID" valueComputed="GET_ROLE_ID('ALERT_ADMIN')"/>
+             <column name="OPERATIONS">255</column>
+            <column name="DESCRIPTOR_ID" valueComputed="GET_DESCRIPTOR_ID('component_tasks')"/>
+            <column name="CONTEXT_ID" valueComputed="GET_CONTEXT_ID('GLOBAL')"/>
+        </insert>
+        <insert tableName="PERMISSION_MATRIX" schemaName="ALERT">
+            <column name="ROLE_ID" valueComputed="GET_ROLE_ID('ALERT_JOB_MANAGER')"/>
+             <column name="OPERATIONS">4</column>
+            <column name="DESCRIPTOR_ID" valueComputed="GET_DESCRIPTOR_ID('component_tasks')"/>
             <column name="CONTEXT_ID" valueComputed="GET_CONTEXT_ID('GLOBAL')"/>
         </insert>
     </changeSet>

--- a/alert-database/src/main/resources/liquibase/6.0.0/init-auth-db.xml
+++ b/alert-database/src/main/resources/liquibase/6.0.0/init-auth-db.xml
@@ -367,6 +367,9 @@
         </insert>
     </changeSet>
     <changeSet author="psantos" id="2020-05-04-14-41-58-554">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from ALERT.PERMISSION_MATRIX where DESCRIPTOR_ID = GET_DESCRIPTOR_ID('component_tasks')</sqlCheck>
+        </preConditions>
         <insert tableName="PERMISSION_MATRIX" schemaName="ALERT">
             <column name="ROLE_ID" valueComputed="GET_ROLE_ID('ALERT_ADMIN')"/>
              <column name="OPERATIONS">255</column>

--- a/alert-database/src/main/resources/liquibase/6.0.0/init-auth-db.xml
+++ b/alert-database/src/main/resources/liquibase/6.0.0/init-auth-db.xml
@@ -366,23 +366,6 @@
             <column name="CONTEXT_ID" valueComputed="GET_CONTEXT_ID('GLOBAL')"/>
         </insert>
     </changeSet>
-    <changeSet author="psantos" id="2020-05-04-14-41-58-554">
-        <preConditions onFail="MARK_RAN">
-            <sqlCheck expectedResult="0">select count(*) from ALERT.PERMISSION_MATRIX where DESCRIPTOR_ID = GET_DESCRIPTOR_ID('component_tasks')</sqlCheck>
-        </preConditions>
-        <insert tableName="PERMISSION_MATRIX" schemaName="ALERT">
-            <column name="ROLE_ID" valueComputed="GET_ROLE_ID('ALERT_ADMIN')"/>
-             <column name="OPERATIONS">255</column>
-            <column name="DESCRIPTOR_ID" valueComputed="GET_DESCRIPTOR_ID('component_tasks')"/>
-            <column name="CONTEXT_ID" valueComputed="GET_CONTEXT_ID('GLOBAL')"/>
-        </insert>
-        <insert tableName="PERMISSION_MATRIX" schemaName="ALERT">
-            <column name="ROLE_ID" valueComputed="GET_ROLE_ID('ALERT_JOB_MANAGER')"/>
-             <column name="OPERATIONS">4</column>
-            <column name="DESCRIPTOR_ID" valueComputed="GET_DESCRIPTOR_ID('component_tasks')"/>
-            <column name="CONTEXT_ID" valueComputed="GET_CONTEXT_ID('GLOBAL')"/>
-        </insert>
-    </changeSet>
     <!-- Initialize user roles -->
     <changeSet author="gavink" id="2019-12-12-09-34-27-326">
         <preConditions onFail="MARK_RAN">

--- a/alert-database/src/main/resources/liquibase/6.0.0/init-config-db.xml
+++ b/alert-database/src/main/resources/liquibase/6.0.0/init-config-db.xml
@@ -175,6 +175,9 @@
         </insert>
     </changeSet>
     <changeSet author="psantos" id="2020-05-04-14-09-12-649" >
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from ALERT.REGISTERED_DESCRIPTORS where NAME = 'component_tasks'</sqlCheck>
+        </preConditions>
         <insert schemaName="ALERT" tableName="REGISTERED_DESCRIPTORS">
             <column name="TYPE_ID" valueComputed="GET_DESCRIPTOR_TYPE_ID('COMPONENT')"/>
             <column name="NAME">component_tasks</column>

--- a/alert-database/src/main/resources/liquibase/6.0.0/init-config-db.xml
+++ b/alert-database/src/main/resources/liquibase/6.0.0/init-config-db.xml
@@ -174,15 +174,6 @@
             <column name="NAME">component_certificates</column>
         </insert>
     </changeSet>
-    <changeSet author="psantos" id="2020-05-04-14-09-12-649" >
-        <preConditions onFail="MARK_RAN">
-            <sqlCheck expectedResult="0">select count(*) from ALERT.REGISTERED_DESCRIPTORS where NAME = 'component_tasks'</sqlCheck>
-        </preConditions>
-        <insert schemaName="ALERT" tableName="REGISTERED_DESCRIPTORS">
-            <column name="TYPE_ID" valueComputed="GET_DESCRIPTOR_TYPE_ID('COMPONENT')"/>
-            <column name="NAME">component_tasks</column>
-        </insert>
-    </changeSet>
     <!-- Initialize defined fields -->
     <changeSet author="gavink" id="2019-12-11-12-28-09-422">
         <preConditions onFail="MARK_RAN">

--- a/alert-database/src/main/resources/liquibase/6.0.0/init-config-db.xml
+++ b/alert-database/src/main/resources/liquibase/6.0.0/init-config-db.xml
@@ -173,6 +173,8 @@
             <column name="TYPE_ID" valueComputed="GET_DESCRIPTOR_TYPE_ID('COMPONENT')"/>
             <column name="NAME">component_certificates</column>
         </insert>
+    </changeSet>
+    <changeSet author="psantos" id="2020-05-04-14-09-12-649" >
         <insert schemaName="ALERT" tableName="REGISTERED_DESCRIPTORS">
             <column name="TYPE_ID" valueComputed="GET_DESCRIPTOR_TYPE_ID('COMPONENT')"/>
             <column name="NAME">component_tasks</column>

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,9 @@ project.ext.javaTargetCompatibility = JavaVersion.VERSION_11
 project.ext.moduleName = 'com.synopsys.integration.alert.main'
 mainClassName = 'com.synopsys.integration.alert.Application'
 
-version = '6.0.0-SIGQA4-SNAPSHOT'
+version = '6.0.0-SIGQA4-DBTEST-SNAPSHOT'
+def testContainerPostgresVersion='12.2'
+
 apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'com.synopsys.integration.solution'
@@ -217,8 +219,8 @@ task runServer(type: com.synopsys.integration.alert.build.RunServerTask, depends
                                 '--spring.datasource.username=sa',
                                 '--spring.datasource.password=blackduck',
                                 '--spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver',
-                                '--spring.datasource.url=jdbc:tc:postgresql:12.2:///alertdb?TC_INITSCRIPT=file:src/test/resources/testDatabase/init_test_db.sql&TC_TMPFS=/testtmpfs:rw',
-                                '--spring.datasource.hikari.jdbc-url=jdbc:tc:postgresql:12.2:///alertdb?TC_INITSCRIPT=file:src/test/resources/testDatabase/init_test_db.sql&TC_TMPFS=/testtmpfs:rw',
+                                "--spring.datasource.url=jdbc:tc:postgresql:${testContainerPostgresVersion}:///alertdb?TC_INITSCRIPT=file:src/test/resources/testDatabase/init_test_db.sql&TC_TMPFS=/testtmpfs:rw",
+                                "--spring.datasource.hikari.jdbc-url=jdbc:tc:postgresql:${testContainerPostgresVersion}:///alertdb?TC_INITSCRIPT=file:src/test/resources/testDatabase/init_test_db.sql&TC_TMPFS=/testtmpfs:rw",
                                 '--spring.test.database.replace=none',
 
                                 "--alert.images.dir=${project.buildDir}/resources/main/images",

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ project.ext.javaTargetCompatibility = JavaVersion.VERSION_11
 project.ext.moduleName = 'com.synopsys.integration.alert.main'
 mainClassName = 'com.synopsys.integration.alert.Application'
 
-version = '6.0.0-SIGQA4-DBTEST-SNAPSHOT'
+version = '6.0.0-SIGQA4-SNAPSHOT'
 def testContainerPostgresVersion='12.2'
 
 apply plugin: 'idea'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -394,14 +394,12 @@ validatePostgresDatabase() {
 
 postgresPrepare600Upgrade() {
     echo "Determining if preparation for 6.0.0 upgrade is necessary..."
-    CONTEXT_QUERY= `psql "${alertDatabaseConfig}" -c 'SELECT COUNT(CONTEXT) FROM Alert.Config_Contexts;'`
-    echo "Query Result $CONTEXT_QUERY"
     if psql "${alertDatabaseConfig}" -c 'SELECT COUNT(CONTEXT) FROM Alert.Config_Contexts;' | grep -q '2';
     then
         echo "Alert postgres database is initialized."
     else
         echo "Preparing the old Alert database to be upgraded to 6.0.0..."
-        if [ -f ${alertDataDir}/alertdb.mv.db ];
+        if [ -f "${alertDataDir}/alertdb.mv.db" ];
         then
             echo "A previous database existed."
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -394,7 +394,7 @@ validatePostgresDatabase() {
 
 postgresPrepare600Upgrade() {
     echo "Determining if preparation for 6.0.0 upgrade is necessary..."
-    CONTEXT_QUERY = `psql "${alertDatabaseConfig}" -c 'SELECT COUNT(CONTEXT) FROM Alert.Config_Contexts;'`
+    CONTEXT_QUERY= `psql "${alertDatabaseConfig}" -c 'SELECT COUNT(CONTEXT) FROM Alert.Config_Contexts;'`
     echo "Query Result $CONTEXT_QUERY"
     if psql "${alertDatabaseConfig}" -c 'SELECT COUNT(CONTEXT) FROM Alert.Config_Contexts;' | grep -q '2';
     then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -394,7 +394,9 @@ validatePostgresDatabase() {
 
 postgresPrepare600Upgrade() {
     echo "Determining if preparation for 6.0.0 upgrade is necessary..."
-    if psql "${alertDatabaseConfig}" -c 'SELECT COUNT(CONTEXT) FROM Alert.Config_Contexts;' |grep -q '2';
+    CONTEXT_QUERY = `psql "${alertDatabaseConfig}" -c 'SELECT COUNT(CONTEXT) FROM Alert.Config_Contexts;'`
+    echo "Query Result $CONTEXT_QUERY"
+    if psql "${alertDatabaseConfig}" -c 'SELECT COUNT(CONTEXT) FROM Alert.Config_Contexts;' | grep -q '2';
     then
         echo "Alert postgres database is initialized."
     else


### PR DESCRIPTION
Fix the check for the H2 database to determine whether to upgrade or not.  Alert was always performing an upgrade.

Create changesets for inserting the component_tasks descriptor.