### PR TITLE
Filter notifications by provider config to prevent duplicates.

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/processor/notification/NotificationProcessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/processor/notification/NotificationProcessor.java
@@ -91,7 +91,8 @@ public class NotificationProcessor {
         StatefulProvider statefulProvider = provider.createStatefulProvider(providerConfig);
 
         ProviderDistributionFilter distributionFilter = statefulProvider.getDistributionFilter();
-        List<AlertNotificationModel> notificationsByType = filterNotificationsByType(job, notifications);
+        List<AlertNotificationModel> notificationsByProviderConfig = filterNotificationsByProviderConfigId(statefulProvider, notifications);
+        List<AlertNotificationModel> notificationsByType = filterNotificationsByType(job, notificationsByProviderConfig);
         List<AlertNotificationModel> filteredNotifications = filterNotificationsByProviderFields(job, distributionFilter, notificationsByType);
 
         if (!filteredNotifications.isEmpty()) {
@@ -114,6 +115,13 @@ public class NotificationProcessor {
         return notifications
                    .stream()
                    .filter(notification -> job.getNotificationTypes().contains(notification.getNotificationType()))
+                   .collect(Collectors.toList());
+    }
+
+    private List<AlertNotificationModel> filterNotificationsByProviderConfigId(StatefulProvider provider, List<AlertNotificationModel> notifications) {
+        return notifications
+                   .stream()
+                   .filter(notification -> notification.getProviderConfigId().equals(provider.getConfigId()))
                    .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
When processing a job only get the notifications that match the provider config id in the job with the provider config id of the accumulated notification.  By using just the project name if two Black Duck providers have projects of the same name, then the jobs using other providers will cause a notification to be sent again because the project name matches. Limit to match the provider config id to solve the issue.