### PR TITLE
real time fix

### DIFF
--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProviderTaskPropertiesAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProviderTaskPropertiesAccessor.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.common.exception.AlertDatabaseConstraintException;
 import com.synopsys.integration.alert.common.persistence.accessor.ProviderTaskPropertiesAccessor;
@@ -34,6 +35,7 @@ import com.synopsys.integration.alert.database.provider.task.ProviderTaskPropert
 import com.synopsys.integration.alert.database.provider.task.ProviderTaskPropertiesRepository;
 
 @Component
+@Transactional
 public class DefaultProviderTaskPropertiesAccessor implements ProviderTaskPropertiesAccessor {
     private ProviderTaskPropertiesRepository providerTaskPropertiesRepository;
 


### PR DESCRIPTION
Need to add transactional to save the task properties.  The getTaskProperty method always returned an optional.empty() in the accumulator task because the saved entity was not getting flushed to the database and written.