### PR TITLE
 hibernate fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ project.ext.javaTargetCompatibility = JavaVersion.VERSION_11
 project.ext.moduleName = 'com.synopsys.integration.alert.main'
 mainClassName = 'com.synopsys.integration.alert.Application'
 
-version = '6.0.0-SIGQA8-TEST-SNAPSHOT'
+version = '6.0.0-SIGQA8-SNAPSHOT'
 def testContainerPostgresVersion = '12.2'
 
 apply plugin: 'idea'

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ project.ext.javaTargetCompatibility = JavaVersion.VERSION_11
 project.ext.moduleName = 'com.synopsys.integration.alert.main'
 mainClassName = 'com.synopsys.integration.alert.Application'
 
-version = '6.0.0-SIGQA8-SNAPSHOT'
+version = '6.0.0-SIGQA8-TEST-SNAPSHOT'
 def testContainerPostgresVersion = '12.2'
 
 apply plugin: 'idea'

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,8 +12,7 @@ spring.main.allow-bean-definition-overriding=true
 # JPA
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-# Hibernate
-hibernate.id.optimizer.pooled.preferred=pooled-lo
+spring.jpa.properties.hibernate.id.optimizer.pooled.preferred=pooled-lo
 # Datasource
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url=jdbc:postgresql://${ALERT_DB_HOST:alertdb}:${ALERT_DB_PORT:5432}/${ALERT_DB_NAME:alertdb}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,8 @@ spring.main.allow-bean-definition-overriding=true
 # JPA
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+# Hibernate
+hibernate.id.optimizer.pooled.preferred=pooled-lo
 # Datasource
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url=jdbc:postgresql://${ALERT_DB_HOST:alertdb}:${ALERT_DB_PORT:5432}/${ALERT_DB_NAME:alertdb}

--- a/src/test/resources/spring-test.properties
+++ b/src/test/resources/spring-test.properties
@@ -11,3 +11,4 @@ logging.level.org.hibernate.SQL=ERROR
 spring.profiles.active=no_ssl
 alert.encryption.password="DO_NOT_USE_automated_test_password_DO_NOT_USE"
 alert.encryption.global.salt="DO_NOT_USE_automated_test_salt_DO_NOT_USE"
+hibernate.id.optimizer.pooled.preferred=pooled-lo

--- a/src/test/resources/spring-test.properties
+++ b/src/test/resources/spring-test.properties
@@ -5,10 +5,11 @@ spring.datasource.password=blackduck
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.properties.hibernate.id.optimizer.pooled.preferred=pooled-lo
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.liquibase.change-log=classpath:liquibase/changelog-postgres-master.xml
 logging.level.org.hibernate.SQL=ERROR
 spring.profiles.active=no_ssl
 alert.encryption.password="DO_NOT_USE_automated_test_password_DO_NOT_USE"
 alert.encryption.global.salt="DO_NOT_USE_automated_test_salt_DO_NOT_USE"
-hibernate.id.optimizer.pooled.preferred=pooled-lo
+


### PR DESCRIPTION
I have configured Spring to use the pooled-lo optimizer by default.  So any SequenceGenerator annotations added will use the pooled-lo optimizer rather than the default pooled optimizer.  The pooled optimizer subtracts from the current hi which is why I was seeing negative IDs in the database. With this change this adds to the lowest rather than subtract from the highest which appears to cause id collisions. 

Here's a link to explain the pooled-lo provider.  
https://vladmihalcea.com/hibernate-hidden-gem-the-pooled-lo-optimizer/