### PR TITLE
 validator fix

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/SystemMessageModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/SystemMessageModel.java
@@ -23,16 +23,22 @@
 package com.synopsys.integration.alert.common.persistence.model;
 
 public class SystemMessageModel {
+    private final String id;
     private final String severity;
     private final String createdAt;
     private final String content;
     private final String type;
 
-    public SystemMessageModel(final String severity, final String createdAt, final String content, final String type) {
+    public SystemMessageModel(String id, String severity, String createdAt, String content, String type) {
+        this.id = id;
         this.severity = severity;
         this.createdAt = createdAt;
         this.content = content;
         this.type = type;
+    }
+
+    public String getId() {
+        return id;
     }
 
     public String getSeverity() {

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/provider/state/ProviderProperties.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/provider/state/ProviderProperties.java
@@ -27,6 +27,7 @@ import com.synopsys.integration.alert.common.persistence.accessor.FieldAccessor;
 
 public abstract class ProviderProperties {
     public static final Long UNKNOWN_CONFIG_ID = -1L;
+    public static final String UNKNOWN_CONFIG_NAME = "UNKNOWN CONFIGURATION";
     private Long configId;
     private boolean configEnabled;
     private String configName;
@@ -34,7 +35,7 @@ public abstract class ProviderProperties {
     public ProviderProperties(Long configId, FieldAccessor fieldAccessor) {
         this.configId = configId;
         this.configEnabled = fieldAccessor.getBooleanOrFalse(ProviderDescriptor.KEY_PROVIDER_CONFIG_ENABLED);
-        this.configName = fieldAccessor.getString(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME).orElse("UNKNOWN CONFIGURATION");
+        this.configName = fieldAccessor.getString(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME).orElse(UNKNOWN_CONFIG_NAME);
     }
 
     public Long getConfigId() {

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/provider/state/StatefulProvider.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/provider/state/StatefulProvider.java
@@ -46,7 +46,7 @@ public class StatefulProvider {
         List<ProviderTask> tasks, ProviderProperties properties, ProviderDistributionFilter distributionFilter, ProviderMessageContentCollector messageContentCollector) {
         FieldAccessor fieldAccessor = new FieldAccessor(configurationModel.getCopyOfKeyToFieldMap());
         boolean configEnabled = fieldAccessor.getBooleanOrFalse(ProviderDescriptor.KEY_PROVIDER_CONFIG_ENABLED);
-        String configName = fieldAccessor.getString(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME).orElse("UNKNOWN CONFIGURATION");
+        String configName = fieldAccessor.getString(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME).orElse(ProviderProperties.UNKNOWN_CONFIG_NAME);
 
         return new StatefulProvider(providerKey, configurationModel.getConfigurationId(), configName, configEnabled, tasks, properties, distributionFilter, messageContentCollector);
     }

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/system/DefaultSystemMessageUtility.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/system/DefaultSystemMessageUtility.java
@@ -118,13 +118,15 @@ public class DefaultSystemMessageUtility implements SystemMessageUtility {
 
     private SystemMessageModel convertToSystemMessageModel(SystemMessageEntity systemMessage) {
         String createdAt = DateUtils.formatDate(systemMessage.getCreated(), RestConstants.JSON_DATE_FORMAT);
-        return new SystemMessageModel(systemMessage.getSeverity(), createdAt, systemMessage.getContent(), systemMessage.getType());
+        return new SystemMessageModel(String.valueOf(systemMessage.getId()), systemMessage.getSeverity(), createdAt, systemMessage.getContent(), systemMessage.getType());
     }
 
     private SystemMessageEntity convertToSystemMessage(SystemMessageModel systemMessageModel) {
         try {
             OffsetDateTime date = DateUtils.parseDate(systemMessageModel.getCreatedAt(), RestConstants.JSON_DATE_FORMAT);
-            return new SystemMessageEntity(date, systemMessageModel.getSeverity(), systemMessageModel.getContent(), systemMessageModel.getType());
+            SystemMessageEntity entity = new SystemMessageEntity(date, systemMessageModel.getSeverity(), systemMessageModel.getContent(), systemMessageModel.getType());
+            entity.setId(Long.valueOf(systemMessageModel.getId()));
+            return entity;
         } catch (ParseException e) {
             logger.error("There was an issue parsing the stored CreatedAt date.");
         }

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckValidator.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckValidator.java
@@ -113,6 +113,7 @@ public class BlackDuckValidator extends BaseSystemValidator {
         return valid;
     }
 
+    // TODO Revisit the system message API perhaps add a new message typ for provider configuration missing
     private void removeNoProviderConfigMessages() {
         Set<String> messageTypes = Set.of(
             SystemMessageType.BLACKDUCK_PROVIDER_CONNECTIVITY.name(),
@@ -124,6 +125,7 @@ public class BlackDuckValidator extends BaseSystemValidator {
         getSystemMessageUtility().deleteSystemMessages(messagesToDelete);
     }
 
+    // TODO Revisit the system message API perhaps add provider config id to be able to delete messages for provider config
     private void removeOldConfigMessages(String configName) {
         List<SystemMessageModel> messagesToDelete = getSystemMessageUtility().getSystemMessages().stream()
                                                         .filter(message -> message.getContent().contains(String.format("'%s'", configName)))

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckValidator.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckValidator.java
@@ -24,7 +24,10 @@ package com.synopsys.integration.alert.provider.blackduck;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +37,8 @@ import com.synopsys.integration.alert.common.enumeration.SystemMessageSeverity;
 import com.synopsys.integration.alert.common.enumeration.SystemMessageType;
 import com.synopsys.integration.alert.common.exception.AlertRuntimeException;
 import com.synopsys.integration.alert.common.persistence.accessor.SystemMessageUtility;
+import com.synopsys.integration.alert.common.persistence.model.SystemMessageModel;
+import com.synopsys.integration.alert.common.provider.state.ProviderProperties;
 import com.synopsys.integration.alert.common.system.BaseSystemValidator;
 import com.synopsys.integration.blackduck.configuration.BlackDuckServerConfig;
 import com.synopsys.integration.exception.IntegrationException;
@@ -42,7 +47,8 @@ import com.synopsys.integration.log.Slf4jIntLogger;
 
 @Component
 public class BlackDuckValidator extends BaseSystemValidator {
-    public static final String MISSING_BLACKDUCK_URL_ERROR_FORMAT = "Black Duck configuration '%s' is Invalid. Black Duck URL missing.";
+    public static final String MISSING_BLACKDUCK_URL_ERROR_W_CONFIG_FORMAT = "Black Duck configuration '%s' is invalid. Black Duck URL missing.";
+    public static final String MISSING_BLACKDUCK_CONFIG_ERROR_FORMAT = "Black Duck configuration is invalid. Black Duck configurations missing.";
     public static final String BLACKDUCK_LOCALHOST_ERROR_FORMAT = "Black Duck configuration '%s' is using localhost.";
     private final Logger logger = LoggerFactory.getLogger(BlackDuckValidator.class);
 
@@ -54,15 +60,21 @@ public class BlackDuckValidator extends BaseSystemValidator {
         boolean valid = true;
         String configName = blackDuckProperties.getConfigName();
         logger.info("Validating Black Duck configuration '{}'...", configName);
-        getSystemMessageUtility().removeSystemMessagesByType(SystemMessageType.BLACKDUCK_PROVIDER_CONNECTIVITY);
-        getSystemMessageUtility().removeSystemMessagesByType(SystemMessageType.BLACKDUCK_PROVIDER_URL_MISSING);
-        getSystemMessageUtility().removeSystemMessagesByType(SystemMessageType.BLACKDUCK_PROVIDER_LOCALHOST);
+
+        removeNoProviderConfigMessages();
         try {
             Optional<String> blackDuckUrlOptional = blackDuckProperties.getBlackDuckUrl();
-            boolean missingUrl = addSystemMessageForError(String.format(MISSING_BLACKDUCK_URL_ERROR_FORMAT, configName), SystemMessageSeverity.WARNING, SystemMessageType.BLACKDUCK_PROVIDER_URL_MISSING,
+            String errorMessage;
+            if (ProviderProperties.UNKNOWN_CONFIG_NAME.equals(configName)) {
+                errorMessage = MISSING_BLACKDUCK_CONFIG_ERROR_FORMAT;
+            } else {
+                removeOldConfigMessages(configName);
+                errorMessage = String.format(MISSING_BLACKDUCK_URL_ERROR_W_CONFIG_FORMAT, configName);
+            }
+            boolean missingUrl = addSystemMessageForError(errorMessage, SystemMessageSeverity.WARNING, SystemMessageType.BLACKDUCK_PROVIDER_URL_MISSING,
                 blackDuckUrlOptional.isEmpty());
             if (missingUrl) {
-                logger.error("  -> {}", String.format(MISSING_BLACKDUCK_URL_ERROR_FORMAT, configName));
+                logger.error("  -> {}", String.format(MISSING_BLACKDUCK_CONFIG_ERROR_FORMAT, configName));
                 valid = false;
             }
             if (blackDuckUrlOptional.isPresent()) {
@@ -94,11 +106,29 @@ public class BlackDuckValidator extends BaseSystemValidator {
                 }
             }
         } catch (MalformedURLException | IntegrationException | AlertRuntimeException ex) {
-            logger.error("  -> Black Duck configuration '{}' is Invalid; cause: {}", configName, ex.getMessage());
+            logger.error("  -> Black Duck configuration '{}' is invalid; cause: {}", configName, ex.getMessage());
             logger.debug(String.format("  -> Black Duck configuration '%s' Stack Trace: ", configName), ex);
             valid = false;
         }
         return valid;
+    }
+
+    private void removeNoProviderConfigMessages() {
+        Set<String> messageTypes = Set.of(
+            SystemMessageType.BLACKDUCK_PROVIDER_CONNECTIVITY.name(),
+            SystemMessageType.BLACKDUCK_PROVIDER_LOCALHOST.name(),
+            SystemMessageType.BLACKDUCK_PROVIDER_URL_MISSING.name());
+        List<SystemMessageModel> messagesToDelete = getSystemMessageUtility().getSystemMessages().stream()
+                                                        .filter(message -> messageTypes.contains(message.getType()) && message.getContent().contains(MISSING_BLACKDUCK_CONFIG_ERROR_FORMAT))
+                                                        .collect(Collectors.toList());
+        getSystemMessageUtility().deleteSystemMessages(messagesToDelete);
+    }
+
+    private void removeOldConfigMessages(String configName) {
+        List<SystemMessageModel> messagesToDelete = getSystemMessageUtility().getSystemMessages().stream()
+                                                        .filter(message -> message.getContent().contains(String.format("'%s'", configName)))
+                                                        .collect(Collectors.toList());
+        getSystemMessageUtility().deleteSystemMessages(messagesToDelete);
     }
 
     private void connectivityWarning(String message) {

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/factories/BlackDuckTaskFactory.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/factories/BlackDuckTaskFactory.java
@@ -36,8 +36,10 @@ import com.synopsys.integration.alert.common.provider.lifecycle.ProviderTask;
 import com.synopsys.integration.alert.common.provider.lifecycle.ProviderTaskFactory;
 import com.synopsys.integration.alert.common.provider.state.ProviderProperties;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProviderKey;
+import com.synopsys.integration.alert.provider.blackduck.BlackDuckValidator;
 import com.synopsys.integration.alert.provider.blackduck.tasks.BlackDuckAccumulator;
 import com.synopsys.integration.alert.provider.blackduck.tasks.BlackDuckDataSyncTask;
+import com.synopsys.integration.alert.provider.blackduck.tasks.BlackDuckValidatorTask;
 
 @Component
 public class BlackDuckTaskFactory implements ProviderTaskFactory {
@@ -47,22 +49,25 @@ public class BlackDuckTaskFactory implements ProviderTaskFactory {
     private final ConfigurationAccessor configurationAccessor;
     private final NotificationManager notificationManager;
     private final ProviderTaskPropertiesAccessor providerTaskPropertiesAccessor;
+    private final BlackDuckValidator blackDuckValidator;
 
     @Autowired
     public BlackDuckTaskFactory(BlackDuckProviderKey blackDuckProviderKey, TaskScheduler taskScheduler, ProviderDataAccessor blackDuckDataAccessor,
-        ConfigurationAccessor configurationAccessor, NotificationManager notificationManager, ProviderTaskPropertiesAccessor providerTaskPropertiesAccessor) {
+        ConfigurationAccessor configurationAccessor, NotificationManager notificationManager, ProviderTaskPropertiesAccessor providerTaskPropertiesAccessor, BlackDuckValidator blackDuckValidator) {
         this.blackDuckProviderKey = blackDuckProviderKey;
         this.taskScheduler = taskScheduler;
         this.blackDuckDataAccessor = blackDuckDataAccessor;
         this.configurationAccessor = configurationAccessor;
         this.notificationManager = notificationManager;
         this.providerTaskPropertiesAccessor = providerTaskPropertiesAccessor;
+        this.blackDuckValidator = blackDuckValidator;
     }
 
     @Override
     public List<ProviderTask> createTasks(ProviderProperties providerProperties) {
         BlackDuckAccumulator accumulator = new BlackDuckAccumulator(blackDuckProviderKey, taskScheduler, notificationManager, providerTaskPropertiesAccessor, providerProperties);
         BlackDuckDataSyncTask syncTask = new BlackDuckDataSyncTask(blackDuckProviderKey, taskScheduler, blackDuckDataAccessor, configurationAccessor, providerProperties);
-        return List.of(accumulator, syncTask);
+        BlackDuckValidatorTask validatorTask = new BlackDuckValidatorTask(blackDuckProviderKey, taskScheduler, providerProperties, blackDuckValidator);
+        return List.of(accumulator, syncTask, validatorTask);
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/tasks/BlackDuckValidatorTask.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/tasks/BlackDuckValidatorTask.java
@@ -1,0 +1,54 @@
+/**
+ * blackduck-alert
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.alert.provider.blackduck.tasks;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.TaskScheduler;
+
+import com.synopsys.integration.alert.common.provider.ProviderKey;
+import com.synopsys.integration.alert.common.provider.lifecycle.ProviderTask;
+import com.synopsys.integration.alert.common.provider.state.ProviderProperties;
+import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
+import com.synopsys.integration.alert.provider.blackduck.BlackDuckValidator;
+
+public class BlackDuckValidatorTask extends ProviderTask {
+    private final Logger logger = LoggerFactory.getLogger(BlackDuckValidatorTask.class);
+    private final BlackDuckValidator validator;
+
+    public BlackDuckValidatorTask(ProviderKey providerKey, TaskScheduler taskScheduler, ProviderProperties providerProperties, BlackDuckValidator validator) {
+        super(providerKey, taskScheduler, providerProperties);
+        this.validator = validator;
+    }
+
+    @Override
+    public void runProviderTask() {
+        BlackDuckProperties providerProperties = getProviderProperties();
+        validator.validate(providerProperties);
+    }
+
+    @Override
+    protected BlackDuckProperties getProviderProperties() {
+        return (BlackDuckProperties) super.getProviderProperties();
+    }
+}

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/tasks/BlackDuckValidatorTask.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/tasks/BlackDuckValidatorTask.java
@@ -22,8 +22,6 @@
  */
 package com.synopsys.integration.alert.provider.blackduck.tasks;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.TaskScheduler;
 
 import com.synopsys.integration.alert.common.provider.ProviderKey;
@@ -33,7 +31,6 @@ import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckValidator;
 
 public class BlackDuckValidatorTask extends ProviderTask {
-    private final Logger logger = LoggerFactory.getLogger(BlackDuckValidatorTask.class);
     private final BlackDuckValidator validator;
 
     public BlackDuckValidatorTask(ProviderKey providerKey, TaskScheduler taskScheduler, ProviderProperties providerProperties, BlackDuckValidator validator) {

--- a/src/test/java/com/synopsys/integration/alert/AboutReaderTest.java
+++ b/src/test/java/com/synopsys/integration/alert/AboutReaderTest.java
@@ -31,7 +31,7 @@ public class AboutReaderTest {
         Mockito.when(defaultSystemStatusUtility.isSystemInitialized()).thenReturn(Boolean.TRUE);
         Mockito.when(defaultSystemStatusUtility.getStartupTime()).thenReturn(DateUtils.createCurrentDateTimestamp());
         defaultSystemMessageUtility = Mockito.mock(DefaultSystemMessageUtility.class);
-        Mockito.when(defaultSystemMessageUtility.getSystemMessages()).thenReturn(Collections.singletonList(new SystemMessageModel(RestConstants.formatDate(new Date()), "ERROR", "startup errors", "type")));
+        Mockito.when(defaultSystemMessageUtility.getSystemMessages()).thenReturn(Collections.singletonList(new SystemMessageModel("1", RestConstants.formatDate(new Date()), "ERROR", "startup errors", "type")));
     }
 
     @Test

--- a/src/test/java/com/synopsys/integration/alert/database/system/SystemMessageUtilityTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/database/system/SystemMessageUtilityTestIT.java
@@ -161,7 +161,7 @@ public class SystemMessageUtilityTestIT extends AlertIntegrationTest {
 
     private SystemMessageModel convertToSystemMessage(SystemMessageEntity systemMessage) {
         String date = DateUtils.formatDate(systemMessage.getCreated(), RestConstants.JSON_DATE_FORMAT);
-        return new SystemMessageModel(date, systemMessage.getSeverity(), systemMessage.getContent(), systemMessage.getType());
+        return new SystemMessageModel(String.valueOf(systemMessage.getId()), date, systemMessage.getSeverity(), systemMessage.getContent(), systemMessage.getType());
     }
 
 }

--- a/src/test/java/com/synopsys/integration/alert/web/actions/SystemActionsTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/actions/SystemActionsTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.ZonedDateTime;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -155,7 +154,7 @@ public class SystemActionsTest {
     private List<SystemMessageModel> createSystemMessageList() {
         ZonedDateTime zonedDateTime = ZonedDateTime.now();
         zonedDateTime = zonedDateTime.minusMinutes(1);
-        return Collections.singletonList(new SystemMessageModel(RestConstants.formatDate(Date.from(zonedDateTime.toInstant())), "type", "content", "type"));
+        return List.of(new SystemMessageModel("1", RestConstants.formatDate(Date.from(zonedDateTime.toInstant())), "type", "content", "type"));
     }
 
 }

--- a/src/test/java/com/synopsys/integration/alert/web/model/SystemMessageModelTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/model/SystemMessageModelTest.java
@@ -10,12 +10,14 @@ public class SystemMessageModelTest {
 
     @Test
     public void testContructor() {
+        final String id = "1";
         final String severity = "type";
         final String createdAt = "createdAt";
         final String content = "content";
         final String type = "type";
 
-        final SystemMessageModel model = new SystemMessageModel(severity, createdAt, content, type);
+        SystemMessageModel model = new SystemMessageModel(id, severity, createdAt, content, type);
+        assertEquals(id, model.getId());
         assertEquals(severity, model.getSeverity());
         assertEquals(createdAt, model.getCreatedAt());
         assertEquals(content, model.getContent());

--- a/src/test/java/com/synopsys/integration/alert/workflow/startup/SystemValidatorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/workflow/startup/SystemValidatorTest.java
@@ -92,7 +92,8 @@ public class SystemValidatorTest {
         BlackDuckValidator blackDuckValidator = new BlackDuckValidator(defaultSystemMessageUtility);
         blackDuckValidator.validate(blackDuckProperties);
         Mockito.verify(defaultSystemMessageUtility)
-            .addSystemMessage(Mockito.eq(String.format(BlackDuckValidator.MISSING_BLACKDUCK_URL_ERROR_FORMAT, DEFAULT_CONFIG_NAME)), Mockito.eq(SystemMessageSeverity.WARNING), Mockito.eq(SystemMessageType.BLACKDUCK_PROVIDER_URL_MISSING));
+            .addSystemMessage(Mockito.eq(String.format(BlackDuckValidator.MISSING_BLACKDUCK_CONFIG_ERROR_FORMAT, DEFAULT_CONFIG_NAME)), Mockito.eq(SystemMessageSeverity.WARNING),
+                Mockito.eq(SystemMessageType.BLACKDUCK_PROVIDER_URL_MISSING));
     }
 
     @Test

--- a/src/test/java/com/synopsys/integration/alert/workflow/startup/SystemValidatorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/workflow/startup/SystemValidatorTest.java
@@ -92,7 +92,7 @@ public class SystemValidatorTest {
         BlackDuckValidator blackDuckValidator = new BlackDuckValidator(defaultSystemMessageUtility);
         blackDuckValidator.validate(blackDuckProperties);
         Mockito.verify(defaultSystemMessageUtility)
-            .addSystemMessage(Mockito.eq(String.format(BlackDuckValidator.MISSING_BLACKDUCK_CONFIG_ERROR_FORMAT, DEFAULT_CONFIG_NAME)), Mockito.eq(SystemMessageSeverity.WARNING),
+            .addSystemMessage(Mockito.eq(String.format(BlackDuckValidator.MISSING_BLACKDUCK_URL_ERROR_W_CONFIG_FORMAT, DEFAULT_CONFIG_NAME)), Mockito.eq(SystemMessageSeverity.WARNING),
                 Mockito.eq(SystemMessageType.BLACKDUCK_PROVIDER_URL_MISSING));
     }
 


### PR DESCRIPTION
Add a task for each provider to validate the configuration every minute and update system messages for any provider configuration errors.