### PR TITLE
ldap password fix

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/accessor/DefaultDescriptorGlobalConfigUtility.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/accessor/DefaultDescriptorGlobalConfigUtility.java
@@ -23,7 +23,9 @@
 package com.synopsys.integration.alert.common.descriptor.accessor;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,9 +98,33 @@ public class DefaultDescriptorGlobalConfigUtility {
 
     public FieldModel update(Long id, FieldModel fieldModel) throws AlertException {
         FieldModel beforeUpdateAction = apiAction.beforeUpdateAction(fieldModel);
-        Collection<ConfigurationFieldModel> values = configurationFieldModelConverter.convertToConfigurationFieldModelMap(beforeUpdateAction).values();
-        ConfigurationModel configurationModel = configurationAccessor.updateConfiguration(id, values);
-        FieldModel convertedFieldModel = configurationFieldModelConverter.convertToFieldModel(configurationModel);
-        return apiAction.afterUpdateAction(convertedFieldModel);
+        Map<String, ConfigurationFieldModel> values = configurationFieldModelConverter.convertToConfigurationFieldModelMap(beforeUpdateAction);
+        Optional<ConfigurationModel> existingConfig = configurationAccessor.getConfigurationById(id);
+
+        if (!existingConfig.isPresent()) {
+            return apiAction.afterUpdateAction(beforeUpdateAction);
+        } else {
+            Map<String, ConfigurationFieldModel> updatedValues = updateSensitiveFields(values, existingConfig.get());
+            ConfigurationModel configurationModel = configurationAccessor.updateConfiguration(id, updatedValues.values());
+            FieldModel convertedFieldModel = configurationFieldModelConverter.convertToFieldModel(configurationModel);
+            return apiAction.afterUpdateAction(convertedFieldModel);
+        }
+    }
+
+    private Map<String, ConfigurationFieldModel> updateSensitiveFields(Map<String, ConfigurationFieldModel> values, ConfigurationModel existingConfig) {
+        Collection<ConfigurationFieldModel> sensitiveFields = existingConfig.getCopyOfFieldList().stream()
+                                                                  .filter(ConfigurationFieldModel::isSensitive)
+                                                                  .collect(Collectors.toSet());
+        for (ConfigurationFieldModel sensitiveConfigurationFieldModel : sensitiveFields) {
+            String key = sensitiveConfigurationFieldModel.getFieldKey();
+            if (values.containsKey(key)) {
+                ConfigurationFieldModel sensitiveFieldModel = values.get(key);
+                if (!sensitiveFieldModel.isSet()) {
+                    ConfigurationFieldModel newFieldModel = values.get(key);
+                    newFieldModel.setFieldValues(sensitiveConfigurationFieldModel.getFieldValues());
+                }
+            }
+        }
+        return values;
     }
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/accessor/DefaultDescriptorGlobalConfigUtility.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/accessor/DefaultDescriptorGlobalConfigUtility.java
@@ -111,6 +111,7 @@ public class DefaultDescriptorGlobalConfigUtility {
         return apiAction.afterUpdateAction(convertedFieldModel);
     }
 
+    // TODO build a new utility to perform this action or try to refactor FieldModelProcessor into the alert-common sub-project
     private Map<String, ConfigurationFieldModel> updateSensitiveFields(Map<String, ConfigurationFieldModel> values, ConfigurationModel existingConfig) {
         Collection<ConfigurationFieldModel> sensitiveFields = existingConfig.getCopyOfFieldList().stream()
                                                                   .filter(ConfigurationFieldModel::isSensitive)

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/accessor/DefaultDescriptorGlobalConfigUtility.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/accessor/DefaultDescriptorGlobalConfigUtility.java
@@ -98,17 +98,17 @@ public class DefaultDescriptorGlobalConfigUtility {
 
     public FieldModel update(Long id, FieldModel fieldModel) throws AlertException {
         FieldModel beforeUpdateAction = apiAction.beforeUpdateAction(fieldModel);
-        Map<String, ConfigurationFieldModel> values = configurationFieldModelConverter.convertToConfigurationFieldModelMap(beforeUpdateAction);
+        Map<String, ConfigurationFieldModel> valueMap = configurationFieldModelConverter.convertToConfigurationFieldModelMap(beforeUpdateAction);
         Optional<ConfigurationModel> existingConfig = configurationAccessor.getConfigurationById(id);
-
-        if (!existingConfig.isPresent()) {
-            return apiAction.afterUpdateAction(beforeUpdateAction);
+        ConfigurationModel configurationModel;
+        if (existingConfig.isPresent()) {
+            Map<String, ConfigurationFieldModel> updatedValues = updateSensitiveFields(valueMap, existingConfig.get());
+            configurationModel = configurationAccessor.updateConfiguration(id, updatedValues.values());
         } else {
-            Map<String, ConfigurationFieldModel> updatedValues = updateSensitiveFields(values, existingConfig.get());
-            ConfigurationModel configurationModel = configurationAccessor.updateConfiguration(id, updatedValues.values());
-            FieldModel convertedFieldModel = configurationFieldModelConverter.convertToFieldModel(configurationModel);
-            return apiAction.afterUpdateAction(convertedFieldModel);
+            configurationModel = configurationAccessor.createConfiguration(key, context, valueMap.values());
         }
+        FieldModel convertedFieldModel = configurationFieldModelConverter.convertToFieldModel(configurationModel);
+        return apiAction.afterUpdateAction(convertedFieldModel);
     }
 
     private Map<String, ConfigurationFieldModel> updateSensitiveFields(Map<String, ConfigurationFieldModel> values, ConfigurationModel existingConfig) {

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/descriptor/accessor/DefaultDescriptorGlobalConfigUtilityTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/descriptor/accessor/DefaultDescriptorGlobalConfigUtilityTest.java
@@ -145,6 +145,27 @@ public class DefaultDescriptorGlobalConfigUtilityTest {
     }
 
     @Test
+    public void testUpdateNoExistingConfig() throws Exception {
+        DescriptorKey descriptorKey = createDescriptorKey();
+        FieldModel fieldModel = new FieldModel(descriptorKey.getUniversalKey(), ConfigContextEnum.GLOBAL.name(), Map.of());
+        Map<String, ConfigurationFieldModel> configurationFieldModelCollection = Map.of();
+        ConfigurationAccessor configurationAccessor = Mockito.mock(ConfigurationAccessor.class);
+        ConfigurationFieldModelConverter converter = Mockito.mock(ConfigurationFieldModelConverter.class);
+        ConfigurationModel configurationModel = Mockito.mock(ConfigurationModel.class);
+        ApiAction apiAction = Mockito.mock(ApiAction.class);
+        Mockito.when(configurationAccessor.createConfiguration(Mockito.eq(descriptorKey), Mockito.any(ConfigContextEnum.class), Mockito.anyCollection())).thenReturn(configurationModel);
+        Mockito.when(converter.convertToConfigurationFieldModelMap(Mockito.eq(fieldModel))).thenReturn(configurationFieldModelCollection);
+        Mockito.when(converter.convertToFieldModel(Mockito.any())).thenReturn(fieldModel);
+        Mockito.when(apiAction.beforeUpdateAction(Mockito.eq(fieldModel))).thenReturn(fieldModel);
+        Mockito.when(apiAction.afterUpdateAction(Mockito.eq(fieldModel))).thenReturn(fieldModel);
+
+        DefaultDescriptorGlobalConfigUtility configUtility = new DefaultDescriptorGlobalConfigUtility(descriptorKey, configurationAccessor, apiAction, converter);
+        FieldModel savedModel = configUtility.update(1L, fieldModel);
+
+        assertEquals(fieldModel, savedModel);
+    }
+
+    @Test
     public void testUpdate() throws Exception {
         DescriptorKey descriptorKey = createDescriptorKey();
         FieldModel fieldModel = new FieldModel(descriptorKey.getUniversalKey(), ConfigContextEnum.GLOBAL.name(), Map.of());
@@ -153,6 +174,7 @@ public class DefaultDescriptorGlobalConfigUtilityTest {
         ConfigurationFieldModelConverter converter = Mockito.mock(ConfigurationFieldModelConverter.class);
         ConfigurationModel configurationModel = Mockito.mock(ConfigurationModel.class);
         ApiAction apiAction = Mockito.mock(ApiAction.class);
+        Mockito.when(configurationAccessor.getConfigurationById(Mockito.anyLong())).thenReturn(Optional.of(configurationModel));
         Mockito.when(configurationAccessor.createConfiguration(Mockito.eq(descriptorKey), Mockito.any(ConfigContextEnum.class), Mockito.anyCollection())).thenReturn(configurationModel);
         Mockito.when(converter.convertToConfigurationFieldModelMap(Mockito.eq(fieldModel))).thenReturn(configurationFieldModelCollection);
         Mockito.when(converter.convertToFieldModel(Mockito.any())).thenReturn(fieldModel);


### PR DESCRIPTION
For sensitive fields read the values from the database and use the value if the value from the field model isn't set.

We were writing the empty string as the LDAP password each time Alert starts up. Read if the value is saved in the database and use that if the field isn't set in the new configuration to be saved.