### PR TITLE
Ps security context fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,10 @@ RUN set -e \
     		zip \
     		postgresql-client
 
-RUN mkdir -p -m 774 $CERTIFICATE_MANAGER_DIR
-RUN mkdir -p -m 774 $SECURITY_DIR
-RUN mkdir -p -m 774 $ALERT_CONFIG_HOME
-RUN mkdir -p -m 774 $ALERT_DATA_DIR
+RUN mkdir -p -m 775 $CERTIFICATE_MANAGER_DIR
+RUN mkdir -p -m 775 $SECURITY_DIR
+RUN mkdir -p -m 775 $ALERT_CONFIG_HOME
+RUN mkdir -p -m 775 $ALERT_DATA_DIR
 
 COPY blackduck-alert-boot-$VERSION $ALERT_HOME/alert-tar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN set -e \
     		postgresql-client
 
 RUN mkdir -p -m 775 $CERTIFICATE_MANAGER_DIR
-RUN mkdir -p -m 775 $SECURITY_DIR
+RUN mkdir -p -m 777 $SECURITY_DIR
 RUN mkdir -p -m 775 $ALERT_CONFIG_HOME
 RUN mkdir -p -m 775 $ALERT_DATA_DIR
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -446,6 +446,7 @@ postgresPrepare600Upgrade() {
     fi
 }
 echo "Checking if certificate management script exists..."
+whoami
 ls -al $certificateManagerDir
 
 if [ ! -f "$certificateManagerDir/certificate-manager.sh" ];

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -445,9 +445,6 @@ postgresPrepare600Upgrade() {
         fi
     fi
 }
-echo "Checking if certificate management script exists..."
-whoami
-ls -al $certificateManagerDir
 
 if [ ! -f "$certificateManagerDir/certificate-manager.sh" ];
 then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -445,6 +445,8 @@ postgresPrepare600Upgrade() {
         fi
     fi
 }
+echo "Checking if certificate management script exists..."
+ls -al $certificateManagerDir
 
 if [ ! -f "$certificateManagerDir/certificate-manager.sh" ];
 then


### PR DESCRIPTION
Fix the application of the security context in helm.  Change file permissions to allow non root users to generate the certificates.