### PR TITLE
Add repository flush call to save method.

### DIFF
--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultNotificationManager.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultNotificationManager.java
@@ -90,7 +90,7 @@ public class DefaultNotificationManager implements NotificationManager {
                                                        .map(this::toModel)
                                                        .collect(Collectors.toList());
         notificationContentRepository.flush();
-
+        // TODO move this sendEvent call out of this class.  We can then remove the flush call since the save will be in a transaction.
         if (!savedModels.isEmpty()) {
             List<Long> notificationIds = savedModels.stream()
                                              .map(AlertNotificationModel::getId)

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultNotificationManager.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultNotificationManager.java
@@ -89,6 +89,7 @@ public class DefaultNotificationManager implements NotificationManager {
                                                        .stream()
                                                        .map(this::toModel)
                                                        .collect(Collectors.toList());
+        notificationContentRepository.flush();
 
         if (!savedModels.isEmpty()) {
             List<Long> notificationIds = savedModels.stream()


### PR DESCRIPTION
Add a flush call before handleEvent in order to ensure the notifications are saved in the database and can be read via notification ID's in the real time event handler.