### PR TITLE
Create and separate a mutable and immutable version of the ConfigurationModel class

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/ConfigurationModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/ConfigurationModel.java
@@ -28,13 +28,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.persistence.model.mutable.ConfigurationModelMutable;
 import com.synopsys.integration.alert.common.rest.model.AlertSerializableModel;
 
-public final class ConfigurationModel extends AlertSerializableModel {
+public class ConfigurationModel extends AlertSerializableModel {
     private final Long descriptorId;
     private final Long configurationId;
     private final String createdAt;
@@ -53,6 +52,10 @@ public final class ConfigurationModel extends AlertSerializableModel {
         this.lastUpdated = lastUpdated;
         this.context = context;
         configuredFields = new HashMap<>();
+    }
+
+    protected Map<String, ConfigurationFieldModel> getConfiguredFields() {
+        return configuredFields;
     }
 
     public Long getDescriptorId() {
@@ -88,20 +91,7 @@ public final class ConfigurationModel extends AlertSerializableModel {
         return new HashMap<>(configuredFields);
     }
 
-    public void put(ConfigurationFieldModel configFieldModel) {
-        Objects.requireNonNull(configFieldModel);
-        String fieldKey = configFieldModel.getFieldKey();
-        Objects.requireNonNull(fieldKey);
-        if (configuredFields.containsKey(fieldKey)) {
-            ConfigurationFieldModel oldConfigField = configuredFields.get(fieldKey);
-            List<String> values = combine(oldConfigField, configFieldModel);
-            oldConfigField.setFieldValues(values);
-        } else {
-            configuredFields.put(fieldKey, configFieldModel);
-        }
-    }
-
-    private List<String> combine(ConfigurationFieldModel first, ConfigurationFieldModel second) {
-        return Stream.concat(first.getFieldValues().stream(), second.getFieldValues().stream()).collect(Collectors.toList());
+    public ConfigurationModelMutable createMutableCopy() {
+        return new ConfigurationModelMutable(descriptorId, configurationId, createdAt, lastUpdated, context);
     }
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/ConfigurationModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/ConfigurationModel.java
@@ -46,12 +46,16 @@ public class ConfigurationModel extends AlertSerializableModel {
     }
 
     public ConfigurationModel(Long registeredDescriptorId, Long descriptorConfigId, String createdAt, String lastUpdated, ConfigContextEnum context) {
+        this(registeredDescriptorId, descriptorConfigId, createdAt, lastUpdated, context, new HashMap<>());
+    }
+
+    public ConfigurationModel(Long registeredDescriptorId, Long descriptorConfigId, String createdAt, String lastUpdated, ConfigContextEnum context, Map<String, ConfigurationFieldModel> configuredFields) {
         descriptorId = registeredDescriptorId;
         configurationId = descriptorConfigId;
         this.createdAt = createdAt;
         this.lastUpdated = lastUpdated;
         this.context = context;
-        configuredFields = new HashMap<>();
+        this.configuredFields = configuredFields;
     }
 
     protected Map<String, ConfigurationFieldModel> getConfiguredFields() {
@@ -92,6 +96,8 @@ public class ConfigurationModel extends AlertSerializableModel {
     }
 
     public ConfigurationModelMutable createMutableCopy() {
-        return new ConfigurationModelMutable(descriptorId, configurationId, createdAt, lastUpdated, context);
+        ConfigurationModelMutable mutableCopy = new ConfigurationModelMutable(descriptorId, configurationId, createdAt, lastUpdated, context);
+        mutableCopy.getConfiguredFields().putAll(configuredFields);
+        return mutableCopy;
     }
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/mutable/ConfigurationModelMutable.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/mutable/ConfigurationModelMutable.java
@@ -1,3 +1,25 @@
+/**
+ * alert-common
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.synopsys.integration.alert.common.persistence.model.mutable;
 
 import java.util.List;

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/mutable/ConfigurationModelMutable.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/mutable/ConfigurationModelMutable.java
@@ -1,0 +1,37 @@
+package com.synopsys.integration.alert.common.persistence.model.mutable;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
+import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
+
+public class ConfigurationModelMutable extends ConfigurationModel {
+    public ConfigurationModelMutable(Long registeredDescriptorId, Long descriptorConfigId, String createdAt, String lastUpdated, String context) {
+        super(registeredDescriptorId, descriptorConfigId, createdAt, lastUpdated, context);
+    }
+
+    public ConfigurationModelMutable(Long registeredDescriptorId, Long descriptorConfigId, String createdAt, String lastUpdated, ConfigContextEnum context) {
+        super(registeredDescriptorId, descriptorConfigId, createdAt, lastUpdated, context);
+    }
+
+    public void put(ConfigurationFieldModel configFieldModel) {
+        Objects.requireNonNull(configFieldModel);
+        String fieldKey = configFieldModel.getFieldKey();
+        Objects.requireNonNull(fieldKey);
+        if (getConfiguredFields().containsKey(fieldKey)) {
+            ConfigurationFieldModel oldConfigField = getConfiguredFields().get(fieldKey);
+            List<String> values = combine(oldConfigField, configFieldModel);
+            oldConfigField.setFieldValues(values);
+        } else {
+            getConfiguredFields().put(fieldKey, configFieldModel);
+        }
+    }
+
+    private List<String> combine(ConfigurationFieldModel first, ConfigurationFieldModel second) {
+        return Stream.concat(first.getFieldValues().stream(), second.getFieldValues().stream()).collect(Collectors.toList());
+    }
+}

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/util/ConfigurationFieldModelConverter.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/util/ConfigurationFieldModelConverter.java
@@ -44,6 +44,7 @@ import com.synopsys.integration.alert.common.persistence.model.ConfigurationFiel
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
 import com.synopsys.integration.alert.common.persistence.model.DefinedFieldModel;
 import com.synopsys.integration.alert.common.persistence.model.RegisteredDescriptorModel;
+import com.synopsys.integration.alert.common.persistence.model.mutable.ConfigurationModelMutable;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
 import com.synopsys.integration.alert.common.security.EncryptionUtility;
@@ -133,7 +134,7 @@ public class ConfigurationFieldModelConverter {
 
         long descriptorId = descriptorAccessor.getRegisteredDescriptorByKey(descriptorKey).map(RegisteredDescriptorModel::getId).orElse(0L);
         long configId = Long.parseLong(fieldModel.getId());
-        ConfigurationModel configurationModel = new ConfigurationModel(configId, descriptorId, fieldModel.getCreatedAt(), fieldModel.getLastUpdated(), fieldModel.getContext());
+        ConfigurationModelMutable configurationModel = new ConfigurationModelMutable(configId, descriptorId, fieldModel.getCreatedAt(), fieldModel.getLastUpdated(), fieldModel.getContext());
         convertToConfigurationFieldModelMap(fieldModel).values().forEach(configurationModel::put);
         return configurationModel;
     }

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/persistence/model/ConfigurationModelTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/persistence/model/ConfigurationModelTest.java
@@ -1,0 +1,80 @@
+package com.synopsys.integration.alert.common.persistence.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.persistence.model.mutable.ConfigurationModelMutable;
+
+public class ConfigurationModelTest {
+    private final Long descriptorId = 1L;
+    private final Long configurationId = 2L;
+    private final String createdAt = "createdAt-test";
+    private final String lastUpdated = "lastUpdated-test";
+    private final ConfigContextEnum configContextEnum = ConfigContextEnum.GLOBAL;
+    private final String fieldKey = "fieldKey";
+
+    @Test
+    public void getDescriptorIdTest() {
+        ConfigurationModel configurationModel = createConfigurationModel();
+        assertEquals(descriptorId, configurationModel.getDescriptorId());
+    }
+
+    @Test
+    public void getConfigurationIdTest() {
+        ConfigurationModel configurationModel = createConfigurationModel();
+        assertEquals(configurationId, configurationModel.getConfigurationId());
+    }
+
+    @Test
+    public void getCreatedAtTest() {
+        ConfigurationModel configurationModel = createConfigurationModel();
+        assertEquals(createdAt, configurationModel.getCreatedAt());
+    }
+
+    @Test
+    public void getLastUpdatedTest() {
+        ConfigurationModel configurationModel = createConfigurationModel();
+        assertEquals(lastUpdated, configurationModel.getLastUpdated());
+    }
+
+    @Test
+    public void getDescriptorContextTest() {
+        ConfigurationModel configurationModel = createConfigurationModel();
+        assertEquals(configContextEnum, configurationModel.getDescriptorContext());
+    }
+
+    @Test
+    public void getFieldTest() {
+        ConfigurationModel configurationModel = createConfigurationModel();
+        assertFalse(configurationModel.getField(fieldKey).isPresent());
+    }
+
+    @Test
+    public void getCopyOfFieldListTest() {
+        ConfigurationModel configurationModel = createConfigurationModel();
+        assertTrue(configurationModel.getCopyOfFieldList().isEmpty());
+    }
+
+    @Test
+    public void getCopyOfKeyToFieldMapTest() {
+        ConfigurationModel configurationModel = createConfigurationModel();
+        assertTrue(configurationModel.getCopyOfKeyToFieldMap().isEmpty());
+    }
+
+    @Test
+    public void createMutableCopyTest() {
+        ConfigurationModel configurationModel = createConfigurationModel();
+        ConfigurationModelMutable configurationModelMutable = configurationModel.createMutableCopy();
+        assertEquals(configurationModel, configurationModelMutable);
+        assertTrue(configurationModel != configurationModelMutable);
+    }
+
+    private ConfigurationModel createConfigurationModel() {
+        return new ConfigurationModel(descriptorId, configurationId, createdAt, lastUpdated, configContextEnum);
+    }
+}
+

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/persistence/model/ConfigurationModelTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/persistence/model/ConfigurationModelTest.java
@@ -4,6 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
@@ -16,6 +20,15 @@ public class ConfigurationModelTest {
     private final String lastUpdated = "lastUpdated-test";
     private final ConfigContextEnum configContextEnum = ConfigContextEnum.GLOBAL;
     private final String fieldKey = "fieldKey";
+    private final String fieldValue = "fieldValue";
+
+    private ConfigurationFieldModel configurationFieldModel;
+
+    @BeforeEach
+    public void init() {
+        configurationFieldModel = ConfigurationFieldModel.create(fieldKey);
+        configurationFieldModel.setFieldValue(fieldValue);
+    }
 
     @Test
     public void getDescriptorIdTest() {
@@ -50,31 +63,41 @@ public class ConfigurationModelTest {
     @Test
     public void getFieldTest() {
         ConfigurationModel configurationModel = createConfigurationModel();
-        assertFalse(configurationModel.getField(fieldKey).isPresent());
+
+        assertTrue(configurationModel.getField(fieldKey).isPresent());
+        assertFalse(configurationModel.getField("badFieldKey").isPresent());
     }
 
     @Test
     public void getCopyOfFieldListTest() {
         ConfigurationModel configurationModel = createConfigurationModel();
-        assertTrue(configurationModel.getCopyOfFieldList().isEmpty());
+        List<ConfigurationFieldModel> fieldList = configurationModel.getCopyOfFieldList();
+
+        assertEquals(1, fieldList.size());
+        assertEquals(configurationFieldModel, fieldList.get(0));
     }
 
     @Test
     public void getCopyOfKeyToFieldMapTest() {
         ConfigurationModel configurationModel = createConfigurationModel();
-        assertTrue(configurationModel.getCopyOfKeyToFieldMap().isEmpty());
+        Map<String, ConfigurationFieldModel> keyToFieldMap = configurationModel.getCopyOfKeyToFieldMap();
+
+        assertFalse(keyToFieldMap.isEmpty());
+        assertTrue(keyToFieldMap.containsValue(configurationFieldModel));
     }
 
     @Test
     public void createMutableCopyTest() {
         ConfigurationModel configurationModel = createConfigurationModel();
         ConfigurationModelMutable configurationModelMutable = configurationModel.createMutableCopy();
+
         assertEquals(configurationModel, configurationModelMutable);
         assertTrue(configurationModel != configurationModelMutable);
     }
 
     private ConfigurationModel createConfigurationModel() {
-        return new ConfigurationModel(descriptorId, configurationId, createdAt, lastUpdated, configContextEnum);
+        Map<String, ConfigurationFieldModel> configuredFields = Map.of(fieldKey, configurationFieldModel);
+        return new ConfigurationModel(descriptorId, configurationId, createdAt, lastUpdated, configContextEnum, configuredFields);
     }
 }
 

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/persistence/model/mutable/ConfigurationModelMutableTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/persistence/model/mutable/ConfigurationModelMutableTest.java
@@ -1,0 +1,95 @@
+package com.synopsys.integration.alert.common.persistence.model.mutable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
+
+public class ConfigurationModelMutableTest {
+    private final Long descriptorId = 1L;
+    private final Long configurationId = 2L;
+    private final String createdAt = "createdAt-test";
+    private final String lastUpdated = "lastUpdated-test";
+    private final ConfigContextEnum configContextEnum = ConfigContextEnum.GLOBAL;
+    private final String fieldKey = "fieldKey";
+    private final String fieldValue = "fieldValue";
+
+    private ConfigurationFieldModel configurationFieldModel;
+
+    @BeforeEach
+    public void init() {
+        configurationFieldModel = ConfigurationFieldModel.create(fieldKey);
+        configurationFieldModel.setFieldValue(fieldValue);
+    }
+
+    @Test
+    public void putTest() {
+        final String fieldValue2 = "fieldValue-2";
+
+        ConfigurationFieldModel configurationFieldModel2 = ConfigurationFieldModel.create(fieldKey);
+        configurationFieldModel2.setFieldValue(fieldValue2);
+
+        ConfigurationModelMutable configurationModelMutable = createConfigurationModelMutable();
+        configurationModelMutable.put(configurationFieldModel);
+        configurationModelMutable.put(configurationFieldModel2);
+
+        Optional<ConfigurationFieldModel> testConfigurationFieldModelOptional = configurationModelMutable.getField(fieldKey);
+
+        assertTrue(testConfigurationFieldModelOptional.isPresent());
+        ArrayList<String> fieldValues = new ArrayList<>(testConfigurationFieldModelOptional.get().getFieldValues());
+
+        assertEquals(2, fieldValues.size());
+        assertTrue(fieldValues.contains(fieldValue));
+        assertTrue(fieldValues.contains(fieldValue2));
+    }
+
+    @Test
+    public void getFieldTest() {
+        ConfigurationModelMutable configurationModelMutable = new ConfigurationModelMutable(descriptorId, configurationId, createdAt, lastUpdated, configContextEnum.name());
+        configurationModelMutable.put(configurationFieldModel);
+
+        Optional<ConfigurationFieldModel> testConfigurationFieldModel = configurationModelMutable.getField(fieldKey);
+        Optional<ConfigurationFieldModel> testConfigurationFieldModelEmpty = configurationModelMutable.getField("badKey");
+
+        assertTrue(testConfigurationFieldModel.isPresent());
+        assertFalse(testConfigurationFieldModelEmpty.isPresent());
+        assertEquals(configurationFieldModel, testConfigurationFieldModel.get());
+    }
+
+    @Test
+    public void getCopyOfFieldListTest() {
+        ConfigurationModelMutable configurationModelMutable = createConfigurationModelMutable();
+        configurationModelMutable.put(configurationFieldModel);
+
+        List<ConfigurationFieldModel> testConfigurationFieldModelList = configurationModelMutable.getCopyOfFieldList();
+
+        assertEquals(1, testConfigurationFieldModelList.size());
+        assertEquals(configurationFieldModel, testConfigurationFieldModelList.get(0));
+    }
+
+    @Test
+    public void getCopyOfKeyToFieldMapTest() {
+        ConfigurationModelMutable configurationModelMutable = createConfigurationModelMutable();
+        configurationModelMutable.put(configurationFieldModel);
+
+        Map<String, ConfigurationFieldModel> configurationFieldModelMap = configurationModelMutable.getCopyOfKeyToFieldMap();
+
+        assertEquals(1, configurationFieldModelMap.size());
+        assertEquals(configurationFieldModel, configurationFieldModelMap.get(fieldKey));
+    }
+
+    private ConfigurationModelMutable createConfigurationModelMutable() {
+        return new ConfigurationModelMutable(descriptorId, configurationId, createdAt, lastUpdated, configContextEnum);
+    }
+
+}

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultConfigurationAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultConfigurationAccessor.java
@@ -50,6 +50,7 @@ import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationA
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationJobModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
+import com.synopsys.integration.alert.common.persistence.model.mutable.ConfigurationModelMutable;
 import com.synopsys.integration.alert.common.security.EncryptionUtility;
 import com.synopsys.integration.alert.common.util.DateUtils;
 import com.synopsys.integration.alert.database.DatabaseEntity;
@@ -266,7 +267,7 @@ public class DefaultConfigurationAccessor implements ConfigurationAccessor {
         DescriptorConfigEntity descriptorConfigToSave = new DescriptorConfigEntity(descriptorId, configContextId, currentTime, currentTime);
         DescriptorConfigEntity savedDescriptorConfig = descriptorConfigsRepository.save(descriptorConfigToSave);
 
-        ConfigurationModel createdConfig = createEmptyConfigModel(descriptorId, savedDescriptorConfig.getId(), savedDescriptorConfig.getCreatedAt(), savedDescriptorConfig.getLastUpdated(), context);
+        ConfigurationModelMutable createdConfig = createEmptyConfigModel(descriptorId, savedDescriptorConfig.getId(), savedDescriptorConfig.getCreatedAt(), savedDescriptorConfig.getLastUpdated(), context);
         if (configuredFields != null && !configuredFields.isEmpty()) {
             for (ConfigurationFieldModel configuredField : configuredFields) {
                 String fieldKey = configuredField.getFieldKey();
@@ -323,7 +324,7 @@ public class DefaultConfigurationAccessor implements ConfigurationAccessor {
         List<FieldValueEntity> oldValues = fieldValueRepository.findByConfigId(descriptorConfigId);
         fieldValueRepository.deleteAll(oldValues);
 
-        ConfigurationModel updatedConfig = createEmptyConfigModel(descriptorConfigEntity.getDescriptorId(), descriptorConfigEntity.getId(),
+        ConfigurationModelMutable updatedConfig = createEmptyConfigModel(descriptorConfigEntity.getDescriptorId(), descriptorConfigEntity.getId(),
             descriptorConfigEntity.getCreatedAt(), descriptorConfigEntity.getLastUpdated(), descriptorConfigEntity.getContextId());
         if (configuredFields != null && !configuredFields.isEmpty()) {
             for (ConfigurationFieldModel configFieldModel : configuredFields) {
@@ -418,13 +419,13 @@ public class DefaultConfigurationAccessor implements ConfigurationAccessor {
         return configs;
     }
 
-    private ConfigurationModel createConfigModel(Long descriptorId, Long configId, OffsetDateTime createdAt, OffsetDateTime lastUpdated, Long contextId) throws AlertDatabaseConstraintException {
+    private ConfigurationModelMutable createConfigModel(Long descriptorId, Long configId, OffsetDateTime createdAt, OffsetDateTime lastUpdated, Long contextId) throws AlertDatabaseConstraintException {
         String configContext = getContextById(contextId);
 
         String createdAtFormatted = DateUtils.formatDate(createdAt, DateUtils.UTC_DATE_FORMAT_TO_MINUTE);
         String lastUpdatedFormatted = DateUtils.formatDate(lastUpdated, DateUtils.UTC_DATE_FORMAT_TO_MINUTE);
 
-        ConfigurationModel newModel = new ConfigurationModel(descriptorId, configId, createdAtFormatted, lastUpdatedFormatted, configContext);
+        ConfigurationModelMutable newModel = new ConfigurationModelMutable(descriptorId, configId, createdAtFormatted, lastUpdatedFormatted, configContext);
         List<FieldValueEntity> fieldValueEntities = fieldValueRepository.findByConfigId(configId);
         for (FieldValueEntity fieldValueEntity : fieldValueEntities) {
             DefinedFieldEntity definedFieldEntity = definedFieldRepository
@@ -439,20 +440,20 @@ public class DefaultConfigurationAccessor implements ConfigurationAccessor {
         return newModel;
     }
 
-    private ConfigurationModel createEmptyConfigModel(Long descriptorId, Long configId, OffsetDateTime createdAt, OffsetDateTime lastUpdated, Long contextId) throws AlertDatabaseConstraintException {
+    private ConfigurationModelMutable createEmptyConfigModel(Long descriptorId, Long configId, OffsetDateTime createdAt, OffsetDateTime lastUpdated, Long contextId) throws AlertDatabaseConstraintException {
         String configContext = getContextById(contextId);
 
         String createdAtFormatted = DateUtils.formatDate(createdAt, DateUtils.UTC_DATE_FORMAT_TO_MINUTE);
         String lastUpdatedFormatted = DateUtils.formatDate(lastUpdated, DateUtils.UTC_DATE_FORMAT_TO_MINUTE);
 
-        return new ConfigurationModel(descriptorId, configId, createdAtFormatted, lastUpdatedFormatted, configContext);
+        return new ConfigurationModelMutable(descriptorId, configId, createdAtFormatted, lastUpdatedFormatted, configContext);
     }
 
-    private ConfigurationModel createEmptyConfigModel(Long descriptorId, Long configId, OffsetDateTime createdAt, OffsetDateTime lastUpdated, ConfigContextEnum context) {
+    private ConfigurationModelMutable createEmptyConfigModel(Long descriptorId, Long configId, OffsetDateTime createdAt, OffsetDateTime lastUpdated, ConfigContextEnum context) {
         String createdAtFormatted = DateUtils.formatDate(createdAt, DateUtils.UTC_DATE_FORMAT_TO_MINUTE);
         String lastUpdatedFormatted = DateUtils.formatDate(lastUpdated, DateUtils.UTC_DATE_FORMAT_TO_MINUTE);
 
-        return new ConfigurationModel(descriptorId, configId, createdAtFormatted, lastUpdatedFormatted, context);
+        return new ConfigurationModelMutable(descriptorId, configId, createdAtFormatted, lastUpdatedFormatted, context);
     }
 
     private Long getDescriptorIdOrThrowException(String descriptorName) throws AlertDatabaseConstraintException {

--- a/alert-database/src/test/java/com/synopsys/integration/alert/database/api/DefaultAuditUtilityTest.java
+++ b/alert-database/src/test/java/com/synopsys/integration/alert/database/api/DefaultAuditUtilityTest.java
@@ -39,7 +39,7 @@ import com.synopsys.integration.alert.common.persistence.model.AuditEntryModel;
 import com.synopsys.integration.alert.common.persistence.model.AuditJobStatusModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationJobModel;
-import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
+import com.synopsys.integration.alert.common.persistence.model.mutable.ConfigurationModelMutable;
 import com.synopsys.integration.alert.common.rest.model.AlertNotificationModel;
 import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 import com.synopsys.integration.alert.common.rest.model.JobAuditModel;
@@ -214,7 +214,7 @@ public class DefaultAuditUtilityTest {
         Mockito.when(auditNotificationRepository.findByNotificationId(Mockito.any())).thenReturn(List.of(auditNotificationRelation));
         Mockito.when(auditEntryRepository.findAllById(Mockito.any())).thenReturn(List.of(auditEntryEntity));
 
-        ConfigurationModel configurationModel = new ConfigurationModel(10L, 11L, "createdAt-test", "lastUpdate-test", ConfigContextEnum.DISTRIBUTION);
+        ConfigurationModelMutable configurationModel = new ConfigurationModelMutable(10L, 11L, "createdAt-test", "lastUpdate-test", ConfigContextEnum.DISTRIBUTION);
         ConfigurationFieldModel configurationFieldModel = ConfigurationFieldModel.create("channel.common.name");
         configurationFieldModel.setFieldValue("test-channel.common.name-value");
         ConfigurationFieldModel configurationFieldModel2 = ConfigurationFieldModel.create("channel.common.channel.name");

--- a/alert-database/src/test/java/com/synopsys/integration/alert/database/api/DefaultNotificationManagerTest.java
+++ b/alert-database/src/test/java/com/synopsys/integration/alert/database/api/DefaultNotificationManagerTest.java
@@ -22,6 +22,7 @@ import com.synopsys.integration.alert.common.event.EventManager;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
+import com.synopsys.integration.alert.common.persistence.model.mutable.ConfigurationModelMutable;
 import com.synopsys.integration.alert.common.rest.model.AlertNotificationModel;
 import com.synopsys.integration.alert.common.util.DateUtils;
 import com.synopsys.integration.alert.database.audit.AuditEntryEntity;
@@ -300,8 +301,8 @@ public class DefaultNotificationManagerTest {
         assertEquals(expected.getContent(), actual.getContent());
     }
 
-    private ConfigurationModel createConfigurationModel() {
-        ConfigurationModel configurationModel = new ConfigurationModel(1L, 1L, "createdAt-test", "lastUpdate-test", ConfigContextEnum.DISTRIBUTION);
+    private ConfigurationModelMutable createConfigurationModel() {
+        ConfigurationModelMutable configurationModel = new ConfigurationModelMutable(1L, 1L, "createdAt-test", "lastUpdate-test", ConfigContextEnum.DISTRIBUTION);
         ConfigurationFieldModel configurationFieldModel = ConfigurationFieldModel.create(KEY_PROVIDER_CONFIG_NAME);
         configurationFieldModel.setFieldValue(fieldValue);
         configurationModel.put(configurationFieldModel);

--- a/alert-database/src/test/java/com/synopsys/integration/alert/database/api/DefaultProviderDataAccessorTest.java
+++ b/alert-database/src/test/java/com/synopsys/integration/alert/database/api/DefaultProviderDataAccessorTest.java
@@ -19,6 +19,7 @@ import com.synopsys.integration.alert.common.persistence.model.ConfigurationFiel
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
 import com.synopsys.integration.alert.common.persistence.model.ProviderProject;
 import com.synopsys.integration.alert.common.persistence.model.ProviderUserModel;
+import com.synopsys.integration.alert.common.persistence.model.mutable.ConfigurationModelMutable;
 import com.synopsys.integration.alert.database.provider.project.ProviderProjectEntity;
 import com.synopsys.integration.alert.database.provider.project.ProviderProjectRepository;
 import com.synopsys.integration.alert.database.provider.project.ProviderUserProjectRelation;
@@ -232,8 +233,8 @@ public class DefaultProviderDataAccessorTest {
         Mockito.verify(providerUserProjectRelationRepository).saveAll(Mockito.any());
     }
 
-    private ConfigurationModel createConfigurationModel() {
-        ConfigurationModel configurationModel = new ConfigurationModel(1L, 1L, "createdAt-test", "lastUpdate-test", ConfigContextEnum.DISTRIBUTION);
+    private ConfigurationModelMutable createConfigurationModel() {
+        ConfigurationModelMutable configurationModel = new ConfigurationModelMutable(1L, 1L, "createdAt-test", "lastUpdate-test", ConfigContextEnum.DISTRIBUTION);
         ConfigurationFieldModel configurationFieldModel = ConfigurationFieldModel.create(KEY_PROVIDER_CONFIG_NAME);
         configurationFieldModel.setFieldValue(fieldValue);
         configurationModel.put(configurationFieldModel);

--- a/src/test/java/com/synopsys/integration/alert/mock/MockConfigurationModelFactory.java
+++ b/src/test/java/com/synopsys/integration/alert/mock/MockConfigurationModelFactory.java
@@ -24,6 +24,7 @@ import com.synopsys.integration.alert.common.persistence.accessor.FieldAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationJobModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
+import com.synopsys.integration.alert.common.persistence.model.mutable.ConfigurationModelMutable;
 import com.synopsys.integration.alert.common.util.DataStructureUtils;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProviderKey;
 import com.synopsys.integration.blackduck.api.manual.enumeration.NotificationType;
@@ -49,7 +50,7 @@ public class MockConfigurationModelFactory {
     }
 
     public static ConfigurationJobModel createDistributionJob(Collection<ConfigurationFieldModel> configurationFieldModels) {
-        ConfigurationModel configurationModel = new ConfigurationModel(1L, 1L, null, null, ConfigContextEnum.DISTRIBUTION);
+        ConfigurationModelMutable configurationModel = new ConfigurationModelMutable(1L, 1L, null, null, ConfigContextEnum.DISTRIBUTION);
         configurationFieldModels.forEach(configurationModel::put);
         return new ConfigurationJobModel(UUID.randomUUID(), Set.of(configurationModel));
     }

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/tasks/BlackDuckProjectSyncTaskTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/tasks/BlackDuckProjectSyncTaskTest.java
@@ -17,7 +17,7 @@ import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationJobModel;
-import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
+import com.synopsys.integration.alert.common.persistence.model.mutable.ConfigurationModelMutable;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProviderKey;
 import com.synopsys.integration.alert.provider.blackduck.mock.MockProviderDataAccessor;
@@ -40,7 +40,7 @@ public class BlackDuckProjectSyncTaskTest {
         Long providerConfigId = 1000L;
         ConfigurationFieldModel configurationFieldModel = ConfigurationFieldModel.create(ProviderDistributionUIConfig.KEY_CONFIGURED_PROJECT);
         configurationFieldModel.setFieldValues(List.of("project", "project2"));
-        ConfigurationModel configurationModel = new ConfigurationModel(1L, 1L, null, null, ConfigContextEnum.DISTRIBUTION);
+        ConfigurationModelMutable configurationModel = new ConfigurationModelMutable(1L, 1L, null, null, ConfigContextEnum.DISTRIBUTION);
         configurationModel.put(configurationFieldModel);
         ConfigurationJobModel configurationJobModel = new ConfigurationJobModel(UUID.randomUUID(), Set.of(configurationModel));
         Mockito.when(configurationAccessor.getAllJobs()).thenReturn(List.of(configurationJobModel));

--- a/src/test/java/com/synopsys/integration/alert/web/security/authentication/ldap/LdapManagerTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/security/authentication/ldap/LdapManagerTest.java
@@ -17,6 +17,7 @@ import com.synopsys.integration.alert.common.exception.AlertConfigurationExcepti
 import com.synopsys.integration.alert.common.persistence.accessor.FieldAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
+import com.synopsys.integration.alert.common.persistence.model.mutable.ConfigurationModelMutable;
 import com.synopsys.integration.alert.component.authentication.descriptor.AuthenticationDescriptor;
 import com.synopsys.integration.alert.component.authentication.descriptor.AuthenticationDescriptorKey;
 import com.synopsys.integration.alert.database.api.DefaultConfigurationAccessor;
@@ -39,7 +40,7 @@ public class LdapManagerTest {
     private static final AuthenticationDescriptorKey AUTHENTICATION_DESCRIPTOR_KEY = new AuthenticationDescriptorKey();
 
     private ConfigurationModel createConfigurationModel() {
-        ConfigurationModel configurationModel = new ConfigurationModel(1L, 1L, null, null, ConfigContextEnum.GLOBAL);
+        ConfigurationModelMutable configurationModel = new ConfigurationModelMutable(1L, 1L, null, null, ConfigContextEnum.GLOBAL);
 
         ConfigurationFieldModel enabledField = ConfigurationFieldModel.create(AuthenticationDescriptor.KEY_LDAP_ENABLED);
         ConfigurationFieldModel serverField = ConfigurationFieldModel.create(AuthenticationDescriptor.KEY_LDAP_SERVER);

--- a/src/test/java/com/synopsys/integration/alert/workflow/scheduled/PurgeTaskTest.java
+++ b/src/test/java/com/synopsys/integration/alert/workflow/scheduled/PurgeTaskTest.java
@@ -12,7 +12,7 @@ import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.exception.AlertDatabaseConstraintException;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
-import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
+import com.synopsys.integration.alert.common.persistence.model.mutable.ConfigurationModelMutable;
 import com.synopsys.integration.alert.component.scheduling.descriptor.SchedulingDescriptor;
 import com.synopsys.integration.alert.component.scheduling.descriptor.SchedulingDescriptorKey;
 
@@ -21,15 +21,15 @@ public class PurgeTaskTest {
     @Test
     public void cronExpressionNotDefault() throws AlertDatabaseConstraintException {
         final String notDefaultValue = "44";
-        final ConfigurationAccessor configurationAccessor = Mockito.mock(ConfigurationAccessor.class);
-        final ConfigurationModel configurationModel = new ConfigurationModel(1L, 1L, null, null, ConfigContextEnum.GLOBAL);
-        final ConfigurationFieldModel configurationFieldModel = ConfigurationFieldModel.create(SchedulingDescriptor.KEY_PURGE_DATA_FREQUENCY_DAYS);
+        ConfigurationAccessor configurationAccessor = Mockito.mock(ConfigurationAccessor.class);
+        ConfigurationModelMutable configurationModel = new ConfigurationModelMutable(1L, 1L, null, null, ConfigContextEnum.GLOBAL);
+        ConfigurationFieldModel configurationFieldModel = ConfigurationFieldModel.create(SchedulingDescriptor.KEY_PURGE_DATA_FREQUENCY_DAYS);
         configurationFieldModel.setFieldValue(notDefaultValue);
         configurationModel.put(configurationFieldModel);
         Mockito.when(configurationAccessor.getConfigurationsByDescriptorKey(Mockito.any(DescriptorKey.class))).thenReturn(List.of(configurationModel));
-        final PurgeTask task = new PurgeTask(new SchedulingDescriptorKey(), null, null, null, null, configurationAccessor);
-        final String cronWithNotDefault = task.scheduleCronExpression();
-        final String expectedCron = String.format(PurgeTask.CRON_FORMAT, notDefaultValue);
+        PurgeTask task = new PurgeTask(new SchedulingDescriptorKey(), null, null, null, null, configurationAccessor);
+        String cronWithNotDefault = task.scheduleCronExpression();
+        String expectedCron = String.format(PurgeTask.CRON_FORMAT, notDefaultValue);
 
         assertEquals(expectedCron, cronWithNotDefault);
     }

--- a/src/test/java/com/synopsys/integration/alert/workflow/scheduled/frequency/DailyTaskTest.java
+++ b/src/test/java/com/synopsys/integration/alert/workflow/scheduled/frequency/DailyTaskTest.java
@@ -13,7 +13,7 @@ import com.synopsys.integration.alert.common.enumeration.FrequencyType;
 import com.synopsys.integration.alert.common.exception.AlertDatabaseConstraintException;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
-import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
+import com.synopsys.integration.alert.common.persistence.model.mutable.ConfigurationModelMutable;
 import com.synopsys.integration.alert.common.workflow.task.ScheduledTask;
 import com.synopsys.integration.alert.component.scheduling.descriptor.SchedulingDescriptor;
 import com.synopsys.integration.alert.component.scheduling.descriptor.SchedulingDescriptorKey;
@@ -37,7 +37,7 @@ public class DailyTaskTest {
     public void cronExpressionNotDefault() throws AlertDatabaseConstraintException {
         final String notDefaultValue = "44";
         ConfigurationAccessor configurationAccessor = Mockito.mock(ConfigurationAccessor.class);
-        ConfigurationModel configurationModel = new ConfigurationModel(1L, 1L, null, null, ConfigContextEnum.GLOBAL);
+        ConfigurationModelMutable configurationModel = new ConfigurationModelMutable(1L, 1L, null, null, ConfigContextEnum.GLOBAL);
         ConfigurationFieldModel configurationFieldModel = ConfigurationFieldModel.create(SchedulingDescriptor.KEY_DAILY_PROCESSOR_HOUR_OF_DAY);
         configurationFieldModel.setFieldValue(notDefaultValue);
         configurationModel.put(configurationFieldModel);


### PR DESCRIPTION
After discussing with Gavin, we decided rather to use a builder to instead separate the model into having a mutable and immutable version, where the mutable is a subclass of main ConfigurationModel by removing the put method. 

Let me know if there are any questions related to the refactor or tests.