### PR TITLE
Move unreferenced SAML Beans out of AuthenticationHandler

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SamlConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SamlConfig.java
@@ -1,0 +1,94 @@
+/**
+ * blackduck-alert
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.alert.web.security.authentication.saml;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.saml.SAMLBootstrap;
+import org.springframework.security.saml.context.SAMLContextProviderImpl;
+import org.springframework.security.saml.log.SAMLDefaultLogger;
+import org.springframework.security.saml.parser.ParserPoolHolder;
+import org.springframework.security.saml.websso.SingleLogoutProfile;
+import org.springframework.security.saml.websso.SingleLogoutProfileImpl;
+import org.springframework.security.saml.websso.WebSSOProfile;
+import org.springframework.security.saml.websso.WebSSOProfileConsumer;
+import org.springframework.security.saml.websso.WebSSOProfileConsumerHoKImpl;
+import org.springframework.security.saml.websso.WebSSOProfileConsumerImpl;
+import org.springframework.security.saml.websso.WebSSOProfileImpl;
+
+@Configuration
+public class SamlConfig {
+    @Bean
+    public static SAMLBootstrap SAMLBootstrap() {
+        return new SAMLBootstrap();
+    }
+
+    @Bean
+    public SAMLDefaultLogger samlLogger() {
+        return new SAMLDefaultLogger();
+    }
+
+    @Bean
+    public SAMLContextProviderImpl contextProvider() {
+        return new SAMLContextProviderImpl();
+    }
+
+    // SAML 2.0 WebSSO Assertion Consumer
+    @Bean
+    public WebSSOProfileConsumer webSSOprofileConsumer() {
+        // If the machine running Alert has a different time than the SSO system the maximum difference allowed by default is 60 seconds
+        // setResponseSkew(...) to change the skew time if needed
+        return new WebSSOProfileConsumerImpl();
+    }
+
+    // SAML 2.0 Web SSO profile
+    @Bean
+    public WebSSOProfile webSSOprofile() {
+        return new WebSSOProfileImpl();
+    }
+
+    // not used but autowired...
+    // SAML 2.0 Holder-of-Key WebSSO Assertion Consumer
+    @Bean
+    public WebSSOProfileConsumerHoKImpl hokWebSSOprofileConsumer() {
+        return new WebSSOProfileConsumerHoKImpl();
+    }
+
+    // not used but autowired...
+    // SAML 2.0 Holder-of-Key Web SSO profile
+    @Bean
+    public WebSSOProfileConsumerHoKImpl hokWebSSOProfile() {
+        return new WebSSOProfileConsumerHoKImpl();
+    }
+
+    @Bean
+    public SingleLogoutProfile logoutProfile() {
+        return new SingleLogoutProfileImpl();
+    }
+
+    @Bean(name = "parserPoolHolder")
+    public ParserPoolHolder parserPoolHolder() {
+        return new ParserPoolHolder();
+    }
+
+}


### PR DESCRIPTION
This is an attempt to remove the clutter in AuthenticationHandler. 