### PR TITLE
Refactor validation functions into a ValidationResult object

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/action/UploadEndpointManager.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/action/UploadEndpointManager.java
@@ -150,13 +150,13 @@ public class UploadEndpointManager {
             if (validationFunction.isPresent()) {
                 writeFile(tempFilename, fileResource);
                 File fileToValidate = filePersistenceUtil.createUploadsFile(tempFilename);
-                ValidationResult errors = validationFunction.get().apply(fileToValidate);
+                ValidationResult validationResult = validationFunction.get().apply(fileToValidate);
                 filePersistenceUtil.delete(fileToValidate);
-                if (!errors.hasErrors()) {
+                if (!validationResult.hasErrors()) {
                     writeFile(targetFilename, fileResource);
                     return responseFactory.createCreatedResponse("", "File uploaded.");
                 }
-                return responseFactory.createBadRequestResponse("", errors.combineErrorMessages());
+                return responseFactory.createBadRequestResponse("", validationResult.combineErrorMessages());
             } else {
                 writeFile(targetFilename, fileResource);
                 return responseFactory.createCreatedResponse("", "File uploaded.");

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/action/UploadEndpointManager.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/action/UploadEndpointManager.java
@@ -25,12 +25,10 @@ package com.synopsys.integration.alert.common.action;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +41,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.synopsys.integration.alert.common.descriptor.DescriptorKey;
 import com.synopsys.integration.alert.common.descriptor.config.field.validators.UploadValidationFunction;
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
@@ -151,13 +150,13 @@ public class UploadEndpointManager {
             if (validationFunction.isPresent()) {
                 writeFile(tempFilename, fileResource);
                 File fileToValidate = filePersistenceUtil.createUploadsFile(tempFilename);
-                Collection<String> errors = validationFunction.get().apply(fileToValidate);
+                ValidationResult errors = validationFunction.get().apply(fileToValidate);
                 filePersistenceUtil.delete(fileToValidate);
-                if (errors.isEmpty()) {
+                if (!errors.hasErrors()) {
                     writeFile(targetFilename, fileResource);
                     return responseFactory.createCreatedResponse("", "File uploaded.");
                 }
-                return responseFactory.createBadRequestResponse("", StringUtils.join(errors, ","));
+                return responseFactory.createBadRequestResponse("", errors.combineErrorMessages());
             } else {
                 writeFile(targetFilename, fileResource);
                 return responseFactory.createCreatedResponse("", "File uploaded.");

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/CheckboxConfigField.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/CheckboxConfigField.java
@@ -48,10 +48,10 @@ public class CheckboxConfigField extends ConfigField {
             boolean trueTextPresent = Boolean.TRUE.toString().equalsIgnoreCase(value);
             boolean falseTextPresent = Boolean.FALSE.toString().equalsIgnoreCase(value);
             if (!trueTextPresent && !falseTextPresent) {
-                ValidationResult.of("Not a boolean value 'true' or 'false'");
+                ValidationResult.errors("Not a boolean value 'true' or 'false'");
             }
         }
-        return ValidationResult.of();
+        return ValidationResult.success();
     }
 
     @Override

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/CheckboxConfigField.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/CheckboxConfigField.java
@@ -22,12 +22,11 @@
  */
 package com.synopsys.integration.alert.common.descriptor.config.field;
 
-import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
 import com.synopsys.integration.alert.common.enumeration.FieldType;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
@@ -43,16 +42,16 @@ public class CheckboxConfigField extends ConfigField {
         applyDefaultValue(Boolean.FALSE.toString());
     }
 
-    private Collection<String> validateValueIsBoolean(FieldValueModel fieldToValidate, FieldModel fieldModel) {
+    private ValidationResult validateValueIsBoolean(FieldValueModel fieldToValidate, FieldModel fieldModel) {
         if (fieldToValidate.hasValues()) {
             String value = fieldToValidate.getValue().orElse("");
             boolean trueTextPresent = Boolean.TRUE.toString().equalsIgnoreCase(value);
             boolean falseTextPresent = Boolean.FALSE.toString().equalsIgnoreCase(value);
             if (!trueTextPresent && !falseTextPresent) {
-                List.of("Not a boolean value 'true' or 'false'");
+                ValidationResult.of("Not a boolean value 'true' or 'false'");
             }
         }
-        return List.of();
+        return ValidationResult.of();
     }
 
     @Override

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/ConfigField.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/ConfigField.java
@@ -205,7 +205,6 @@ public abstract class ConfigField extends AlertSerializableModel {
         if (!errors.hasErrors()) {
             for (ConfigValidationFunction validation : validationFunctions) {
                 if (null != validation) {
-                    //errors.addAll(validation.apply(fieldToValidate, fieldModel));
                     errors = ValidationResult.of(validation.apply(fieldToValidate, fieldModel));
                 }
             }
@@ -288,15 +287,15 @@ public abstract class ConfigField extends AlertSerializableModel {
 
     private ValidationResult validateRequiredField(FieldValueModel fieldToValidate) {
         if (isRequired() && fieldToValidate.containsNoData()) {
-            return ValidationResult.of(REQUIRED_FIELD_MISSING);
+            return ValidationResult.errors(REQUIRED_FIELD_MISSING);
         }
-        return ValidationResult.of();
+        return ValidationResult.success();
     }
 
     private ValidationResult validateLength(FieldValueModel fieldValueModel) {
         Collection<String> values = fieldValueModel.getValues();
         if (null == values) {
-            return ValidationResult.of();
+            return ValidationResult.success();
         }
 
         boolean tooLargeFound = values
@@ -304,9 +303,9 @@ public abstract class ConfigField extends AlertSerializableModel {
                                     .filter(StringUtils::isNotBlank)
                                     .anyMatch(value -> MAX_FIELD_LENGTH < value.length());
         if (tooLargeFound) {
-            return ValidationResult.of(FIELD_LENGTH_LARGE);
+            return ValidationResult.errors(FIELD_LENGTH_LARGE);
         }
-        return ValidationResult.of();
+        return ValidationResult.success();
     }
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/ConfigField.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/ConfigField.java
@@ -199,21 +199,6 @@ public abstract class ConfigField extends AlertSerializableModel {
         return validate(fieldToValidate, fieldModel, getValidationFunctions());
     }
 
-    /*
-    private ValidationResult validate(FieldValueModel fieldToValidate, FieldModel fieldModel, List<ConfigValidationFunction> validationFunctions) {
-        Collection<String> errors = new LinkedList<>();
-        validateRequiredField(fieldToValidate, errors);
-        validateLength(fieldToValidate, errors);
-
-        if (errors.isEmpty()) {
-            for (ConfigValidationFunction validation : validationFunctions) {
-                if (null != validation) {
-                    errors.addAll(validation.apply(fieldToValidate, fieldModel));
-                }
-            }
-        }
-        return ValidationResult.of(errors);
-    }*/
     private ValidationResult validate(FieldValueModel fieldToValidate, FieldModel fieldModel, List<ConfigValidationFunction> validationFunctions) {
         ValidationResult errors = ValidationResult.of(validateRequiredField(fieldToValidate), validateLength(fieldToValidate));
 
@@ -301,13 +286,6 @@ public abstract class ConfigField extends AlertSerializableModel {
         this.defaultValues = defaultValues;
     }
 
-    /*
-    private void validateRequiredField(FieldValueModel fieldToValidate, Collection<String> errors) {
-        if (isRequired() && fieldToValidate.containsNoData()) {
-            errors.add(REQUIRED_FIELD_MISSING);
-        }
-    }
-     */
     private ValidationResult validateRequiredField(FieldValueModel fieldToValidate) {
         if (isRequired() && fieldToValidate.containsNoData()) {
             return ValidationResult.of(REQUIRED_FIELD_MISSING);
@@ -315,22 +293,6 @@ public abstract class ConfigField extends AlertSerializableModel {
         return ValidationResult.of();
     }
 
-    /*
-    private void validateLength(FieldValueModel fieldValueModel, Collection<String> errors) {
-        Collection<String> values = fieldValueModel.getValues();
-        if (null == values) {
-            return;
-        }
-
-        boolean tooLargeFound = values
-                                    .stream()
-                                    .filter(StringUtils::isNotBlank)
-                                    .anyMatch(value -> MAX_FIELD_LENGTH < value.length());
-        if (tooLargeFound) {
-            errors.add(FIELD_LENGTH_LARGE);
-        }
-    }
-     */
     private ValidationResult validateLength(FieldValueModel fieldValueModel) {
         Collection<String> values = fieldValueModel.getValues();
         if (null == values) {

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/NumberConfigField.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/NumberConfigField.java
@@ -43,11 +43,11 @@ public class NumberConfigField extends ConfigField {
             try {
                 Integer.valueOf(value);
             } catch (NumberFormatException ex) {
-                return ValidationResult.of(NOT_AN_INTEGER_VALUE);
+                return ValidationResult.errors(NOT_AN_INTEGER_VALUE);
             }
         }
 
-        return ValidationResult.of();
+        return ValidationResult.success();
     }
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/NumberConfigField.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/NumberConfigField.java
@@ -22,9 +22,9 @@
  */
 package com.synopsys.integration.alert.common.descriptor.config.field;
 
-import java.util.Collection;
 import java.util.List;
 
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
 import com.synopsys.integration.alert.common.enumeration.FieldType;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
@@ -37,17 +37,17 @@ public class NumberConfigField extends ConfigField {
         createValidators(List.of(this::validateIsNumber), null);
     }
 
-    private Collection<String> validateIsNumber(FieldValueModel fieldToValidate, FieldModel fieldModel) {
+    private ValidationResult validateIsNumber(FieldValueModel fieldToValidate, FieldModel fieldModel) {
         if (fieldToValidate.hasValues()) {
             String value = fieldToValidate.getValue().orElse("");
             try {
                 Integer.valueOf(value);
             } catch (NumberFormatException ex) {
-                return List.of(NOT_AN_INTEGER_VALUE);
+                return ValidationResult.of(NOT_AN_INTEGER_VALUE);
             }
         }
 
-        return List.of();
+        return ValidationResult.of();
     }
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/SelectConfigField.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/SelectConfigField.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
 import com.synopsys.integration.alert.common.enumeration.FieldType;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
@@ -96,7 +97,7 @@ public class SelectConfigField extends ConfigField {
         return clearable;
     }
 
-    private Collection<String> validateIsValidOption(FieldValueModel fieldToValidate, FieldModel fieldModel) {
+    private ValidationResult validateIsValidOption(FieldValueModel fieldToValidate, FieldModel fieldModel) {
         Collection<LabelValueSelectOption> fieldOptions = getOptions();
         if (fieldToValidate.hasValues() && !fieldOptions.isEmpty()) {
             boolean doesMatchKnownReferral = fieldToValidate.getValues()
@@ -107,10 +108,10 @@ public class SelectConfigField extends ConfigField {
                                                                         .map(LabelValueSelectOption::getValue)
                                                                         .anyMatch(fieldOption -> fieldOption.equalsIgnoreCase(value)));
             if (!doesMatchKnownReferral) {
-                return List.of(INVALID_OPTION_SELECTED);
+                return ValidationResult.of(INVALID_OPTION_SELECTED);
             }
         }
-        return List.of();
+        return ValidationResult.of();
     }
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/SelectConfigField.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/SelectConfigField.java
@@ -108,10 +108,10 @@ public class SelectConfigField extends ConfigField {
                                                                         .map(LabelValueSelectOption::getValue)
                                                                         .anyMatch(fieldOption -> fieldOption.equalsIgnoreCase(value)));
             if (!doesMatchKnownReferral) {
-                return ValidationResult.of(INVALID_OPTION_SELECTED);
+                return ValidationResult.errors(INVALID_OPTION_SELECTED);
             }
         }
-        return ValidationResult.of();
+        return ValidationResult.success();
     }
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/URLInputConfigField.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/URLInputConfigField.java
@@ -24,11 +24,10 @@ package com.synopsys.integration.alert.common.descriptor.config.field;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Collection;
-import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
 
@@ -39,16 +38,16 @@ public class URLInputConfigField extends TextInputConfigField {
         applyValidationFunctions(this::validateURL);
     }
 
-    private Collection<String> validateURL(FieldValueModel fieldValueModel, FieldModel fieldModel) {
+    private ValidationResult validateURL(FieldValueModel fieldValueModel, FieldModel fieldModel) {
         String url = fieldValueModel.getValue().orElse("");
         if (StringUtils.isNotBlank(url)) {
             try {
                 new URL(url);
             } catch (MalformedURLException e) {
-                return List.of(e.getMessage());
+                return ValidationResult.of(e.getMessage());
             }
         }
 
-        return List.of();
+        return ValidationResult.of();
     }
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/URLInputConfigField.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/URLInputConfigField.java
@@ -44,10 +44,10 @@ public class URLInputConfigField extends TextInputConfigField {
             try {
                 new URL(url);
             } catch (MalformedURLException e) {
-                return ValidationResult.of(e.getMessage());
+                return ValidationResult.errors(e.getMessage());
             }
         }
 
-        return ValidationResult.of();
+        return ValidationResult.success();
     }
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/ConfigValidationFunction.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/ConfigValidationFunction.java
@@ -22,12 +22,11 @@
  */
 package com.synopsys.integration.alert.common.descriptor.config.field.validators;
 
-import java.util.Collection;
 import java.util.function.BiFunction;
 
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
 
 @FunctionalInterface
-public interface ConfigValidationFunction extends BiFunction<FieldValueModel, FieldModel, Collection<String>> {
+public interface ConfigValidationFunction extends BiFunction<FieldValueModel, FieldModel, ValidationResult> {
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/EncryptionSettingsValidator.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/EncryptionSettingsValidator.java
@@ -42,9 +42,9 @@ public final class EncryptionSettingsValidator extends EncryptionValidator {
     @Override
     public ValidationResult apply(FieldValueModel fieldValueModel, FieldModel fieldModel) {
         if (encryptionUtility.isInitialized()) {
-            return ValidationResult.of();
+            return ValidationResult.success();
         }
-        return ValidationResult.of(ENCRYPTION_MISSING);
+        return ValidationResult.errors(ENCRYPTION_MISSING);
     }
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/EncryptionSettingsValidator.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/EncryptionSettingsValidator.java
@@ -43,7 +43,6 @@ public final class EncryptionSettingsValidator extends EncryptionValidator {
     public ValidationResult apply(FieldValueModel fieldValueModel, FieldModel fieldModel) {
         if (encryptionUtility.isInitialized()) {
             return ValidationResult.of();
-            //return List.of();
         }
         return ValidationResult.of(ENCRYPTION_MISSING);
     }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/EncryptionSettingsValidator.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/EncryptionSettingsValidator.java
@@ -22,9 +22,6 @@
  */
 package com.synopsys.integration.alert.common.descriptor.config.field.validators;
 
-import java.util.Collection;
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -43,11 +40,12 @@ public final class EncryptionSettingsValidator extends EncryptionValidator {
     }
 
     @Override
-    public Collection<String> apply(FieldValueModel fieldValueModel, FieldModel fieldModel) {
+    public ValidationResult apply(FieldValueModel fieldValueModel, FieldModel fieldModel) {
         if (encryptionUtility.isInitialized()) {
-            return List.of();
+            return ValidationResult.of();
+            //return List.of();
         }
-        return List.of(ENCRYPTION_MISSING);
+        return ValidationResult.of(ENCRYPTION_MISSING);
     }
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/UploadValidationFunction.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/UploadValidationFunction.java
@@ -23,9 +23,8 @@
 package com.synopsys.integration.alert.common.descriptor.config.field.validators;
 
 import java.io.File;
-import java.util.Collection;
 import java.util.function.Function;
 
 @FunctionalInterface
-public interface UploadValidationFunction extends Function<File, Collection<String>> {
+public interface UploadValidationFunction extends Function<File, ValidationResult> {
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/ValidationResult.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/ValidationResult.java
@@ -22,16 +22,36 @@
  */
 package com.synopsys.integration.alert.common.descriptor.config.field.validators;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
 public class ValidationResult {
 
     private Collection<String> errors;
+
+    public static ValidationResult success() {
+        return new ValidationResult();
+    }
+
+    public static ValidationResult errors(Collection<String> errors) {
+        return new ValidationResult(errors);
+    }
+
+    public static ValidationResult errors(String... errors) {
+        return new ValidationResult(Arrays.asList(errors));
+    }
+
+    public static ValidationResult of(ValidationResult... validationResults) {
+        Collection<String> validationErrors = Arrays.stream(validationResults)
+                                                  .map(ValidationResult::getErrors)
+                                                  .flatMap(Collection::stream)
+                                                  .collect(Collectors.toList());
+        return new ValidationResult(validationErrors);
+    }
 
     private ValidationResult() {
         this.errors = List.of();
@@ -51,25 +71,5 @@ public class ValidationResult {
 
     public String combineErrorMessages() {
         return StringUtils.join(errors, ", ");
-    }
-
-    public static ValidationResult of() {
-        return new ValidationResult();
-    }
-
-    public static ValidationResult of(Collection<String> errors) {
-        return new ValidationResult(errors);
-    }
-
-    public static ValidationResult of(String... errors) {
-        return new ValidationResult(Arrays.asList(errors));
-    }
-
-    public static ValidationResult of(ValidationResult... validationResults) {
-        Collection<String> newValidationResult = new ArrayList(validationResults.length);
-        for (ValidationResult result : validationResults) {
-            newValidationResult.addAll(result.getErrors());
-        }
-        return new ValidationResult(newValidationResult);
     }
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/ValidationResult.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/ValidationResult.java
@@ -1,0 +1,78 @@
+/**
+ * alert-common
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.alert.common.descriptor.config.field.validators;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class ValidationResult {
+
+    private Collection<String> errors;
+
+    private ValidationResult() {
+        this.errors = List.of();
+    }
+
+    private ValidationResult(Collection<String> errors) {
+        this.errors = errors;
+    }
+
+    public Collection<String> getErrors() {
+        return errors;
+    }
+
+    public boolean hasErrors() {
+        return !errors.isEmpty();
+    }
+
+    public String combineErrorMessages() {
+        //loop through the list and combine the error messages
+        //Look into StringBuilder & StringUtils
+        //Stringable
+        return StringUtils.join(errors, ", ");
+    }
+
+    public static ValidationResult of() {
+        return new ValidationResult();
+    }
+
+    public static ValidationResult of(Collection<String> errors) {
+        return new ValidationResult(errors);
+    }
+
+    public static ValidationResult of(String... errors) {
+        return new ValidationResult(Arrays.asList(errors));
+    }
+
+    public static ValidationResult of(ValidationResult... validationResults) {
+        Collection<String> newValidationResult = new ArrayList(validationResults.length);
+        for (ValidationResult result : validationResults) {
+            newValidationResult.addAll(result.getErrors());
+        }
+        return new ValidationResult(newValidationResult);
+    }
+}

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/ValidationResult.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/ValidationResult.java
@@ -50,9 +50,6 @@ public class ValidationResult {
     }
 
     public String combineErrorMessages() {
-        //loop through the list and combine the error messages
-        //Look into StringBuilder & StringUtils
-        //Stringable
         return StringUtils.join(errors, ", ");
     }
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderDistributionUIConfig.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderDistributionUIConfig.java
@@ -148,10 +148,10 @@ public abstract class ProviderDistributionUIConfig extends UIConfig {
             try {
                 Pattern.compile(projectNamePattern);
             } catch (PatternSyntaxException e) {
-                return ValidationResult.of("Project name pattern is not a regular expression. " + e.getMessage());
+                return ValidationResult.errors("Project name pattern is not a regular expression. " + e.getMessage());
             }
         }
-        return ValidationResult.of();
+        return ValidationResult.success();
     }
 
     private ValidationResult validateConfiguredProject(FieldValueModel fieldToValidate, FieldModel fieldModel) {
@@ -160,9 +160,9 @@ public abstract class ProviderDistributionUIConfig extends UIConfig {
         String projectNamePattern = fieldModel.getFieldValueModel(KEY_PROJECT_NAME_PATTERN).flatMap(FieldValueModel::getValue).orElse(null);
         boolean missingProject = configuredProjects.isEmpty() && StringUtils.isBlank(projectNamePattern);
         if (filterByProject && missingProject) {
-            return ValidationResult.of("You must select at least one project.");
+            return ValidationResult.errors("You must select at least one project.");
         }
-        return ValidationResult.of();
+        return ValidationResult.success();
     }
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderDistributionUIConfig.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderDistributionUIConfig.java
@@ -42,6 +42,7 @@ import com.synopsys.integration.alert.common.descriptor.config.field.TextInputCo
 import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.EndpointSelectField;
 import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.table.EndpointTableSelectField;
 import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.table.TableSelectColumn;
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
 import com.synopsys.integration.alert.common.enumeration.ProcessingType;
 import com.synopsys.integration.alert.common.provider.ProviderContent;
 import com.synopsys.integration.alert.common.provider.ProviderNotificationType;
@@ -141,27 +142,27 @@ public abstract class ProviderDistributionUIConfig extends UIConfig {
         return formatDescription.toString();
     }
 
-    private Collection<String> validateProjectNamePattern(FieldValueModel fieldToValidate, FieldModel fieldModel) {
+    private ValidationResult validateProjectNamePattern(FieldValueModel fieldToValidate, FieldModel fieldModel) {
         String projectNamePattern = fieldToValidate.getValue().orElse(null);
         if (StringUtils.isNotBlank(projectNamePattern)) {
             try {
                 Pattern.compile(projectNamePattern);
             } catch (PatternSyntaxException e) {
-                return List.of("Project name pattern is not a regular expression. " + e.getMessage());
+                return ValidationResult.of("Project name pattern is not a regular expression. " + e.getMessage());
             }
         }
-        return List.of();
+        return ValidationResult.of();
     }
 
-    private Collection<String> validateConfiguredProject(FieldValueModel fieldToValidate, FieldModel fieldModel) {
+    private ValidationResult validateConfiguredProject(FieldValueModel fieldToValidate, FieldModel fieldModel) {
         Collection<String> configuredProjects = Optional.ofNullable(fieldToValidate.getValues()).orElse(List.of());
         boolean filterByProject = fieldModel.getFieldValueModel(KEY_FILTER_BY_PROJECT).flatMap(FieldValueModel::getValue).map(Boolean::parseBoolean).orElse(false);
         String projectNamePattern = fieldModel.getFieldValueModel(KEY_PROJECT_NAME_PATTERN).flatMap(FieldValueModel::getValue).orElse(null);
         boolean missingProject = configuredProjects.isEmpty() && StringUtils.isBlank(projectNamePattern);
         if (filterByProject && missingProject) {
-            return List.of("You must select at least one project.");
+            return ValidationResult.of("You must select at least one project.");
         }
-        return List.of();
+        return ValidationResult.of();
     }
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderGlobalUIConfig.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderGlobalUIConfig.java
@@ -80,7 +80,7 @@ public abstract class ProviderGlobalUIConfig extends UIConfig {
         try {
             List<ConfigurationModel> configurations = configurationAccessor.getConfigurationsByDescriptorType(DescriptorType.PROVIDER);
             if (configurations.isEmpty()) {
-                return ValidationResult.of();
+                return ValidationResult.success();
             }
 
             List<ConfigurationModel> modelsWithName = configurations.stream()
@@ -102,6 +102,6 @@ public abstract class ProviderGlobalUIConfig extends UIConfig {
         } catch (AlertDatabaseConstraintException ex) {
             logger.error("Error reading provider configurations to detect duplicate names.", ex);
         }
-        return ValidationResult.of(errorList);
+        return ValidationResult.errors(errorList);
     }
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderGlobalUIConfig.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderGlobalUIConfig.java
@@ -22,7 +22,6 @@
  */
 package com.synopsys.integration.alert.common.descriptor.config.ui;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -34,6 +33,7 @@ import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.descriptor.config.field.CheckboxConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.ConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.TextInputConfigField;
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.enumeration.DescriptorType;
 import com.synopsys.integration.alert.common.exception.AlertDatabaseConstraintException;
@@ -75,12 +75,12 @@ public abstract class ProviderGlobalUIConfig extends UIConfig {
         return providerKey;
     }
 
-    private Collection<String> validateDuplicateNames(FieldValueModel fieldToValidate, FieldModel fieldModel) {
+    private ValidationResult validateDuplicateNames(FieldValueModel fieldToValidate, FieldModel fieldModel) {
         List<String> errorList = List.of();
         try {
             List<ConfigurationModel> configurations = configurationAccessor.getConfigurationsByDescriptorType(DescriptorType.PROVIDER);
             if (configurations.isEmpty()) {
-                return List.of();
+                return ValidationResult.of();
             }
 
             List<ConfigurationModel> modelsWithName = configurations.stream()
@@ -102,6 +102,6 @@ public abstract class ProviderGlobalUIConfig extends UIConfig {
         } catch (AlertDatabaseConstraintException ex) {
             logger.error("Error reading provider configurations to detect duplicate names.", ex);
         }
-        return errorList;
+        return ValidationResult.of(errorList);
     }
 }

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/ConfigurationFieldModelTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/ConfigurationFieldModelTest.java
@@ -46,7 +46,7 @@ public class ConfigurationFieldModelTest {
 
     private List<ConfigField> createConfigFields() {
         EncryptionSettingsValidator encryptionValidator = Mockito.mock(EncryptionSettingsValidator.class);
-        Mockito.when(encryptionValidator.apply(Mockito.any(), Mockito.any())).thenReturn(ValidationResult.of());
+        Mockito.when(encryptionValidator.apply(Mockito.any(), Mockito.any())).thenReturn(ValidationResult.success());
         return List.of(new TextInputConfigField(KEY_FIELD_1, KEY_FIELD_1, DESCRIPTION_1), new PasswordConfigField(KEY_FIELD_2, KEY_FIELD_2, DESCRIPTION_2, encryptionValidator));
     }
 

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/ConfigurationFieldModelTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/ConfigurationFieldModelTest.java
@@ -17,6 +17,7 @@ import com.synopsys.integration.alert.common.descriptor.config.field.ConfigField
 import com.synopsys.integration.alert.common.descriptor.config.field.PasswordConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.TextInputConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.validators.EncryptionSettingsValidator;
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.common.persistence.accessor.DescriptorAccessor;
@@ -45,7 +46,7 @@ public class ConfigurationFieldModelTest {
 
     private List<ConfigField> createConfigFields() {
         EncryptionSettingsValidator encryptionValidator = Mockito.mock(EncryptionSettingsValidator.class);
-        Mockito.when(encryptionValidator.apply(Mockito.any(), Mockito.any())).thenReturn(List.of());
+        Mockito.when(encryptionValidator.apply(Mockito.any(), Mockito.any())).thenReturn(ValidationResult.of());
         return List.of(new TextInputConfigField(KEY_FIELD_1, KEY_FIELD_1, DESCRIPTION_1), new PasswordConfigField(KEY_FIELD_2, KEY_FIELD_2, DESCRIPTION_2, encryptionValidator));
     }
 

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/action/UploadEndpointManagerTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/action/UploadEndpointManagerTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +19,7 @@ import org.springframework.http.ResponseEntity;
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.common.descriptor.DescriptorKey;
 import com.synopsys.integration.alert.common.descriptor.config.field.validators.UploadValidationFunction;
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
@@ -105,7 +105,7 @@ public class UploadEndpointManagerTest {
         UploadEndpointManager manager = new UploadEndpointManager(gson, filePersistenceUtil, authorizationManager, responseFactory);
         Mockito.when(authorizationManager.hasUploadWritePermission(Mockito.anyString(), Mockito.anyString())).thenReturn(Boolean.TRUE);
 
-        UploadValidationFunction validationFunction = (file) -> List.of();
+        UploadValidationFunction validationFunction = (file) -> ValidationResult.of();
         manager.registerTarget(TEST_TARGET_KEY, ConfigContextEnum.GLOBAL, descriptorKey, TEST_FILE_NAME, validationFunction);
         assertTrue(manager.containsTarget(TEST_TARGET_KEY));
         ResponseEntity<String> response = manager.performUpload(TEST_TARGET_KEY, testResource);
@@ -117,7 +117,7 @@ public class UploadEndpointManagerTest {
         UploadEndpointManager manager = new UploadEndpointManager(gson, filePersistenceUtil, authorizationManager, responseFactory);
         Mockito.when(authorizationManager.hasUploadWritePermission(Mockito.anyString(), Mockito.anyString())).thenReturn(Boolean.TRUE);
 
-        UploadValidationFunction validationFunction = (file) -> List.of("validation error");
+        UploadValidationFunction validationFunction = (file) -> ValidationResult.of("validation error");
         manager.registerTarget(TEST_TARGET_KEY, ConfigContextEnum.GLOBAL, descriptorKey, TEST_FILE_NAME, validationFunction);
         assertTrue(manager.containsTarget(TEST_TARGET_KEY));
         ResponseEntity<String> response = manager.performUpload(TEST_TARGET_KEY, testResource);

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/action/UploadEndpointManagerTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/action/UploadEndpointManagerTest.java
@@ -105,7 +105,7 @@ public class UploadEndpointManagerTest {
         UploadEndpointManager manager = new UploadEndpointManager(gson, filePersistenceUtil, authorizationManager, responseFactory);
         Mockito.when(authorizationManager.hasUploadWritePermission(Mockito.anyString(), Mockito.anyString())).thenReturn(Boolean.TRUE);
 
-        UploadValidationFunction validationFunction = (file) -> ValidationResult.of();
+        UploadValidationFunction validationFunction = (file) -> ValidationResult.success();
         manager.registerTarget(TEST_TARGET_KEY, ConfigContextEnum.GLOBAL, descriptorKey, TEST_FILE_NAME, validationFunction);
         assertTrue(manager.containsTarget(TEST_TARGET_KEY));
         ResponseEntity<String> response = manager.performUpload(TEST_TARGET_KEY, testResource);
@@ -117,7 +117,7 @@ public class UploadEndpointManagerTest {
         UploadEndpointManager manager = new UploadEndpointManager(gson, filePersistenceUtil, authorizationManager, responseFactory);
         Mockito.when(authorizationManager.hasUploadWritePermission(Mockito.anyString(), Mockito.anyString())).thenReturn(Boolean.TRUE);
 
-        UploadValidationFunction validationFunction = (file) -> ValidationResult.of("validation error");
+        UploadValidationFunction validationFunction = (file) -> ValidationResult.errors("validation error");
         manager.registerTarget(TEST_TARGET_KEY, ConfigContextEnum.GLOBAL, descriptorKey, TEST_FILE_NAME, validationFunction);
         assertTrue(manager.containsTarget(TEST_TARGET_KEY));
         ResponseEntity<String> response = manager.performUpload(TEST_TARGET_KEY, testResource);

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/ValidationResultTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/ValidationResultTest.java
@@ -17,7 +17,7 @@ public class ValidationResultTest {
 
     @Test
     public void getErrorsTest() {
-        ValidationResult errors = ValidationResult.of(ERROR_MESSAGE_1);
+        ValidationResult errors = ValidationResult.errors(ERROR_MESSAGE_1);
         ArrayList<String> errorList = new ArrayList<>(errors.getErrors());
 
         assertEquals(1, errorList.size());
@@ -26,8 +26,8 @@ public class ValidationResultTest {
 
     @Test
     public void hasErrorsTest() {
-        ValidationResult errors = ValidationResult.of(ERROR_MESSAGE_1);
-        ValidationResult emptyErrors = ValidationResult.of();
+        ValidationResult errors = ValidationResult.errors(ERROR_MESSAGE_1);
+        ValidationResult emptyErrors = ValidationResult.success();
 
         assertTrue(errors.hasErrors());
         assertFalse(emptyErrors.hasErrors());
@@ -36,7 +36,7 @@ public class ValidationResultTest {
     @Test
     public void combineErrorMessages() {
         List<String> listOfErrorStrings = List.of(ERROR_MESSAGE_1, ERROR_MESSAGE_2);
-        ValidationResult errors = ValidationResult.of(listOfErrorStrings);
+        ValidationResult errors = ValidationResult.errors(listOfErrorStrings);
 
         String expectedString = StringUtils.join(listOfErrorStrings, ", ");
 
@@ -46,8 +46,8 @@ public class ValidationResultTest {
 
     @Test
     public void ofValidationResultTest() {
-        ValidationResult error1 = ValidationResult.of(ERROR_MESSAGE_1);
-        ValidationResult error2 = ValidationResult.of(ERROR_MESSAGE_2);
+        ValidationResult error1 = ValidationResult.errors(ERROR_MESSAGE_1);
+        ValidationResult error2 = ValidationResult.errors(ERROR_MESSAGE_2);
 
         ValidationResult combinedErrors = ValidationResult.of(error1, error2);
         Collection<String> errorList = combinedErrors.getErrors();

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/ValidationResultTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/descriptor/config/field/validators/ValidationResultTest.java
@@ -1,0 +1,60 @@
+package com.synopsys.integration.alert.common.descriptor.config.field.validators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+public class ValidationResultTest {
+    private final String ERROR_MESSAGE_1 = "Error Message 1";
+    private final String ERROR_MESSAGE_2 = "Error Message 2";
+
+    @Test
+    public void getErrorsTest() {
+        ValidationResult errors = ValidationResult.of(ERROR_MESSAGE_1);
+        ArrayList<String> errorList = new ArrayList<>(errors.getErrors());
+
+        assertEquals(1, errorList.size());
+        assertEquals(ERROR_MESSAGE_1, errorList.get(0));
+    }
+
+    @Test
+    public void hasErrorsTest() {
+        ValidationResult errors = ValidationResult.of(ERROR_MESSAGE_1);
+        ValidationResult emptyErrors = ValidationResult.of();
+
+        assertTrue(errors.hasErrors());
+        assertFalse(emptyErrors.hasErrors());
+    }
+
+    @Test
+    public void combineErrorMessages() {
+        List<String> listOfErrorStrings = List.of(ERROR_MESSAGE_1, ERROR_MESSAGE_2);
+        ValidationResult errors = ValidationResult.of(listOfErrorStrings);
+
+        String expectedString = StringUtils.join(listOfErrorStrings, ", ");
+
+        assertEquals(2, errors.getErrors().size());
+        assertEquals(expectedString, errors.combineErrorMessages());
+    }
+
+    @Test
+    public void ofValidationResultTest() {
+        ValidationResult error1 = ValidationResult.of(ERROR_MESSAGE_1);
+        ValidationResult error2 = ValidationResult.of(ERROR_MESSAGE_2);
+
+        ValidationResult combinedErrors = ValidationResult.of(error1, error2);
+        Collection<String> errorList = combinedErrors.getErrors();
+
+        assertEquals(2, errorList.size());
+        assertTrue(errorList.contains(ERROR_MESSAGE_1));
+        assertTrue(errorList.contains(ERROR_MESSAGE_2));
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/alert/channel/email/descriptor/EmailDistributionUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/email/descriptor/EmailDistributionUIConfig.java
@@ -99,10 +99,10 @@ public class EmailDistributionUIConfig extends ChannelDistributionUIConfig {
                                                  .filter(additionalEmailAddresses -> !additionalEmailAddresses.isEmpty())
                                                  .isPresent();
             if (!hasAdditionalAddresses) {
-                return ValidationResult.of("No additional email addresses were provided.");
+                return ValidationResult.errors("No additional email addresses were provided.");
             }
         }
-        return ValidationResult.of();
+        return ValidationResult.success();
     }
 
 }

--- a/src/main/java/com/synopsys/integration/alert/channel/email/descriptor/EmailDistributionUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/email/descriptor/EmailDistributionUIConfig.java
@@ -22,9 +22,7 @@
  */
 package com.synopsys.integration.alert.channel.email.descriptor;
 
-import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -41,6 +39,7 @@ import com.synopsys.integration.alert.common.descriptor.config.field.SelectConfi
 import com.synopsys.integration.alert.common.descriptor.config.field.TextInputConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.table.EndpointTableSelectField;
 import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.table.TableSelectColumn;
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
 import com.synopsys.integration.alert.common.descriptor.config.ui.ChannelDistributionUIConfig;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
@@ -91,7 +90,7 @@ public class EmailDistributionUIConfig extends ChannelDistributionUIConfig {
         return List.of(subjectLine, additionalEmailAddresses, additionalEmailAddressesOnly, projectOwnerOnly, attachmentFormat);
     }
 
-    private Collection<String> validateAdditionalEmailAddressesOnly(FieldValueModel fieldToValidate, FieldModel fieldModel) {
+    private ValidationResult validateAdditionalEmailAddressesOnly(FieldValueModel fieldToValidate, FieldModel fieldModel) {
         boolean useOnlyAdditionalEmailAddresses = fieldToValidate.getValue().map(Boolean::parseBoolean).orElse(false);
         if (useOnlyAdditionalEmailAddresses) {
             boolean hasAdditionalAddresses = fieldModel
@@ -100,10 +99,10 @@ public class EmailDistributionUIConfig extends ChannelDistributionUIConfig {
                                                  .filter(additionalEmailAddresses -> !additionalEmailAddresses.isEmpty())
                                                  .isPresent();
             if (!hasAdditionalAddresses) {
-                return Set.of("No additional email addresses were provided.");
+                return ValidationResult.of("No additional email addresses were provided.");
             }
         }
-        return Set.of();
+        return ValidationResult.of();
     }
 
 }

--- a/src/main/java/com/synopsys/integration/alert/component/authentication/descriptor/AuthenticationUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/component/authentication/descriptor/AuthenticationUIConfig.java
@@ -201,9 +201,9 @@ public class AuthenticationUIConfig extends UIConfig {
                                   .map(Boolean::valueOf)
                                   .orElse(false);
         if (samlEnabled && !fieldToValidate.hasValues() && !filePersistenceUtil.uploadFileExists(AuthenticationDescriptor.SAML_METADATA_FILE)) {
-            return ValidationResult.of(AuthenticationDescriptor.FIELD_ERROR_SAML_METADATA_URL_MISSING);
+            return ValidationResult.errors(AuthenticationDescriptor.FIELD_ERROR_SAML_METADATA_URL_MISSING);
         }
-        return ValidationResult.of();
+        return ValidationResult.success();
     }
 
     private ValidationResult validateMetaDataFile(FieldValueModel fieldToValidate, FieldModel fieldModel) {
@@ -215,10 +215,10 @@ public class AuthenticationUIConfig extends UIConfig {
             Optional<FieldValueModel> metadataUrlField = fieldModel.getFieldValueModel(AuthenticationDescriptor.KEY_SAML_METADATA_URL);
             boolean metadataUrlEmpty = metadataUrlField.map(field -> !field.hasValues()).orElse(true);
             if (metadataUrlEmpty && !filePersistenceUtil.uploadFileExists(AuthenticationDescriptor.SAML_METADATA_FILE)) {
-                return ValidationResult.of(AuthenticationDescriptor.FIELD_ERROR_SAML_METADATA_FILE_MISSING);
+                return ValidationResult.errors(AuthenticationDescriptor.FIELD_ERROR_SAML_METADATA_FILE_MISSING);
             }
         }
-        return ValidationResult.of();
+        return ValidationResult.success();
     }
 
 }

--- a/src/main/java/com/synopsys/integration/alert/component/authentication/descriptor/AuthenticationUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/component/authentication/descriptor/AuthenticationUIConfig.java
@@ -39,6 +39,7 @@ import com.synopsys.integration.alert.common.descriptor.config.field.SelectConfi
 import com.synopsys.integration.alert.common.descriptor.config.field.TextInputConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.UploadFileButtonField;
 import com.synopsys.integration.alert.common.descriptor.config.field.validators.EncryptionSettingsValidator;
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
 import com.synopsys.integration.alert.common.descriptor.config.ui.UIConfig;
 import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
@@ -194,18 +195,18 @@ public class AuthenticationUIConfig extends UIConfig {
         return List.of(userName, password, samlInfo);
     }
 
-    private Collection<String> validateMetaDataUrl(FieldValueModel fieldToValidate, FieldModel fieldModel) {
+    private ValidationResult validateMetaDataUrl(FieldValueModel fieldToValidate, FieldModel fieldModel) {
         Optional<FieldValueModel> samlEnabledField = fieldModel.getFieldValueModel(AuthenticationDescriptor.KEY_SAML_ENABLED);
         boolean samlEnabled = samlEnabledField.flatMap(FieldValueModel::getValue)
                                   .map(Boolean::valueOf)
                                   .orElse(false);
         if (samlEnabled && !fieldToValidate.hasValues() && !filePersistenceUtil.uploadFileExists(AuthenticationDescriptor.SAML_METADATA_FILE)) {
-            return List.of(AuthenticationDescriptor.FIELD_ERROR_SAML_METADATA_URL_MISSING);
+            return ValidationResult.of(AuthenticationDescriptor.FIELD_ERROR_SAML_METADATA_URL_MISSING);
         }
-        return List.of();
+        return ValidationResult.of();
     }
 
-    private Collection<String> validateMetaDataFile(FieldValueModel fieldToValidate, FieldModel fieldModel) {
+    private ValidationResult validateMetaDataFile(FieldValueModel fieldToValidate, FieldModel fieldModel) {
         Optional<FieldValueModel> samlEnabledField = fieldModel.getFieldValueModel(AuthenticationDescriptor.KEY_SAML_ENABLED);
         boolean samlEnabled = samlEnabledField.flatMap(FieldValueModel::getValue)
                                   .map(Boolean::valueOf)
@@ -214,10 +215,10 @@ public class AuthenticationUIConfig extends UIConfig {
             Optional<FieldValueModel> metadataUrlField = fieldModel.getFieldValueModel(AuthenticationDescriptor.KEY_SAML_METADATA_URL);
             boolean metadataUrlEmpty = metadataUrlField.map(field -> !field.hasValues()).orElse(true);
             if (metadataUrlEmpty && !filePersistenceUtil.uploadFileExists(AuthenticationDescriptor.SAML_METADATA_FILE)) {
-                return List.of(AuthenticationDescriptor.FIELD_ERROR_SAML_METADATA_FILE_MISSING);
+                return ValidationResult.of(AuthenticationDescriptor.FIELD_ERROR_SAML_METADATA_FILE_MISSING);
             }
         }
-        return List.of();
+        return ValidationResult.of();
     }
 
 }

--- a/src/main/java/com/synopsys/integration/alert/component/settings/descriptor/SettingsUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/component/settings/descriptor/SettingsUIConfig.java
@@ -35,6 +35,7 @@ import com.synopsys.integration.alert.common.descriptor.config.field.NumberConfi
 import com.synopsys.integration.alert.common.descriptor.config.field.PasswordConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.TextInputConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.validators.EncryptionValidator;
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
 import com.synopsys.integration.alert.common.descriptor.config.ui.UIConfig;
 import com.synopsys.integration.alert.common.rest.ProxyManager;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
@@ -114,33 +115,33 @@ public class SettingsUIConfig extends UIConfig {
         return List.of(proxyHost, proxyPort, proxyUsername, proxyPassword);
     }
 
-    private Collection<String> minimumEncryptionFieldLength(FieldValueModel fieldToValidate, FieldModel fieldModel) {
+    private ValidationResult minimumEncryptionFieldLength(FieldValueModel fieldToValidate, FieldModel fieldModel) {
         if (fieldToValidate.hasValues() && fieldToValidate.getValue().orElse("").length() < 8) {
-            return List.of(SettingsDescriptor.FIELD_ERROR_ENCRYPTION_FIELD_TOO_SHORT);
+            return ValidationResult.of(SettingsDescriptor.FIELD_ERROR_ENCRYPTION_FIELD_TOO_SHORT);
         }
-        return List.of();
+        return ValidationResult.of();
     }
 
     private class EncryptionFieldsSetValidator extends EncryptionValidator {
         @Override
-        public Collection<String> apply(FieldValueModel fieldValueModel, FieldModel fieldModel) {
+        public ValidationResult apply(FieldValueModel fieldValueModel, FieldModel fieldModel) {
             Function<FieldValueModel, Boolean> fieldSetCheck = field -> field.hasValues() || field.isSet();
             boolean pwdFieldSet = fieldModel.getFieldValueModel(SettingsDescriptor.KEY_ENCRYPTION_PWD).map(fieldSetCheck).orElse(false);
             boolean saltFieldSet = fieldModel.getFieldValueModel(SettingsDescriptor.KEY_ENCRYPTION_GLOBAL_SALT).map(fieldSetCheck).orElse(false);
             if (pwdFieldSet && saltFieldSet) {
-                return List.of();
+                return ValidationResult.of();
             }
-            return List.of(ConfigField.REQUIRED_FIELD_MISSING);
+            return ValidationResult.of(ConfigField.REQUIRED_FIELD_MISSING);
         }
     }
 
     private class EncryptionFieldValidator extends EncryptionValidator {
         @Override
-        public Collection<String> apply(FieldValueModel fieldValueModel, FieldModel fieldModel) {
+        public ValidationResult apply(FieldValueModel fieldValueModel, FieldModel fieldModel) {
             if (fieldValueModel.containsNoData() && !fieldValueModel.isSet()) {
-                return List.of(ConfigField.REQUIRED_FIELD_MISSING);
+                return ValidationResult.of(ConfigField.REQUIRED_FIELD_MISSING);
             }
-            return List.of();
+            return ValidationResult.of();
         }
     }
 

--- a/src/main/java/com/synopsys/integration/alert/component/settings/descriptor/SettingsUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/component/settings/descriptor/SettingsUIConfig.java
@@ -117,9 +117,9 @@ public class SettingsUIConfig extends UIConfig {
 
     private ValidationResult minimumEncryptionFieldLength(FieldValueModel fieldToValidate, FieldModel fieldModel) {
         if (fieldToValidate.hasValues() && fieldToValidate.getValue().orElse("").length() < 8) {
-            return ValidationResult.of(SettingsDescriptor.FIELD_ERROR_ENCRYPTION_FIELD_TOO_SHORT);
+            return ValidationResult.errors(SettingsDescriptor.FIELD_ERROR_ENCRYPTION_FIELD_TOO_SHORT);
         }
-        return ValidationResult.of();
+        return ValidationResult.success();
     }
 
     private class EncryptionFieldsSetValidator extends EncryptionValidator {
@@ -129,9 +129,9 @@ public class SettingsUIConfig extends UIConfig {
             boolean pwdFieldSet = fieldModel.getFieldValueModel(SettingsDescriptor.KEY_ENCRYPTION_PWD).map(fieldSetCheck).orElse(false);
             boolean saltFieldSet = fieldModel.getFieldValueModel(SettingsDescriptor.KEY_ENCRYPTION_GLOBAL_SALT).map(fieldSetCheck).orElse(false);
             if (pwdFieldSet && saltFieldSet) {
-                return ValidationResult.of();
+                return ValidationResult.success();
             }
-            return ValidationResult.of(ConfigField.REQUIRED_FIELD_MISSING);
+            return ValidationResult.errors(ConfigField.REQUIRED_FIELD_MISSING);
         }
     }
 
@@ -139,9 +139,9 @@ public class SettingsUIConfig extends UIConfig {
         @Override
         public ValidationResult apply(FieldValueModel fieldValueModel, FieldModel fieldModel) {
             if (fieldValueModel.containsNoData() && !fieldValueModel.isSet()) {
-                return ValidationResult.of(ConfigField.REQUIRED_FIELD_MISSING);
+                return ValidationResult.errors(ConfigField.REQUIRED_FIELD_MISSING);
             }
-            return ValidationResult.of();
+            return ValidationResult.success();
         }
     }
 

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckProviderUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckProviderUIConfig.java
@@ -22,7 +22,6 @@
  */
 package com.synopsys.integration.alert.provider.blackduck.descriptor;
 
-import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -34,6 +33,7 @@ import com.synopsys.integration.alert.common.descriptor.config.field.NumberConfi
 import com.synopsys.integration.alert.common.descriptor.config.field.PasswordConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.URLInputConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.validators.EncryptionSettingsValidator;
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
 import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderGlobalUIConfig;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
@@ -72,12 +72,12 @@ public class BlackDuckProviderUIConfig extends ProviderGlobalUIConfig {
         return List.of(blackDuckUrl, blackDuckApiKey, blackDuckTimeout);
     }
 
-    private Collection<String> validateAPIToken(FieldValueModel fieldToValidate, FieldModel fieldModel) {
+    private ValidationResult validateAPIToken(FieldValueModel fieldToValidate, FieldModel fieldModel) {
         String apiKey = fieldToValidate.getValue().orElse("");
         if (StringUtils.isNotBlank(apiKey) && (apiKey.length() < 64 || apiKey.length() > 256)) {
-            return List.of("Invalid Black Duck API Token.");
+            return ValidationResult.of("Invalid Black Duck API Token.");
         }
-        return List.of();
+        return ValidationResult.of();
     }
 
 }

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckProviderUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckProviderUIConfig.java
@@ -75,9 +75,9 @@ public class BlackDuckProviderUIConfig extends ProviderGlobalUIConfig {
     private ValidationResult validateAPIToken(FieldValueModel fieldToValidate, FieldModel fieldModel) {
         String apiKey = fieldToValidate.getValue().orElse("");
         if (StringUtils.isNotBlank(apiKey) && (apiKey.length() < 64 || apiKey.length() > 256)) {
-            return ValidationResult.of("Invalid Black Duck API Token.");
+            return ValidationResult.errors("Invalid Black Duck API Token.");
         }
-        return ValidationResult.of();
+        return ValidationResult.success();
     }
 
 }

--- a/src/main/java/com/synopsys/integration/alert/web/config/FieldValidationAction.java
+++ b/src/main/java/com/synopsys/integration/alert/web/config/FieldValidationAction.java
@@ -22,16 +22,15 @@
  */
 package com.synopsys.integration.alert.web.config;
 
-import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.common.descriptor.config.field.ConfigField;
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
 import com.synopsys.integration.alert.common.enumeration.FieldType;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
@@ -39,6 +38,7 @@ import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
 @Component
 public class FieldValidationAction {
     private final Logger logger = LoggerFactory.getLogger(FieldValidationAction.class);
+
     public void validateConfig(Map<String, ConfigField> descriptorFields, FieldModel fieldModel, Map<String, String> fieldErrors) {
         logger.debug("Begin validating fields in configuration field model.");
         for (Map.Entry<String, ConfigField> fieldEntry : descriptorFields.entrySet()) {
@@ -58,10 +58,10 @@ public class FieldValidationAction {
                 if (hasValueOrChecked(fieldValueModel, field.getType())) {
                     checkRelatedFields(field, descriptorFields, fieldModel, fieldErrors);
                 }
-                Collection<String> validationErrors = field.validate(fieldValueModel, fieldModel);
-                logger.debug("Validating '{}' errors: {}", key, validationErrors);
-                if (!validationErrors.isEmpty()) {
-                    fieldErrors.put(key, StringUtils.join(validationErrors, ", "));
+                ValidationResult validationResult = field.validate(fieldValueModel, fieldModel);
+                logger.debug("Validating '{}' errors: {}", key, validationResult);
+                if (validationResult.hasErrors()) {
+                    fieldErrors.put(key, validationResult.combineErrorMessages());
                 }
             }
         }

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SamlMetaDataFileUpload.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SamlMetaDataFileUpload.java
@@ -26,8 +26,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collection;
-import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -43,6 +41,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
 import com.synopsys.integration.alert.common.action.UploadEndpointManager;
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.component.authentication.descriptor.AuthenticationDescriptor;
@@ -57,7 +56,7 @@ public class SamlMetaDataFileUpload {
         uploadEndpointManager.registerTarget(AuthenticationDescriptor.KEY_SAML_METADATA_FILE, ConfigContextEnum.GLOBAL, descriptorKey, AuthenticationDescriptor.SAML_METADATA_FILE, this::validateXMLFile);
     }
 
-    private Collection<String> validateXMLFile(File file) {
+    private ValidationResult validateXMLFile(File file) {
 
         try (InputStream fileInputStream = new FileInputStream(file)) {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -68,9 +67,9 @@ public class SamlMetaDataFileUpload {
             builder.setErrorHandler(errorHandler);
             builder.parse(new InputSource(fileInputStream));
         } catch (ParserConfigurationException | SAXException | IOException ex) {
-            return List.of(String.format("XML file error: %s", ex.getMessage()));
+            return ValidationResult.of(String.format("XML file error: %s", ex.getMessage()));
         }
-        return List.of();
+        return ValidationResult.of();
     }
 
     private class XMLErrorHandler implements ErrorHandler {

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SamlMetaDataFileUpload.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SamlMetaDataFileUpload.java
@@ -67,9 +67,9 @@ public class SamlMetaDataFileUpload {
             builder.setErrorHandler(errorHandler);
             builder.parse(new InputSource(fileInputStream));
         } catch (ParserConfigurationException | SAXException | IOException ex) {
-            return ValidationResult.of(String.format("XML file error: %s", ex.getMessage()));
+            return ValidationResult.errors(String.format("XML file error: %s", ex.getMessage()));
         }
-        return ValidationResult.of();
+        return ValidationResult.success();
     }
 
     private class XMLErrorHandler implements ErrorHandler {

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckDescriptorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckDescriptorTest.java
@@ -2,13 +2,13 @@ package com.synopsys.integration.alert.provider.blackduck.descriptor;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.synopsys.integration.alert.common.descriptor.config.field.validators.EncryptionSettingsValidator;
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.model.DefinedFieldModel;
@@ -19,7 +19,7 @@ public class BlackDuckDescriptorTest {
     public void testGetDefinedFields() {
         EncryptionSettingsValidator encryptionValidator = Mockito.mock(EncryptionSettingsValidator.class);
         ConfigurationAccessor configurationAccessor = Mockito.mock(ConfigurationAccessor.class);
-        Mockito.when(encryptionValidator.apply(Mockito.any(), Mockito.any())).thenReturn(List.of());
+        Mockito.when(encryptionValidator.apply(Mockito.any(), Mockito.any())).thenReturn(ValidationResult.of());
         BlackDuckProviderKey blackDuckProviderKey = new BlackDuckProviderKey();
         BlackDuckContent blackDuckContent = new BlackDuckContent();
         BlackDuckDistributionUIConfig blackDuckDistributionUIConfig = new BlackDuckDistributionUIConfig(blackDuckContent);

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckDescriptorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckDescriptorTest.java
@@ -19,7 +19,7 @@ public class BlackDuckDescriptorTest {
     public void testGetDefinedFields() {
         EncryptionSettingsValidator encryptionValidator = Mockito.mock(EncryptionSettingsValidator.class);
         ConfigurationAccessor configurationAccessor = Mockito.mock(ConfigurationAccessor.class);
-        Mockito.when(encryptionValidator.apply(Mockito.any(), Mockito.any())).thenReturn(ValidationResult.of());
+        Mockito.when(encryptionValidator.apply(Mockito.any(), Mockito.any())).thenReturn(ValidationResult.success());
         BlackDuckProviderKey blackDuckProviderKey = new BlackDuckProviderKey();
         BlackDuckContent blackDuckContent = new BlackDuckContent();
         BlackDuckDistributionUIConfig blackDuckDistributionUIConfig = new BlackDuckDistributionUIConfig(blackDuckContent);


### PR DESCRIPTION
Previously we used a Collection of strings to handle error messages produced by the validators. In this refactor I instead created a ValidationResult object to instead be used with several other convenience methods.