### PR TITLE
Add an afterUpdateAction to get the latest fieldModel after an update

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/component/scheduling/actions/SchedulingGlobalApiAction.java
+++ b/src/main/java/com/synopsys/integration/alert/component/scheduling/actions/SchedulingGlobalApiAction.java
@@ -57,15 +57,15 @@ public class SchedulingGlobalApiAction extends ApiAction {
 
     @Override
     public FieldModel afterGetAction(FieldModel fieldModel) {
-        fieldModel.putField(SchedulingDescriptor.KEY_DAILY_PROCESSOR_NEXT_RUN, new FieldValueModel(List.of(taskManager.getNextRunTime(ScheduledTask.computeTaskName(DailyTask.class)).orElse("")), true));
-        String processFrequency = fieldModel.getFieldValue(SchedulingDescriptor.KEY_DAILY_PROCESSOR_HOUR_OF_DAY).orElse(String.valueOf(DailyTask.DEFAULT_HOUR_OF_DAY));
-        fieldModel.putField(SchedulingDescriptor.KEY_DAILY_PROCESSOR_HOUR_OF_DAY, new FieldValueModel(List.of(processFrequency), true));
+        return calculateNextRuntime(fieldModel);
+    }
 
-        fieldModel.putField(SchedulingDescriptor.KEY_PURGE_DATA_NEXT_RUN, new FieldValueModel(List.of(taskManager.getNextRunTime(ScheduledTask.computeTaskName(PurgeTask.class)).orElse("")), true));
-        String purgeFrequency = fieldModel.getFieldValue(SchedulingDescriptor.KEY_PURGE_DATA_FREQUENCY_DAYS).orElse(String.valueOf(PurgeTask.DEFAULT_FREQUENCY));
-        fieldModel.putField(SchedulingDescriptor.KEY_PURGE_DATA_FREQUENCY_DAYS, new FieldValueModel(List.of(purgeFrequency), true));
+    @Override
+    public FieldModel afterUpdateAction(FieldModel fieldModel) {
+        FieldModel updatedFieldModel = handleNewAndSavedConfig(fieldModel);
+        updatedFieldModel = calculateNextRuntime(updatedFieldModel);
 
-        return fieldModel;
+        return updatedFieldModel;
     }
 
     public FieldModel handleNewAndSavedConfig(FieldModel fieldModel) {
@@ -75,6 +75,18 @@ public class SchedulingGlobalApiAction extends ApiAction {
         String purgeDataCron = String.format(PurgeTask.CRON_FORMAT, purgeDataFrequencyDays);
         taskManager.scheduleCronTask(dailyDigestCron, ScheduledTask.computeTaskName(DailyTask.class));
         taskManager.scheduleCronTask(purgeDataCron, ScheduledTask.computeTaskName(PurgeTask.class));
+        return fieldModel;
+    }
+
+    private FieldModel calculateNextRuntime(FieldModel fieldModel) {
+        fieldModel.putField(SchedulingDescriptor.KEY_DAILY_PROCESSOR_NEXT_RUN, new FieldValueModel(List.of(taskManager.getNextRunTime(ScheduledTask.computeTaskName(DailyTask.class)).orElse("")), true));
+        String processFrequency = fieldModel.getFieldValue(SchedulingDescriptor.KEY_DAILY_PROCESSOR_HOUR_OF_DAY).orElse(String.valueOf(DailyTask.DEFAULT_HOUR_OF_DAY));
+        fieldModel.putField(SchedulingDescriptor.KEY_DAILY_PROCESSOR_HOUR_OF_DAY, new FieldValueModel(List.of(processFrequency), true));
+
+        fieldModel.putField(SchedulingDescriptor.KEY_PURGE_DATA_NEXT_RUN, new FieldValueModel(List.of(taskManager.getNextRunTime(ScheduledTask.computeTaskName(PurgeTask.class)).orElse("")), true));
+        String purgeFrequency = fieldModel.getFieldValue(SchedulingDescriptor.KEY_PURGE_DATA_FREQUENCY_DAYS).orElse(String.valueOf(PurgeTask.DEFAULT_FREQUENCY));
+        fieldModel.putField(SchedulingDescriptor.KEY_PURGE_DATA_FREQUENCY_DAYS, new FieldValueModel(List.of(purgeFrequency), true));
+
         return fieldModel;
     }
 


### PR DESCRIPTION
While working on IALERT-1740, Paulo and I realized that we cannot remove refreshConfig from globalConfiguration.js. Because the update is a PUT call it returns no body and in order for the UI to be correctly updated to reflect the new cron we need the refresh to still run.

The changes here will let the fieldModel be updated since currently it will only be updated when a GET call is run. This method will clean up that process so we do not need to run a GET after a PUT to get the new/next runtimes.