### PR TITLE
table id fix

### DIFF
--- a/src/main/js/dynamic/loaded/certificates/CertificatesPage.js
+++ b/src/main/js/dynamic/loaded/certificates/CertificatesPage.js
@@ -1,7 +1,12 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { clearCertificateFieldErrors, deleteCertificate, fetchCertificates, saveCertificate } from 'store/actions/certificates';
+import {
+    clearCertificateFieldErrors,
+    deleteCertificate,
+    fetchCertificates,
+    saveCertificate
+} from 'store/actions/certificates';
 import ConfigurationLabel from 'component/common/ConfigurationLabel';
 import TableDisplay from 'field/TableDisplay';
 import TextInput from 'field/input/TextInput';
@@ -14,7 +19,6 @@ class CertificatesPage extends Component {
         super(props);
         this.retrieveData = this.retrieveData.bind(this);
         this.clearModalFieldState = this.clearModalFieldState.bind(this);
-        this.createColumns = this.createColumns.bind(this);
         this.handleChange = this.handleChange.bind(this);
         this.onSave = this.onSave.bind(this);
         this.onConfigClose = this.onConfigClose.bind(this);
@@ -31,11 +35,124 @@ class CertificatesPage extends Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (prevProps.saveStatus === 'SAVING' && (this.props.saveStatus === 'SAVED' || this.props.saveStatus === 'ERROR')) {
-            this.state.saveCallback(true);
+        const { saveCallback, deleteCallback } = this.state;
+        const { saveStatus, deleteSuccess, inProgress } = this.props;
+        if (prevProps.saveStatus === 'SAVING' && (saveStatus === 'SAVED' || saveStatus === 'ERROR')) {
+            saveCallback(true);
         }
-        if (prevProps.inProgress && !prevProps.deleteSuccess && !this.props.inProgress && this.props.deleteSuccess) {
-            this.state.deleteCallback();
+        if (prevProps.inProgress && !prevProps.deleteSuccess && !inProgress && deleteSuccess) {
+            deleteCallback();
+        }
+    }
+
+
+    onConfigClose(callback) {
+        const { clearFieldErrors } = this.props;
+        clearFieldErrors();
+        callback();
+    }
+
+    onSave(callback) {
+        const { saveCertificateAction } = this.props;
+        const { certificate } = this.state;
+        saveCertificateAction(certificate);
+        this.setState({
+            saveCallback: callback
+        });
+        return true;
+    }
+
+    onDelete(certificatesToDelete, callback) {
+        const { deleteCertificateAction } = this.props;
+        if (certificatesToDelete) {
+            certificatesToDelete.forEach((certificateId) => {
+                deleteCertificateAction(certificateId);
+            });
+        }
+        this.setState({
+            deleteCallback: callback
+        });
+    }
+
+    onEdit(selectedRow, callback) {
+        this.setState({
+            certificate: selectedRow
+        }, callback);
+    }
+
+    onCopy(selectedRow, callback) {
+        const copy = JSON.parse(JSON.stringify(selectedRow));
+        copy.id = null;
+        this.setState({
+            certificate: copy
+        }, callback);
+    }
+
+    createModalFields() {
+        const { certificate } = this.state;
+        const { fieldErrors } = this.props;
+        const aliasKey = 'alias';
+        const certificateContentKey = 'certificateContent';
+        return (
+            <div>
+                <ReadOnlyField
+                    id="lastUpdated"
+                    label="Last Updated"
+                    name="lastUpdated"
+                    readOnly="true"
+                    value={certificate.lastUpdated}
+                />
+                <TextInput
+                    id={aliasKey}
+                    name={aliasKey}
+                    label="Alias"
+                    description="The certificate alias name."
+                    required
+                    onChange={this.handleChange}
+                    value={certificate[aliasKey]}
+                    errorName={aliasKey}
+                    errorValue={fieldErrors[aliasKey]}
+                />
+                <TextArea
+                    id={certificateContentKey}
+                    name={certificateContentKey}
+                    label="Certificate Content"
+                    description="The certificate content text."
+                    required
+                    onChange={this.handleChange}
+                    value={certificate[certificateContentKey]}
+                    errorName={certificateContentKey}
+                    errorValue={fieldErrors[certificateContentKey]}
+                />
+            </div>
+        );
+    }
+
+    handleChange(e) {
+        const {
+            name, value, type, checked
+        } = e.target;
+        const { certificate } = this.state;
+
+        const updatedValue = type === 'checkbox' ? checked.toString()
+        .toLowerCase() === 'true' : value;
+        const newCertificate = Object.assign(certificate, { [name]: updatedValue });
+        this.setState({
+            certificate: newCertificate
+        });
+    }
+
+    retrieveData() {
+        const { getCertificates } = this.props;
+        getCertificates();
+    }
+
+    clearModalFieldState() {
+        const { certificate } = this.state;
+        if (certificate && Object.keys(certificate).length > 0) {
+            this.setState({
+                certificate: {}
+            });
         }
     }
 
@@ -63,93 +180,12 @@ class CertificatesPage extends Component {
         ];
     }
 
-    onConfigClose(callback) {
-        this.props.clearFieldErrors();
-        callback();
-    }
-
-    clearModalFieldState() {
-        if (this.state.certificate && Object.keys(this.state.certificate).length > 0) {
-            this.setState({
-                certificate: {}
-            });
-        }
-    }
-
-    retrieveData() {
-        this.props.getCertificates();
-    }
-
-    handleChange(e) {
-        const { name, value, type, checked } = e.target;
-        const { certificate } = this.state;
-
-        const updatedValue = type === 'checkbox' ? checked.toString().toLowerCase() === 'true' : value;
-        const newCertificate = Object.assign(certificate, { [name]: updatedValue });
-        this.setState({
-            certificate: newCertificate
-        });
-    }
-
-    onSave(callback) {
-        const { certificate } = this.state;
-        this.props.saveCertificate(certificate);
-        this.setState({
-            saveCallback: callback
-        });
-        return true;
-    }
-
-    onDelete(certificatesToDelete, callback) {
-        if (certificatesToDelete) {
-            certificatesToDelete.forEach(certificateId => {
-                this.props.deleteCertificate(certificateId);
-            });
-        }
-        this.setState({
-            deleteCallback: callback
-        });
-    }
-
-    createModalFields() {
-        const { certificate } = this.state;
-        const { fieldErrors } = this.props;
-        const aliasKey = 'alias';
-        const certificateContentKey = 'certificateContent';
-        return (
-            <div>
-                <ReadOnlyField label="Last Updated" name="lastUpdated" readOnly="true" value={certificate['lastUpdated']} />
-                <TextInput
-                    name={aliasKey} label="Alias" description="The certificate alias name."
-                    required onChange={this.handleChange} value={certificate[aliasKey]}
-                    errorName={aliasKey}
-                    errorValue={fieldErrors[aliasKey]} />
-                <TextArea
-                    name={certificateContentKey} label="Certificate Content" description="The certificate content text."
-                    required onChange={this.handleChange} value={certificate[certificateContentKey]}
-                    errorName={certificateContentKey}
-                    errorValue={fieldErrors[certificateContentKey]} />
-            </div>
-        );
-    }
-
-    onEdit(selectedRow, callback) {
-        this.setState({
-            certificate: selectedRow
-        }, callback);
-    }
-
-    onCopy(selectedRow, callback) {
-        selectedRow.id = null;
-        this.setState({
-            certificate: selectedRow
-        }, callback);
-    }
-
     render() {
-        const { fetching, inProgress, certificates, certificateDeleteError, label, description, fieldErrors, descriptors } = this.props;
+        const {
+            fetching, inProgress, certificates, certificateDeleteError, label, description, fieldErrors, descriptors
+        } = this.props;
 
-        const descriptor = DescriptorUtilities.findFirstDescriptorByNameAndContext(descriptors, DescriptorUtilities.DESCRIPTOR_NAME.COMPONENT_CERTIFICATES, DescriptorUtilities.CONTEXT_TYPE.GLOBAL)
+        const descriptor = DescriptorUtilities.findFirstDescriptorByNameAndContext(descriptors, DescriptorUtilities.DESCRIPTOR_NAME.COMPONENT_CERTIFICATES, DescriptorUtilities.CONTEXT_TYPE.GLOBAL);
         const hasFieldErrors = fieldErrors && Object.keys(fieldErrors).length > 0;
         const canCreate = DescriptorUtilities.isOperationAssigned(descriptor, DescriptorUtilities.OPERATIONS.CREATE);
         const canDelete = DescriptorUtilities.isOperationAssigned(descriptor, DescriptorUtilities.OPERATIONS.DELETE);
@@ -190,8 +226,8 @@ class CertificatesPage extends Component {
 CertificatesPage.propTypes = {
     descriptors: PropTypes.arrayOf(PropTypes.object).isRequired,
     certificates: PropTypes.arrayOf(PropTypes.object),
-    saveCertificate: PropTypes.func.isRequired,
-    deleteCertificate: PropTypes.func.isRequired,
+    saveCertificateAction: PropTypes.func.isRequired,
+    deleteCertificateAction: PropTypes.func.isRequired,
     getCertificates: PropTypes.func.isRequired,
     clearFieldErrors: PropTypes.func.isRequired,
     certificateDeleteError: PropTypes.string,
@@ -213,7 +249,7 @@ CertificatesPage.defaultProps = {
     fieldErrors: {}
 };
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
     descriptors: state.descriptors.items,
     certificates: state.certificates.data,
     certificateDeleteError: state.certificates.certificateDeleteError,
@@ -224,9 +260,9 @@ const mapStateToProps = state => ({
     deleteSuccess: state.certificates.deleteSuccess
 });
 
-const mapDispatchToProps = dispatch => ({
-    saveCertificate: certificate => dispatch(saveCertificate(certificate)),
-    deleteCertificate: certificateId => dispatch(deleteCertificate(certificateId)),
+const mapDispatchToProps = (dispatch) => ({
+    saveCertificateAction: (certificate) => dispatch(saveCertificate(certificate)),
+    deleteCertificateAction: (certificateId) => dispatch(deleteCertificate(certificateId)),
     getCertificates: () => dispatch(fetchCertificates()),
     clearFieldErrors: () => dispatch(clearCertificateFieldErrors())
 });

--- a/src/main/js/dynamic/loaded/tasks/TaskManagement.js
+++ b/src/main/js/dynamic/loaded/tasks/TaskManagement.js
@@ -19,6 +19,12 @@ class TaskManagement extends Component {
         };
     }
 
+    onEdit(selectedRow, callback) {
+        this.setState({
+            task: selectedRow
+        }, callback);
+    }
+
     createColumns() {
         return [
             {
@@ -49,7 +55,8 @@ class TaskManagement extends Component {
     }
 
     clearModalFieldState() {
-        if (this.state.task && Object.keys(this.state.task).length > 0) {
+        const { task } = this.state;
+        if (task && Object.keys(task).length > 0) {
             this.setState({
                 task: {}
             });
@@ -63,8 +70,16 @@ class TaskManagement extends Component {
             return null;
         }
         const propertyFields = [];
-        properties.forEach(property => {
-            const field = <ReadOnlyField label={property.displayName} name={property.key} readOnly="true" value={property.value} />
+        properties.forEach((property) => {
+            const field = (
+                <ReadOnlyField
+                    id={property.key}
+                    label={property.displayName}
+                    name={property.key}
+                    readOnly="true"
+                    value={property.value}
+                />
+            );
             propertyFields.push(field);
         });
 
@@ -79,31 +94,45 @@ class TaskManagement extends Component {
         const propertyFields = this.createPropertyFields();
         return (
             <div>
-                <ReadOnlyField label="Type" name={nameKey} readOnly="true" value={task[nameKey]} />
-                <ReadOnlyField label="Full Type Name" name={fullyQualifiedNameKey} readOnly="true" value={task[fullyQualifiedNameKey]} />
-                <ReadOnlyField label="Next Run Time" name={nextRunTimeKey} readOnly="true" value={task[nextRunTimeKey]} />
+                <ReadOnlyField
+                    id={nameKey}
+                    label="Type"
+                    name={nameKey}
+                    readOnly="true"
+                    value={task[nameKey]}
+                />
+                <ReadOnlyField
+                    id={fullyQualifiedNameKey}
+                    label="Full Type Name"
+                    name={fullyQualifiedNameKey}
+                    readOnly="true"
+                    value={task[fullyQualifiedNameKey]}
+                />
+                <ReadOnlyField
+                    id={nextRunTimeKey}
+                    label="Next Run Time"
+                    name={nextRunTimeKey}
+                    readOnly="true"
+                    value={task[nextRunTimeKey]}
+                />
                 {propertyFields}
             </div>
         );
     }
 
-    onEdit(selectedRow, callback) {
-        this.setState({
-            task: selectedRow
-        }, callback);
-    }
-
     retrieveData() {
-        this.props.getTasks();
+        const { getTasks } = this.props;
+        getTasks();
     }
 
     createTaskData() {
         const { tasks } = this.props;
-        return tasks.map(task => {
+        return tasks.map((task) => {
             const searchableProperties = JSON.stringify(task.properties);
-            return Object.assign({}, task, {
-                searchableProperties: searchableProperties
-            });
+            return {
+                ...task,
+                searchableProperties
+            };
         });
     }
 
@@ -113,7 +142,8 @@ class TaskManagement extends Component {
             <div>
                 <ConfigurationLabel
                     configurationName={label}
-                    description={description} />
+                    description={description}
+                />
                 <TableDisplay
                     newConfigFields={this.createModalFields}
                     modalTitle="Task Details"
@@ -139,18 +169,19 @@ TaskManagement.propTypes = {
     tasks: PropTypes.array.isRequired,
     description: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
-    fetching: PropTypes.bool
+    fetching: PropTypes.bool,
+    getTasks: PropTypes.func.isRequired
 };
 
 TaskManagement.defaultProps = {
     fetching: false
-}
+};
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
     tasks: state.tasks.data
 });
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = (dispatch) => ({
     getTasks: () => dispatch(fetchTasks())
 });
 

--- a/src/main/js/dynamic/loaded/users/PermissionTable.js
+++ b/src/main/js/dynamic/loaded/users/PermissionTable.js
@@ -191,42 +191,50 @@ class PermissionTable extends Component {
                     onChange={this.handlePermissionsChange}
                     value={permissionsData[PERMISSIONS_TABLE.CONTEXT]} />
                 <CheckboxInput
-                    name={PERMISSIONS_TABLE.CREATE} label="Create"
+                    name={PERMISSIONS_TABLE.CREATE} id={PERMISSIONS_TABLE.CREATE}
+                    label="Create"
                     description="Allow users to create new items with this permission."
                     onChange={this.handlePermissionsChange}
                     isChecked={permissionsData[PERMISSIONS_TABLE.CREATE]} />
                 <CheckboxInput
-                    name={PERMISSIONS_TABLE.DELETE_OPERATION} label="Delete"
+                    name={PERMISSIONS_TABLE.DELETE_OPERATION} id={PERMISSIONS_TABLE.DELETE_OPERATION}
+                    label="Delete"
                     description="Allow users to delete items with this permission."
                     onChange={this.handlePermissionsChange}
                     isChecked={permissionsData[PERMISSIONS_TABLE.DELETE_OPERATION]} />
                 <CheckboxInput
-                    name={PERMISSIONS_TABLE.READ} label="Read"
+                    name={PERMISSIONS_TABLE.READ} id={PERMISSIONS_TABLE.READ}
+                    label="Read"
                     description="This permission shows or hides content for the user."
                     onChange={this.handlePermissionsChange}
                     isChecked={permissionsData[PERMISSIONS_TABLE.READ]} />
                 <CheckboxInput
-                    name={PERMISSIONS_TABLE.WRITE} label="Write"
+                    name={PERMISSIONS_TABLE.WRITE} id={PERMISSIONS_TABLE.WRITE}
+                    label="Write"
                     description="Allow users to edit items with this permission."
                     onChange={this.handlePermissionsChange}
                     isChecked={permissionsData[PERMISSIONS_TABLE.WRITE]} />
                 <CheckboxInput
-                    name={PERMISSIONS_TABLE.EXECUTE} label="Execute"
+                    name={PERMISSIONS_TABLE.EXECUTE} id={PERMISSIONS_TABLE.EXECUTE}
+                    label="Execute"
                     description="Allow users to perform functionality with this permission."
                     onChange={this.handlePermissionsChange}
                     isChecked={permissionsData[PERMISSIONS_TABLE.EXECUTE]} />
                 <CheckboxInput
-                    name={PERMISSIONS_TABLE.UPLOAD_READ} label="Upload Read"
+                    name={PERMISSIONS_TABLE.UPLOAD_READ} id={PERMISSIONS_TABLE.UPLOAD_READ}
+                    label="Upload Read"
                     description="This permission shows or hides upload related content for the user."
                     onChange={this.handlePermissionsChange}
                     isChecked={permissionsData[PERMISSIONS_TABLE.UPLOAD_READ]} />
                 <CheckboxInput
-                    name={PERMISSIONS_TABLE.UPLOAD_WRITE} label="Upload Write"
+                    name={PERMISSIONS_TABLE.UPLOAD_WRITE} id={PERMISSIONS_TABLE.UPLOAD_WRITE}
+                    label="Upload Write"
                     description="Allow users to modify uploaded content with this permission."
                     onChange={this.handlePermissionsChange}
                     isChecked={permissionsData[PERMISSIONS_TABLE.UPLOAD_WRITE]} />
                 <CheckboxInput
-                    name={PERMISSIONS_TABLE.UPLOAD_DELETE} label="Upload Delete"
+                    name={PERMISSIONS_TABLE.UPLOAD_DELETE} id={PERMISSIONS_TABLE.UPLOAD_DELETE}
+                    label="Upload Delete"
                     description="Allow users to delete uploaded content with this permission."
                     onChange={this.handlePermissionsChange}
                     isChecked={permissionsData[PERMISSIONS_TABLE.UPLOAD_DELETE]} />

--- a/src/main/js/dynamic/loaded/users/RoleTable.js
+++ b/src/main/js/dynamic/loaded/users/RoleTable.js
@@ -11,7 +11,6 @@ class RoleTable extends Component {
         super(props);
 
         this.retrieveData = this.retrieveData.bind(this);
-        this.createColumns = this.createColumns.bind(this);
         this.handleChange = this.handleChange.bind(this);
         this.onSave = this.onSave.bind(this);
         this.onDelete = this.onDelete.bind(this);
@@ -21,7 +20,6 @@ class RoleTable extends Component {
         this.deletePermission = this.deletePermission.bind(this);
         this.onEdit = this.onEdit.bind(this);
         this.onCopy = this.onCopy.bind(this);
-        
         this.state = {
             role: {
                 permissions: []
@@ -32,17 +30,81 @@ class RoleTable extends Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (prevProps.saveStatus === 'SAVING' && (this.props.saveStatus === 'SAVED' || this.props.saveStatus === 'ERROR')) {
+        const { saveStatus } = this.props;
+        const { saveCallback } = this.state;
+        if (prevProps.saveStatus === 'SAVING' && (saveStatus === 'SAVED' || saveStatus === 'ERROR')) {
             this.setState({
                 role: {
                     permissions: []
                 }
-            }, () => this.state.saveCallback(true));
+            }, () => saveCallback(true));
         }
     }
 
+
+    onEdit(selectedRow, callback) {
+        this.setState({
+            role: selectedRow
+        }, callback);
+    }
+
+    onCopy(selectedRow, callback) {
+        const copy = JSON.parse(JSON.stringify(selectedRow));
+        copy.id = null;
+        this.setState({
+            role: copy
+        }, callback);
+    }
+
+    onSave(callback) {
+        const { descriptors, saveRoleAction } = this.props;
+        const { role } = this.state;
+        const { permissions } = role;
+        const correctedPermissions = [];
+        permissions.forEach((permission) => {
+            const descriptorName = permission[PERMISSIONS_TABLE.DESCRIPTOR_NAME];
+            const descriptor = descriptors.find((currentDescriptor) => currentDescriptor.label === descriptorName);
+            if (descriptor) {
+                const descriptorKey = descriptor.name;
+                const permissionCopy = JSON.parse(JSON.stringify(permission));
+                permissionCopy[PERMISSIONS_TABLE.DESCRIPTOR_NAME] = descriptorKey;
+                correctedPermissions.push(permissionCopy);
+            }
+        });
+        role.permissions = correctedPermissions;
+
+        this.setState({
+            saveCallback: callback
+        }, () => saveRoleAction(role));
+
+        return true;
+    }
+
+    onDelete(rolesToDelete, callback) {
+        const { deleteRoleAction } = this.props;
+        if (rolesToDelete) {
+            rolesToDelete.forEach((roleId) => {
+                deleteRoleAction(roleId);
+            });
+        }
+        callback();
+        this.retrieveData();
+    }
+
+    onRoleClose(callback) {
+        const { clearFieldErrorsAction } = this.props;
+        this.setState({
+            role: {
+                permissions: []
+            }
+        }, callback);
+        clearFieldErrorsAction();
+    }
+
     handleChange(e) {
-        const { name, value, type, checked } = e.target;
+        const {
+            name, value, type, checked
+        } = e.target;
         const { role } = this.state;
         const updatedValue = type === 'checkbox' ? checked.toString()
         .toLowerCase() === 'true' : value;
@@ -70,85 +132,29 @@ class RoleTable extends Component {
     }
 
     retrieveData() {
-        this.props.getRoles();
-    }
-
-    onEdit(selectedRow, callback) {
-        this.setState({
-            role: selectedRow
-        }, callback);
-    }
-
-    onCopy(selectedRow, callback) {
-        selectedRow.id = null;
-        this.setState({
-            role: selectedRow
-        }, callback);
-    }
-
-    onSave(callback) {
-        const { descriptors } = this.props;
-        const { role } = this.state;
-        const { permissions } = role;
-        let correctedPermissions = [];
-        permissions.forEach(permission => {
-            const descriptorName = permission[PERMISSIONS_TABLE.DESCRIPTOR_NAME];
-            const descriptor = descriptors.find(currentDescriptor => currentDescriptor.label === descriptorName);
-            if (descriptor) {
-                const descriptorKey = descriptor.name;
-
-                permission[PERMISSIONS_TABLE.DESCRIPTOR_NAME] = descriptorKey;
-                correctedPermissions.push(permission);
-            }
-        });
-        role.permissions = correctedPermissions;
-
-        this.setState({
-            saveCallback: callback
-        }, () => this.props.saveRole(role));
-
-        return true;
-    }
-
-    onDelete(rolesToDelete, callback) {
-        if (rolesToDelete) {
-            rolesToDelete.forEach(roleId => {
-                this.props.deleteRole(roleId);
-            });
-        }
-        callback();
-        this.retrieveData();
-    }
-
-    onRoleClose(callback) {
-        this.setState({
-            role: {
-                permissions: []
-            }
-        }, callback);
-        this.props.clearFieldErrors();
-
+        const { getRoles } = this.props;
+        getRoles();
     }
 
     async savePermissions(permission) {
         const { role, incrementalId } = this.state;
         const { permissions } = role;
-
-        if (!permission.id) {
-            permission.id = incrementalId;
+        const permissionCopy = JSON.parse(JSON.stringify(permission));
+        if (!permissionCopy.id) {
+            permissionCopy.id = incrementalId;
             this.setState({
                 incrementalId: incrementalId + 1
             });
-            permissions.push(permission);
+            permissions.push(permissionCopy);
         } else {
-            const matchingPermissionIndex = permissions.findIndex(listPermission => listPermission.id === permission.id);
+            const matchingPermissionIndex = permissions.findIndex((listPermission) => listPermission.id === permission.id);
             if (matchingPermissionIndex > -1) {
                 permissions[matchingPermissionIndex] = permission;
             }
         }
         role.permissions = permissions;
         this.setState({
-            role: role
+            role
         });
         return true;
     }
@@ -156,8 +162,8 @@ class RoleTable extends Component {
     deletePermission(permissionIds) {
         const { role } = this.state;
         const { permissions } = role;
-        const filteredPermissions = permissions.filter(listPermission => !permissionIds.includes(listPermission.id));
-        let newRole = { ...role };
+        const filteredPermissions = permissions.filter((listPermission) => !permissionIds.includes(listPermission.id));
+        const newRole = { ...role };
         newRole.permissions = filteredPermissions;
         this.setState({
             role: newRole
@@ -165,51 +171,67 @@ class RoleTable extends Component {
     }
 
     createModalFields() {
-        const { role } = this.state;
+        const { role, incrementalId } = this.state;
 
         const { permissions } = role;
-        let incrementedId = this.state.incrementalId;
-        permissions.forEach(permission => {
-            if (!permission.id) {
-                permission.id = incrementedId;
-                incrementedId++;
+        let incrementedId = incrementalId;
+        const updatedPermissions = [];
+        permissions.forEach((permission) => {
+            const permissionCopy = JSON.parse(JSON.stringify(permission));
+            if (!permissionCopy.id) {
+                permissionCopy.id = incrementedId;
+                incrementedId += 1;
             }
+            updatedPermissions.push(permissionCopy);
         });
 
-        if (incrementedId !== this.state.incrementalId) {
-            role.permissions = permissions;
+        if (incrementedId !== incrementalId) {
+            role.permissions = updatedPermissions;
             this.setState({
-                role: role,
-                incrementedId: incrementedId
+                role,
+                incrementalId: incrementedId
             });
         }
 
         const roleNameKey = 'roleName';
         const roleNameValue = role[roleNameKey];
 
-        const { canCreate, canDelete, fieldErrors, inProgress, fetching } = this.props;
+        const {
+            canCreate, canDelete, fieldErrors, inProgress, fetching, descriptors
+        } = this.props;
 
         return (
             <div>
-                <TextInput name={roleNameKey} label="Role Name" description="The name of the role." required={true}
-                           onChange={this.handleChange} value={roleNameValue} errorName={roleNameKey}
-                           errorValue={fieldErrors[roleNameKey]} />
+                <TextInput
+                    id={roleNameKey}
+                    name={roleNameKey}
+                    label="Role Name"
+                    description="The name of the role."
+                    required
+                    onChange={this.handleChange}
+                    value={roleNameValue}
+                    errorName={roleNameKey}
+                    errorValue={fieldErrors[roleNameKey]}
+                />
                 <PermissionTable
                     inProgress={inProgress}
                     fetching={fetching}
                     data={permissions}
                     saveRole={this.savePermissions}
                     deleteRole={this.deletePermission}
-                    descriptors={this.props.descriptors}
+                    descriptors={descriptors}
                     canCreate={canCreate}
                     canDelete={canDelete}
-                    nestedInModal={true} />
+                    nestedInModal
+                />
             </div>
         );
     }
 
     render() {
-        const { canCreate, canDelete, fieldErrors, roleError, inProgress, fetching } = this.props;
+        const {
+            canCreate, canDelete, fieldErrors, roleError, inProgress, fetching, roles
+        } = this.props;
         const fieldErrorKeys = Object.keys(fieldErrors);
         const hasErrors = fieldErrorKeys && fieldErrorKeys.length > 0;
         return (
@@ -223,7 +245,7 @@ class RoleTable extends Component {
                     onConfigClose={this.onRoleClose}
                     onConfigCopy={this.onCopy}
                     refreshData={this.retrieveData}
-                    data={this.props.roles}
+                    data={roles}
                     columns={this.createColumns()}
                     newButton={canCreate}
                     deleteButton={canDelete}
@@ -243,12 +265,16 @@ RoleTable.defaultProps = {
     roleError: null,
     fieldErrors: {},
     inProgress: false,
-    fetching: false
+    fetching: false,
+    roles: [],
+    descriptors: [],
+    saveStatus: null
 };
 
 RoleTable.propTypes = {
-    saveRole: PropTypes.func.isRequired,
-    deleteRole: PropTypes.func.isRequired,
+    saveRoleAction: PropTypes.func.isRequired,
+    deleteRoleAction: PropTypes.func.isRequired,
+    clearFieldErrorsAction: PropTypes.func.isRequired,
     getRoles: PropTypes.func.isRequired,
     canCreate: PropTypes.bool,
     canDelete: PropTypes.bool,
@@ -257,10 +283,11 @@ RoleTable.propTypes = {
     fieldErrors: PropTypes.object,
     inProgress: PropTypes.bool,
     fetching: PropTypes.bool,
-    saveStatus: PropTypes.string
+    saveStatus: PropTypes.string,
+    roles: PropTypes.array
 };
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
     roles: state.roles.data,
     descriptors: state.descriptors.items,
     roleError: state.roles.roleError,
@@ -270,11 +297,11 @@ const mapStateToProps = state => ({
     saveStatus: state.roles.saveStatus
 });
 
-const mapDispatchToProps = dispatch => ({
-    saveRole: role => dispatch(saveRole(role)),
-    deleteRole: roleId => dispatch(deleteRole(roleId)),
+const mapDispatchToProps = (dispatch) => ({
+    saveRoleAction: (role) => dispatch(saveRole(role)),
+    deleteRoleAction: (roleId) => dispatch(deleteRole(roleId)),
     getRoles: () => dispatch(fetchRoles()),
-    clearFieldErrors: () => dispatch(clearRoleFieldErrors())
+    clearFieldErrorsAction: () => dispatch(clearRoleFieldErrors())
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(RoleTable);

--- a/src/main/js/dynamic/loaded/users/UserTable.js
+++ b/src/main/js/dynamic/loaded/users/UserTable.js
@@ -35,10 +35,12 @@ class UserTable extends Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (prevProps.saveStatus === 'SAVING' && this.props.saveStatus === 'SAVED') {
-            this.state.saveCallback(true);
-        } else if (prevProps.saveStatus === 'SAVING' && this.props.saveStatus === 'ERROR') {
-            this.state.saveCallback(false);
+        const { saveStatus } = this.props;
+        const { saveCallback } = this.state;
+        if (prevProps.saveStatus === 'SAVING' && saveStatus === 'SAVED') {
+            saveCallback(true);
+        } else if (prevProps.saveStatus === 'SAVING' && saveStatus === 'ERROR') {
+            saveCallback(false);
         }
     }
 
@@ -78,14 +80,18 @@ class UserTable extends Component {
     }
 
     retrieveData() {
-        this.props.getUsers();
+        const { getUsers } = this.props;
+        getUsers();
     }
 
     handleChange(e) {
-        const { name, value, type, checked } = e.target;
+        const {
+            name, value, type, checked
+        } = e.target;
         const { user } = this.state;
 
-        const updatedValue = type === 'checkbox' ? checked.toString().toLowerCase() === 'true' : value;
+        const updatedValue = type === 'checkbox' ? checked.toString()
+        .toLowerCase() === 'true' : value;
         const newUser = Object.assign(user, { [name]: updatedValue });
         this.setState({
             user: newUser
@@ -93,15 +99,15 @@ class UserTable extends Component {
     }
 
     onSave(callback) {
+        const { saveUserAction } = this.props;
         const { user } = this.state;
         if (this.checkIfPasswordsMatch(user)) {
             this.setState({
                 saveCallback: callback
-            }, () => this.props.saveUser(user));
+            }, () => saveUserAction(user));
             return true;
-        } else {
-            callback(false);
         }
+        callback(false);
         return false;
     }
 
@@ -124,24 +130,28 @@ class UserTable extends Component {
     }
 
     onDelete(usersToDelete, callback) {
+        const { deleteUserAction } = this.props;
         if (usersToDelete) {
-            usersToDelete.forEach(userId => {
-                this.props.deleteUser(userId);
+            usersToDelete.forEach((userId) => {
+                deleteUserAction(userId);
             });
         }
         callback();
     }
 
     onConfigClose(callback) {
-        this.props.clearFieldErrors();
-        if (this.state.user && this.state.user[KEY_CONFIRM_PASSWORD_ERROR]) {
-            delete this.state.user[KEY_CONFIRM_PASSWORD_ERROR];
+        const { clearFieldErrors } = this.props;
+        const { user } = this.state;
+        clearFieldErrors();
+        if (user && user[KEY_CONFIRM_PASSWORD_ERROR]) {
+            delete user[KEY_CONFIRM_PASSWORD_ERROR];
         }
         callback();
     }
 
     clearModalFieldState() {
-        if (this.state.user && Object.keys(this.state.user).length > 0) {
+        const { user } = this.state;
+        if (user && Object.keys(user).length > 0) {
             this.setState({
                 user: {}
             });
@@ -149,7 +159,8 @@ class UserTable extends Component {
     }
 
     retrieveRoles() {
-        return this.props.roles.map(role => {
+        const { roles } = this.props;
+        return roles.map((role) => {
             const rolename = role.roleName;
             return {
                 label: rolename,
@@ -166,16 +177,17 @@ class UserTable extends Component {
     }
 
     onCopy(selectedRow, callback) {
-        selectedRow.id = null;
+        const copy = JSON.parse(JSON.stringify(selectedRow));
+        copy.id = null;
         this.setState({
-            user: selectedRow
+            user: copy
         });
         callback();
     }
 
     createModalFields() {
         const { user } = this.state;
-        const { fieldErrors } = this.props;
+        const { fieldErrors, getRoles } = this.props;
 
         const usernameKey = 'username';
         const passwordKey = 'password';
@@ -201,32 +213,63 @@ class UserTable extends Component {
         );
         let passwordConfirmField = null;
         if (!external) {
-            passwordConfirmField = (<PasswordInput
-                name={confirmPasswordKey} label="Confirm Password" description="The user's password." readOnly={false}
-                required onChange={this.handleChange} value={user[confirmPasswordKey]}
-                errorName={confirmPasswordKey} errorValue={user[confirmPasswordError]}
-            />);
+            passwordConfirmField = (
+                <PasswordInput
+                    id={confirmPasswordKey}
+                    name={confirmPasswordKey}
+                    label="Confirm Password"
+                    description="The user's password."
+                    readOnly={false}
+                    required
+                    onChange={this.handleChange}
+                    value={user[confirmPasswordKey]}
+                    errorName={confirmPasswordKey}
+                    errorValue={user[confirmPasswordError]}
+                />
+            );
         }
 
         return (
             <div>
                 {external && externalNote}
                 <TextInput
-                    name={usernameKey} label="Username" description="The user's username." readOnly={external}
-                    required={!external} onChange={this.handleChange} value={user[usernameKey]}
+                    id={usernameKey}
+                    name={usernameKey}
+                    label="Username"
+                    description="The user's username."
+                    readOnly={external}
+                    required={!external}
+                    onChange={this.handleChange}
+                    value={user[usernameKey]}
                     errorName={usernameKey}
-                    errorValue={fieldErrors[usernameKey]} />
+                    errorValue={fieldErrors[usernameKey]}
+                />
                 <PasswordInput
-                    name={passwordKey} label="Password" description="The user's password." readOnly={external}
-                    required={!external} onChange={this.handleChange} value={user[passwordKey]}
+                    id={passwordKey}
+                    name={passwordKey}
+                    label="Password"
+                    description="The user's password."
+                    readOnly={external}
+                    required={!external}
+                    onChange={this.handleChange}
+                    value={user[passwordKey]}
                     isSet={user[passwordSetKey]}
                     errorName={passwordKey}
-                    errorValue={fieldErrors[passwordKey]} />
+                    errorValue={fieldErrors[passwordKey]}
+                />
                 {passwordConfirmField}
                 <TextInput
-                    name={emailKey} label="Email" description="The user's email." readOnly={external}
-                    required={!external} onChange={this.handleChange} value={user[emailKey]} errorName={emailKey}
-                    errorValue={fieldErrors[emailKey]} />
+                    id={emailKey}
+                    name={emailKey}
+                    label="Email"
+                    description="The user's email."
+                    readOnly={external}
+                    required={!external}
+                    onChange={this.handleChange}
+                    value={user[emailKey]}
+                    errorName={emailKey}
+                    errorValue={fieldErrors[emailKey]}
+                />
                 <DynamicSelectInput
                     name={roleNames}
                     id={roleNames}
@@ -236,15 +279,20 @@ class UserTable extends Component {
                     multiSelect
                     options={this.retrieveRoles()}
                     value={user[roleNames]}
-                    onFocus={this.props.getRoles} />
+                    onFocus={getRoles}
+                />
             </div>
         );
     }
 
     render() {
-        const { canCreate, canDelete, fieldErrors, userDeleteError, inProgress, fetching } = this.props;
+        const {
+            canCreate, canDelete, fieldErrors, userDeleteError, inProgress, fetching, users
+        } = this.props;
+        const { user } = this.state;
         const fieldErrorKeys = Object.keys(fieldErrors);
-        const hasErrors = fieldErrorKeys && fieldErrorKeys.length > 0 || this.state.user[KEY_CONFIRM_PASSWORD_ERROR] && this.state.user[KEY_CONFIRM_PASSWORD_ERROR].length > 0;
+        const hasErrors = (fieldErrorKeys && fieldErrorKeys.length > 0)
+            || (user[KEY_CONFIRM_PASSWORD_ERROR] && user[KEY_CONFIRM_PASSWORD_ERROR].length > 0);
         return (
             <div>
                 <div>
@@ -258,7 +306,7 @@ class UserTable extends Component {
                         onEditState={this.onEdit}
                         onConfigCopy={this.onCopy}
                         refreshData={this.retrieveData}
-                        data={this.props.users}
+                        data={users}
                         columns={this.createColumns()}
                         newButton={canCreate}
                         deleteButton={canDelete}
@@ -279,12 +327,15 @@ UserTable.defaultProps = {
     userDeleteError: null,
     fieldErrors: {},
     inProgress: false,
-    fetching: false
+    fetching: false,
+    saveStatus: null,
+    users: [],
+    roles: []
 };
 
 UserTable.propTypes = {
-    saveUser: PropTypes.func.isRequired,
-    deleteUser: PropTypes.func.isRequired,
+    saveUserAction: PropTypes.func.isRequired,
+    deleteUserAction: PropTypes.func.isRequired,
     getUsers: PropTypes.func.isRequired,
     getRoles: PropTypes.func.isRequired,
     clearFieldErrors: PropTypes.func.isRequired,
@@ -294,10 +345,12 @@ UserTable.propTypes = {
     fieldErrors: PropTypes.object,
     inProgress: PropTypes.bool,
     fetching: PropTypes.bool,
-    saveStatus: PropTypes.string
+    saveStatus: PropTypes.string,
+    users: PropTypes.array,
+    roles: PropTypes.array
 };
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
     users: state.users.data,
     roles: state.roles.data,
     userDeleteError: state.users.userDeleteError,
@@ -307,9 +360,9 @@ const mapStateToProps = state => ({
     saveStatus: state.users.saveStatus
 });
 
-const mapDispatchToProps = dispatch => ({
-    saveUser: user => dispatch(saveUser(user)),
-    deleteUser: userId => dispatch(deleteUser(userId)),
+const mapDispatchToProps = (dispatch) => ({
+    saveUserAction: (user) => dispatch(saveUser(user)),
+    deleteUserAction: (userId) => dispatch(deleteUser(userId)),
     getUsers: () => dispatch(fetchUsers()),
     getRoles: () => dispatch(fetchRoles()),
     clearFieldErrors: () => dispatch(clearUserFieldErrors())

--- a/src/main/js/field/TableDisplay.js
+++ b/src/main/js/field/TableDisplay.js
@@ -80,8 +80,8 @@ class TableDisplay extends Component {
 
         const { columns } = this.props;
         return columns.map((column) => {
-            const assignedDataFormate = column.dataFormat ? column.dataFormat : defaultDataFormat;
-            const searchable = column.searchable ? column.searchable : true;
+            const assignedDataFormat = column.dataFormat ? column.dataFormat : defaultDataFormat;
+            const searchable = Object.prototype.hasOwnProperty.call(column, 'searchable') ? column.searchable : true;
             return (
                 <TableHeaderColumn
                     key={column.header}
@@ -92,7 +92,7 @@ class TableDisplay extends Component {
                     dataSort
                     columnClassName="tableCell"
                     tdStyle={{ whiteSpace: 'normal' }}
-                    dataFormat={assignedDataFormate}
+                    dataFormat={assignedDataFormat}
                 >
                     {column.headerLabel}
                 </TableHeaderColumn>
@@ -239,15 +239,11 @@ class TableDisplay extends Component {
         const popupActionMessage = errorDialogMessage || actionMessage;
         const configFields = isInsertModal ? newConfigFields() : newConfigFields(currentRowSelected);
         let cancelFunction = this.handleCancel;
-        if (isInsertModal) {
-            cancelFunction = tablePopupRef && tablePopupRef.onCancel;
-        }
         let submitFunction = this.handleSubmit;
-        if (isInsertModal) {
-            submitFunction = tablePopupRef && tablePopupRef.handleSubmit;
-        }
         let testFunction = this.handleTest;
         if (isInsertModal) {
+            cancelFunction = tablePopupRef && tablePopupRef.onCancel;
+            submitFunction = tablePopupRef && tablePopupRef.handleSubmit;
             testFunction = tablePopupRef && tablePopupRef.handleTest;
         }
         return (
@@ -369,6 +365,20 @@ class TableDisplay extends Component {
         );
     }
 
+    createIconTableHeader(dataFormat, text) {
+        return (
+            <TableHeaderColumn
+                dataField=""
+                width="48"
+                columnClassName="tableCell"
+                dataFormat={dataFormat}
+                thStyle={{ textAlign: 'center' }}
+            >
+                {text}
+            </TableHeaderColumn>
+        );
+    }
+
     render() {
         const tableColumns = this.createTableColumns();
         const { showDelete } = this.state;
@@ -377,31 +387,11 @@ class TableDisplay extends Component {
             tableSearchable, enableEdit, enableCopy, inProgress, tableRefresh, refreshData
         } = this.props;
         if (enableEdit) {
-            const editColumn = (
-                <TableHeaderColumn
-                    dataField=""
-                    width="48"
-                    columnClassName="tableCell"
-                    dataFormat={this.editButtonClick}
-                    thStyle={{ textAlign: 'center' }}
-                >
-                    Edit
-                </TableHeaderColumn>
-            );
+            const editColumn = this.createIconTableHeader(this.editButtonClick, 'Edit');
             tableColumns.push(editColumn);
         }
         if (enableCopy) {
-            const copyColumn = (
-                <TableHeaderColumn
-                    dataField=""
-                    width="48"
-                    columnClassName="tableCell"
-                    dataFormat={this.copyButtonClick}
-                    thStyle={{ textAlign: 'center' }}
-                >
-                    Copy
-                </TableHeaderColumn>
-            );
+            const copyColumn = this.createIconTableHeader(this.copyButtonClick, 'Copy');
             tableColumns.push(copyColumn);
         }
 


### PR DESCRIPTION
- Fix table display to only have one popup used for both insert and edit which prevents the duplicate ids. 
- Use a table reference to be able to change the save and test functions that are called since insert and edit call different functions.
- Add ids to the fields table display renders to help with automation.
- Fix lint issues with the classes that use TableDisplay