### PR TITLE
When configurations are fetched clear the errors.

### DIFF
--- a/src/main/js/field/TableDisplay.js
+++ b/src/main/js/field/TableDisplay.js
@@ -37,6 +37,7 @@ class TableDisplay extends Component {
         this.hideModal = this.hideModal.bind(this);
         this.handleInsertModalSubmit = this.handleInsertModalSubmit.bind(this);
         this.handleInsertModalTest = this.handleInsertModalTest.bind(this);
+        this.onAutoRefresh = this.onAutoRefresh.bind(this);
         this.tablePopup = React.createRef();
         this.table = React.createRef();
         this.state = {
@@ -59,6 +60,14 @@ class TableDisplay extends Component {
         if (!showConfiguration && currentRowSelected && !inProgress && !hasFieldErrors
             && uiValidation === VALIDATION_STATE.SUCCESS) {
             this.handleClose();
+        }
+    }
+
+    onAutoRefresh() {
+        const { refreshData } = this.props;
+        const { showConfiguration } = this.state;
+        if (!showConfiguration) {
+            refreshData();
         }
     }
 
@@ -384,7 +393,7 @@ class TableDisplay extends Component {
         const { showDelete } = this.state;
         const {
             selectRowBox, sortName, sortOrder, autoRefresh, tableMessage, newButton, deleteButton, data,
-            tableSearchable, enableEdit, enableCopy, inProgress, tableRefresh, refreshData
+            tableSearchable, enableEdit, enableCopy, inProgress, tableRefresh
         } = this.props;
         if (enableEdit) {
             const editColumn = this.createIconTableHeader(this.editButtonClick, 'Edit');
@@ -460,7 +469,7 @@ class TableDisplay extends Component {
 
         const refresh = tableRefresh && (
             <div className="pull-right">
-                <AutoRefresh startAutoReload={refreshData} autoRefresh={autoRefresh} />
+                <AutoRefresh startAutoReload={this.onAutoRefresh} autoRefresh={autoRefresh} />
             </div>
         );
 

--- a/src/main/js/providers/ProviderTable.js
+++ b/src/main/js/providers/ProviderTable.js
@@ -57,8 +57,6 @@ class ProviderTable extends Component {
     }
 
     componentDidUpdate(prevProps) {
-        console.log('Previous Props: ', prevProps);
-        console.log('Current state: ', this.props);
         if (prevProps.updateStatus === 'UPDATING' && (this.props.updateStatus === 'UPDATED' || this.props.updateStatus === 'ERROR')) {
             this.state.saveCallback(true);
         }

--- a/src/main/js/providers/ProviderTable.js
+++ b/src/main/js/providers/ProviderTable.js
@@ -3,7 +3,13 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import ConfigurationLabel from 'component/common/ConfigurationLabel';
 import PropTypes from 'prop-types';
-import { clearConfigFieldErrors, deleteConfig, getAllConfigs, testConfig, updateConfig } from 'store/actions/globalConfiguration';
+import {
+    clearConfigFieldErrors,
+    deleteConfig,
+    getAllConfigs,
+    testConfig,
+    updateConfig
+} from 'store/actions/globalConfiguration';
 import * as DescriptorUtilities from 'util/descriptorUtilities';
 import * as FieldModelUtilities from 'util/fieldModelUtilities';
 import TableDisplay from 'field/TableDisplay';
@@ -51,6 +57,8 @@ class ProviderTable extends Component {
     }
 
     componentDidUpdate(prevProps) {
+        console.log('Previous Props: ', prevProps);
+        console.log('Current state: ', this.props);
         if (prevProps.updateStatus === 'UPDATING' && (this.props.updateStatus === 'UPDATED' || this.props.updateStatus === 'ERROR')) {
             this.state.saveCallback(true);
         }

--- a/src/main/js/store/reducers/globalConfiguration.js
+++ b/src/main/js/store/reducers/globalConfiguration.js
@@ -42,6 +42,10 @@ const globalConfiguration = (state = initialState, action) => {
             return Object.assign({}, state, {
                 fetching: false,
                 allConfigs: action.config,
+                error: {
+                    message: '',
+                    fieldErrors: {}
+                }
             });
         case CONFIG_FETCHED:
             return Object.assign({}, state, {
@@ -68,7 +72,11 @@ const globalConfiguration = (state = initialState, action) => {
                 fetching: false,
                 updateStatus: 'FETCHED',
                 testing: false,
-                config: action.config
+                config: action.config,
+                error: {
+                    message: '',
+                    fieldErrors: {}
+                }
             });
 
         case CONFIG_UPDATE_ERROR:


### PR DESCRIPTION
Clear the Global Configuration errors when reading all the configurations.
The clearing of the errors when fetching all configurations is an issue with TableDisplay because in the background it keeps reading all the configs which clears the errors when the modal is up.  Therefore if the modal is up disable the refresh of the table data.  While the new or edit modals are up we save processing in the UI because we aren't making a request every 10 seconds to the Alert server. When the modal is closed the table will be refreshed with data.