### PR TITLE
fix delete

### DIFF
--- a/src/main/js/store/actions/globalConfiguration.js
+++ b/src/main/js/store/actions/globalConfiguration.js
@@ -287,11 +287,8 @@ export function deleteConfig(id) {
             response.json()
             .then((responseData) => {
                 if (response.ok) {
-                    response.json()
-                    .then(() => {
-                        dispatch(configDeleted());
-                        dispatch(refreshConfig());
-                    });
+                    dispatch(configDeleted());
+                    dispatch(refreshConfig());
                 } else {
                     handleFailureResponse(dispatch, responseData, response.status);
                 }


### PR DESCRIPTION
The global configuration delete action was calling the .json() function on the response inside a lambda function for the response.json() promise.  There is an error with the JSON body being locked therefore the delete operation never dispatches its state changes.