### PR TITLE
 fix select style

### DIFF
--- a/src/main/js/field/input/TableSelectInput.js
+++ b/src/main/js/field/input/TableSelectInput.js
@@ -364,34 +364,38 @@ class TableSelectInput extends Component {
         const confirmModalId = `${fieldKey}-confirmModal`;
         return (
             <div className="col-sm-8 d-inline-flex p-2">
-                <Select
-                    id={selectFieldId}
-                    className="typeAheadField"
-                    onChange={null}
-                    options={[]}
-                    isMulti
-                    components={components}
-                    noOptionsMessage={null}
-                    isDisabled
-                    clearable={false}
-                    value={this.state.displayedData}
-                />
-                <GeneralButton id={selectButtonId} className="selectButton" onClick={this.selectOnClick}
-                               disabled={this.state.showTable || this.props.readOnly}>
-                    Select
-                </GeneralButton>
-                {this.state.selectedData && this.state.selectedData.length > 0 &&
-                <GeneralButton id={clearButtonId} className="selectClearButton"
-                               onClick={this.handleShowClearConfirm}>
-                    Clear
-                </GeneralButton>
-                }
-                <ConfirmModal id={confirmModalId}
-                              showModal={this.state.showClearConfirm}
-                              title="Are you sure you want to clear all selected items?"
-                              affirmativeAction={this.handleClearClick}
-                              negativeAction={this.handleHideClearConfirm}
-                />
+                <div className="d-block typeAheadField">
+                    <Select
+                        id={selectFieldId}
+                        className="typeAheadField"
+                        onChange={null}
+                        options={[]}
+                        isMulti
+                        components={components}
+                        noOptionsMessage={null}
+                        isDisabled
+                        clearable={false}
+                        value={this.state.displayedData}
+                    />
+                    <div className="d-inline-flex float-right">
+                        <GeneralButton id={selectButtonId} className="selectButton" onClick={this.selectOnClick}
+                                       disabled={this.state.showTable || this.props.readOnly}>
+                            Select
+                        </GeneralButton>
+                        {this.state.selectedData && this.state.selectedData.length > 0 &&
+                        <GeneralButton id={clearButtonId} className="selectClearButton"
+                                       onClick={this.handleShowClearConfirm}>
+                            Clear
+                        </GeneralButton>
+                        }
+                    </div>
+                    <ConfirmModal id={confirmModalId}
+                                  showModal={this.state.showClearConfirm}
+                                  title="Are you sure you want to clear all selected items?"
+                                  affirmativeAction={this.handleClearClick}
+                                  negativeAction={this.handleHideClearConfirm}
+                    />
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
Make the buttons for select and clear appear underneath the select input.  This allows the screen to re-size and not display the buttons off of the modal window.