### PR TITLE
 Change the size of the text area to match the column size.

### DIFF
--- a/src/main/js/dynamic/loaded/audit/Details.js
+++ b/src/main/js/dynamic/loaded/audit/Details.js
@@ -49,7 +49,7 @@ class Details extends Component {
         let errorStackTrace = null;
         if (row.errorStackTrace) {
             errorStackTrace =
-                <TextArea id="auditDetailStackTrace" inputClass="auditJobDetails" sizeClass="col-sm-12"
+                <TextArea id="auditDetailStackTrace" inputClass="auditJobDetails" sizeClass="col-sm-8"
                           label="Stack Trace" readOnly
                           name="errorStackTrace"
                           value={row.errorStackTrace} cols={'auto'} />;


### PR DESCRIPTION
Change the size of the text area to be the same size as the column.  The size it had was larger than the error message in the same column causing the issue.