### PR TITLE
Fix sonar cloud issues with exception tests.

### DIFF
--- a/src/test/java/com/synopsys/integration/alert/channel/email/EmailChannelTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/email/EmailChannelTestIT.java
@@ -74,18 +74,17 @@ public class EmailChannelTestIT extends ChannelTest {
     }
 
     @Test
-    public void sendEmailNullGlobalTest() {
+    public void sendEmailNullGlobalTest() throws Exception {
+        EmailChannelMessageParser emailChannelMessageParser = new EmailChannelMessageParser();
+        EmailAttachmentFileCreator emailAttachmentFileCreator = new EmailAttachmentFileCreator(null, new MessageContentGroupCsvCreator(), gson);
+        EmailChannel emailChannel = new EmailChannel(CHANNEL_KEY, gson, null, null, null, null, emailChannelMessageParser, emailAttachmentFileCreator);
+        LinkableItem subTopic = new LinkableItem("subTopic", "sub topic", null);
+        ProviderMessageContent content = new ProviderMessageContent.Builder()
+                                             .applyProvider("testProvider", 1L, "testProviderConfig")
+                                             .applyTopic("testTopic", "topic")
+                                             .applySubTopic(subTopic.getName(), subTopic.getValue())
+                                             .build();
         try {
-            EmailChannelMessageParser emailChannelMessageParser = new EmailChannelMessageParser();
-            EmailAttachmentFileCreator emailAttachmentFileCreator = new EmailAttachmentFileCreator(null, new MessageContentGroupCsvCreator(), gson);
-            EmailChannel emailChannel = new EmailChannel(CHANNEL_KEY, gson, null, null, null, null, emailChannelMessageParser, emailAttachmentFileCreator);
-            LinkableItem subTopic = new LinkableItem("subTopic", "sub topic", null);
-            ProviderMessageContent content = new ProviderMessageContent.Builder()
-                                                 .applyProvider("testProvider", 1L, "testProviderConfig")
-                                                 .applyTopic("testTopic", "topic")
-                                                 .applySubTopic(subTopic.getName(), subTopic.getValue())
-                                                 .build();
-
             Map<String, ConfigurationFieldModel> fieldMap = new HashMap<>();
             FieldAccessor fieldAccessor = new FieldAccessor(fieldMap);
             DistributionEvent event = new DistributionEvent(

--- a/src/test/java/com/synopsys/integration/alert/database/api/configuration/ConfigurationAccessorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/database/api/configuration/ConfigurationAccessorTestIT.java
@@ -467,10 +467,10 @@ public class ConfigurationAccessorTestIT extends AlertIntegrationTest {
     }
 
     @Test
-    public void updateConfigurationWithInvalidFieldKeyTest() {
+    public void updateConfigurationWithInvalidFieldKeyTest() throws Exception {
+        DescriptorKey descriptorKey = createDescriptorKey(DESCRIPTOR_NAME);
+        ConfigurationModel configurationModel = configurationAccessor.createConfiguration(descriptorKey, ConfigContextEnum.DISTRIBUTION, List.of());
         try {
-            DescriptorKey descriptorKey = createDescriptorKey(DESCRIPTOR_NAME);
-            ConfigurationModel configurationModel = configurationAccessor.createConfiguration(descriptorKey, ConfigContextEnum.DISTRIBUTION, List.of());
             ConfigurationFieldModel field = ConfigurationFieldModel.create(null);
             configurationAccessor.updateConfiguration(configurationModel.getConfigurationId(), Arrays.asList(field));
             fail("Expected exception to be thrown");


### PR DESCRIPTION
Only use the try catch block to test a single exception.  Move the methods that throw IntegrationExceptions that aren't part of the test out of the try/catch block to address sonar cloud issues.