### PR TITLE
Method called in a for loop so flush the repository at the end.

### DIFF
--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProviderDataAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProviderDataAccessor.java
@@ -177,6 +177,7 @@ public class DefaultProviderDataAccessor implements ProviderDataAccessor {
         logger.debug("Removing {} user relations from project {} ", userRelationsToRemove.size(), project.getName());
         providerUserProjectRelationRepository.saveAll(userRelationsToAdd);
         providerUserProjectRelationRepository.deleteAll(userRelationsToRemove);
+        providerUserProjectRelationRepository.flush();
     }
 
     private List<ProviderUserModel> saveUsers(Long providerConfigId, Collection<ProviderUserModel> users) {


### PR DESCRIPTION
The mapUsersToProjectByEmail method is called inside a forloop in a transaction.  It uses the batch methods deleteAll and saveAll.  Need to flush after those methods are called so the next iteration of the loop can find the repository data.