### PR TITLE
Auto-refresh Improvements

### DIFF
--- a/src/main/js/component/common/AutoRefresh.js
+++ b/src/main/js/component/common/AutoRefresh.js
@@ -20,7 +20,8 @@ class AutoRefresh extends Component {
     }
 
     componentDidUpdate(prevProps, prevState) {
-        const { autoRefresh } = this.props;
+        const { autoRefresh, isEnabled } = this.props;
+
         if ((prevProps.autoRefresh !== autoRefresh)) {
             this.setState({
                 refresh: this.props.autoRefresh
@@ -32,6 +33,10 @@ class AutoRefresh extends Component {
             this.toggleTimer();
             this.props.updateRefresh(this.state.refresh);
         }
+
+        if (prevState.isEnabled !== isEnabled) {
+            this.toggleTimer();
+        }
     }
 
     componentWillUnmount() {
@@ -39,7 +44,8 @@ class AutoRefresh extends Component {
     }
 
     toggleTimer() {
-        if (this.state.refresh) {
+        console.log("isEnabled(toggleTimer): ", this.props.isEnabled);
+        if (this.state.refresh && this.props.isEnabled) {
             clearInterval(this.timer);
             this.timer = setInterval(() => this.props.startAutoReload(), this.props.refreshRate);
         } else {
@@ -67,12 +73,14 @@ AutoRefresh.propTypes = {
     startAutoReload: PropTypes.func.isRequired,
     updateRefresh: PropTypes.func.isRequired,
     autoRefresh: PropTypes.bool,
+    isEnabled: PropTypes.bool,
     refreshRate: PropTypes.number,
     label: PropTypes.string
 };
 
 AutoRefresh.defaultProps = {
     autoRefresh: true,
+    isEnabled: true,
     refreshRate: 10000,
     label: 'Enable Auto-Refresh'
 };

--- a/src/main/js/component/common/AutoRefresh.js
+++ b/src/main/js/component/common/AutoRefresh.js
@@ -81,7 +81,7 @@ AutoRefresh.propTypes = {
 AutoRefresh.defaultProps = {
     autoRefresh: true,
     isEnabled: true,
-    refreshRate: 10000,
+    refreshRate: 30000,
     label: 'Enable Auto-Refresh'
 };
 

--- a/src/main/js/component/common/AutoRefresh.js
+++ b/src/main/js/component/common/AutoRefresh.js
@@ -20,18 +20,19 @@ class AutoRefresh extends Component {
     }
 
     componentDidUpdate(prevProps, prevState) {
+        const { refresh } = this.state;
         const { autoRefresh, isEnabled } = this.props;
 
         if ((prevProps.autoRefresh !== autoRefresh)) {
             this.setState({
-                refresh: this.props.autoRefresh
+                refresh: autoRefresh
             });
             this.toggleTimer();
         }
 
-        if (prevState.refresh !== this.state.refresh) {
+        if (prevState.refresh !== refresh) {
             this.toggleTimer();
-            this.props.updateRefresh(this.state.refresh);
+            this.props.updateRefresh(refresh);
         }
 
         if (prevState.isEnabled !== isEnabled) {
@@ -44,10 +45,12 @@ class AutoRefresh extends Component {
     }
 
     toggleTimer() {
-        console.log("isEnabled(toggleTimer): ", this.props.isEnabled);
-        if (this.state.refresh && this.props.isEnabled) {
+        const { refresh } = this.state;
+        const { refreshRate, isEnabled } = this.props;
+
+        if (refresh && isEnabled) {
             clearInterval(this.timer);
-            this.timer = setInterval(() => this.props.startAutoReload(), this.props.refreshRate);
+            this.timer = setInterval(() => this.props.startAutoReload(), refreshRate);
         } else {
             clearInterval(this.timer);
         }
@@ -55,10 +58,11 @@ class AutoRefresh extends Component {
 
     render() {
         const { refresh } = this.state;
+        const { label } = this.props;
         return (
             <CheckboxInput
                 id="autoRefresh-id"
-                label={this.props.label}
+                label={label}
                 name="autoRefresh"
                 showDescriptionPlaceHolder={false}
                 labelClass="tableCheckbox"

--- a/src/main/js/distribution/Index.js
+++ b/src/main/js/distribution/Index.js
@@ -11,13 +11,7 @@ import * as DescriptorUtilities from 'util/descriptorUtilities';
 import JobDeleteModal from 'distribution/JobDeleteModal';
 import * as FieldModelUtilities from 'util/fieldModelUtilities';
 import ConfigurationLabel from 'component/common/ConfigurationLabel';
-import DistributionConfiguration, {
-    KEY_CHANNEL_NAME,
-    KEY_ENABLED,
-    KEY_FREQUENCY,
-    KEY_NAME,
-    KEY_PROVIDER_NAME
-} from 'dynamic/DistributionConfiguration';
+import DistributionConfiguration, { KEY_CHANNEL_NAME, KEY_ENABLED, KEY_FREQUENCY, KEY_NAME, KEY_PROVIDER_NAME } from 'dynamic/DistributionConfiguration';
 import StatusMessage from 'field/StatusMessage';
 
 /**
@@ -347,6 +341,10 @@ class Index extends Component {
         const canCreate = this.checkJobPermissions(DescriptorUtilities.OPERATIONS.CREATE);
         const canDelete = this.checkJobPermissions(DescriptorUtilities.OPERATIONS.DELETE);
 
+        //TODO: Refresh is enabled on insert, but disabled on edit and delete modals
+        //TODO: Convert to TableDisplay to resolve autoRefresh issues
+        const shouldRefresh = !this.state.currentRowSelected && !this.state.showDeleteModal;
+
         const content = (
             <div>
                 {this.getCurrentJobConfig()}
@@ -417,7 +415,7 @@ class Index extends Component {
 
                 <ConfigurationLabel configurationName="Distribution" description="Create jobs from the channels Alert provides. Double click the row to edit that job." />
                 <div className="pull-right">
-                    <AutoRefresh startAutoReload={this.reloadJobs} autoRefresh={this.props.autoRefresh} />
+                    <AutoRefresh startAutoReload={this.reloadJobs} autoRefresh={this.props.autoRefresh} isEnabled={shouldRefresh} />
                 </div>
                 {content}
             </div>

--- a/src/main/js/dynamic/loaded/audit/AuditPage.js
+++ b/src/main/js/dynamic/loaded/audit/AuditPage.js
@@ -304,11 +304,13 @@ class AuditPage extends Component {
         };
         const { label, description } = this.props;
 
+        const shouldRefresh = !this.state.showDetailModal;
+
         return (
             <div>
                 <ConfigurationLabel configurationName={label} description={description} />
                 <div className="pull-right">
-                    <AutoRefresh startAutoReload={this.reloadAuditEntries} autoRefresh={this.props.autoRefresh} />
+                    <AutoRefresh startAutoReload={this.reloadAuditEntries} autoRefresh={this.props.autoRefresh} isEnabled={shouldRefresh} />
                 </div>
                 <div className="pull-right">
                     <CheckboxInput

--- a/src/main/js/field/TableDisplay.js
+++ b/src/main/js/field/TableDisplay.js
@@ -409,7 +409,7 @@ class TableDisplay extends Component {
 
     render() {
         const tableColumns = this.createTableColumns();
-        const { showDelete } = this.state;
+        const { showConfiguration, showDelete } = this.state;
         const {
             id, actionMessage, selectRowBox, sortName, sortOrder, autoRefresh, tableMessage, newButton, deleteButton,
             data, tableSearchable, enableEdit, editColumnText, enableCopy, copyColumnText, inProgress,
@@ -492,9 +492,11 @@ class TableDisplay extends Component {
             </div>
         );
 
+        const shouldRefresh = !showConfiguration && !showDelete;
+
         const refresh = tableRefresh && (
             <div className="pull-right">
-                <AutoRefresh startAutoReload={this.onAutoRefresh} autoRefresh={autoRefresh} />
+                <AutoRefresh startAutoReload={this.onAutoRefresh} autoRefresh={autoRefresh} isEnabled={shouldRefresh} />
             </div>
         );
         return (


### PR DESCRIPTION
The following changes are updates and improvements to the auto-refresh, bringing the refresh rate up to 30 seconds as well as pausing it on modals that it previously did not effect such as some delete modals. 

As a note, currently the insert modal for the distribution jobs will continue to refresh the table in the background as we cannot get the state of the table easily. After discussing it with Paulo, the solution for this table will be to change update the distributions page to use TableDisplay to simplify the modals in a future ticket.

Laslty, several style changes were made to use object destructuring.