### PR TITLE
Ps endpoint select clear

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckDistributionUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckDistributionUIConfig.java
@@ -34,6 +34,7 @@ import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.ta
 import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.table.TableSelectColumn;
 import com.synopsys.integration.alert.common.descriptor.config.ui.ChannelDistributionUIConfig;
 import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderDistributionUIConfig;
+import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
 
 @Component
 public class BlackDuckDistributionUIConfig extends ProviderDistributionUIConfig {
@@ -46,8 +47,8 @@ public class BlackDuckDistributionUIConfig extends ProviderDistributionUIConfig 
     private static final String PANEL_NOTIFICATION_FILTERING = "Black Duck Notification Filtering";
 
     @Autowired
-    public BlackDuckDistributionUIConfig(BlackDuckContent blackDuckContent) {
-        super(BlackDuckDescriptor.BLACKDUCK_LABEL, BlackDuckDescriptor.BLACKDUCK_URL, blackDuckContent);
+    public BlackDuckDistributionUIConfig(BlackDuckContent blackDuckContent, ConfigurationAccessor configurationAccessor) {
+        super(BlackDuckDescriptor.BLACKDUCK_LABEL, BlackDuckDescriptor.BLACKDUCK_URL, blackDuckContent, configurationAccessor);
     }
 
     @Override

--- a/src/main/js/field/EndpointSelectField.js
+++ b/src/main/js/field/EndpointSelectField.js
@@ -10,10 +10,10 @@ class EndpointSelectField extends Component {
         super(props);
 
         this.onSendClick = this.onSendClick.bind(this);
-
+        this.emptyFieldValue = this.emptyFieldValue.bind(this);
         this.state = ({
             options: [],
-            progress: false,
+            progress: false
         });
     }
 
@@ -35,7 +35,7 @@ class EndpointSelectField extends Component {
             success: false
         });
         const {
-            fieldKey, csrfToken, currentConfig, endpoint, requestedDataFieldKeys
+            fieldKey, csrfToken, currentConfig, endpoint, requestedDataFieldKeys, value
         } = this.props;
 
         const newFieldModel = FieldModelUtilities.createFieldModelFromRequestedFields(currentConfig, requestedDataFieldKeys);
@@ -45,8 +45,16 @@ class EndpointSelectField extends Component {
                 response.json().then((data) => {
                     const options = data.map(item => {
                         const dataValue = item.value;
-                        return { key: dataValue, label: item.label, value: dataValue };
+                        return {
+                            key: dataValue,
+                            label: item.label,
+                            value: dataValue
+                        };
                     });
+                    const selectedValues = options.filter(option => value.includes(option.value));
+                    if (options.length === 0 || selectedValues.length === 0) {
+                        this.emptyFieldValue();
+                    }
 
                     this.setState({
                         options,
@@ -54,20 +62,34 @@ class EndpointSelectField extends Component {
                     });
                 });
             } else {
-                response.json().then((data) => {
+                response.json()
+                .then((data) => {
                     this.setState({
                         options: [],
                         fieldError: data.message
-                    });
+                    }, this.emptyFieldValue);
                 });
             }
         });
     }
 
+    emptyFieldValue() {
+        const { fieldKey, onChange } = this.props;
+        const eventObject = {
+            target: {
+                name: fieldKey,
+                value: []
+            }
+        };
+
+        onChange(eventObject);
+    }
+
     render() {
         return (
             <div>
-                <DynamicSelectInput onChange={this.props.onChange} onFocus={this.onSendClick} options={this.state.options} {...this.props} />
+                <DynamicSelectInput onChange={this.props.onChange} onFocus={this.onSendClick}
+                                    options={this.state.options} {...this.props} />
             </div>
         );
     }

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckDescriptorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckDescriptorTest.java
@@ -22,7 +22,7 @@ public class BlackDuckDescriptorTest {
         Mockito.when(encryptionValidator.apply(Mockito.any(), Mockito.any())).thenReturn(ValidationResult.success());
         BlackDuckProviderKey blackDuckProviderKey = new BlackDuckProviderKey();
         BlackDuckContent blackDuckContent = new BlackDuckContent();
-        BlackDuckDistributionUIConfig blackDuckDistributionUIConfig = new BlackDuckDistributionUIConfig(blackDuckContent);
+        BlackDuckDistributionUIConfig blackDuckDistributionUIConfig = new BlackDuckDistributionUIConfig(blackDuckContent, configurationAccessor);
         blackDuckDistributionUIConfig.setConfigFields();
         BlackDuckProviderUIConfig blackDuckProviderUIConfig = new BlackDuckProviderUIConfig(blackDuckProviderKey, encryptionValidator, configurationAccessor);
         blackDuckProviderUIConfig.setConfigFields();

--- a/src/test/java/com/synopsys/integration/alert/web/config/JobConfigControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/web/config/JobConfigControllerTestIT.java
@@ -57,6 +57,7 @@ import com.synopsys.integration.alert.util.DatabaseConfiguredFieldTest;
 
 @Transactional
 public class JobConfigControllerTestIT extends DatabaseConfiguredFieldTest {
+    private static final String DEFAULT_BLACK_DUCK_CONFIG = "Default Black Duck Config";
     private final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(), MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
     private final String url = JobConfigController.JOB_CONFIGURATION_PATH;
 
@@ -152,6 +153,7 @@ public class JobConfigControllerTestIT extends DatabaseConfiguredFieldTest {
         }
         ConfigurationJobModel emptyConfigurationModel = addJob(slackChannelKey.getUniversalKey(), blackDuckProviderKey.getUniversalKey(), fieldValueModels);
         addGlobalConfiguration(blackDuckProviderKey, Map.of(
+            ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME, List.of(DEFAULT_BLACK_DUCK_CONFIG),
             BlackDuckDescriptor.KEY_BLACKDUCK_URL, List.of("BLACKDUCK_URL"),
             BlackDuckDescriptor.KEY_BLACKDUCK_API_KEY, List.of("BLACKDUCK_API")));
         String configId = String.valueOf(emptyConfigurationModel.getJobId());
@@ -174,6 +176,7 @@ public class JobConfigControllerTestIT extends DatabaseConfiguredFieldTest {
     @WithMockUser(roles = AlertIntegrationTest.ROLE_ALERT_ADMIN)
     public void testSaveConfig() throws Exception {
         addGlobalConfiguration(blackDuckProviderKey, Map.of(
+            ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME, List.of(DEFAULT_BLACK_DUCK_CONFIG),
             BlackDuckDescriptor.KEY_BLACKDUCK_URL, List.of("BLACKDUCK_URL"),
             BlackDuckDescriptor.KEY_BLACKDUCK_API_KEY, List.of("BLACKDUCK_API")));
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(url)
@@ -196,6 +199,7 @@ public class JobConfigControllerTestIT extends DatabaseConfiguredFieldTest {
     public void testValidateConfig() throws Exception {
         final String urlPath = url + "/validate";
         addGlobalConfiguration(blackDuckProviderKey, Map.of(
+            ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME, List.of(DEFAULT_BLACK_DUCK_CONFIG),
             BlackDuckDescriptor.KEY_BLACKDUCK_URL, List.of("BLACKDUCK_URL"),
             BlackDuckDescriptor.KEY_BLACKDUCK_API_KEY, List.of("BLACKDUCK_API")));
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(urlPath)
@@ -214,7 +218,7 @@ public class JobConfigControllerTestIT extends DatabaseConfiguredFieldTest {
         String descriptorName = slackChannelKey.getUniversalKey();
         String context = ConfigContextEnum.DISTRIBUTION.name();
 
-        FieldValueModel providerConfig = new FieldValueModel(List.of("Default Black Duck Config"), true);
+        FieldValueModel providerConfig = new FieldValueModel(List.of(DEFAULT_BLACK_DUCK_CONFIG), true);
         FieldValueModel slackChannelName = new FieldValueModel(List.of("channelName"), true);
         FieldValueModel frequency = new FieldValueModel(List.of(FrequencyType.DAILY.name()), true);
         FieldValueModel name = new FieldValueModel(List.of("name"), true);


### PR DESCRIPTION
Clear the fieldmodel of a value for the endpoint select field if the options are empty or if the value of the field is not present in the options.  This will update the field model to have an empty value which will be validated.  If the field is required like the provider config name then saving a configuration will report a field validation error for the required field because the fiedlModel sent to the server has an empty value for the config name.  If this isn't done the UI will not display any options but the fieldModel will have the old value which is still valid.  Also add a validation check to see if the config name exists in the back end java code in case a request is made via the API.  

