### PR TITLE
delete message fix

### DIFF
--- a/src/main/js/field/TableDisplay.js
+++ b/src/main/js/field/TableDisplay.js
@@ -250,9 +250,10 @@ class TableDisplay extends Component {
         const { currentRowSelected, isInsertModal } = this.state;
         const {
             id, modalTitle, newConfigFields, inProgress, saveButton, testButton, testButtonLabel, errorDialogMessage,
-            actionMessage, hasFieldErrors
+            actionMessage, hasFieldErrors, ignoredActionMessages
         } = this.props;
-        const popupActionMessage = (hasFieldErrors && errorDialogMessage) || actionMessage;
+        //TODO have a better way of displaying action messages for the dialog versus the table. The ignoredActionMessages is to fix an issue with the provider table in a generic way.
+        const popupActionMessage = (hasFieldErrors && errorDialogMessage) || (!ignoredActionMessages.includes(actionMessage) && actionMessage);
         const configFields = isInsertModal ? newConfigFields() : newConfigFields(currentRowSelected);
         const popupAssignmentFunction = (functionToTest, defaultFunction) => {
             if (tablePopupRef && functionToTest) {
@@ -546,7 +547,8 @@ TableDisplay.propTypes = {
     nestedInAnotherModal: PropTypes.bool,
     enableEdit: PropTypes.bool,
     enableCopy: PropTypes.bool,
-    testButtonLabel: PropTypes.string
+    testButtonLabel: PropTypes.string,
+    ignoredActionMessages: PropTypes.arrayOf(PropTypes.string)
 };
 
 TableDisplay.defaultProps = {
@@ -580,7 +582,8 @@ TableDisplay.defaultProps = {
     nestedInAnotherModal: false,
     enableEdit: true,
     enableCopy: true,
-    testButtonLabel: 'Test Configuration'
+    testButtonLabel: 'Test Configuration',
+    ignoredActionMessages: []
 };
 
 const mapStateToProps = (state) => ({

--- a/src/main/js/providers/ProviderTable.js
+++ b/src/main/js/providers/ProviderTable.js
@@ -307,6 +307,7 @@ class ProviderTable extends Component {
                         hasFieldErrors={hasFieldErrors}
                         errorDialogMessage={errorMessage}
                         actionMessage={providerActionMessage}
+                        ignoredActionMessages={['Delete successful']}
                         inProgress={inProgress}
                         fetching={fetching}
                     />


### PR DESCRIPTION
The provider table uses the globalConfiguration.js actions and reducers therefore the action messages are sent the same as the global configuration screens in alert.  The provider table has multiple configurations and displays a dialog with the error message.  To delete a provider a user clicks on the delete button.  If the user presses the edit button of an existing config due to redux state change timing the message in the dialog may show 'delete successful' which is the status of the items that were deleted.  To fix this issue add a mechanism to ignore action messages for the time being.  There are other changes in the future to render errors and messages in TableDisplay in a better way.  This is to fix the immediate issue.