### PR TITLE
Azure AD SAML Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
 }
 
 mainClassName = 'com.synopsys.integration.alert.Application'
-version = '6.2.0-SNAPSHOT'
+version = '6.2.0-SNAPSHOT-SAML-TEST'
 
 apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
 }
 
 mainClassName = 'com.synopsys.integration.alert.Application'
-version = '6.2.0-SNAPSHOT-SAML-TEST'
+version = '6.2.0-SNAPSHOT'
 
 apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'

--- a/src/main/java/com/synopsys/integration/alert/web/security/AuthenticationHandler.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/AuthenticationHandler.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.activemq.broker.BrokerService;
 import org.apache.commons.httpclient.HttpClient;
@@ -45,7 +44,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.FileSystemResource;
 import org.springframework.security.access.vote.AffirmativeBased;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -59,7 +57,6 @@ import org.springframework.security.saml.SAMLLogoutFilter;
 import org.springframework.security.saml.SAMLLogoutProcessingFilter;
 import org.springframework.security.saml.SAMLProcessingFilter;
 import org.springframework.security.saml.key.EmptyKeyManager;
-import org.springframework.security.saml.key.JKSKeyManager;
 import org.springframework.security.saml.key.KeyManager;
 import org.springframework.security.saml.metadata.CachingMetadataManager;
 import org.springframework.security.saml.metadata.ExtendedMetadata;
@@ -90,7 +87,6 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.descriptor.accessor.AuthorizationUtility;
-import com.synopsys.integration.alert.common.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.model.UserRoleModel;
 import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
@@ -365,14 +361,14 @@ public class AuthenticationHandler extends WebSecurityConfigurerAdapter {
 
     @Bean
     public KeyManager keyManager() {
-        KeyManager keyManager;
-        try {
-            FileSystemResource storeFile = new FileSystemResource(certificateUtility.getAndValidateTrustStoreFile());
-            keyManager = new JKSKeyManager(storeFile, alertProperties.getTrustStorePass().orElse(null), Map.of(), null);
-        } catch (AlertConfigurationException ex) {
-            keyManager = new EmptyKeyManager();
-        }
-        return keyManager;
+        //        KeyManager keyManager;
+        //        try {
+        //            FileSystemResource storeFile = new FileSystemResource(certificateUtility.getAndValidateTrustStoreFile());
+        //            keyManager = new JKSKeyManager(storeFile, alertProperties.getTrustStorePass().orElse(null), Map.of(), "");
+        //        } catch (AlertConfigurationException ex) {
+        //            keyManager = new EmptyKeyManager();
+        //        }
+        return new EmptyKeyManager();
     }
 
     @Bean

--- a/src/main/java/com/synopsys/integration/alert/web/security/AuthenticationHandler.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/AuthenticationHandler.java
@@ -95,7 +95,6 @@ import com.synopsys.integration.alert.common.descriptor.accessor.AuthorizationUt
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.model.UserRoleModel;
 import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
-import com.synopsys.integration.alert.common.security.CertificateUtility;
 import com.synopsys.integration.alert.component.authentication.descriptor.AuthenticationDescriptorKey;
 import com.synopsys.integration.alert.web.security.authentication.UserManagementAuthoritiesPopulator;
 import com.synopsys.integration.alert.web.security.authentication.event.AuthenticationEventManager;
@@ -125,12 +124,11 @@ public class AuthenticationHandler extends WebSecurityConfigurerAdapter {
     private final ConfigurationAccessor configurationAccessor;
     private final AuthenticationDescriptorKey authenticationDescriptorKey;
     private final AuthenticationEventManager authenticationEventManager;
-    private final CertificateUtility certificateUtility;
 
     @Autowired
     AuthenticationHandler(HttpPathManager httpPathManager, CsrfTokenRepository csrfTokenRepository, AlertProperties alertProperties, AuthorizationUtility authorizationUtility,
         FilePersistenceUtil filePersistenceUtil, UserManagementAuthoritiesPopulator authoritiesPopulator, ConfigurationAccessor configurationAccessor,
-        AuthenticationDescriptorKey authenticationDescriptorKey, AuthenticationEventManager authenticationEventManager, CertificateUtility certificateUtility) {
+        AuthenticationDescriptorKey authenticationDescriptorKey, AuthenticationEventManager authenticationEventManager) {
         this.httpPathManager = httpPathManager;
         this.csrfTokenRepository = csrfTokenRepository;
         this.alertProperties = alertProperties;
@@ -140,7 +138,6 @@ public class AuthenticationHandler extends WebSecurityConfigurerAdapter {
         this.configurationAccessor = configurationAccessor;
         this.authenticationDescriptorKey = authenticationDescriptorKey;
         this.authenticationEventManager = authenticationEventManager;
-        this.certificateUtility = certificateUtility;
     }
 
     @Override

--- a/src/main/java/com/synopsys/integration/alert/web/security/AuthenticationHandler.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/AuthenticationHandler.java
@@ -37,6 +37,7 @@ import org.apache.velocity.app.VelocityEngine;
 import org.opensaml.common.xml.SAMLConstants;
 import org.opensaml.saml2.core.NameIDType;
 import org.opensaml.saml2.metadata.provider.MetadataProviderException;
+import org.opensaml.xml.parse.ParserPool;
 import org.opensaml.xml.parse.StaticBasicParserPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,12 +63,16 @@ import org.springframework.security.saml.metadata.CachingMetadataManager;
 import org.springframework.security.saml.metadata.ExtendedMetadata;
 import org.springframework.security.saml.metadata.MetadataGenerator;
 import org.springframework.security.saml.metadata.MetadataGeneratorFilter;
+import org.springframework.security.saml.processor.HTTPArtifactBinding;
+import org.springframework.security.saml.processor.HTTPPAOS11Binding;
 import org.springframework.security.saml.processor.HTTPPostBinding;
 import org.springframework.security.saml.processor.HTTPRedirectDeflateBinding;
+import org.springframework.security.saml.processor.HTTPSOAP11Binding;
 import org.springframework.security.saml.processor.SAMLBinding;
 import org.springframework.security.saml.processor.SAMLProcessorImpl;
 import org.springframework.security.saml.userdetails.SAMLUserDetailsService;
 import org.springframework.security.saml.util.VelocityFactory;
+import org.springframework.security.saml.websso.ArtifactResolutionProfileImpl;
 import org.springframework.security.saml.websso.WebSSOProfileOptions;
 import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.FilterChainProxy;
@@ -361,13 +366,6 @@ public class AuthenticationHandler extends WebSecurityConfigurerAdapter {
 
     @Bean
     public KeyManager keyManager() {
-        //        KeyManager keyManager;
-        //        try {
-        //            FileSystemResource storeFile = new FileSystemResource(certificateUtility.getAndValidateTrustStoreFile());
-        //            keyManager = new JKSKeyManager(storeFile, alertProperties.getTrustStorePass().orElse(null), Map.of(), "");
-        //        } catch (AlertConfigurationException ex) {
-        //            keyManager = new EmptyKeyManager();
-        //        }
         return new EmptyKeyManager();
     }
 
@@ -408,6 +406,23 @@ public class AuthenticationHandler extends WebSecurityConfigurerAdapter {
         return new HTTPPostBinding(parserPool(), velocityEngine());
     }
 
+    @Bean
+    public HTTPArtifactBinding artifactBinding(ParserPool parserPool, VelocityEngine velocityEngine) {
+        ArtifactResolutionProfileImpl profileImpl = new ArtifactResolutionProfileImpl(new HttpClient(new MultiThreadedHttpConnectionManager()));
+        profileImpl.setProcessor(new SAMLProcessorImpl(soapBinding()));
+        return new HTTPArtifactBinding(parserPool, velocityEngine, profileImpl);
+    }
+
+    @Bean
+    public HTTPSOAP11Binding soapBinding() {
+        return new HTTPSOAP11Binding(parserPool());
+    }
+
+    @Bean
+    public HTTPPAOS11Binding paosBinding() {
+        return new HTTPPAOS11Binding(parserPool());
+    }
+
     @Bean(initMethod = "initialize")
     public StaticBasicParserPool parserPool() {
         return new StaticBasicParserPool();
@@ -423,6 +438,9 @@ public class AuthenticationHandler extends WebSecurityConfigurerAdapter {
         Collection<SAMLBinding> bindings = new ArrayList<>();
         bindings.add(httpRedirectDeflateBinding());
         bindings.add(httpPostBinding());
+        bindings.add(artifactBinding(parserPool(), velocityEngine()));
+        bindings.add(soapBinding());
+        bindings.add(paosBinding());
         return new SAMLProcessorImpl(bindings);
     }
 

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SAMLManager.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SAMLManager.java
@@ -147,6 +147,8 @@ public class SAMLManager {
         return Optional.of(createDelegate(provider));
     }
 
+    // This needs to be created in order for Azure AD SAML configuration to work. The entity id in the metadata is different
+    // than the entity id configured in Azure.  This allows the the entity id to get mapped and found correctly for the application.
     private Optional<ExtendedMetadataDelegate> createMemoryProvider() throws MetadataProviderException {
         EntityDescriptor descriptor = metadataGenerator.generateMetadata();
         MetadataMemoryProvider provider = new MetadataMemoryProvider(descriptor);

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SAMLManager.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SAMLManager.java
@@ -114,6 +114,7 @@ public class SAMLManager {
                                                .flatMap(Optional::stream)
                                                .collect(Collectors.toList());
         metadataManager.setProviders(providers);
+        metadataManager.setHostedSPName(entityId);
         metadataManager.afterPropertiesSet();
     }
 
@@ -144,7 +145,7 @@ public class SAMLManager {
 
     private ExtendedMetadataDelegate createDelegate(MetadataProvider provider) {
         ExtendedMetadataDelegate delegate = new ExtendedMetadataDelegate(provider, extendedMetadata);
-        delegate.setMetadataTrustCheck(true);
+        delegate.setMetadataTrustCheck(false);
         delegate.setMetadataRequireSignature(false);
         return delegate;
     }

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SAMLManager.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SAMLManager.java
@@ -29,7 +29,9 @@ import java.util.Timer;
 import java.util.stream.Collectors;
 
 import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.commons.lang3.StringUtils;
+import org.opensaml.saml2.metadata.EntityDescriptor;
 import org.opensaml.saml2.metadata.provider.FilesystemMetadataProvider;
 import org.opensaml.saml2.metadata.provider.HTTPMetadataProvider;
 import org.opensaml.saml2.metadata.provider.MetadataProvider;
@@ -41,6 +43,7 @@ import org.springframework.security.saml.metadata.ExtendedMetadata;
 import org.springframework.security.saml.metadata.ExtendedMetadataDelegate;
 import org.springframework.security.saml.metadata.MetadataGenerator;
 import org.springframework.security.saml.metadata.MetadataManager;
+import org.springframework.security.saml.metadata.MetadataMemoryProvider;
 
 import com.synopsys.integration.alert.common.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
@@ -110,7 +113,8 @@ public class SAMLManager {
 
         Optional<ExtendedMetadataDelegate> httpProvider = createHttpProvider(metadataURL);
         Optional<ExtendedMetadataDelegate> fileProvider = createFileProvider();
-        List<MetadataProvider> providers = List.of(httpProvider, fileProvider).stream()
+        Optional<ExtendedMetadataDelegate> memoryProvider = createMemoryProvider();
+        List<MetadataProvider> providers = List.of(httpProvider, fileProvider, memoryProvider).stream()
                                                .flatMap(Optional::stream)
                                                .collect(Collectors.toList());
         metadataManager.setProviders(providers);
@@ -126,7 +130,7 @@ public class SAMLManager {
         // The URL can not end in a '/' because it messes with the paths for saml
         String correctedMetadataURL = StringUtils.removeEnd(metadataUrl, "/");
         Timer backgroundTaskTimer = new Timer(true);
-        HTTPMetadataProvider provider = new HTTPMetadataProvider(backgroundTaskTimer, new HttpClient(), correctedMetadataURL);
+        HTTPMetadataProvider provider = new HTTPMetadataProvider(backgroundTaskTimer, httpClient(), correctedMetadataURL);
         provider.setParserPool(parserPool);
         return Optional.of(createDelegate(provider));
     }
@@ -143,10 +147,21 @@ public class SAMLManager {
         return Optional.of(createDelegate(provider));
     }
 
+    private Optional<ExtendedMetadataDelegate> createMemoryProvider() throws MetadataProviderException {
+        EntityDescriptor descriptor = metadataGenerator.generateMetadata();
+        MetadataMemoryProvider provider = new MetadataMemoryProvider(descriptor);
+        provider.initialize();
+        return Optional.of(createDelegate(provider));
+    }
+
     private ExtendedMetadataDelegate createDelegate(MetadataProvider provider) {
         ExtendedMetadataDelegate delegate = new ExtendedMetadataDelegate(provider, extendedMetadata);
         delegate.setMetadataTrustCheck(false);
         delegate.setMetadataRequireSignature(false);
         return delegate;
+    }
+
+    private HttpClient httpClient() {
+        return new HttpClient(new MultiThreadedHttpConnectionManager());
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SamlConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SamlConfig.java
@@ -46,7 +46,9 @@ public class SamlConfig {
 
     @Bean
     public SAMLDefaultLogger samlLogger() {
-        return new SAMLDefaultLogger();
+        SAMLDefaultLogger logger = new SAMLDefaultLogger();
+        logger.setLogErrors(true);
+        return logger;
     }
 
     @Bean

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SamlConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/saml/SamlConfig.java
@@ -34,6 +34,7 @@ import org.springframework.security.saml.websso.WebSSOProfile;
 import org.springframework.security.saml.websso.WebSSOProfileConsumer;
 import org.springframework.security.saml.websso.WebSSOProfileConsumerHoKImpl;
 import org.springframework.security.saml.websso.WebSSOProfileConsumerImpl;
+import org.springframework.security.saml.websso.WebSSOProfileECPImpl;
 import org.springframework.security.saml.websso.WebSSOProfileImpl;
 
 @Configuration
@@ -79,6 +80,12 @@ public class SamlConfig {
     @Bean
     public WebSSOProfileConsumerHoKImpl hokWebSSOProfile() {
         return new WebSSOProfileConsumerHoKImpl();
+    }
+
+    // SAML 2.0 ECP profile
+    @Bean
+    public WebSSOProfileECPImpl ecpprofile() {
+        return new WebSSOProfileECPImpl();
     }
 
     @Bean


### PR DESCRIPTION
Fix the SAML functionality to work with Azure AD SAML.  Needed to disable signature verification to avoid the certificate errors.  Then needed to add an additional metadata provider to create the SAML hand shake.