### PR TITLE
Enhance MessageResult

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/channel/issuetracker/message/IssueTrackerResponse.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/channel/issuetracker/message/IssueTrackerResponse.java
@@ -22,12 +22,11 @@
  */
 package com.synopsys.integration.alert.common.channel.issuetracker.message;
 
-import java.io.Serializable;
 import java.util.Collection;
 
-import com.synopsys.integration.util.Stringable;
+import com.synopsys.integration.alert.common.rest.model.AlertSerializableModel;
 
-public class IssueTrackerResponse extends Stringable implements Serializable {
+public class IssueTrackerResponse extends AlertSerializableModel {
     private final String statusMessage;
     private final Collection<IssueTrackerIssueResponseModel> updatedIssues;
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/errors/AlertFieldStatus.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/errors/AlertFieldStatus.java
@@ -24,18 +24,18 @@ package com.synopsys.integration.alert.common.descriptor.config.field.errors;
 
 public class AlertFieldStatus {
     private final String fieldName;
-    private final FieldErrorSeverity severity;
+    private final FieldStatusSeverity severity;
     private final String fieldMessage;
 
     public static AlertFieldStatus error(String fieldName, String fieldErrorMessage) {
-        return new AlertFieldStatus(fieldName, FieldErrorSeverity.ERROR, fieldErrorMessage);
+        return new AlertFieldStatus(fieldName, FieldStatusSeverity.ERROR, fieldErrorMessage);
     }
 
     public static AlertFieldStatus warning(String fieldName, String fieldErrorMessage) {
-        return new AlertFieldStatus(fieldName, FieldErrorSeverity.WARNING, fieldErrorMessage);
+        return new AlertFieldStatus(fieldName, FieldStatusSeverity.WARNING, fieldErrorMessage);
     }
 
-    private AlertFieldStatus(String fieldName, FieldErrorSeverity severity, String fieldMessage) {
+    private AlertFieldStatus(String fieldName, FieldStatusSeverity severity, String fieldMessage) {
         this.fieldName = fieldName;
         this.severity = severity;
         this.fieldMessage = fieldMessage;
@@ -45,7 +45,7 @@ public class AlertFieldStatus {
         return fieldName;
     }
 
-    public FieldErrorSeverity getSeverity() {
+    public FieldStatusSeverity getSeverity() {
         return severity;
     }
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/errors/FieldStatusSeverity.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/errors/FieldStatusSeverity.java
@@ -22,7 +22,7 @@
  */
 package com.synopsys.integration.alert.common.descriptor.config.field.errors;
 
-public enum FieldErrorSeverity {
+public enum FieldStatusSeverity {
     WARNING,
     ERROR
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/message/model/MessageResult.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/message/model/MessageResult.java
@@ -34,6 +34,20 @@ public class MessageResult extends AlertSerializableModel {
     private final String statusMessage;
     private final List<AlertFieldStatus> fieldStatuses;
 
+    public static List<AlertFieldStatus> getFieldStatusesBySeverity(List<AlertFieldStatus> fieldStatuses, FieldStatusSeverity severity) {
+        return fieldStatuses
+                   .stream()
+                   .filter(status -> status.getSeverity().equals(severity))
+                   .collect(Collectors.toList());
+    }
+
+    public static boolean hasFieldStatusBySeverity(List<AlertFieldStatus> fieldStatuses, FieldStatusSeverity severity) {
+        return fieldStatuses
+                   .stream()
+                   .map(AlertFieldStatus::getSeverity)
+                   .anyMatch(severity::equals);
+    }
+
     public MessageResult(String statusMessage) {
         this.statusMessage = statusMessage;
         fieldStatuses = List.of();
@@ -75,17 +89,11 @@ public class MessageResult extends AlertSerializableModel {
     }
 
     public List<AlertFieldStatus> getFieldStatusesBySeverity(FieldStatusSeverity severity) {
-        return fieldStatuses
-                   .stream()
-                   .filter(status -> status.getSeverity().equals(severity))
-                   .collect(Collectors.toList());
+        return getFieldStatusesBySeverity(fieldStatuses, severity);
     }
 
     public boolean hasFieldStatusBySeverity(FieldStatusSeverity severity) {
-        return fieldStatuses
-                   .stream()
-                   .map(AlertFieldStatus::getSeverity)
-                   .anyMatch(severity::equals);
+        return hasFieldStatusBySeverity(fieldStatuses, severity);
     }
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/message/model/MessageResult.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/message/model/MessageResult.java
@@ -33,6 +33,11 @@ public class MessageResult extends AlertSerializableModel {
     private final String statusMessage;
     private final List<AlertFieldStatus> fieldStatuses;
 
+    public static MessageResult singleFieldError(String fieldName, String errorMessage) {
+        AlertFieldStatus fieldError = AlertFieldStatus.error(fieldName, errorMessage);
+        return new MessageResult("Field error", List.of(fieldError));
+    }
+
     public MessageResult(String statusMessage) {
         this.statusMessage = statusMessage;
         fieldStatuses = List.of();

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/message/model/MessageResult.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/message/model/MessageResult.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import com.synopsys.integration.alert.common.descriptor.config.field.errors.AlertFieldStatus;
 import com.synopsys.integration.alert.common.descriptor.config.field.errors.FieldStatusSeverity;
+import com.synopsys.integration.alert.common.exception.AlertFieldException;
 import com.synopsys.integration.alert.common.rest.model.AlertSerializableModel;
 
 public class MessageResult extends AlertSerializableModel {
@@ -49,6 +50,12 @@ public class MessageResult extends AlertSerializableModel {
 
     public List<AlertFieldStatus> getFieldStatuses() {
         return fieldStatuses;
+    }
+
+    public void throwExceptionForFieldStatues() throws AlertFieldException {
+        if (!fieldStatuses.isEmpty()) {
+            throw new AlertFieldException(statusMessage, fieldStatuses);
+        }
     }
 
     public boolean hasErrors() {

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/message/model/MessageResult.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/message/model/MessageResult.java
@@ -26,15 +26,16 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.synopsys.integration.alert.common.descriptor.config.field.errors.AlertFieldStatus;
-import com.synopsys.integration.alert.common.descriptor.config.field.errors.FieldErrorSeverity;
+import com.synopsys.integration.alert.common.descriptor.config.field.errors.FieldStatusSeverity;
 import com.synopsys.integration.alert.common.rest.model.AlertSerializableModel;
 
 public class MessageResult extends AlertSerializableModel {
-    private String statusMessage;
-    private List<AlertFieldStatus> fieldStatuses;
+    private final String statusMessage;
+    private final List<AlertFieldStatus> fieldStatuses;
 
     public MessageResult(String statusMessage) {
         this.statusMessage = statusMessage;
+        fieldStatuses = List.of();
     }
 
     public MessageResult(String statusMessage, List<AlertFieldStatus> fieldStatuses) {
@@ -46,38 +47,34 @@ public class MessageResult extends AlertSerializableModel {
         return statusMessage;
     }
 
-    public void setStatusMessage(String statusMessage) {
-        this.statusMessage = statusMessage;
-    }
-
     public List<AlertFieldStatus> getFieldStatuses() {
         return fieldStatuses;
     }
 
     public boolean hasErrors() {
-        return hasFieldStatusBySeverity(FieldErrorSeverity.ERROR);
+        return hasFieldStatusBySeverity(FieldStatusSeverity.ERROR);
     }
 
     public List<AlertFieldStatus> fieldErrors() {
-        return getFieldStatusesBySeverity(FieldErrorSeverity.ERROR);
+        return getFieldStatusesBySeverity(FieldStatusSeverity.ERROR);
     }
 
     public boolean hasWarnings() {
-        return hasFieldStatusBySeverity(FieldErrorSeverity.WARNING);
+        return hasFieldStatusBySeverity(FieldStatusSeverity.WARNING);
     }
 
     public List<AlertFieldStatus> fieldWarnings() {
-        return getFieldStatusesBySeverity(FieldErrorSeverity.WARNING);
+        return getFieldStatusesBySeverity(FieldStatusSeverity.WARNING);
     }
 
-    public List<AlertFieldStatus> getFieldStatusesBySeverity(FieldErrorSeverity severity) {
+    public List<AlertFieldStatus> getFieldStatusesBySeverity(FieldStatusSeverity severity) {
         return fieldStatuses
                    .stream()
                    .filter(status -> status.getSeverity().equals(severity))
                    .collect(Collectors.toList());
     }
 
-    public boolean hasFieldStatusBySeverity(FieldErrorSeverity severity) {
+    public boolean hasFieldStatusBySeverity(FieldStatusSeverity severity) {
         return fieldStatuses
                    .stream()
                    .map(AlertFieldStatus::getSeverity)

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/message/model/MessageResult.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/message/model/MessageResult.java
@@ -22,13 +22,24 @@
  */
 package com.synopsys.integration.alert.common.message.model;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.synopsys.integration.alert.common.descriptor.config.field.errors.AlertFieldStatus;
+import com.synopsys.integration.alert.common.descriptor.config.field.errors.FieldErrorSeverity;
 import com.synopsys.integration.alert.common.rest.model.AlertSerializableModel;
 
 public class MessageResult extends AlertSerializableModel {
     private String statusMessage;
+    private List<AlertFieldStatus> fieldStatuses;
 
     public MessageResult(String statusMessage) {
         this.statusMessage = statusMessage;
+    }
+
+    public MessageResult(String statusMessage, List<AlertFieldStatus> fieldStatuses) {
+        this.statusMessage = statusMessage;
+        this.fieldStatuses = fieldStatuses;
     }
 
     public String getStatusMessage() {
@@ -37,6 +48,40 @@ public class MessageResult extends AlertSerializableModel {
 
     public void setStatusMessage(String statusMessage) {
         this.statusMessage = statusMessage;
+    }
+
+    public List<AlertFieldStatus> getFieldStatuses() {
+        return fieldStatuses;
+    }
+
+    public boolean hasErrors() {
+        return hasFieldStatusBySeverity(FieldErrorSeverity.ERROR);
+    }
+
+    public List<AlertFieldStatus> fieldErrors() {
+        return getFieldStatusesBySeverity(FieldErrorSeverity.ERROR);
+    }
+
+    public boolean hasWarnings() {
+        return hasFieldStatusBySeverity(FieldErrorSeverity.WARNING);
+    }
+
+    public List<AlertFieldStatus> fieldWarnings() {
+        return getFieldStatusesBySeverity(FieldErrorSeverity.WARNING);
+    }
+
+    public List<AlertFieldStatus> getFieldStatusesBySeverity(FieldErrorSeverity severity) {
+        return fieldStatuses
+                   .stream()
+                   .filter(status -> status.getSeverity().equals(severity))
+                   .collect(Collectors.toList());
+    }
+
+    public boolean hasFieldStatusBySeverity(FieldErrorSeverity severity) {
+        return fieldStatuses
+                   .stream()
+                   .map(AlertFieldStatus::getSeverity)
+                   .anyMatch(severity::equals);
     }
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/message/model/MessageResult.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/message/model/MessageResult.java
@@ -33,11 +33,6 @@ public class MessageResult extends AlertSerializableModel {
     private final String statusMessage;
     private final List<AlertFieldStatus> fieldStatuses;
 
-    public static MessageResult singleFieldError(String fieldName, String errorMessage) {
-        AlertFieldStatus fieldError = AlertFieldStatus.error(fieldName, errorMessage);
-        return new MessageResult("Field error", List.of(fieldError));
-    }
-
     public MessageResult(String statusMessage) {
         this.statusMessage = statusMessage;
         fieldStatuses = List.of();

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/model/JobFieldStatuses.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/model/JobFieldStatuses.java
@@ -26,19 +26,20 @@ import java.util.List;
 
 import com.synopsys.integration.alert.common.descriptor.config.field.errors.AlertFieldStatus;
 
-public class JobFieldErrors extends Config {
-    private final List<AlertFieldStatus> fieldErrors;
+public class JobFieldStatuses extends Config {
+    private final List<AlertFieldStatus> fieldStatuses;
 
-    public JobFieldErrors(List<AlertFieldStatus> fieldErrors) {
-        this.fieldErrors = fieldErrors;
+    public JobFieldStatuses(List<AlertFieldStatus> fieldStatuses) {
+        this.fieldStatuses = fieldStatuses;
     }
 
-    public JobFieldErrors(String id, List<AlertFieldStatus> fieldErrors) {
+    public JobFieldStatuses(String id, List<AlertFieldStatus> fieldStatuses) {
         super(id);
-        this.fieldErrors = fieldErrors;
+        this.fieldStatuses = fieldStatuses;
     }
 
-    public List<AlertFieldStatus> getFieldErrors() {
-        return fieldErrors;
+    public List<AlertFieldStatus> getFieldStatuses() {
+        return fieldStatuses;
     }
+
 }

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/rest/model/JobFieldErrorsTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/rest/model/JobFieldErrorsTest.java
@@ -17,7 +17,7 @@ public class JobFieldErrorsTest {
 
         List<AlertFieldStatus> fieldError = new ArrayList<>();
         fieldError.add(AlertFieldStatus.error(fieldErrorKey, fieldErrorValue));
-        List<AlertFieldStatus> testResult = new JobFieldErrors(fieldError).getFieldErrors();
+        List<AlertFieldStatus> testResult = new JobFieldStatuses(fieldError).getFieldStatuses();
 
         assertEquals(fieldError, testResult);
     }
@@ -31,8 +31,8 @@ public class JobFieldErrorsTest {
 
         List<AlertFieldStatus> fieldError = new ArrayList<>();
         fieldError.add(AlertFieldStatus.error(fieldErrorKey, fieldErrorValue));
-        JobFieldErrors jobFieldError = new JobFieldErrors(configId, fieldError);
-        List<AlertFieldStatus> testResult = jobFieldError.getFieldErrors();
+        JobFieldStatuses jobFieldError = new JobFieldStatuses(configId, fieldError);
+        List<AlertFieldStatus> testResult = jobFieldError.getFieldStatuses();
 
         assertEquals(testResult, fieldError);
         assertEquals(configId, jobFieldError.getId());

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/actions/BlackDuckDistributionTestAction.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/actions/BlackDuckDistributionTestAction.java
@@ -35,6 +35,7 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.common.action.TestAction;
 import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.descriptor.config.field.errors.AlertFieldStatus;
+import com.synopsys.integration.alert.common.descriptor.config.field.errors.FieldStatusSeverity;
 import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderDistributionUIConfig;
 import com.synopsys.integration.alert.common.message.model.MessageResult;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
@@ -84,6 +85,10 @@ public class BlackDuckDistributionTestAction extends TestAction {
             }
         } else {
             fieldStatuses.add(AlertFieldStatus.error(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME, "A provider configuration is required"));
+        }
+
+        if (MessageResult.hasFieldStatusBySeverity(fieldStatuses, FieldStatusSeverity.ERROR)) {
+            return new MessageResult("There were errors with the BlackDuck provider fields", fieldStatuses);
         }
         return new MessageResult("Successfully tested BlackDuck provider fields", fieldStatuses);
     }

--- a/src/main/java/com/synopsys/integration/alert/web/config/ConfigActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/config/ConfigActions.java
@@ -158,6 +158,8 @@ public class ConfigActions {
             FieldModel upToDateFieldModel = fieldModelProcessor.createCustomMessageFieldModel(restModel);
             FieldAccessor fieldAccessor = modelConverter.convertToFieldAccessor(upToDateFieldModel);
             TestAction testAction = testActionOptional.get();
+
+            // TODO return the message from the result of testAction.testConfig(...)
             testAction.testConfig(upToDateFieldModel.getId(), upToDateFieldModel, fieldAccessor);
             return "Successfully sent test message.";
         }

--- a/src/main/java/com/synopsys/integration/alert/web/config/JobConfigActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/config/JobConfigActions.java
@@ -132,10 +132,7 @@ public class JobConfigActions {
 
     public JobFieldModel saveJob(JobFieldModel jobFieldModel) throws AlertException {
         MessageResult validationResult = validateJob(jobFieldModel);
-        List<AlertFieldStatus> fieldStatuses = validationResult.getFieldStatuses();
-        if (!fieldStatuses.isEmpty()) {
-            throw new AlertFieldException(fieldStatuses);
-        }
+        validationResult.throwExceptionForFieldStatues();
         validateJobNameUnique(null, jobFieldModel);
 
         Set<String> descriptorNames = new HashSet<>();
@@ -160,10 +157,7 @@ public class JobConfigActions {
 
     public JobFieldModel updateJob(UUID id, JobFieldModel jobFieldModel) throws AlertException {
         MessageResult validationResult = validateJob(jobFieldModel);
-        List<AlertFieldStatus> fieldStatuses = validationResult.getFieldStatuses();
-        if (!fieldStatuses.isEmpty()) {
-            throw new AlertFieldException(fieldStatuses);
-        }
+        validationResult.throwExceptionForFieldStatues();
         validateJobNameUnique(id, jobFieldModel);
 
         ConfigurationJobModel previousJob = configurationAccessor.getJobById(id)

--- a/src/main/java/com/synopsys/integration/alert/web/config/JobConfigActions.java
+++ b/src/main/java/com/synopsys/integration/alert/web/config/JobConfigActions.java
@@ -255,7 +255,7 @@ public class JobConfigActions {
     }
 
     // TODO abstract duplicate functionality
-    public String testJob(JobFieldModel jobFieldModel) throws IntegrationException {
+    public MessageResult testJob(JobFieldModel jobFieldModel) throws IntegrationException {
         validateJob(jobFieldModel);
         Collection<FieldModel> otherJobModels = new LinkedList<>();
         FieldModel channelFieldModel = getChannelFieldModelAndPopulateOtherJobModels(jobFieldModel, otherJobModels);
@@ -275,15 +275,14 @@ public class JobConfigActions {
                 String jobId = channelFieldModel.getId();
 
                 testProviderConfig(fieldAccessor, jobId, channelFieldModel);
-                MessageResult testResult = testAction.testConfig(jobId, channelFieldModel, fieldAccessor);
-                return testResult.getStatusMessage();
+                return testAction.testConfig(jobId, channelFieldModel, fieldAccessor);
             } else {
                 String descriptorName = channelFieldModel.getDescriptorName();
                 logger.error("Test action did not exist: {}", descriptorName);
                 throw new AlertMethodNotAllowedException("Test functionality not implemented for " + descriptorName);
             }
         }
-        return "No field model of type channel was was sent to test.";
+        return new MessageResult("No field model of type channel was was sent to test.");
     }
 
     public Optional<String> checkGlobalConfigExists(String descriptorName) {

--- a/src/test/java/com/synopsys/integration/alert/common/exception/AlertFieldStatusTest.java
+++ b/src/test/java/com/synopsys/integration/alert/common/exception/AlertFieldStatusTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 import com.synopsys.integration.alert.common.descriptor.config.field.errors.AlertFieldStatus;
-import com.synopsys.integration.alert.common.descriptor.config.field.errors.FieldErrorSeverity;
+import com.synopsys.integration.alert.common.descriptor.config.field.errors.FieldStatusSeverity;
 
 public class AlertFieldStatusTest {
     private final String FIELD_NAME = "FieldName";
@@ -26,8 +26,8 @@ public class AlertFieldStatusTest {
         AlertFieldStatus alertFieldStatusError = AlertFieldStatus.error(FIELD_NAME, FIELD_ERROR_MESSAGE);
         AlertFieldStatus alertFieldStatusWarning = AlertFieldStatus.warning(FIELD_NAME, FIELD_WARNING_MESSAGE);
 
-        assertEquals(FieldErrorSeverity.ERROR, alertFieldStatusError.getSeverity());
-        assertEquals(FieldErrorSeverity.WARNING, alertFieldStatusWarning.getSeverity());
+        assertEquals(FieldStatusSeverity.ERROR, alertFieldStatusError.getSeverity());
+        assertEquals(FieldStatusSeverity.WARNING, alertFieldStatusWarning.getSeverity());
     }
 
     @Test

--- a/src/test/java/com/synopsys/integration/alert/web/config/JobConfigControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/web/config/JobConfigControllerTestIT.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -58,7 +58,7 @@ import com.synopsys.integration.alert.util.DatabaseConfiguredFieldTest;
 @Transactional
 public class JobConfigControllerTestIT extends DatabaseConfiguredFieldTest {
     private static final String DEFAULT_BLACK_DUCK_CONFIG = "Default Black Duck Config";
-    private final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(), MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
+    private final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(), MediaType.APPLICATION_JSON.getSubtype(), StandardCharsets.UTF_8);
     private final String url = JobConfigController.JOB_CONFIGURATION_PATH;
 
     @Autowired


### PR DESCRIPTION
- Include field statuses in `MessageResult` to allow channels to expose more granular error/warning messages.  
- Implement combined usage of `MessageResult` in `JobConfigActions` for job validation, provider validation, and test messages