### PR TITLE
 oauth  request validation

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestPurgeTask.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestPurgeTask.java
@@ -35,7 +35,7 @@ import com.synopsys.integration.alert.common.workflow.task.TaskManager;
 @Component
 public class OAuthRequestPurgeTask extends StartupScheduledTask {
     // every 5 minutes.
-    public static final String CRON_EXPRESSION = "0 0/5 * 1/1 * ?";
+    public static final String CRON_EXPRESSION_EVERY_5_MINUTES = "0 0/5 * 1/1 * ?";
     private final OAuthRequestValidator oAuthRequestValidator;
 
     @Autowired
@@ -46,7 +46,7 @@ public class OAuthRequestPurgeTask extends StartupScheduledTask {
 
     @Override
     public String scheduleCronExpression() {
-        return CRON_EXPRESSION;
+        return CRON_EXPRESSION_EVERY_5_MINUTES;
     }
 
     @Override

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestPurgeTask.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestPurgeTask.java
@@ -34,7 +34,8 @@ import com.synopsys.integration.alert.common.workflow.task.TaskManager;
 
 @Component
 public class OAuthRequestPurgeTask extends StartupScheduledTask {
-    private static final String CRON_EXPRESSION = "0 0/5 * 1/1 * ?";
+    // every 5 minutes.
+    public static final String CRON_EXPRESSION = "0 0/5 * 1/1 * ?";
     private final OAuthRequestValidator oAuthRequestValidator;
 
     @Autowired
@@ -50,7 +51,11 @@ public class OAuthRequestPurgeTask extends StartupScheduledTask {
 
     @Override
     public void runTask() {
-        Instant requestsBefore = Instant.now().minus(5, ChronoUnit.MINUTES);
+        Instant requestsBefore = getRequestsBeforeInstant();
         oAuthRequestValidator.removeRequestsOlderThanInstant(requestsBefore);
+    }
+
+    protected Instant getRequestsBeforeInstant() {
+        return Instant.now().minus(5, ChronoUnit.MINUTES);
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestPurgeTask.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestPurgeTask.java
@@ -1,0 +1,56 @@
+/**
+ * blackduck-alert
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.alert.channel.azure.boards.oauth;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.common.workflow.task.StartupScheduledTask;
+import com.synopsys.integration.alert.common.workflow.task.TaskManager;
+
+@Component
+public class OAuthRequestPurgeTask extends StartupScheduledTask {
+    private static final String CRON_EXPRESSION = "0 0/5 * 1/1 * ?";
+    private final OAuthRequestValidator oAuthRequestValidator;
+
+    @Autowired
+    public OAuthRequestPurgeTask(TaskScheduler taskScheduler, TaskManager taskManager, OAuthRequestValidator oAuthRequestValidator) {
+        super(taskScheduler, taskManager);
+        this.oAuthRequestValidator = oAuthRequestValidator;
+    }
+
+    @Override
+    public String scheduleCronExpression() {
+        return CRON_EXPRESSION;
+    }
+
+    @Override
+    public void runTask() {
+        Instant requestsBefore = Instant.now().minus(5, ChronoUnit.MINUTES);
+        oAuthRequestValidator.removeRequestsOlderThanInstant(requestsBefore);
+    }
+}

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidator.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidator.java
@@ -1,0 +1,57 @@
+/**
+ * blackduck-alert
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.alert.channel.azure.boards.oauth;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class OAuthRequestValidator {
+    private final Map<String, Instant> requestMap = new ConcurrentHashMap<>();
+
+    public void addAuthorizationRequest(String requestKey) {
+        requestMap.put(requestKey, Instant.now());
+    }
+
+    public void removeAuthorizationRequest(String requestKey) {
+        requestMap.remove(requestKey);
+    }
+
+    public boolean hasRequestKey(String requestKey) {
+        return requestMap.containsKey(requestKey);
+    }
+
+    public void removeRequestsOlderThanInstant(Instant instant) {
+        Set<Map.Entry<String, Instant>> entriesToRemove = requestMap.entrySet().stream()
+                                                              .filter(entry -> entry.getValue().isBefore(instant))
+                                                              .collect(Collectors.toSet());
+        entriesToRemove.stream()
+            .map(Map.Entry::getKey)
+            .forEach(this::removeAuthorizationRequest);
+    }
+}

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidator.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidator.java
@@ -28,18 +28,23 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class OAuthRequestValidator {
+    private final Logger logger = LoggerFactory.getLogger(OAuthRequestValidator.class);
     private final Map<String, Instant> requestMap = new ConcurrentHashMap<>();
 
     public void addAuthorizationRequest(String requestKey) {
+        logger.debug("Adding OAuth authorization key {}", requestKey);
         requestMap.put(requestKey, Instant.now());
     }
 
     public void removeAuthorizationRequest(String requestKey) {
         requestMap.remove(requestKey);
+        logger.debug("Removed OAuth authorization key {}", requestKey);
     }
 
     public boolean hasRequestKey(String requestKey) {

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidator.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidator.java
@@ -24,9 +24,7 @@ package com.synopsys.integration.alert.channel.azure.boards.oauth;
 
 import java.time.Instant;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,11 +50,10 @@ public class OAuthRequestValidator {
     }
 
     public void removeRequestsOlderThanInstant(Instant instant) {
-        Set<Map.Entry<String, Instant>> entriesToRemove = requestMap.entrySet().stream()
-                                                              .filter(entry -> entry.getValue().isBefore(instant))
-                                                              .collect(Collectors.toSet());
-        entriesToRemove.stream()
+        requestMap.entrySet().stream()
+            .filter(entry -> entry.getValue().isBefore(instant))
             .map(Map.Entry::getKey)
             .forEach(this::removeAuthorizationRequest);
+
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/web/AzureOAuthCallbackController.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/web/AzureOAuthCallbackController.java
@@ -42,6 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsChannelKey;
 import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUtil;
+import com.synopsys.integration.alert.channel.azure.boards.oauth.OAuthRequestValidator;
 import com.synopsys.integration.alert.channel.azure.boards.oauth.storage.AzureBoardsCredentialDataStoreFactory;
 import com.synopsys.integration.alert.channel.azure.boards.service.AzureBoardsProperties;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
@@ -72,11 +73,12 @@ public class AzureOAuthCallbackController {
     private final ProxyManager proxyManager;
     private final ConfigurationAccessor configurationAccessor;
     private final AzureRedirectUtil azureRedirectUtil;
+    private final OAuthRequestValidator oAuthRequestValidator;
 
     @Autowired
     public AzureOAuthCallbackController(ResponseFactory responseFactory, Gson gson, AzureBoardsChannelKey azureBoardsChannelKey,
         AzureBoardsCredentialDataStoreFactory azureBoardsCredentialDataStoreFactory, ProxyManager proxyManager, ConfigurationAccessor configurationAccessor,
-        AzureRedirectUtil azureRedirectUtil) {
+        AzureRedirectUtil azureRedirectUtil, OAuthRequestValidator oAuthRequestValidator) {
         this.responseFactory = responseFactory;
         this.gson = gson;
         this.azureBoardsChannelKey = azureBoardsChannelKey;
@@ -84,61 +86,74 @@ public class AzureOAuthCallbackController {
         this.proxyManager = proxyManager;
         this.configurationAccessor = configurationAccessor;
         this.azureRedirectUtil = azureRedirectUtil;
+        this.oAuthRequestValidator = oAuthRequestValidator;
     }
 
     @GetMapping
     public ResponseEntity<String> oauthCallback(HttpServletRequest request) {
         logger.debug("Azure OAuth callback method called");
+        String state = request.getParameter("state");
         try {
             String requestURI = request.getRequestURI();
             String requestQueryString = request.getQueryString();
             logger.debug("Request URI {}?{}", requestURI, requestQueryString);
             String authorizationCode = request.getParameter("code");
-            String state = request.getParameter("state");
-            FieldAccessor fieldAccessor = createFieldAccessor();
-            if (fieldAccessor.getFields().isEmpty()) {
-                logger.error("Azure oauth callback: Channel global configuration missing");
+            if (!oAuthRequestValidator.hasRequestKey(state)) {
+                logger.info("OAuth request {} not found.", state);
             } else {
-                if (StringUtils.isBlank(authorizationCode)) {
-                    logger.error("Azure oauth callback: Authorization code isn't valid. Stop processing");
+                logger.info(createOAuthRequestLoggerMessage(state, "Processing..."));
+                oAuthRequestValidator.removeAuthorizationRequest(state);
+                FieldAccessor fieldAccessor = createFieldAccessor();
+                if (fieldAccessor.getFields().isEmpty()) {
+                    logger.error(createOAuthRequestLoggerMessage(state, "Azure oauth callback: Channel global configuration missing"));
                 } else {
-                    String oAuthRedirectUri = azureRedirectUtil.createOAuthRedirectUri();
-                    AzureBoardsProperties properties = AzureBoardsProperties.fromFieldAccessor(azureBoardsCredentialDataStoreFactory, oAuthRedirectUri, fieldAccessor);
-                    testOAuthConnection(properties, authorizationCode);
+                    if (StringUtils.isBlank(authorizationCode)) {
+                        logger.error(createOAuthRequestLoggerMessage(state, "Azure oauth callback: Authorization code isn't valid. Stop processing"));
+                    } else {
+                        String oAuthRedirectUri = azureRedirectUtil.createOAuthRedirectUri();
+                        AzureBoardsProperties properties = AzureBoardsProperties.fromFieldAccessor(azureBoardsCredentialDataStoreFactory, oAuthRedirectUri, fieldAccessor);
+                        testOAuthConnection(properties, authorizationCode, state);
+                    }
                 }
             }
         } catch (Exception ex) {
             // catch any exceptions so the redirect back to the UI happens and doesn't display the URL with the authorization code to the user.
-            logger.error("Azure OAuth callback error occurred", ex);
+            logger.error(createOAuthRequestLoggerMessage(state, "Azure OAuth callback error occurred"), ex);
         }
         // redirect back to the global channel configuration URL in the Alert UI.
         return responseFactory.createFoundRedirectResponse(azureRedirectUtil.createUIRedirectLocation());
     }
 
-    private void testOAuthConnection(AzureBoardsProperties azureBoardsProperties, String authorizationCode) {
+    private void testOAuthConnection(AzureBoardsProperties azureBoardsProperties, String authorizationCode, String oAuthRequestKey) {
         try {
             Proxy proxy = proxyManager.createProxy();
             String organizationName = azureBoardsProperties.getOrganizationName();
             // save initiate token requests with the authorization code.
-            logger.info("Testing with authorization code to save tokens.");
-            testGetProjects(azureBoardsProperties.createAzureHttpService(proxy, gson, authorizationCode), organizationName);
+            logger.info(createOAuthRequestLoggerMessage(oAuthRequestKey, "Testing with authorization code to save tokens."));
+            testGetProjects(azureBoardsProperties.createAzureHttpService(proxy, gson, authorizationCode), organizationName, oAuthRequestKey);
             // load the oauth credentials from the store.
 
-            logger.info("Testing with store to read tokens.");
-            testGetProjects(azureBoardsProperties.createAzureHttpService(proxy, gson), organizationName);
+            logger.info(createOAuthRequestLoggerMessage(oAuthRequestKey, "Testing with store to read tokens."));
+            testGetProjects(azureBoardsProperties.createAzureHttpService(proxy, gson), organizationName, oAuthRequestKey);
         } catch (AlertException ex) {
-            logger.error("Error in azure oauth validation test ", ex);
+            logger.error(createOAuthRequestLoggerMessage(oAuthRequestKey, "Error in azure oauth validation test "), ex);
         }
     }
 
-    private void testGetProjects(AzureHttpService azureHttpService, String organizationName) {
+    // This method take a logger formatting string and appends a prefix for the OAuth authorization request in order to correlate the
+    // authorization requests from the custom endpoint and the callback controller for debugging potential customer issues.
+    private String createOAuthRequestLoggerMessage(String oAuthRequestKey, String loggerMessageFormat) {
+        return String.format("OAuth request %s: %s", oAuthRequestKey, loggerMessageFormat);
+    }
+
+    private void testGetProjects(AzureHttpService azureHttpService, String organizationName, String oAuthRequestKey) {
         try {
             AzureProjectService azureProjectService = new AzureProjectService(azureHttpService);
             AzureArrayResponseModel<TeamProjectReferenceResponseModel> projects = azureProjectService.getProjects(organizationName);
             Integer projectCount = projects.getCount();
-            logger.info("Azure Boards project count: {}", projectCount);
+            logger.info(createOAuthRequestLoggerMessage(oAuthRequestKey, "Azure Boards project count: {}"), projectCount);
         } catch (HttpServiceException ex) {
-            logger.error("Error in azure oauth get projects validation test ", ex);
+            logger.error(createOAuthRequestLoggerMessage(oAuthRequestKey, "Error in azure oauth get projects validation test "), ex);
         }
     }
 

--- a/src/test/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestPurgeTaskTest.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestPurgeTaskTest.java
@@ -1,2 +1,41 @@
-package com.synopsys.integration.alert.channel.azure.boards.oauth;public class OAuthRequestPurgeTask {
+package com.synopsys.integration.alert.channel.azure.boards.oauth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.scheduling.TaskScheduler;
+
+import com.synopsys.integration.alert.common.workflow.task.TaskManager;
+
+public class OAuthRequestPurgeTaskTest {
+    @Test
+    public void testCronSchedule() {
+        OAuthRequestPurgeTask task = new OAuthRequestPurgeTask(null, null, null);
+        assertEquals(OAuthRequestPurgeTask.CRON_EXPRESSION, task.scheduleCronExpression());
+    }
+
+    @Test
+    public void testTaskRun() {
+        TaskScheduler taskScheduler = Mockito.mock(TaskScheduler.class);
+        TaskManager taskManager = Mockito.mock(TaskManager.class);
+        OAuthRequestValidator oAuthRequestValidator = new OAuthRequestValidator();
+        String requestKey = "request-key-1";
+        String requestKey2 = "request-key-2";
+        oAuthRequestValidator.addAuthorizationRequest(requestKey);
+        oAuthRequestValidator.addAuthorizationRequest(requestKey2);
+
+        OAuthRequestPurgeTask task = new OAuthRequestPurgeTask(taskScheduler, taskManager, oAuthRequestValidator) {
+            @Override
+            protected Instant getRequestsBeforeInstant() {
+                return Instant.now();
+            }
+        };
+        task.runTask();
+        assertFalse(oAuthRequestValidator.hasRequestKey(requestKey));
+        assertFalse(oAuthRequestValidator.hasRequestKey(requestKey2));
+    }
 }

--- a/src/test/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestPurgeTaskTest.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestPurgeTaskTest.java
@@ -15,7 +15,7 @@ public class OAuthRequestPurgeTaskTest {
     @Test
     public void testCronSchedule() {
         OAuthRequestPurgeTask task = new OAuthRequestPurgeTask(null, null, null);
-        assertEquals(OAuthRequestPurgeTask.CRON_EXPRESSION, task.scheduleCronExpression());
+        assertEquals(OAuthRequestPurgeTask.CRON_EXPRESSION_EVERY_5_MINUTES, task.scheduleCronExpression());
     }
 
     @Test

--- a/src/test/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestPurgeTaskTest.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestPurgeTaskTest.java
@@ -1,0 +1,2 @@
+package com.synopsys.integration.alert.channel.azure.boards.oauth;public class OAuthRequestPurgeTask {
+}

--- a/src/test/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidatorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidatorTest.java
@@ -1,0 +1,2 @@
+package com.synopsys.integration.alert.channel.azure.boards.oauth;public class OAuthRequestValidatorTest {
+}

--- a/src/test/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidatorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidatorTest.java
@@ -1,2 +1,42 @@
-package com.synopsys.integration.alert.channel.azure.boards.oauth;public class OAuthRequestValidatorTest {
+package com.synopsys.integration.alert.channel.azure.boards.oauth;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+public class OAuthRequestValidatorTest {
+
+    @Test
+    public void testAddKey() {
+        OAuthRequestValidator oAuthRequestValidator = new OAuthRequestValidator();
+        String requestKey = "request-key-1";
+        oAuthRequestValidator.addAuthorizationRequest(requestKey);
+        assertTrue(oAuthRequestValidator.hasRequestKey(requestKey));
+    }
+
+    @Test
+    public void testRemoveKey() {
+        OAuthRequestValidator oAuthRequestValidator = new OAuthRequestValidator();
+        String requestKey = "request-key-1";
+        oAuthRequestValidator.addAuthorizationRequest(requestKey);
+        oAuthRequestValidator.removeAuthorizationRequest(requestKey);
+        assertFalse(oAuthRequestValidator.hasRequestKey(requestKey));
+    }
+
+    @Test
+    public void testRemoveKeysByInstant() {
+        OAuthRequestValidator oAuthRequestValidator = new OAuthRequestValidator();
+        String requestKey = "request-key-1";
+        String requestKey2 = "request-key-2";
+        oAuthRequestValidator.addAuthorizationRequest(requestKey);
+        oAuthRequestValidator.addAuthorizationRequest(requestKey2);
+
+        Instant instant = Instant.now();
+        oAuthRequestValidator.removeRequestsOlderThanInstant(instant);
+        assertFalse(oAuthRequestValidator.hasRequestKey(requestKey));
+        assertFalse(oAuthRequestValidator.hasRequestKey(requestKey2));
+    }
 }


### PR DESCRIPTION
Create a small in memory cache to manage the OAuth request keys contained in the state as part of validating a request to the AzureOAuthCallbackController.  If it isn't a request that Alert has made then do not process the request further.