### PR TITLE
Add validator for OAuth 

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/ProxyManager.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/ProxyManager.java
@@ -22,7 +22,6 @@
  */
 package com.synopsys.integration.alert.common.rest;
 
-import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.Optional;
 
@@ -116,15 +115,8 @@ public class ProxyManager {
     }
 
     public Proxy createProxy() {
-        if (!getProxyHost().isPresent()) {
-            return Proxy.NO_PROXY;
-        }
-        //InetSocketAddress will validate the host name isn't null and the port is in the correct range.
-        String hostname = getProxyHost().orElse(null);
-        String port = getProxyPort().orElse("-1");
-        InetSocketAddress socketAddress = new InetSocketAddress(hostname, Integer.valueOf(port));
-
-        return new Proxy(Proxy.Type.HTTP, socketAddress);
+        return createProxyInfo()
+                   .getProxy()
+                   .orElse(Proxy.NO_PROXY);
     }
-
 }

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/ConfigurationFieldModelTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/ConfigurationFieldModelTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.synopsys.integration.alert.common.descriptor.DescriptorKey;
-import com.synopsys.integration.alert.common.descriptor.DescriptorMap;
 import com.synopsys.integration.alert.common.descriptor.config.field.ConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.PasswordConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.TextInputConfigField;
@@ -50,7 +49,7 @@ public class ConfigurationFieldModelTest {
         return List.of(new TextInputConfigField(KEY_FIELD_1, KEY_FIELD_1, DESCRIPTION_1), new PasswordConfigField(KEY_FIELD_2, KEY_FIELD_2, DESCRIPTION_2, encryptionValidator));
     }
 
-    private DescriptorMap createDescriptorMap() throws AlertException {
+    private List<DescriptorKey> createDescriptorKeyList() throws AlertException {
         DescriptorKey descriptorKey = new DescriptorKey() {
             @Override
             public String getUniversalKey() {
@@ -63,8 +62,8 @@ public class ConfigurationFieldModelTest {
             }
         };
 
-        DescriptorMap descriptorMap = new DescriptorMap(List.of(descriptorKey), List.of(), List.of(), List.of());
-        return descriptorMap;
+        return List.of(descriptorKey);
+
     }
 
     @Test
@@ -74,8 +73,8 @@ public class ConfigurationFieldModelTest {
         EncryptionUtility encryptionUtility = Mockito.mock(EncryptionUtility.class);
         Mockito.when(encryptionUtility.isInitialized()).thenReturn(true);
         DescriptorAccessor descriptorAccessor = new MockDescriptorAccessor(configFields);
-        DescriptorMap descriptorMap = createDescriptorMap();
-        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorMap);
+        List<DescriptorKey> descriptorKeys = createDescriptorKeyList();
+        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorKeys);
         FieldAccessor accessor = modelConverter.convertToFieldAccessor(fieldModel);
 
         assertEquals(VALUE_FIELD_1, accessor.getString(KEY_FIELD_1).orElseThrow(IllegalArgumentException::new));
@@ -89,8 +88,8 @@ public class ConfigurationFieldModelTest {
         EncryptionUtility encryptionUtility = Mockito.mock(EncryptionUtility.class);
         Mockito.when(encryptionUtility.isInitialized()).thenReturn(Boolean.TRUE);
         DescriptorAccessor descriptorAccessor = new MockDescriptorAccessor(configFields);
-        DescriptorMap descriptorMap = createDescriptorMap();
-        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorMap);
+        List<DescriptorKey> descriptorKeys = createDescriptorKeyList();
+        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorKeys);
         Map<String, ConfigurationFieldModel> actualModelMap = modelConverter.convertToConfigurationFieldModelMap(fieldModel);
         assertTrue(actualModelMap.containsKey(KEY_FIELD_1));
         assertTrue(actualModelMap.containsKey(KEY_FIELD_2));
@@ -103,8 +102,8 @@ public class ConfigurationFieldModelTest {
         FieldModel fieldModel = createFieldModel();
         EncryptionUtility encryptionUtility = Mockito.mock(EncryptionUtility.class);
         DescriptorAccessor descriptorAccessor = new MockDescriptorAccessor(List.of());
-        DescriptorMap descriptorMap = createDescriptorMap();
-        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorMap);
+        List<DescriptorKey> descriptorKeys = createDescriptorKeyList();
+        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorKeys);
         Map<String, ConfigurationFieldModel> actualModelMap = modelConverter.convertToConfigurationFieldModelMap(fieldModel);
         assertTrue(actualModelMap.isEmpty());
     }
@@ -115,8 +114,8 @@ public class ConfigurationFieldModelTest {
         EncryptionUtility encryptionUtility = Mockito.mock(EncryptionUtility.class);
         Mockito.when(encryptionUtility.isInitialized()).thenReturn(true);
         DescriptorAccessor descriptorAccessor = new MockDescriptorAccessor(configFields);
-        DescriptorMap descriptorMap = createDescriptorMap();
-        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorMap);
+        List<DescriptorKey> descriptorKeys = createDescriptorKeyList();
+        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorKeys);
         Optional<ConfigurationFieldModel> optionalModel = modelConverter.convertFromDefinedFieldModel(new DefinedFieldModel(KEY_FIELD_1, ConfigContextEnum.GLOBAL, false), VALUE_FIELD_1, true);
 
         assertTrue(optionalModel.isPresent());
@@ -139,8 +138,8 @@ public class ConfigurationFieldModelTest {
         List<ConfigField> configFields = createConfigFields();
         EncryptionUtility encryptionUtility = Mockito.mock(EncryptionUtility.class);
         DescriptorAccessor descriptorAccessor = new MockDescriptorAccessor(configFields);
-        DescriptorMap descriptorMap = createDescriptorMap();
-        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorMap);
+        List<DescriptorKey> descriptorKeys = createDescriptorKeyList();
+        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorKeys);
         Optional<ConfigurationFieldModel> optionalModel = modelConverter.convertFromDefinedFieldModel(new DefinedFieldModel(KEY_FIELD_1, ConfigContextEnum.GLOBAL, true), VALUE_FIELD_1, true);
         assertTrue(optionalModel.isEmpty());
     }
@@ -151,8 +150,8 @@ public class ConfigurationFieldModelTest {
         EncryptionUtility encryptionUtility = Mockito.mock(EncryptionUtility.class);
         Mockito.when(encryptionUtility.isInitialized()).thenReturn(true);
         DescriptorAccessor descriptorAccessor = new MockDescriptorAccessor(configFields);
-        DescriptorMap descriptorMap = createDescriptorMap();
-        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorMap);
+        List<DescriptorKey> descriptorKeys = createDescriptorKeyList();
+        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorKeys);
         Optional<ConfigurationFieldModel> optionalModel = modelConverter.convertFromDefinedFieldModel(new DefinedFieldModel(KEY_FIELD_1, ConfigContextEnum.GLOBAL, false), List.of(VALUE_FIELD_1, VALUE_FIELD_2), true);
 
         assertTrue(optionalModel.isPresent());
@@ -175,8 +174,8 @@ public class ConfigurationFieldModelTest {
         List<ConfigField> configFields = createConfigFields();
         EncryptionUtility encryptionUtility = Mockito.mock(EncryptionUtility.class);
         DescriptorAccessor descriptorAccessor = new MockDescriptorAccessor(configFields);
-        DescriptorMap descriptorMap = createDescriptorMap();
-        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorMap);
+        List<DescriptorKey> descriptorKeys = createDescriptorKeyList();
+        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorKeys);
         Optional<ConfigurationFieldModel> optionalModel = modelConverter.convertFromDefinedFieldModel(new DefinedFieldModel(KEY_FIELD_1, ConfigContextEnum.GLOBAL, true), List.of(VALUE_FIELD_1, VALUE_FIELD_2), true);
         assertTrue(optionalModel.isEmpty());
     }

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureRedirectUtil.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureRedirectUtil.java
@@ -38,6 +38,10 @@ public class AzureRedirectUtil {
         this.alertProperties = alertProperties;
     }
 
+    /**
+     * The OAuth callback controller will redirect back to the Alert UI and is the only place where this method.
+     * @return The url location to redirect to the UI.
+     */
     public String createUIRedirectLocation() {
         StringBuilder locationBuilder = new StringBuilder(200);
         alertProperties.getServerUrl()
@@ -47,6 +51,11 @@ public class AzureRedirectUtil {
         return locationBuilder.toString();
     }
 
+    /**
+     * The OAuth  callback controller URI as a string for Azure to redirect to send the authorization code.
+     * This URI string should match the redirect URI in the Azure registered client application.
+     * @return The URI string to redirect to from azure when obtaining the authorization code
+     */
     public String createOAuthRedirectUri() {
         StringBuilder locationBuilder = new StringBuilder(200);
         alertProperties.getServerUrl()

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureRedirectUtil.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureRedirectUtil.java
@@ -39,8 +39,11 @@ public class AzureRedirectUtil {
     }
 
     /**
-     * The OAuth callback controller will redirect back to the Alert UI and is the only place where this method.
+     * The OAuth callback controller will redirect back to the Alert UI.
+     * Only the callback controller should use this method.  All other requests for redirect URIs should use the
+     * createOAuthRedirectUri method.
      * @return The url location to redirect to the UI.
+     * @see #createOAuthRedirectUri()
      */
     public String createUIRedirectLocation() {
         StringBuilder locationBuilder = new StringBuilder(200);

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/descriptor/AzureBoardsGlobalUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/descriptor/AzureBoardsGlobalUIConfig.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.synopsys.integration.alert.channel.azure.boards.oauth.AzureOAuthTokenValidator;
 import com.synopsys.integration.alert.common.descriptor.config.field.ConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.PasswordConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.TextInputConfigField;
@@ -51,23 +52,26 @@ public class AzureBoardsGlobalUIConfig extends UIConfig {
     public static final String BUTTON_LABEL_OAUTH = "Authenticate";
 
     private final EncryptionValidator encryptionValidator;
+    private final AzureOAuthTokenValidator authTokenValidator;
 
     @Autowired
-    public AzureBoardsGlobalUIConfig(EncryptionValidator encryptionValidator) {
+
+    public AzureBoardsGlobalUIConfig(EncryptionValidator encryptionValidator, AzureOAuthTokenValidator authTokenValidator) {
         super(AzureBoardsDescriptor.AZURE_BOARDS_LABEL, AzureBoardsDescriptor.AZURE_BOARDS_DESCRIPTION, AzureBoardsDescriptor.AZURE_BOARDS_URL);
         this.encryptionValidator = encryptionValidator;
+        this.authTokenValidator = authTokenValidator;
     }
-    
+
     @Override
     public List<ConfigField> createFields() {
-        //        ConfigField azureBoardsUrlField = new URLInputConfigField(AzureBoardsDescriptor.KEY_AZURE_BOARDS_URL, LABEL_AZURE_BOARDS_URL, DESCRIPTION_AZURE_BOARDS_URL);
         ConfigField organizationName = new TextInputConfigField(AzureBoardsDescriptor.KEY_ORGANIZATION_NAME, LABEL_ORGANIZATION_NAME, DESCRIPTION_ORGANIZATION_NAME).applyRequired(true);
         ConfigField clientId = new TextInputConfigField(AzureBoardsDescriptor.KEY_CLIENT_ID, LABEL_CLIENT_ID, DESCRIPTION_CLIENT_ID).applyRequired(true);
         ConfigField clientSecret = new PasswordConfigField(AzureBoardsDescriptor.KEY_CLIENT_SECRET, LABEL_CLIENT_SECRET, DESCRIPTION_CLIENT_SECRET, encryptionValidator).applyRequired(true);
         ConfigField configureOAuth = new OAuthEndpointButtonField(AzureBoardsDescriptor.KEY_OAUTH, LABEL_OAUTH, DESCRIPTION_OAUTH, BUTTON_LABEL_OAUTH)
                                          .applyRequestedDataFieldKey(AzureBoardsDescriptor.KEY_ORGANIZATION_NAME)
                                          .applyRequestedDataFieldKey(AzureBoardsDescriptor.KEY_CLIENT_ID);
+        // FIXME when we have consistent result objects containing the HTTP status code, content, and warnings versus errors this validator can be added.
+        //.applyValidationFunctions(authTokenValidator);
         return List.of(organizationName, clientId, clientSecret, configureOAuth);
     }
-
 }

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/AzureOAuthTokenValidator.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/AzureOAuthTokenValidator.java
@@ -54,10 +54,6 @@ public class AzureOAuthTokenValidator implements ConfigValidationFunction {
         this.proxyManager = proxyManager;
     }
 
-    public ValidationResult validate(FieldValueModel fieldValueModel, FieldModel fieldModel) {
-        return this.apply(fieldValueModel, fieldModel);
-    }
-
     @Override
     public ValidationResult apply(FieldValueModel fieldValueModel, FieldModel fieldModel) {
         ValidationResult result = ValidationResult.success();

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/AzureOAuthTokenValidator.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/AzureOAuthTokenValidator.java
@@ -1,0 +1,77 @@
+/**
+ * blackduck-alert
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.alert.channel.azure.boards.oauth;
+
+import java.net.Proxy;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUtil;
+import com.synopsys.integration.alert.channel.azure.boards.oauth.storage.AzureBoardsCredentialDataStoreFactory;
+import com.synopsys.integration.alert.channel.azure.boards.service.AzureBoardsProperties;
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ConfigValidationFunction;
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
+import com.synopsys.integration.alert.common.persistence.accessor.FieldAccessor;
+import com.synopsys.integration.alert.common.persistence.util.ConfigurationFieldModelConverter;
+import com.synopsys.integration.alert.common.rest.ProxyManager;
+import com.synopsys.integration.alert.common.rest.model.FieldModel;
+import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
+
+@Component
+public class AzureOAuthTokenValidator implements ConfigValidationFunction {
+    private final AzureRedirectUtil azureRedirectUtil;
+    private final AzureBoardsCredentialDataStoreFactory azureBoardsCredentialDataStoreFactory;
+    private final ConfigurationFieldModelConverter configurationFieldModelConverter;
+    private final ProxyManager proxyManager;
+
+    @Autowired
+    public AzureOAuthTokenValidator(AzureRedirectUtil azureRedirectUtil, AzureBoardsCredentialDataStoreFactory azureBoardsCredentialDataStoreFactory,
+        ConfigurationFieldModelConverter configurationFieldModelConverter, ProxyManager proxyManager) {
+        this.azureRedirectUtil = azureRedirectUtil;
+        this.azureBoardsCredentialDataStoreFactory = azureBoardsCredentialDataStoreFactory;
+        this.configurationFieldModelConverter = configurationFieldModelConverter;
+        this.proxyManager = proxyManager;
+    }
+
+    public ValidationResult validate(FieldValueModel fieldValueModel, FieldModel fieldModel) {
+        return this.apply(fieldValueModel, fieldModel);
+    }
+
+    @Override
+    public ValidationResult apply(FieldValueModel fieldValueModel, FieldModel fieldModel) {
+        ValidationResult result = ValidationResult.success();
+        try {
+            Proxy proxy = proxyManager.createProxy();
+            FieldAccessor fieldAccessor = configurationFieldModelConverter.convertToFieldAccessor(fieldModel);
+            String oAuthRedirectUri = azureRedirectUtil.createOAuthRedirectUri();
+            AzureBoardsProperties properties = AzureBoardsProperties.fromFieldAccessor(azureBoardsCredentialDataStoreFactory, oAuthRedirectUri, fieldAccessor);
+            if (!properties.hasOAuthCredentials(proxy)) {
+                result = ValidationResult.warnings("OAuth token credentials missing. Please save then authenticate.");
+            }
+        } catch (Exception ex) {
+            result = ValidationResult.errors(ex.getMessage());
+        }
+        return result;
+    }
+}

--- a/src/test/java/com/synopsys/integration/alert/workflow/startup/AlertStartupInitializerTest.java
+++ b/src/test/java/com/synopsys/integration/alert/workflow/startup/AlertStartupInitializerTest.java
@@ -53,7 +53,7 @@ public class AlertStartupInitializerTest {
         List<ComponentDescriptor> componentDescriptors = List.of();
         EnvironmentVariableUtility environmentVariableUtility = new EnvironmentVariableUtility(environment);
         DescriptorMap descriptorMap = new DescriptorMap(descriptorKeys, channelDescriptors, providerDescriptors, componentDescriptors);
-        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, baseDescriptorAccessor, descriptorMap);
+        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, baseDescriptorAccessor, descriptorKeys);
         Mockito.when(baseDescriptorAccessor.getFieldsForDescriptor(Mockito.any(DescriptorKey.class), Mockito.any(ConfigContextEnum.class))).thenReturn(List.copyOf(channelDescriptor.getAllDefinedFields(ConfigContextEnum.GLOBAL)));
 
         FieldModelProcessor fieldModelProcessor = new FieldModelProcessor(modelConverter, new FieldValidationAction(), new DescriptorProcessor(descriptorMap, baseConfigurationAccessor, List.of(), List.of()));
@@ -74,7 +74,7 @@ public class AlertStartupInitializerTest {
         EncryptionUtility encryptionUtility = Mockito.mock(EncryptionUtility.class);
         Mockito.when(encryptionUtility.isInitialized()).thenReturn(Boolean.TRUE);
         EnvironmentVariableUtility environmentVariableUtility = new EnvironmentVariableUtility(environment);
-        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, baseDescriptorAccessor, descriptorMap);
+        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, baseDescriptorAccessor, List.of());
         FieldModelProcessor fieldModelProcessor = new FieldModelProcessor(modelConverter, new FieldValidationAction(), new DescriptorProcessor(descriptorMap, baseConfigurationAccessor, List.of(), List.of()));
         SettingsUtility settingsUtility = Mockito.mock(SettingsUtility.class);
         Mockito.when(settingsUtility.getKey()).thenReturn(new SettingsDescriptorKey());
@@ -102,7 +102,7 @@ public class AlertStartupInitializerTest {
         List<ProviderDescriptor> providerDescriptors = List.of();
         List<ComponentDescriptor> componentDescriptors = List.of();
         DescriptorMap descriptorMap = new DescriptorMap(descriptorKeys, channelDescriptors, providerDescriptors, componentDescriptors);
-        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, baseDescriptorAccessor, descriptorMap);
+        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, baseDescriptorAccessor, descriptorKeys);
         Mockito.when(baseDescriptorAccessor.getFieldsForDescriptor(Mockito.any(DescriptorKey.class), Mockito.any(ConfigContextEnum.class))).thenReturn(List.copyOf(channelDescriptor.getAllDefinedFields(ConfigContextEnum.GLOBAL)));
         final String value = "newValue";
         Mockito.when(environment.getProperty(Mockito.anyString())).thenReturn(value);
@@ -133,7 +133,7 @@ public class AlertStartupInitializerTest {
         List<ProviderDescriptor> providerDescriptors = List.of();
         List<ComponentDescriptor> componentDescriptors = List.of();
         DescriptorMap descriptorMap = new DescriptorMap(descriptorKeys, channelDescriptors, providerDescriptors, componentDescriptors);
-        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, baseDescriptorAccessor, descriptorMap);
+        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, baseDescriptorAccessor, descriptorKeys);
         Mockito.when(baseConfigurationAccessor.getConfigurationsByDescriptorKeyAndContext(Mockito.any(DescriptorKey.class), Mockito.any(ConfigContextEnum.class))).thenThrow(new AlertDatabaseConstraintException("Test Exception"));
         FieldModelProcessor fieldModelProcessor = new FieldModelProcessor(modelConverter, new FieldValidationAction(), new DescriptorProcessor(descriptorMap, baseConfigurationAccessor, List.of(), List.of()));
         SettingsUtility settingsUtility = Mockito.mock(SettingsUtility.class);
@@ -167,7 +167,7 @@ public class AlertStartupInitializerTest {
         List<ProviderDescriptor> providerDescriptors = List.of();
         List<ComponentDescriptor> componentDescriptors = List.of();
         DescriptorMap descriptorMap = new DescriptorMap(descriptorKeys, channelDescriptors, providerDescriptors, componentDescriptors);
-        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, baseDescriptorAccessor, descriptorMap);
+        ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, baseDescriptorAccessor, descriptorKeys);
         Mockito.when(baseDescriptorAccessor.getFieldsForDescriptor(Mockito.any(DescriptorKey.class), Mockito.any(ConfigContextEnum.class))).thenReturn(List.copyOf(channelDescriptor.getAllDefinedFields(ConfigContextEnum.GLOBAL)));
 
         final String value = "newValue";


### PR DESCRIPTION
Was going to add this in 6.2.0 but the warnings are treated as errors and would prevent saving.  This will allow pushing the save and test button and having the UI display a warning message.

Fixed the cause of a circular dependency in the ConfigurationFieldModelConverter.  The class uses the descriptor keys.  If we use the DescriptorMap it needs all the descriptors which is where the validator is getting used.  So it can't autowire the objects correctly.