### PR TITLE
Make Azure Work Item Type a required field

### DIFF
--- a/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/service/comment/model/WorkItemCommentRequestModel.java
+++ b/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/service/comment/model/WorkItemCommentRequestModel.java
@@ -1,3 +1,25 @@
+/**
+ * azure-boards-common
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.synopsys.integration.azure.boards.common.service.comment.model;
 
 public class WorkItemCommentRequestModel {

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/descriptor/AzureBoardsDistributionUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/descriptor/AzureBoardsDistributionUIConfig.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsChannelKey;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsConstants;
 import com.synopsys.integration.alert.common.descriptor.config.field.CheckboxConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.ConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.TextInputConfigField;
@@ -59,7 +60,9 @@ public class AzureBoardsDistributionUIConfig extends ChannelDistributionUIConfig
         ConfigField azureWorkItemComments = new CheckboxConfigField(AzureBoardsDescriptor.KEY_WORK_ITEM_COMMENT, LABEL_WORK_ITEM_COMMENT, DESCRIPTION_WORK_ITEM_COMMENT);
         ConfigField azureProject = new TextInputConfigField(AzureBoardsDescriptor.KEY_AZURE_PROJECT, LABEL_AZURE_PROJECT, DESCRIPTION_AZURE_PROJECT).applyRequired(true);
         ConfigField azureBoard = new TextInputConfigField(AzureBoardsDescriptor.KEY_WORK_ITEM_CREATOR_EMAIL, LABEL_AZURE_CREATOR_EMAIL, DESCRIPTION_AZURE_CREATOR_EMAIL);
-        ConfigField workItemType = new TextInputConfigField(AzureBoardsDescriptor.KEY_WORK_ITEM_TYPE, LABEL_WORK_ITEM_TYPE, DESCRIPTION_WORK_ITEM_TYPE);
+        ConfigField workItemType = new TextInputConfigField(AzureBoardsDescriptor.KEY_WORK_ITEM_TYPE, LABEL_WORK_ITEM_TYPE, DESCRIPTION_WORK_ITEM_TYPE)
+                                       .applyRequired(true)
+                                       .applyDefaultValue(AzureBoardsConstants.DEFAULT_WORK_ITEM_TYPE);
         ConfigField workItemCompletedState = new TextInputConfigField(AzureBoardsDescriptor.KEY_WORK_ITEM_COMPLETED_STATE, LABEL_WORK_ITEM_COMPLETED_STATE, DESCRIPTION_WORK_ITEM_COMPLETED_STATE);
         ConfigField workItemReopenState = new TextInputConfigField(AzureBoardsDescriptor.KEY_WORK_ITEM_REOPEN_STATE, LABEL_WORK_ITEM_REOPEN_STATE, DESCRIPTION_WORK_ITEM_REOPEN_STATE);
 


### PR DESCRIPTION
This fixes an error when previously submitting this field without a value. Now it will be pre-populated with the DEFAULT_WORK_ITEM_TYPE of "Task" and the field will be made required.