### PR TITLE
Fix Azure Custom Fields

### DIFF
--- a/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/service/comment/model/WorkItemCommentRequestModel.java
+++ b/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/service/comment/model/WorkItemCommentRequestModel.java
@@ -1,3 +1,25 @@
+/**
+ * azure-boards-common
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.synopsys.integration.azure.boards.common.service.comment.model;
 
 public class WorkItemCommentRequestModel {

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsSearchProperties.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsSearchProperties.java
@@ -31,12 +31,20 @@ import com.synopsys.integration.alert.common.channel.issuetracker.message.IssueS
 public class AzureBoardsSearchProperties implements IssueSearchProperties {
     private final String providerKey;
     private final String topicKey;
+    private final String subTopicKey;
+    private final String categoryKey;
     private final String componentKey;
+    private final String subComponentKey;
+    private final String additionalInfoKey;
 
-    public AzureBoardsSearchProperties(String providerKey, String topicKey, @Nullable String componentKey) {
+    public AzureBoardsSearchProperties(String providerKey, String topicKey, @Nullable String subTopicKey, @Nullable String categoryKey, @Nullable String componentKey, @Nullable String subComponentKey, @Nullable String additionalInfoKey) {
         this.providerKey = providerKey;
         this.topicKey = topicKey;
+        this.subTopicKey = subTopicKey;
+        this.categoryKey = categoryKey;
         this.componentKey = componentKey;
+        this.subComponentKey = subComponentKey;
+        this.additionalInfoKey = additionalInfoKey;
     }
 
     public String getProviderKey() {
@@ -47,8 +55,24 @@ public class AzureBoardsSearchProperties implements IssueSearchProperties {
         return topicKey;
     }
 
+    public Optional<String> getSubTopicKey() {
+        return Optional.ofNullable(subTopicKey);
+    }
+
+    public Optional<String> getCategoryKey() {
+        return Optional.ofNullable(categoryKey);
+    }
+
     public Optional<String> getComponentKey() {
         return Optional.ofNullable(componentKey);
+    }
+
+    public Optional<String> getSubComponentKey() {
+        return Optional.ofNullable(subComponentKey);
+    }
+
+    public Optional<String> getAdditionalInfoKey() {
+        return Optional.ofNullable(additionalInfoKey);
     }
 
 }

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsSearchProperties.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsSearchProperties.java
@@ -29,20 +29,26 @@ import javax.annotation.Nullable;
 import com.synopsys.integration.alert.common.channel.issuetracker.message.IssueSearchProperties;
 
 public class AzureBoardsSearchProperties implements IssueSearchProperties {
-    private final String topLevelKey;
-    private final String componentLevelKey;
+    private final String providerKey;
+    private final String topicKey;
+    private final String componentKey;
 
-    public AzureBoardsSearchProperties(String topLevelKey, @Nullable String componentLevelKey) {
-        this.topLevelKey = topLevelKey;
-        this.componentLevelKey = componentLevelKey;
+    public AzureBoardsSearchProperties(String providerKey, String topicKey, @Nullable String componentKey) {
+        this.providerKey = providerKey;
+        this.topicKey = topicKey;
+        this.componentKey = componentKey;
     }
 
-    public String getTopLevelKey() {
-        return topLevelKey;
+    public String getProviderKey() {
+        return providerKey;
     }
 
-    public Optional<String> getComponentLevelKey() {
-        return Optional.ofNullable(componentLevelKey);
+    public String getTopicKey() {
+        return topicKey;
+    }
+
+    public Optional<String> getComponentKey() {
+        return Optional.ofNullable(componentKey);
     }
 
 }

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsSearchProperties.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsSearchProperties.java
@@ -27,8 +27,9 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 
 import com.synopsys.integration.alert.common.channel.issuetracker.message.IssueSearchProperties;
+import com.synopsys.integration.alert.common.rest.model.AlertSerializableModel;
 
-public class AzureBoardsSearchProperties implements IssueSearchProperties {
+public class AzureBoardsSearchProperties extends AlertSerializableModel implements IssueSearchProperties {
     private final String providerKey;
     private final String topicKey;
     private final String subTopicKey;

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsSearchPropertiesUtil.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsSearchPropertiesUtil.java
@@ -32,15 +32,20 @@ import com.synopsys.integration.alert.common.message.model.ComponentItem;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 
 public class AzureBoardsSearchPropertiesUtil {
+    public static String createProviderKey(String providerName, String providerUrl) {
+        StringBuilder providerKeyBuilder = new StringBuilder();
 
-    public static String createTopLevelKey(String providerName, String providerUrl, LinkableItem topic, @Nullable LinkableItem subTopic) {
+        providerKeyBuilder.append("Provider=(");
+        providerKeyBuilder.append(providerName);
+        providerKeyBuilder.append(", ");
+        providerKeyBuilder.append(providerUrl);
+        providerKeyBuilder.append(')');
+
+        return providerKeyBuilder.toString();
+    }
+
+    public static String createTopicKey(LinkableItem topic, @Nullable LinkableItem subTopic) {
         StringBuilder topLevelKeyBuilder = new StringBuilder();
-
-        topLevelKeyBuilder.append("Provider=(");
-        topLevelKeyBuilder.append(providerName);
-        topLevelKeyBuilder.append(", ");
-        topLevelKeyBuilder.append(providerUrl);
-        topLevelKeyBuilder.append(')');
 
         topLevelKeyBuilder.append("Topic=(");
         appendLinkableItem(topLevelKeyBuilder, topic);
@@ -55,7 +60,7 @@ public class AzureBoardsSearchPropertiesUtil {
         return topLevelKeyBuilder.toString();
     }
 
-    public static String createComponentLevelKey(@Nullable ComponentItem componentItem, String additionalInfo) {
+    public static String createComponentKey(@Nullable ComponentItem componentItem, String additionalInfo) {
         if (null == componentItem) {
             return null;
         }
@@ -96,4 +101,5 @@ public class AzureBoardsSearchPropertiesUtil {
                 stringBuilder.append(url);
             });
     }
+
 }

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsSearchPropertiesUtil.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsSearchPropertiesUtil.java
@@ -22,84 +22,36 @@
  */
 package com.synopsys.integration.alert.channel.azure.boards;
 
-import java.util.Optional;
-
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang3.StringUtils;
-
-import com.synopsys.integration.alert.common.message.model.ComponentItem;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 
 public class AzureBoardsSearchPropertiesUtil {
+    private static final char URL_DELIMITER = '|';
+
     public static String createProviderKey(String providerName, String providerUrl) {
         StringBuilder providerKeyBuilder = new StringBuilder();
-
-        providerKeyBuilder.append("Provider=(");
         providerKeyBuilder.append(providerName);
-        providerKeyBuilder.append(", ");
+        providerKeyBuilder.append(URL_DELIMITER);
         providerKeyBuilder.append(providerUrl);
-        providerKeyBuilder.append(')');
-
         return providerKeyBuilder.toString();
     }
 
-    public static String createTopicKey(LinkableItem topic, @Nullable LinkableItem subTopic) {
-        StringBuilder topLevelKeyBuilder = new StringBuilder();
-
-        topLevelKeyBuilder.append("Topic=(");
-        appendLinkableItem(topLevelKeyBuilder, topic);
-        topLevelKeyBuilder.append(')');
-
-        if (null != subTopic) {
-            topLevelKeyBuilder.append("SubTopic=(");
-            appendLinkableItem(topLevelKeyBuilder, subTopic);
-            topLevelKeyBuilder.append(')');
-        }
-
-        return topLevelKeyBuilder.toString();
-    }
-
-    public static String createComponentKey(@Nullable ComponentItem componentItem, String additionalInfo) {
-        if (null == componentItem) {
+    public static String createNullableLinkableItemKey(@Nullable LinkableItem linkableItem) {
+        if (null == linkableItem) {
             return null;
         }
 
-        StringBuilder componentLevelKeyBuilder = new StringBuilder();
-
-        componentLevelKeyBuilder.append("Category=(");
-        componentLevelKeyBuilder.append(componentItem.getCategory());
-        componentLevelKeyBuilder.append(')');
-
-        componentLevelKeyBuilder.append("Component=(");
-        appendLinkableItem(componentLevelKeyBuilder, componentItem.getComponent());
-        componentLevelKeyBuilder.append(')');
-
-        Optional<LinkableItem> subComponent = componentItem.getSubComponent();
-        if (subComponent.isPresent()) {
-            componentLevelKeyBuilder.append("SubComponent=(");
-            appendLinkableItem(componentLevelKeyBuilder, subComponent.get());
-            componentLevelKeyBuilder.append(')');
-        }
-
-        if (StringUtils.isNotBlank(additionalInfo)) {
-            componentLevelKeyBuilder.append("AdditionalInfo=(");
-            componentLevelKeyBuilder.append(additionalInfo);
-            componentLevelKeyBuilder.append(')');
-        }
-
-        return componentLevelKeyBuilder.toString();
-    }
-
-    private static void appendLinkableItem(StringBuilder stringBuilder, LinkableItem linkableItem) {
-        stringBuilder.append(linkableItem.getName());
-        stringBuilder.append(", ");
-        stringBuilder.append(linkableItem.getValue());
+        StringBuilder linkableItemBuilder = new StringBuilder();
+        linkableItemBuilder.append(linkableItem.getName());
+        linkableItemBuilder.append(':');
+        linkableItemBuilder.append(linkableItem.getValue());
         linkableItem.getUrl()
             .ifPresent(url -> {
-                stringBuilder.append(", ");
-                stringBuilder.append(url);
+                linkableItemBuilder.append(URL_DELIMITER);
+                linkableItemBuilder.append(url);
             });
+        return linkableItemBuilder.toString();
     }
 
 }

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsTestIssueRequestCreator.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsTestIssueRequestCreator.java
@@ -84,9 +84,10 @@ public class AzureBoardsTestIssueRequestCreator implements TestIssueRequestCreat
                                               .findFirst()
                                               .orElse(null);
 
-            String topLevelKey = AzureBoardsSearchPropertiesUtil.createTopLevelKey(providerName, providerUrl, topicItem, subTopicItem);
-            String componentLevelKey = AzureBoardsSearchPropertiesUtil.createComponentLevelKey(componentItem, StringUtils.EMPTY);
-            AzureBoardsSearchProperties azureBoardsSearchProperties = new AzureBoardsSearchProperties(topLevelKey, componentLevelKey);
+            String providerKey = AzureBoardsSearchPropertiesUtil.createProviderKey(providerName, providerUrl);
+            String topLevelKey = AzureBoardsSearchPropertiesUtil.createTopicKey(topicItem, subTopicItem);
+            String componentLevelKey = AzureBoardsSearchPropertiesUtil.createComponentKey(componentItem, StringUtils.EMPTY);
+            AzureBoardsSearchProperties azureBoardsSearchProperties = new AzureBoardsSearchProperties(providerKey, topLevelKey, componentLevelKey);
 
             switch (operation) {
                 case RESOLVE:
@@ -137,4 +138,5 @@ public class AzureBoardsTestIssueRequestCreator implements TestIssueRequestCreat
                    .applyNotificationId(1L)
                    .build();
     }
+
 }

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsTestIssueRequestCreator.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsTestIssueRequestCreator.java
@@ -25,11 +25,11 @@ package com.synopsys.integration.alert.channel.azure.boards;
 import java.util.Optional;
 import java.util.Set;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.synopsys.integration.alert.channel.azure.boards.service.AzureBoardsMessageParser;
+import com.synopsys.integration.alert.channel.azure.boards.service.AzureBoardsRequestCreator;
 import com.synopsys.integration.alert.common.action.TestAction;
 import com.synopsys.integration.alert.common.channel.issuetracker.enumeration.IssueOperation;
 import com.synopsys.integration.alert.common.channel.issuetracker.message.AlertIssueOrigin;
@@ -53,10 +53,12 @@ import com.synopsys.integration.alert.common.util.UrlUtils;
 public class AzureBoardsTestIssueRequestCreator implements TestIssueRequestCreator {
     private final Logger logger = LoggerFactory.getLogger(AzureBoardsTestIssueRequestCreator.class);
     private final FieldAccessor fieldAccessor;
+    private final AzureBoardsRequestCreator azureBoardsRequestCreator;
     private final AzureBoardsMessageParser azureBoardsMessageParser;
 
-    public AzureBoardsTestIssueRequestCreator(FieldAccessor fieldAccessor, AzureBoardsMessageParser azureBoardsMessageParser) {
+    public AzureBoardsTestIssueRequestCreator(FieldAccessor fieldAccessor, AzureBoardsRequestCreator azureBoardsRequestCreator, AzureBoardsMessageParser azureBoardsMessageParser) {
         this.fieldAccessor = fieldAccessor;
+        this.azureBoardsRequestCreator = azureBoardsRequestCreator;
         this.azureBoardsMessageParser = azureBoardsMessageParser;
     }
 
@@ -83,11 +85,7 @@ public class AzureBoardsTestIssueRequestCreator implements TestIssueRequestCreat
                                               .stream()
                                               .findFirst()
                                               .orElse(null);
-
-            String providerKey = AzureBoardsSearchPropertiesUtil.createProviderKey(providerName, providerUrl);
-            String topLevelKey = AzureBoardsSearchPropertiesUtil.createTopicKey(topicItem, subTopicItem);
-            String componentLevelKey = AzureBoardsSearchPropertiesUtil.createComponentKey(componentItem, StringUtils.EMPTY);
-            AzureBoardsSearchProperties azureBoardsSearchProperties = new AzureBoardsSearchProperties(providerKey, topLevelKey, componentLevelKey);
+            AzureBoardsSearchProperties azureBoardsSearchProperties = azureBoardsRequestCreator.createIssueSearchProperties(providerName, providerUrl, topicItem, subTopicItem, componentItem, null);
 
             switch (operation) {
                 case RESOLVE:

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/actions/AzureBoardsCreateIssueTestAction.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/actions/AzureBoardsCreateIssueTestAction.java
@@ -65,7 +65,7 @@ public class AzureBoardsCreateIssueTestAction extends IssueCreatorTestAction {
 
     @Override
     protected String getTodoStatusFieldKey() {
-        return AzureTransitionHandler.WORK_ITEM_STATE_CATEGORY_IN_PROGRESS;
+        return AzureTransitionHandler.WORK_ITEM_STATE_CATEGORY_PROPOSED;
     }
 
     @Override
@@ -104,4 +104,5 @@ public class AzureBoardsCreateIssueTestAction extends IssueCreatorTestAction {
         ProxyInfo proxy = proxyManager.createProxyInfo();
         return azureBoardsProperties.createAzureHttpService(proxy, gson);
     }
+
 }

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/actions/AzureBoardsDistributionTestAction.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/actions/AzureBoardsDistributionTestAction.java
@@ -31,6 +31,7 @@ import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsContext;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsContextFactory;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsTestIssueRequestCreator;
 import com.synopsys.integration.alert.channel.azure.boards.service.AzureBoardsMessageParser;
+import com.synopsys.integration.alert.channel.azure.boards.service.AzureBoardsRequestCreator;
 import com.synopsys.integration.alert.common.channel.ChannelDistributionTestAction;
 import com.synopsys.integration.alert.common.message.model.MessageResult;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldAccessor;
@@ -41,14 +42,17 @@ import com.synopsys.integration.exception.IntegrationException;
 @Component
 public class AzureBoardsDistributionTestAction extends ChannelDistributionTestAction {
     private final Gson gson;
+    private final AzureBoardsRequestCreator azureBoardsRequestCreator;
     private final AzureBoardsMessageParser azureBoardsMessageParser;
     private final AzureBoardsContextFactory azureBoardsContextFactory;
     private final ProxyManager proxyManager;
 
     @Autowired
-    public AzureBoardsDistributionTestAction(AzureBoardsChannel azureBoardsChannel, Gson gson, AzureBoardsMessageParser azureBoardsMessageParser, AzureBoardsContextFactory azureBoardsContextFactory, ProxyManager proxyManager) {
+    public AzureBoardsDistributionTestAction(AzureBoardsChannel azureBoardsChannel, Gson gson, AzureBoardsRequestCreator azureBoardsRequestCreator,
+        AzureBoardsMessageParser azureBoardsMessageParser, AzureBoardsContextFactory azureBoardsContextFactory, ProxyManager proxyManager) {
         super(azureBoardsChannel);
         this.gson = gson;
+        this.azureBoardsRequestCreator = azureBoardsRequestCreator;
         this.azureBoardsMessageParser = azureBoardsMessageParser;
         this.azureBoardsContextFactory = azureBoardsContextFactory;
         this.proxyManager = proxyManager;
@@ -57,7 +61,7 @@ public class AzureBoardsDistributionTestAction extends ChannelDistributionTestAc
     @Override
     public MessageResult testConfig(String jobId, FieldModel fieldModel, FieldAccessor registeredFieldValues) throws IntegrationException {
         AzureBoardsContext azureBoardsContext = azureBoardsContextFactory.build(registeredFieldValues);
-        AzureBoardsTestIssueRequestCreator issueCreator = new AzureBoardsTestIssueRequestCreator(registeredFieldValues, azureBoardsMessageParser);
+        AzureBoardsTestIssueRequestCreator issueCreator = new AzureBoardsTestIssueRequestCreator(registeredFieldValues, azureBoardsRequestCreator, azureBoardsMessageParser);
         AzureBoardsCreateIssueTestAction azureBoardsCreateIssueTestAction = new AzureBoardsCreateIssueTestAction((AzureBoardsChannel) getDistributionChannel(), gson, issueCreator, proxyManager);
         return azureBoardsCreateIssueTestAction.testConfig(azureBoardsContext);
     }

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsIssueHandler.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsIssueHandler.java
@@ -185,15 +185,11 @@ public class AzureBoardsIssueHandler extends IssueHandler<WorkItemResponseModel>
     protected IssueTrackerIssueResponseModel createResponseModel(AlertIssueOrigin alertIssueOrigin, String issueTitle, IssueOperation issueOperation, WorkItemResponseModel issueResponse) {
         Integer workItemId = issueResponse.getId();
         Map<String, ReferenceLinkModel> issueLinks = issueResponse.getLinks();
-        // the AzureWorkItemReponst does not contain any links when called via the rest API.
-        // only when the issue is created will the html link be present.
-        String uiLink = null;
-        if (null != issueLinks) {
-            ReferenceLinkModel htmlLink = issueLinks.get("html");
-            uiLink = Optional.ofNullable(htmlLink)
-                         .map(ReferenceLinkModel::getHref)
-                         .orElseGet(this::getIssueTrackerUrl);
-        }
+        // AzureWorkItemResponse does not contain any links other than when a work item is created.
+        String uiLink = Optional.ofNullable(issueLinks)
+                            .flatMap(issueLinkMap -> Optional.ofNullable(issueLinkMap.get("html")))
+                            .map(ReferenceLinkModel::getHref)
+                            .orElseGet(this::getIssueTrackerUrl);
         return new IssueTrackerIssueResponseModel(alertIssueOrigin, workItemId.toString(), uiLink, issueTitle, issueOperation);
     }
 

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsIssueHandler.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsIssueHandler.java
@@ -124,10 +124,10 @@ public class AzureBoardsIssueHandler extends IssueHandler<WorkItemResponseModel>
         WorkItemQueryWhere queryBuilder = WorkItemQuery
                                               .select(systemIdFieldName)
                                               .fromWorkItems()
-                                              .whereGroup(AzureCustomFieldManager.ALERT_TOP_LEVEL_KEY_FIELD_NAME, WorkItemQueryWhereOperator.EQ, searchProperties.getTopLevelKey());
-        Optional<String> optionalComponentLevelKey = searchProperties.getComponentLevelKey();
+                                              .whereGroup(AzureCustomFieldManager.ALERT_TOPIC_KEY_FIELD_NAME, WorkItemQueryWhereOperator.EQ, searchProperties.getTopicKey());
+        Optional<String> optionalComponentLevelKey = searchProperties.getComponentKey();
         if (optionalComponentLevelKey.isPresent()) {
-            queryBuilder = queryBuilder.and(AzureCustomFieldManager.ALERT_COMPONENT_LEVEL_KEY_FIELD_REFERENCE_NAME, WorkItemQueryWhereOperator.EQ, optionalComponentLevelKey.get());
+            queryBuilder = queryBuilder.and(AzureCustomFieldManager.ALERT_COMPONENT_KEY_FIELD_REFERENCE_NAME, WorkItemQueryWhereOperator.EQ, optionalComponentLevelKey.get());
         }
 
         WorkItemQuery query = queryBuilder.orderBy(systemIdFieldName).build();
@@ -206,8 +206,8 @@ public class AzureBoardsIssueHandler extends IssueHandler<WorkItemResponseModel>
     @Override
     protected void logIssueAction(String issueTrackerProjectName, IssueTrackerRequest request) {
         AzureBoardsSearchProperties issueProperties = request.getIssueSearchProperties();
-        String topLevelKey = issueProperties.getTopLevelKey();
-        String componentLevelKey = issueProperties.getComponentLevelKey().orElse("Absent");
+        String topLevelKey = issueProperties.getTopicKey();
+        String componentLevelKey = issueProperties.getComponentKey().orElse("Absent");
         logger.debug("Attempting the {} action in Azure Boards. Top Level Key: {}. Component Level Key: {}", request.getOperation().name(), topLevelKey, componentLevelKey);
     }
 
@@ -220,15 +220,19 @@ public class AzureBoardsIssueHandler extends IssueHandler<WorkItemResponseModel>
         WorkItemElementOperationModel descriptionField = createAddFieldModel(WorkItemResponseFields.System_Description, issueContentModel.getDescription());
         requestElementOps.add(descriptionField);
 
-        AzureFieldDefinition<String> alertTopLevelKeyFieldDefinition = AzureFieldDefinition.stringField(AzureCustomFieldManager.ALERT_TOP_LEVEL_KEY_FIELD_REFERENCE_NAME);
-        WorkItemElementOperationModel alertTopLevelKey = createAddFieldModel(alertTopLevelKeyFieldDefinition, issueSearchProperties.getTopLevelKey());
-        requestElementOps.add(alertTopLevelKey);
+        AzureFieldDefinition<String> alertProviderKeyFieldDefinition = AzureFieldDefinition.stringField(AzureCustomFieldManager.ALERT_PROVIDER_KEY_FIELD_REFERENCE_NAME);
+        WorkItemElementOperationModel alertProviderKeyField = createAddFieldModel(alertProviderKeyFieldDefinition, issueSearchProperties.getProviderKey());
+        requestElementOps.add(alertProviderKeyField);
 
-        Optional<String> optionalComponentLevelKey = issueSearchProperties.getComponentLevelKey();
-        if (optionalComponentLevelKey.isPresent()) {
-            AzureFieldDefinition<String> alertComponentLevelKeyFieldDefinition = AzureFieldDefinition.stringField(AzureCustomFieldManager.ALERT_COMPONENT_LEVEL_KEY_FIELD_REFERENCE_NAME);
-            WorkItemElementOperationModel alertComponentLevelKeyField = createAddFieldModel(alertComponentLevelKeyFieldDefinition, optionalComponentLevelKey.get());
-            requestElementOps.add(alertComponentLevelKeyField);
+        AzureFieldDefinition<String> alertTopicKeyFieldDefinition = AzureFieldDefinition.stringField(AzureCustomFieldManager.ALERT_TOPIC_KEY_FIELD_REFERENCE_NAME);
+        WorkItemElementOperationModel alertTopicKeyField = createAddFieldModel(alertTopicKeyFieldDefinition, issueSearchProperties.getTopicKey());
+        requestElementOps.add(alertTopicKeyField);
+
+        Optional<String> optionalComponentKey = issueSearchProperties.getComponentKey();
+        if (optionalComponentKey.isPresent()) {
+            AzureFieldDefinition<String> alertComponentKeyFieldDefinition = AzureFieldDefinition.stringField(AzureCustomFieldManager.ALERT_COMPONENT_KEY_FIELD_REFERENCE_NAME);
+            WorkItemElementOperationModel alertComponentKeyField = createAddFieldModel(alertComponentKeyFieldDefinition, optionalComponentKey.get());
+            requestElementOps.add(alertComponentKeyField);
         }
 
         // TODO determine if we can support this

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsIssueHandler.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsIssueHandler.java
@@ -216,28 +216,39 @@ public class AzureBoardsIssueHandler extends IssueHandler<WorkItemResponseModel>
         WorkItemElementOperationModel descriptionField = createAddFieldModel(WorkItemResponseFields.System_Description, issueContentModel.getDescription());
         requestElementOps.add(descriptionField);
 
-        AzureFieldDefinition<String> alertProviderKeyFieldDefinition = AzureFieldDefinition.stringField(AzureCustomFieldManager.ALERT_PROVIDER_KEY_FIELD_REFERENCE_NAME);
-        WorkItemElementOperationModel alertProviderKeyField = createAddFieldModel(alertProviderKeyFieldDefinition, issueSearchProperties.getProviderKey());
-        requestElementOps.add(alertProviderKeyField);
-
-        AzureFieldDefinition<String> alertTopicKeyFieldDefinition = AzureFieldDefinition.stringField(AzureCustomFieldManager.ALERT_TOPIC_KEY_FIELD_REFERENCE_NAME);
-        WorkItemElementOperationModel alertTopicKeyField = createAddFieldModel(alertTopicKeyFieldDefinition, issueSearchProperties.getTopicKey());
-        requestElementOps.add(alertTopicKeyField);
-
-        Optional<String> optionalComponentKey = issueSearchProperties.getComponentKey();
-        if (optionalComponentKey.isPresent()) {
-            AzureFieldDefinition<String> alertComponentKeyFieldDefinition = AzureFieldDefinition.stringField(AzureCustomFieldManager.ALERT_COMPONENT_KEY_FIELD_REFERENCE_NAME);
-            WorkItemElementOperationModel alertComponentKeyField = createAddFieldModel(alertComponentKeyFieldDefinition, optionalComponentKey.get());
-            requestElementOps.add(alertComponentKeyField);
-        }
-
         // TODO determine if we can support this
         // if (StringUtils.isNotBlank(issueCreatorUniqueName)) {
         // WorkItemUserModel workItemUserModel = new WorkItemUserModel(null, null, issueConfig.getIssueCreator(), null, null, null, null, null);
         // WorkItemElementOperationModel createdByField = createAddFieldModel(WorkItemResponseFields.System_CreatedBy, workItemUserModel);
         // requestElementOps.add(createdByField);
         // }
+
+        List<WorkItemElementOperationModel> alertAzureCustomFields = createWorkItemRequestCustomFields(issueSearchProperties);
+        requestElementOps.addAll(alertAzureCustomFields);
+
         return new WorkItemRequest(requestElementOps);
+    }
+
+    private List<WorkItemElementOperationModel> createWorkItemRequestCustomFields(AzureBoardsSearchProperties issueSearchProperties) {
+        List<WorkItemElementOperationModel> customFields = new ArrayList<>(7);
+        addStringField(customFields, AzureCustomFieldManager.ALERT_PROVIDER_KEY_FIELD_REFERENCE_NAME, issueSearchProperties.getProviderKey());
+        addStringField(customFields, AzureCustomFieldManager.ALERT_TOPIC_KEY_FIELD_REFERENCE_NAME, issueSearchProperties.getTopicKey());
+        addStringField(customFields, AzureCustomFieldManager.ALERT_SUB_TOPIC_KEY_FIELD_REFERENCE_NAME, issueSearchProperties.getSubTopicKey());
+        addStringField(customFields, AzureCustomFieldManager.ALERT_CATEGORY_KEY_FIELD_REFERENCE_NAME, issueSearchProperties.getCategoryKey());
+        addStringField(customFields, AzureCustomFieldManager.ALERT_COMPONENT_KEY_FIELD_REFERENCE_NAME, issueSearchProperties.getComponentKey());
+        addStringField(customFields, AzureCustomFieldManager.ALERT_SUB_COMPONENT_KEY_FIELD_REFERENCE_NAME, issueSearchProperties.getSubComponentKey());
+        addStringField(customFields, AzureCustomFieldManager.ALERT_ADDITIONAL_INFO_KEY_FIELD_REFERENCE_NAME, issueSearchProperties.getAdditionalInfoKey());
+        return customFields;
+    }
+
+    private void addStringField(List<WorkItemElementOperationModel> customFields, String fieldReferenceName, Optional<String> optionalFieldValue) {
+        optionalFieldValue.ifPresent(fieldValue -> addStringField(customFields, fieldReferenceName, fieldValue));
+    }
+
+    private void addStringField(List<WorkItemElementOperationModel> customFields, String fieldReferenceName, String fieldValue) {
+        AzureFieldDefinition<String> alertProviderKeyFieldDefinition = AzureFieldDefinition.stringField(fieldReferenceName);
+        WorkItemElementOperationModel alertProviderKeyField = createAddFieldModel(alertProviderKeyFieldDefinition, fieldValue);
+        customFields.add(alertProviderKeyField);
     }
 
     private <T> WorkItemElementOperationModel createAddFieldModel(AzureFieldDefinition<T> field, T value) {

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsMessageParser.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsMessageParser.java
@@ -37,8 +37,6 @@ public class AzureBoardsMessageParser extends IssueTrackerMessageParser {
 
     @Override
     protected String encodeString(String txt) {
-        // TODO is this necessary?
-        //  URLEncoder.encode(txt, StandardCharsets.UTF_8);
         return txt;
     }
 

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsMessageParser.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsMessageParser.java
@@ -22,9 +22,6 @@
  */
 package com.synopsys.integration.alert.channel.azure.boards.service;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.common.channel.issuetracker.message.IssueTrackerMessageParser;
@@ -40,7 +37,9 @@ public class AzureBoardsMessageParser extends IssueTrackerMessageParser {
 
     @Override
     protected String encodeString(String txt) {
-        return URLEncoder.encode(txt, StandardCharsets.UTF_8);
+        // TODO is this necessary?
+        //  URLEncoder.encode(txt, StandardCharsets.UTF_8);
+        return txt;
     }
 
     @Override

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsRequestCreator.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsRequestCreator.java
@@ -39,11 +39,20 @@ public class AzureBoardsRequestCreator extends IssueTrackerRequestCreator {
     }
 
     @Override
-    protected AzureBoardsSearchProperties createIssueSearchProperties(String providerName, String providerUrl, LinkableItem topic, @Nullable LinkableItem subTopic, @Nullable ComponentItem componentItem, String additionalInfo) {
+    public AzureBoardsSearchProperties createIssueSearchProperties(String providerName, String providerUrl, LinkableItem topic, @Nullable LinkableItem subTopic, @Nullable ComponentItem componentItem, @Nullable String additionalInfo) {
         String providerKey = AzureBoardsSearchPropertiesUtil.createProviderKey(providerName, providerUrl);
-        String topicKey = AzureBoardsSearchPropertiesUtil.createTopicKey(topic, subTopic);
-        String componentLevelKey = AzureBoardsSearchPropertiesUtil.createComponentKey(componentItem, additionalInfo);
-        return new AzureBoardsSearchProperties(providerKey, topicKey, componentLevelKey);
+        String topicKey = AzureBoardsSearchPropertiesUtil.createNullableLinkableItemKey(topic);
+        String subTopicKey = AzureBoardsSearchPropertiesUtil.createNullableLinkableItemKey(subTopic);
+
+        String categoryKey = null;
+        String componentKey = null;
+        String subComponentKey = null;
+        if (null != componentItem) {
+            categoryKey = componentItem.getCategory();
+            componentKey = AzureBoardsSearchPropertiesUtil.createNullableLinkableItemKey(componentItem.getComponent());
+            subComponentKey = AzureBoardsSearchPropertiesUtil.createNullableLinkableItemKey(componentItem.getSubComponent().orElse(null));
+        }
+        return new AzureBoardsSearchProperties(providerKey, topicKey, subTopicKey, categoryKey, componentKey, subComponentKey, additionalInfo);
     }
 
 }

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsRequestCreator.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsRequestCreator.java
@@ -40,9 +40,10 @@ public class AzureBoardsRequestCreator extends IssueTrackerRequestCreator {
 
     @Override
     protected AzureBoardsSearchProperties createIssueSearchProperties(String providerName, String providerUrl, LinkableItem topic, @Nullable LinkableItem subTopic, @Nullable ComponentItem componentItem, String additionalInfo) {
-        String topLevelKey = AzureBoardsSearchPropertiesUtil.createTopLevelKey(providerName, providerUrl, topic, subTopic);
-        String componentLevelKey = AzureBoardsSearchPropertiesUtil.createComponentLevelKey(componentItem, additionalInfo);
-        return new AzureBoardsSearchProperties(topLevelKey, componentLevelKey);
+        String providerKey = AzureBoardsSearchPropertiesUtil.createProviderKey(providerName, providerUrl);
+        String topicKey = AzureBoardsSearchPropertiesUtil.createTopicKey(topic, subTopic);
+        String componentLevelKey = AzureBoardsSearchPropertiesUtil.createComponentKey(componentItem, additionalInfo);
+        return new AzureBoardsSearchProperties(providerKey, topicKey, componentLevelKey);
     }
 
 }

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureCustomFieldManager.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureCustomFieldManager.java
@@ -103,29 +103,6 @@ public class AzureCustomFieldManager {
 
     public void installCustomFields(String projectName, String workItemTypeName) throws AlertException {
         installCustomFields(projectName, workItemTypeName, AZURE_CUSTOM_FIELDS);
-        //        Future<ProjectWorkItemFieldModel> providerKeyFieldCreationResultHolder =
-        //            executorService.submit(() -> findOrCreateAlertCustomProjectField(projectName, ALERT_PROVIDER_KEY_FIELD_NAME, ALERT_PROVIDER_KEY_FIELD_REFERENCE_NAME, ALERT_PROVIDER_KEY_FIELD_DESCRIPTION));
-        //        Future<ProjectWorkItemFieldModel> topicKeyFieldCreationResultHolder =
-        //            executorService.submit(() -> findOrCreateAlertCustomProjectField(projectName, ALERT_TOPIC_KEY_FIELD_NAME, ALERT_TOPIC_KEY_FIELD_REFERENCE_NAME, ALERT_TOPIC_KEY_FIELD_DESCRIPTION));
-        //        Future<ProjectWorkItemFieldModel> componentKeyFieldCreationResultHolder =
-        //            executorService.submit(() -> findOrCreateAlertCustomProjectField(projectName, ALERT_COMPONENT_KEY_FIELD_NAME, ALERT_COMPONENT_KEY_FIELD_REFERENCE_NAME, ALERT_COMPONENT_KEY_FIELD_DESCRIPTION));
-        //
-        //        TeamProjectReferenceResponseModel project = getProject(projectName);
-        //        String processId = getProjectPropertyValue(project, ProjectPropertyResponseModel.COMMON_PROPERTIES_PROCESS_ID);
-        //        String workItemTypeRefName = getWorkItemTypeRefName(processId, workItemTypeName);
-        //
-        //        ProjectWorkItemFieldModel providerKeyField = extractFutureResult(providerKeyFieldCreationResultHolder);
-        //        Future<ProcessFieldResponseModel> processProviderFieldKeyResultHolder = executorService.submit(() -> addAlertCustomFieldToProcess(processId, workItemTypeRefName, providerKeyField));
-        //
-        //        ProjectWorkItemFieldModel topicKeyField = extractFutureResult(topicKeyFieldCreationResultHolder);
-        //        Future<ProcessFieldResponseModel> processTopicFieldKeyResultHolder = executorService.submit(() -> addAlertCustomFieldToProcess(processId, workItemTypeRefName, topicKeyField));
-        //
-        //        ProjectWorkItemFieldModel componentKeyField = extractFutureResult(componentKeyFieldCreationResultHolder);
-        //        Future<ProcessFieldResponseModel> processComponentFieldKeyResultHolder = executorService.submit(() -> addAlertCustomFieldToProcess(processId, workItemTypeRefName, componentKeyField));
-        //
-        //        extractFutureResult(processProviderFieldKeyResultHolder);
-        //        extractFutureResult(processTopicFieldKeyResultHolder);
-        //        extractFutureResult(processComponentFieldKeyResultHolder);
     }
 
     private void installCustomFields(String projectName, String workItemTypeName, List<AzureCustomFieldDescriptor> customFieldDescriptors) throws AlertException {

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureCustomFieldManager.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureCustomFieldManager.java
@@ -102,12 +102,8 @@ public class AzureCustomFieldManager {
     }
 
     public void installCustomFields(String projectName, String workItemTypeName) throws AlertException {
-        installCustomFields(projectName, workItemTypeName, AZURE_CUSTOM_FIELDS);
-    }
-
-    private void installCustomFields(String projectName, String workItemTypeName, List<AzureCustomFieldDescriptor> customFieldDescriptors) throws AlertException {
         List<Future<ProjectWorkItemFieldModel>> projectFieldFindOrCreateHolders = new ArrayList<>(7);
-        for (AzureCustomFieldDescriptor fieldDesc : customFieldDescriptors) {
+        for (AzureCustomFieldDescriptor fieldDesc : AZURE_CUSTOM_FIELDS) {
             Future<ProjectWorkItemFieldModel> fieldFindOrCreateHolder =
                 executorService.submit(() -> findOrCreateAlertCustomProjectField(projectName, fieldDesc.getFieldName(), fieldDesc.getFieldReferenceName(), fieldDesc.getFieldDescription()));
             projectFieldFindOrCreateHolders.add(fieldFindOrCreateHolder);

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureCustomFieldManager.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureCustomFieldManager.java
@@ -46,13 +46,17 @@ import com.synopsys.integration.azure.boards.common.service.project.ProjectWorkI
 import com.synopsys.integration.azure.boards.common.service.project.TeamProjectReferenceResponseModel;
 
 public class AzureCustomFieldManager {
-    public static final String ALERT_TOP_LEVEL_KEY_FIELD_NAME = "Alert Top Level Key";
-    public static final String ALERT_TOP_LEVEL_KEY_FIELD_REFERENCE_NAME = "Custom.AlertTopLevelKey";
-    public static final String ALERT_TOP_LEVEL_KEY_FIELD_DESCRIPTION = "A top-level tracking key for Alert";
+    public static final String ALERT_PROVIDER_KEY_FIELD_NAME = "Alert Provider Key";
+    public static final String ALERT_PROVIDER_KEY_FIELD_REFERENCE_NAME = "Custom.AlertProviderKey";
+    public static final String ALERT_PROVIDER_KEY_FIELD_DESCRIPTION = "A provider-level tracking key for Alert";
 
-    public static final String ALERT_COMPONENT_LEVEL_KEY_FIELD_NAME = "Alert Component Level Key";
-    public static final String ALERT_COMPONENT_LEVEL_KEY_FIELD_REFERENCE_NAME = "Custom.AlertComponentLevelKey";
-    public static final String ALERT_COMPONENT_LEVEL_KEY_FIELD_DESCRIPTION = "A component-level tracking key for Alert";
+    public static final String ALERT_TOPIC_KEY_FIELD_NAME = "Alert Topic Key";
+    public static final String ALERT_TOPIC_KEY_FIELD_REFERENCE_NAME = "Custom.AlertTopicKey";
+    public static final String ALERT_TOPIC_KEY_FIELD_DESCRIPTION = "A topic-level tracking key for Alert";
+
+    public static final String ALERT_COMPONENT_KEY_FIELD_NAME = "Alert Component Key";
+    public static final String ALERT_COMPONENT_KEY_FIELD_REFERENCE_NAME = "Custom.AlertComponentKey";
+    public static final String ALERT_COMPONENT_KEY_FIELD_DESCRIPTION = "A component-level tracking key for Alert";
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -69,23 +73,29 @@ public class AzureCustomFieldManager {
     }
 
     public void installCustomFields(String projectName, String workItemTypeName) throws AlertException {
-        Future<ProjectWorkItemFieldModel> topLevelKeyFieldCreationResultHolder =
-            executorService.submit(() -> findOrCreateAlertCustomProjectField(projectName, ALERT_TOP_LEVEL_KEY_FIELD_NAME, ALERT_TOP_LEVEL_KEY_FIELD_REFERENCE_NAME, ALERT_TOP_LEVEL_KEY_FIELD_DESCRIPTION));
-        Future<ProjectWorkItemFieldModel> componentLevelKeyFieldCreationResultHolder =
-            executorService.submit(() -> findOrCreateAlertCustomProjectField(projectName, ALERT_COMPONENT_LEVEL_KEY_FIELD_NAME, ALERT_COMPONENT_LEVEL_KEY_FIELD_REFERENCE_NAME, ALERT_COMPONENT_LEVEL_KEY_FIELD_DESCRIPTION));
+        Future<ProjectWorkItemFieldModel> providerKeyFieldCreationResultHolder =
+            executorService.submit(() -> findOrCreateAlertCustomProjectField(projectName, ALERT_PROVIDER_KEY_FIELD_NAME, ALERT_PROVIDER_KEY_FIELD_REFERENCE_NAME, ALERT_PROVIDER_KEY_FIELD_DESCRIPTION));
+        Future<ProjectWorkItemFieldModel> topicKeyFieldCreationResultHolder =
+            executorService.submit(() -> findOrCreateAlertCustomProjectField(projectName, ALERT_TOPIC_KEY_FIELD_NAME, ALERT_TOPIC_KEY_FIELD_REFERENCE_NAME, ALERT_TOPIC_KEY_FIELD_DESCRIPTION));
+        Future<ProjectWorkItemFieldModel> componentKeyFieldCreationResultHolder =
+            executorService.submit(() -> findOrCreateAlertCustomProjectField(projectName, ALERT_COMPONENT_KEY_FIELD_NAME, ALERT_COMPONENT_KEY_FIELD_REFERENCE_NAME, ALERT_COMPONENT_KEY_FIELD_DESCRIPTION));
 
         TeamProjectReferenceResponseModel project = getProject(projectName);
         String processId = getProjectPropertyValue(project, ProjectPropertyResponseModel.COMMON_PROPERTIES_PROCESS_ID);
         String workItemTypeRefName = getWorkItemTypeRefName(processId, workItemTypeName);
 
-        ProjectWorkItemFieldModel topLevelKeyField = extractFutureResult(topLevelKeyFieldCreationResultHolder);
-        Future<ProcessFieldResponseModel> processTopLevelFieldKeyResultHolder = executorService.submit(() -> addAlertCustomFieldToProcess(processId, workItemTypeRefName, topLevelKeyField));
+        ProjectWorkItemFieldModel providerKeyField = extractFutureResult(providerKeyFieldCreationResultHolder);
+        Future<ProcessFieldResponseModel> processProviderFieldKeyResultHolder = executorService.submit(() -> addAlertCustomFieldToProcess(processId, workItemTypeRefName, providerKeyField));
 
-        ProjectWorkItemFieldModel componentLevelKeyField = extractFutureResult(componentLevelKeyFieldCreationResultHolder);
-        Future<ProcessFieldResponseModel> processComponentLevelFieldKeyResultHolder = executorService.submit(() -> addAlertCustomFieldToProcess(processId, workItemTypeRefName, componentLevelKeyField));
+        ProjectWorkItemFieldModel topicKeyField = extractFutureResult(topicKeyFieldCreationResultHolder);
+        Future<ProcessFieldResponseModel> processTopicFieldKeyResultHolder = executorService.submit(() -> addAlertCustomFieldToProcess(processId, workItemTypeRefName, topicKeyField));
 
-        extractFutureResult(processTopLevelFieldKeyResultHolder);
-        extractFutureResult(processComponentLevelFieldKeyResultHolder);
+        ProjectWorkItemFieldModel componentKeyField = extractFutureResult(componentKeyFieldCreationResultHolder);
+        Future<ProcessFieldResponseModel> processComponentFieldKeyResultHolder = executorService.submit(() -> addAlertCustomFieldToProcess(processId, workItemTypeRefName, componentKeyField));
+
+        extractFutureResult(processProviderFieldKeyResultHolder);
+        extractFutureResult(processTopicFieldKeyResultHolder);
+        extractFutureResult(processComponentFieldKeyResultHolder);
     }
 
     private Optional<ProjectWorkItemFieldModel> getAlertCustomProjectField(String projectName, String fieldReferenceName) {

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureCustomFieldManager.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureCustomFieldManager.java
@@ -23,6 +23,8 @@
 package com.synopsys.integration.alert.channel.azure.boards.service;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -33,6 +35,7 @@ import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.synopsys.integration.alert.channel.azure.boards.service.model.AzureCustomFieldDescriptor;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.azure.boards.common.http.HttpServiceException;
 import com.synopsys.integration.azure.boards.common.model.AzureArrayResponseModel;
@@ -48,15 +51,41 @@ import com.synopsys.integration.azure.boards.common.service.project.TeamProjectR
 public class AzureCustomFieldManager {
     public static final String ALERT_PROVIDER_KEY_FIELD_NAME = "Alert Provider Key";
     public static final String ALERT_PROVIDER_KEY_FIELD_REFERENCE_NAME = "Custom.AlertProviderKey";
-    public static final String ALERT_PROVIDER_KEY_FIELD_DESCRIPTION = "A provider-level tracking key for Alert";
+    public static final String ALERT_PROVIDER_KEY_FIELD_DESCRIPTION = "A provider tracking key for Alert";
 
     public static final String ALERT_TOPIC_KEY_FIELD_NAME = "Alert Topic Key";
     public static final String ALERT_TOPIC_KEY_FIELD_REFERENCE_NAME = "Custom.AlertTopicKey";
-    public static final String ALERT_TOPIC_KEY_FIELD_DESCRIPTION = "A topic-level tracking key for Alert";
+    public static final String ALERT_TOPIC_KEY_FIELD_DESCRIPTION = "A topic tracking key for Alert";
+
+    public static final String ALERT_SUB_TOPIC_KEY_FIELD_NAME = "Alert SubTopic Key";
+    public static final String ALERT_SUB_TOPIC_KEY_FIELD_REFERENCE_NAME = "Custom.AlertSubTopicKey";
+    public static final String ALERT_SUB_TOPIC_KEY_FIELD_DESCRIPTION = "A sub-topic tracking key for Alert";
+
+    public static final String ALERT_CATEGORY_KEY_FIELD_NAME = "Alert Category Key";
+    public static final String ALERT_CATEGORY_KEY_FIELD_REFERENCE_NAME = "Custom.AlertCategoryKey";
+    public static final String ALERT_CATEGORY_KEY_FIELD_DESCRIPTION = "A category tracking key for Alert";
 
     public static final String ALERT_COMPONENT_KEY_FIELD_NAME = "Alert Component Key";
     public static final String ALERT_COMPONENT_KEY_FIELD_REFERENCE_NAME = "Custom.AlertComponentKey";
-    public static final String ALERT_COMPONENT_KEY_FIELD_DESCRIPTION = "A component-level tracking key for Alert";
+    public static final String ALERT_COMPONENT_KEY_FIELD_DESCRIPTION = "A component tracking key for Alert";
+
+    public static final String ALERT_SUB_COMPONENT_KEY_FIELD_NAME = "Alert SubComponent Key";
+    public static final String ALERT_SUB_COMPONENT_KEY_FIELD_REFERENCE_NAME = "Custom.AlertSubComponentKey";
+    public static final String ALERT_SUB_COMPONENT_KEY_FIELD_DESCRIPTION = "A sub-component tracking key for Alert";
+
+    public static final String ALERT_ADDITIONAL_INFO_KEY_FIELD_NAME = "Alert AdditionalInfo Key";
+    public static final String ALERT_ADDITIONAL_INFO_KEY_FIELD_REFERENCE_NAME = "Custom.AlertAdditionalInfoKey";
+    public static final String ALERT_ADDITIONAL_INFO_KEY_FIELD_DESCRIPTION = "A tracking key for any additional info needed by Alert";
+
+    private static final List<AzureCustomFieldDescriptor> AZURE_CUSTOM_FIELDS = List.of(
+        new AzureCustomFieldDescriptor(ALERT_PROVIDER_KEY_FIELD_NAME, ALERT_PROVIDER_KEY_FIELD_REFERENCE_NAME, ALERT_PROVIDER_KEY_FIELD_DESCRIPTION),
+        new AzureCustomFieldDescriptor(ALERT_TOPIC_KEY_FIELD_NAME, ALERT_TOPIC_KEY_FIELD_REFERENCE_NAME, ALERT_TOPIC_KEY_FIELD_DESCRIPTION),
+        new AzureCustomFieldDescriptor(ALERT_SUB_TOPIC_KEY_FIELD_NAME, ALERT_SUB_TOPIC_KEY_FIELD_REFERENCE_NAME, ALERT_SUB_TOPIC_KEY_FIELD_DESCRIPTION),
+        new AzureCustomFieldDescriptor(ALERT_CATEGORY_KEY_FIELD_NAME, ALERT_CATEGORY_KEY_FIELD_REFERENCE_NAME, ALERT_CATEGORY_KEY_FIELD_DESCRIPTION),
+        new AzureCustomFieldDescriptor(ALERT_COMPONENT_KEY_FIELD_NAME, ALERT_COMPONENT_KEY_FIELD_REFERENCE_NAME, ALERT_COMPONENT_KEY_FIELD_DESCRIPTION),
+        new AzureCustomFieldDescriptor(ALERT_SUB_COMPONENT_KEY_FIELD_NAME, ALERT_SUB_COMPONENT_KEY_FIELD_REFERENCE_NAME, ALERT_SUB_COMPONENT_KEY_FIELD_DESCRIPTION),
+        new AzureCustomFieldDescriptor(ALERT_ADDITIONAL_INFO_KEY_FIELD_NAME, ALERT_ADDITIONAL_INFO_KEY_FIELD_REFERENCE_NAME, ALERT_ADDITIONAL_INFO_KEY_FIELD_DESCRIPTION)
+    );
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -73,29 +102,54 @@ public class AzureCustomFieldManager {
     }
 
     public void installCustomFields(String projectName, String workItemTypeName) throws AlertException {
-        Future<ProjectWorkItemFieldModel> providerKeyFieldCreationResultHolder =
-            executorService.submit(() -> findOrCreateAlertCustomProjectField(projectName, ALERT_PROVIDER_KEY_FIELD_NAME, ALERT_PROVIDER_KEY_FIELD_REFERENCE_NAME, ALERT_PROVIDER_KEY_FIELD_DESCRIPTION));
-        Future<ProjectWorkItemFieldModel> topicKeyFieldCreationResultHolder =
-            executorService.submit(() -> findOrCreateAlertCustomProjectField(projectName, ALERT_TOPIC_KEY_FIELD_NAME, ALERT_TOPIC_KEY_FIELD_REFERENCE_NAME, ALERT_TOPIC_KEY_FIELD_DESCRIPTION));
-        Future<ProjectWorkItemFieldModel> componentKeyFieldCreationResultHolder =
-            executorService.submit(() -> findOrCreateAlertCustomProjectField(projectName, ALERT_COMPONENT_KEY_FIELD_NAME, ALERT_COMPONENT_KEY_FIELD_REFERENCE_NAME, ALERT_COMPONENT_KEY_FIELD_DESCRIPTION));
+        installCustomFields(projectName, workItemTypeName, AZURE_CUSTOM_FIELDS);
+        //        Future<ProjectWorkItemFieldModel> providerKeyFieldCreationResultHolder =
+        //            executorService.submit(() -> findOrCreateAlertCustomProjectField(projectName, ALERT_PROVIDER_KEY_FIELD_NAME, ALERT_PROVIDER_KEY_FIELD_REFERENCE_NAME, ALERT_PROVIDER_KEY_FIELD_DESCRIPTION));
+        //        Future<ProjectWorkItemFieldModel> topicKeyFieldCreationResultHolder =
+        //            executorService.submit(() -> findOrCreateAlertCustomProjectField(projectName, ALERT_TOPIC_KEY_FIELD_NAME, ALERT_TOPIC_KEY_FIELD_REFERENCE_NAME, ALERT_TOPIC_KEY_FIELD_DESCRIPTION));
+        //        Future<ProjectWorkItemFieldModel> componentKeyFieldCreationResultHolder =
+        //            executorService.submit(() -> findOrCreateAlertCustomProjectField(projectName, ALERT_COMPONENT_KEY_FIELD_NAME, ALERT_COMPONENT_KEY_FIELD_REFERENCE_NAME, ALERT_COMPONENT_KEY_FIELD_DESCRIPTION));
+        //
+        //        TeamProjectReferenceResponseModel project = getProject(projectName);
+        //        String processId = getProjectPropertyValue(project, ProjectPropertyResponseModel.COMMON_PROPERTIES_PROCESS_ID);
+        //        String workItemTypeRefName = getWorkItemTypeRefName(processId, workItemTypeName);
+        //
+        //        ProjectWorkItemFieldModel providerKeyField = extractFutureResult(providerKeyFieldCreationResultHolder);
+        //        Future<ProcessFieldResponseModel> processProviderFieldKeyResultHolder = executorService.submit(() -> addAlertCustomFieldToProcess(processId, workItemTypeRefName, providerKeyField));
+        //
+        //        ProjectWorkItemFieldModel topicKeyField = extractFutureResult(topicKeyFieldCreationResultHolder);
+        //        Future<ProcessFieldResponseModel> processTopicFieldKeyResultHolder = executorService.submit(() -> addAlertCustomFieldToProcess(processId, workItemTypeRefName, topicKeyField));
+        //
+        //        ProjectWorkItemFieldModel componentKeyField = extractFutureResult(componentKeyFieldCreationResultHolder);
+        //        Future<ProcessFieldResponseModel> processComponentFieldKeyResultHolder = executorService.submit(() -> addAlertCustomFieldToProcess(processId, workItemTypeRefName, componentKeyField));
+        //
+        //        extractFutureResult(processProviderFieldKeyResultHolder);
+        //        extractFutureResult(processTopicFieldKeyResultHolder);
+        //        extractFutureResult(processComponentFieldKeyResultHolder);
+    }
+
+    private void installCustomFields(String projectName, String workItemTypeName, List<AzureCustomFieldDescriptor> customFieldDescriptors) throws AlertException {
+        List<Future<ProjectWorkItemFieldModel>> projectFieldFindOrCreateHolders = new ArrayList<>(7);
+        for (AzureCustomFieldDescriptor fieldDesc : customFieldDescriptors) {
+            Future<ProjectWorkItemFieldModel> fieldFindOrCreateHolder =
+                executorService.submit(() -> findOrCreateAlertCustomProjectField(projectName, fieldDesc.getFieldName(), fieldDesc.getFieldReferenceName(), fieldDesc.getFieldDescription()));
+            projectFieldFindOrCreateHolders.add(fieldFindOrCreateHolder);
+        }
 
         TeamProjectReferenceResponseModel project = getProject(projectName);
         String processId = getProjectPropertyValue(project, ProjectPropertyResponseModel.COMMON_PROPERTIES_PROCESS_ID);
         String workItemTypeRefName = getWorkItemTypeRefName(processId, workItemTypeName);
 
-        ProjectWorkItemFieldModel providerKeyField = extractFutureResult(providerKeyFieldCreationResultHolder);
-        Future<ProcessFieldResponseModel> processProviderFieldKeyResultHolder = executorService.submit(() -> addAlertCustomFieldToProcess(processId, workItemTypeRefName, providerKeyField));
+        List<Future<ProcessFieldResponseModel>> processFieldAdditionHolders = new ArrayList<>(7);
+        for (Future<ProjectWorkItemFieldModel> projectFieldFuture : projectFieldFindOrCreateHolders) {
+            ProjectWorkItemFieldModel projectField = extractFutureResult(projectFieldFuture);
+            Future<ProcessFieldResponseModel> processFieldAdditionHolder = executorService.submit(() -> addAlertCustomFieldToProcess(processId, workItemTypeRefName, projectField));
+            processFieldAdditionHolders.add(processFieldAdditionHolder);
+        }
 
-        ProjectWorkItemFieldModel topicKeyField = extractFutureResult(topicKeyFieldCreationResultHolder);
-        Future<ProcessFieldResponseModel> processTopicFieldKeyResultHolder = executorService.submit(() -> addAlertCustomFieldToProcess(processId, workItemTypeRefName, topicKeyField));
-
-        ProjectWorkItemFieldModel componentKeyField = extractFutureResult(componentKeyFieldCreationResultHolder);
-        Future<ProcessFieldResponseModel> processComponentFieldKeyResultHolder = executorService.submit(() -> addAlertCustomFieldToProcess(processId, workItemTypeRefName, componentKeyField));
-
-        extractFutureResult(processProviderFieldKeyResultHolder);
-        extractFutureResult(processTopicFieldKeyResultHolder);
-        extractFutureResult(processComponentFieldKeyResultHolder);
+        for (Future<ProcessFieldResponseModel> processFieldAdditionHolder : processFieldAdditionHolders) {
+            extractFutureResult(processFieldAdditionHolder);
+        }
     }
 
     private Optional<ProjectWorkItemFieldModel> getAlertCustomProjectField(String projectName, String fieldReferenceName) {

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/model/AzureCustomFieldDescriptor.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/model/AzureCustomFieldDescriptor.java
@@ -1,0 +1,48 @@
+/**
+ * blackduck-alert
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.alert.channel.azure.boards.service.model;
+
+public class AzureCustomFieldDescriptor {
+    private final String fieldName;
+    private final String fieldReferenceName;
+    private final String fieldDescription;
+
+    public AzureCustomFieldDescriptor(String fieldName, String fieldReferenceName, String fieldDescription) {
+        this.fieldName = fieldName;
+        this.fieldReferenceName = fieldReferenceName;
+        this.fieldDescription = fieldDescription;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public String getFieldReferenceName() {
+        return fieldReferenceName;
+    }
+
+    public String getFieldDescription() {
+        return fieldDescription;
+    }
+
+}


### PR DESCRIPTION
The hope with the original custom fields was since they are potentially user-visible, to minimize the number of them. Unfortunately, the text fields we used have a size limit of 255, and the other option is not queryable beyond 255 characters, so we needed to add more fields.