### PR TITLE
Ps refresh token fix

### DIFF
--- a/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureAuthorizationCodeFlow.java
+++ b/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureAuthorizationCodeFlow.java
@@ -69,16 +69,10 @@ public class AzureAuthorizationCodeFlow extends AuthorizationCodeFlow {
             return null;
         }
         AzureCredential.Builder credentialBuilder = new AzureCredential.Builder(credential.getMethod());
-        credentialBuilder.setClientAuthentication(credential.getClientAuthentication());
-        credentialBuilder.setClock(credential.getClock());
-        credentialBuilder.setJsonFactory(credential.getJsonFactory());
-        credentialBuilder.setRefreshListeners(credential.getRefreshListeners());
-        credentialBuilder.setRequestInitializer(credential.getRequestInitializer());
-        credentialBuilder.setTokenServerEncodedUrl(credential.getTokenServerEncodedUrl());
-        credentialBuilder.setTransport(credential.getTransport());
+        credentialBuilder.copyFromExisting(credential);
         credentialBuilder.setRedirectUri(redirectUri);
         credentialBuilder.setClientSecret(clientSecret);
-        credentialBuilder.setCachedRefreshToken(credential.getRefreshToken());
+
         return credentialBuilder.build();
     }
 

--- a/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureAuthorizationCodeFlow.java
+++ b/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureAuthorizationCodeFlow.java
@@ -77,6 +77,7 @@ public class AzureAuthorizationCodeFlow extends AuthorizationCodeFlow {
         credentialBuilder.setTokenServerEncodedUrl(credential.getTokenServerEncodedUrl());
         credentialBuilder.setTransport(credential.getTransport());
         credentialBuilder.setRedirectUri(redirectUri);
+        credentialBuilder.setClientSecret(clientSecret);
         credentialBuilder.setCachedRefreshToken(credential.getRefreshToken());
         return credentialBuilder.build();
     }

--- a/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureAuthorizationCodeFlow.java
+++ b/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureAuthorizationCodeFlow.java
@@ -22,6 +22,8 @@
  */
 package com.synopsys.integration.azure.boards.common.oauth;
 
+import java.io.IOException;
+
 import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
 import com.google.api.client.auth.oauth2.AuthorizationCodeTokenRequest;
 import com.google.api.client.auth.oauth2.Credential;
@@ -32,8 +34,6 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.util.Preconditions;
 
 public class AzureAuthorizationCodeFlow extends AuthorizationCodeFlow {
-    public static final String DEFAULT_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
-    public static final String DEFAULT_CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
     private final String clientSecret;
     private final String redirectUri;
 
@@ -53,13 +53,28 @@ public class AzureAuthorizationCodeFlow extends AuthorizationCodeFlow {
     @Override
     public AuthorizationCodeTokenRequest newTokenRequest(String authorizationCode) {
         AuthorizationCodeTokenRequest request = super.newTokenRequest(authorizationCode);
-        request.setGrantType(DEFAULT_GRANT_TYPE);
+        request.setGrantType(AzureOAuthConstants.DEFAULT_GRANT_TYPE);
         request.setResponseClass(AzureTokenResponse.class);
-        request.put("assertion", authorizationCode);
-        request.put("client_assertion_type", DEFAULT_CLIENT_ASSERTION_TYPE);
-        request.put("client_assertion", clientSecret);
-        request.put("redirect_uri", redirectUri);
+        request.put(AzureOAuthConstants.REQUEST_BODY_FIELD_ASSERTION, authorizationCode);
+        request.put(AzureOAuthConstants.REQUEST_BODY_FIELD_CLIENT_ASSERTION_TYPE, AzureOAuthConstants.DEFAULT_CLIENT_ASSERTION_TYPE);
+        request.put(AzureOAuthConstants.REQUEST_BODY_FIELD_CLIENT_ASSERTION, clientSecret);
+        request.put(AzureOAuthConstants.REQUEST_BODY_FIELD_REDIRECT_URI, redirectUri);
         return request;
+    }
+
+    @Override
+    public Credential loadCredential(String userId) throws IOException {
+        Credential credential = super.loadCredential(userId);
+        AzureCredential.Builder credentialBuilder = new AzureCredential.Builder(credential.getMethod());
+        credentialBuilder.setClientAuthentication(credential.getClientAuthentication());
+        credentialBuilder.setClock(credential.getClock());
+        credentialBuilder.setJsonFactory(credential.getJsonFactory());
+        credentialBuilder.setRefreshListeners(credential.getRefreshListeners());
+        credentialBuilder.setRequestInitializer(credential.getRequestInitializer());
+        credentialBuilder.setTokenServerEncodedUrl(credential.getTokenServerEncodedUrl());
+        credentialBuilder.setTransport(credential.getTransport());
+        credentialBuilder.setRedirectUri(redirectUri);
+        return credentialBuilder.build();
     }
 
     public String getClientSecret() {

--- a/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureAuthorizationCodeFlow.java
+++ b/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureAuthorizationCodeFlow.java
@@ -65,6 +65,9 @@ public class AzureAuthorizationCodeFlow extends AuthorizationCodeFlow {
     @Override
     public Credential loadCredential(String userId) throws IOException {
         Credential credential = super.loadCredential(userId);
+        if (null == credential) {
+            return null;
+        }
         AzureCredential.Builder credentialBuilder = new AzureCredential.Builder(credential.getMethod());
         credentialBuilder.setClientAuthentication(credential.getClientAuthentication());
         credentialBuilder.setClock(credential.getClock());
@@ -74,6 +77,7 @@ public class AzureAuthorizationCodeFlow extends AuthorizationCodeFlow {
         credentialBuilder.setTokenServerEncodedUrl(credential.getTokenServerEncodedUrl());
         credentialBuilder.setTransport(credential.getTransport());
         credentialBuilder.setRedirectUri(redirectUri);
+        credentialBuilder.setCachedRefreshToken(credential.getRefreshToken());
         return credentialBuilder.build();
     }
 

--- a/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureCredential.java
+++ b/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureCredential.java
@@ -1,0 +1,76 @@
+package com.synopsys.integration.azure.boards.common.oauth;
+
+import java.io.IOException;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.auth.oauth2.RefreshTokenRequest;
+import com.google.api.client.auth.oauth2.TokenResponse;
+import com.google.api.client.http.GenericUrl;
+
+public class AzureCredential extends Credential {
+    private String clientSecret;
+    private String redirectUri;
+
+    public AzureCredential(AccessMethod method) {
+        super(method);
+    }
+
+    public AzureCredential(Builder builder) {
+        super(builder);
+        this.clientSecret = builder.getClientSecret();
+        this.redirectUri = builder.getRedirectUri();
+    }
+
+    public String getRedirectUri() {
+        return redirectUri;
+    }
+
+    @Override
+    protected TokenResponse executeRefreshToken() throws IOException {
+        String refreshToken = getRefreshToken();
+        if (refreshToken == null) {
+            return null;
+        }
+        RefreshTokenRequest request = new RefreshTokenRequest(getTransport(), getJsonFactory(), new GenericUrl(getTokenServerEncodedUrl()),
+            refreshToken);
+        request.setClientAuthentication(getClientAuthentication());
+        request.setRequestInitializer(getRequestInitializer());
+        request.put(AzureOAuthConstants.REQUEST_BODY_FIELD_ASSERTION, refreshToken);
+        request.put(AzureOAuthConstants.REQUEST_BODY_FIELD_CLIENT_ASSERTION_TYPE, AzureOAuthConstants.DEFAULT_CLIENT_ASSERTION_TYPE);
+        request.put(AzureOAuthConstants.REQUEST_BODY_FIELD_CLIENT_ASSERTION, clientSecret);
+        request.put(AzureOAuthConstants.REQUEST_BODY_FIELD_REDIRECT_URI, redirectUri);
+        return request.execute();
+    }
+
+    public static class Builder extends Credential.Builder {
+        private String clientSecret;
+        private String redirectUri;
+
+        public Builder(AccessMethod method) {
+            super(method);
+        }
+
+        public String getClientSecret() {
+            return clientSecret;
+        }
+
+        public Builder setClientSecret(String clientSecret) {
+            this.clientSecret = clientSecret;
+            return this;
+        }
+
+        public String getRedirectUri() {
+            return redirectUri;
+        }
+
+        public Builder setRedirectUri(String redirectUri) {
+            this.redirectUri = redirectUri;
+            return this;
+        }
+
+        @Override
+        public Credential build() {
+            return new AzureCredential(this);
+        }
+    }
+}

--- a/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureCredential.java
+++ b/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureCredential.java
@@ -10,6 +10,7 @@ import com.google.api.client.http.GenericUrl;
 public class AzureCredential extends Credential {
     private String clientSecret;
     private String redirectUri;
+    private String cachedRefreshToken;
 
     public AzureCredential(AccessMethod method) {
         super(method);
@@ -19,6 +20,15 @@ public class AzureCredential extends Credential {
         super(builder);
         this.clientSecret = builder.getClientSecret();
         this.redirectUri = builder.getRedirectUri();
+        this.cachedRefreshToken = builder.getCachedRefreshToken();
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public String getCachedRefreshToken() {
+        return cachedRefreshToken;
     }
 
     public String getRedirectUri() {
@@ -29,12 +39,17 @@ public class AzureCredential extends Credential {
     protected TokenResponse executeRefreshToken() throws IOException {
         String refreshToken = getRefreshToken();
         if (refreshToken == null) {
-            return null;
+            if (cachedRefreshToken == null) {
+                return null;
+            }
+            refreshToken = cachedRefreshToken;
         }
+
         RefreshTokenRequest request = new RefreshTokenRequest(getTransport(), getJsonFactory(), new GenericUrl(getTokenServerEncodedUrl()),
             refreshToken);
         request.setClientAuthentication(getClientAuthentication());
         request.setRequestInitializer(getRequestInitializer());
+        request.setResponseClass(AzureTokenResponse.class);
         request.put(AzureOAuthConstants.REQUEST_BODY_FIELD_ASSERTION, refreshToken);
         request.put(AzureOAuthConstants.REQUEST_BODY_FIELD_CLIENT_ASSERTION_TYPE, AzureOAuthConstants.DEFAULT_CLIENT_ASSERTION_TYPE);
         request.put(AzureOAuthConstants.REQUEST_BODY_FIELD_CLIENT_ASSERTION, clientSecret);
@@ -45,6 +60,7 @@ public class AzureCredential extends Credential {
     public static class Builder extends Credential.Builder {
         private String clientSecret;
         private String redirectUri;
+        private String cachedRefreshToken;
 
         public Builder(AccessMethod method) {
             super(method);
@@ -65,6 +81,15 @@ public class AzureCredential extends Credential {
 
         public Builder setRedirectUri(String redirectUri) {
             this.redirectUri = redirectUri;
+            return this;
+        }
+
+        public String getCachedRefreshToken() {
+            return cachedRefreshToken;
+        }
+
+        public Builder setCachedRefreshToken(String cachedRefreshToken) {
+            this.cachedRefreshToken = cachedRefreshToken;
             return this;
         }
 

--- a/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureCredential.java
+++ b/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureCredential.java
@@ -1,3 +1,25 @@
+/**
+ * azure-boards-common
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.synopsys.integration.azure.boards.common.oauth;
 
 import java.io.IOException;

--- a/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureCredential.java
+++ b/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureCredential.java
@@ -88,6 +88,18 @@ public class AzureCredential extends Credential {
             super(method);
         }
 
+        public Builder copyFromExisting(Credential credential) {
+            this.setCachedRefreshToken(credential.getRefreshToken())
+                .setClientAuthentication(credential.getClientAuthentication())
+                .setClock(credential.getClock())
+                .setJsonFactory(credential.getJsonFactory())
+                .setRefreshListeners(credential.getRefreshListeners())
+                .setRequestInitializer(credential.getRequestInitializer())
+                .setTokenServerEncodedUrl(credential.getTokenServerEncodedUrl())
+                .setTransport(credential.getTransport());
+            return this;
+        }
+
         public String getClientSecret() {
             return clientSecret;
         }

--- a/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureOAuthConstants.java
+++ b/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureOAuthConstants.java
@@ -1,0 +1,11 @@
+package com.synopsys.integration.azure.boards.common.oauth;
+
+public class AzureOAuthConstants {
+    public static final String DEFAULT_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+    public static final String DEFAULT_CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+    
+    public static final String REQUEST_BODY_FIELD_ASSERTION = "assertion";
+    public static final String REQUEST_BODY_FIELD_CLIENT_ASSERTION_TYPE = "client_assertion_type";
+    public static final String REQUEST_BODY_FIELD_CLIENT_ASSERTION = "client_assertion";
+    public static final String REQUEST_BODY_FIELD_REDIRECT_URI = "redirect_uri";
+}

--- a/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureOAuthConstants.java
+++ b/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureOAuthConstants.java
@@ -1,3 +1,25 @@
+/**
+ * azure-boards-common
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.synopsys.integration.azure.boards.common.oauth;
 
 public class AzureOAuthConstants {

--- a/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureTokenResponse.java
+++ b/azure-boards-common/src/main/java/com/synopsys/integration/azure/boards/common/oauth/AzureTokenResponse.java
@@ -39,67 +39,6 @@ public class AzureTokenResponse extends TokenResponse {
     }
 
     @Override
-    public String getAccessToken() {
-        return super.getAccessToken();
-    }
-
-    @Override
-    public AzureTokenResponse setAccessToken(String accessToken) {
-        super.setAccessToken(accessToken);
-        return this;
-    }
-
-    @Override
-    public String getTokenType() {
-        return super.getTokenType();
-    }
-
-    @Override
-    public AzureTokenResponse setTokenType(String tokenType) {
-        super.setTokenType(tokenType);
-        return this;
-    }
-
-    @Override
-    public Long getExpiresInSeconds() {
-        return this.expiresInSeconds;
-    }
-
-    @Override
-    public AzureTokenResponse setExpiresInSeconds(Long expiresInSeconds) {
-        this.expiresInSeconds = expiresInSeconds;
-        return this;
-    }
-
-    @Override
-    public String getRefreshToken() {
-        return super.getRefreshToken();
-    }
-
-    @Override
-    public AzureTokenResponse setRefreshToken(String refreshToken) {
-        super.setRefreshToken(refreshToken);
-        return this;
-    }
-
-    @Override
-    public String getScope() {
-        return super.getScope();
-    }
-
-    @Override
-    public AzureTokenResponse setScope(String scope) {
-        super.setScope(scope);
-        return this;
-    }
-
-    @Override
-    public AzureTokenResponse set(String fieldName, Object value) {
-        super.set(fieldName, value);
-        return this;
-    }
-
-    @Override
     public AzureTokenResponse clone() {
         return (AzureTokenResponse) super.clone();
     }


### PR DESCRIPTION
Implement custom classes to be able to construct a refresh token request with the same type of body as the new token request.  The refresh token is used as the assertion in the body rather than the authorization code in the request.

Also updated the AzureTokenResponse class to only include the bare minimum that is needed.  The overridden methods weren't needed the way we were using it.