### PR TITLE
Changing the build to no longer always run npm_run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,10 @@ tasks.dockerLogin.mustRunAfter(helmPushChart)
 
 tasks.helmPushChart.mustRunAfter(helmValidation)
 
-task all(dependsOn: [build, helmValidation, createDeploymentZip, dockerLogin, buildDockerImage, pushImage]) {
+tasks.build.mustRunAfter(copyToTemplates)
+tasks.runServer.dependsOn copyToTemplates
+
+task all(dependsOn: [copyToTemplates, build, helmValidation, createDeploymentZip, dockerLogin, buildDockerImage, pushImage]) {
     helmValidation.mustRunAfter build
     createDeploymentZip.mustRunAfter helmValidation
 

--- a/buildSrc/buildTasks.gradle
+++ b/buildSrc/buildTasks.gradle
@@ -91,4 +91,3 @@ task copyToTemplates(type: Copy, dependsOn: [npm_run]) {
 }
 
 tasks.compileJava.mustRunAfter(createAboutText)
-tasks.compileJava.finalizedBy(copyToTemplates)


### PR DESCRIPTION
Changing the build to no longer always run npm_run or the copyToTemplates task. These 2 tasks will now only run if you call them directly OR if you are calling the task 'runServer' or 'all'