### PR TITLE
Ps authenticate save fix

### DIFF
--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultConfigurationAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultConfigurationAccessor.java
@@ -325,6 +325,7 @@ public class DefaultConfigurationAccessor implements ConfigurationAccessor {
 
         List<FieldValueEntity> oldValues = fieldValueRepository.findByConfigId(descriptorConfigId);
         fieldValueRepository.deleteAll(oldValues);
+        fieldValueRepository.flush();
 
         ConfigurationModelMutable updatedConfig = createEmptyConfigModel(descriptorConfigEntity.getDescriptorId(), descriptorConfigEntity.getId(),
             descriptorConfigEntity.getCreatedAt(), descriptorConfigEntity.getLastUpdated(), descriptorConfigEntity.getContextId());
@@ -341,6 +342,7 @@ public class DefaultConfigurationAccessor implements ConfigurationAccessor {
                 updatedConfig.put(configFieldModel);
             }
             fieldValueRepository.saveAll(fieldValuesToSave);
+            fieldValueRepository.flush();
         }
         descriptorConfigEntity.setLastUpdated(DateUtils.createCurrentDateTimestamp());
         descriptorConfigsRepository.save(descriptorConfigEntity);

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/actions/AzureBoardsConfigurationAction.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/actions/AzureBoardsConfigurationAction.java
@@ -31,9 +31,11 @@ import com.synopsys.integration.alert.common.action.ConfigurationAction;
 @Component
 public class AzureBoardsConfigurationAction extends ConfigurationAction {
     @Autowired
-    protected AzureBoardsConfigurationAction(AzureBoardsChannelKey descriptorKey, AzureBoardsDistributionTestAction azureBoardsDistributionTestAction, AzureBoardsGlobalTestAction azureBoardsGlobalTestAction) {
+    protected AzureBoardsConfigurationAction(AzureBoardsChannelKey descriptorKey, AzureBoardsDistributionTestAction azureBoardsDistributionTestAction, AzureBoardsGlobalTestAction azureBoardsGlobalTestAction,
+        AzureBoardsGlobalApiAction azureBoardsGlobalApiAction) {
         super(descriptorKey);
         addGlobalTestAction(azureBoardsGlobalTestAction);
+        addGlobalApiAction(azureBoardsGlobalApiAction);
         addDistributionTestAction(azureBoardsDistributionTestAction);
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/actions/AzureBoardsGlobalApiAction.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/actions/AzureBoardsGlobalApiAction.java
@@ -1,0 +1,100 @@
+/**
+ * blackduck-alert
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.alert.channel.azure.boards.actions;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.channel.azure.boards.descriptor.AzureBoardsDescriptor;
+import com.synopsys.integration.alert.common.action.ApiAction;
+import com.synopsys.integration.alert.common.descriptor.DescriptorKey;
+import com.synopsys.integration.alert.common.descriptor.DescriptorMap;
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.exception.AlertException;
+import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
+import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
+import com.synopsys.integration.alert.common.persistence.util.ConfigurationFieldModelConverter;
+import com.synopsys.integration.alert.common.rest.model.FieldModel;
+import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
+
+@Component
+public class AzureBoardsGlobalApiAction extends ApiAction {
+    private ConfigurationAccessor configurationAccessor;
+    private DescriptorMap descriptorMap;
+    private ConfigurationFieldModelConverter fieldModelConverter;
+
+    @Autowired
+    public AzureBoardsGlobalApiAction(ConfigurationAccessor configurationAccessor, DescriptorMap descriptorMap, ConfigurationFieldModelConverter configurationFieldModelConverter) {
+        this.configurationAccessor = configurationAccessor;
+        this.descriptorMap = descriptorMap;
+        this.fieldModelConverter = configurationFieldModelConverter;
+    }
+
+    @Override
+    public FieldModel beforeSaveAction(FieldModel fieldModel) throws AlertException {
+        FieldModel updatedFieldModel = super.beforeSaveAction(fieldModel);
+        Optional<DescriptorKey> descriptorKey = descriptorMap.getDescriptorKey(fieldModel.getDescriptorName());
+
+        if (descriptorKey.isPresent()) {
+            ConfigContextEnum context = ConfigContextEnum.valueOf(fieldModel.getContext());
+            List<ConfigurationModel> existingConfig = configurationAccessor.getConfigurationsByDescriptorKeyAndContext(descriptorKey.get(), context);
+            Optional<ConfigurationModel> configurationModel = existingConfig.stream()
+                                                                  .findFirst();
+            updatedFieldModel = updateTokenFields(updatedFieldModel, configurationModel);
+        }
+        return updatedFieldModel;
+    }
+
+    @Override
+    public FieldModel beforeUpdateAction(FieldModel fieldModel) throws AlertException {
+        FieldModel updatedFieldModel = super.beforeUpdateAction(fieldModel);
+        Optional<ConfigurationModel> existingConfig = configurationAccessor.getConfigurationById(Long.valueOf(fieldModel.getId()));
+        return updateTokenFields(updatedFieldModel, existingConfig);
+    }
+
+    private FieldModel updateTokenFields(FieldModel fieldModel, Optional<ConfigurationModel> existingConfig) {
+        Map<String, FieldValueModel> keyToValues = new HashMap<>(fieldModel.getKeyToValues());
+        if (existingConfig.isPresent()) {
+            ConfigurationModel configurationModel = existingConfig.get();
+            Map<String, FieldValueModel> existingFields = fieldModelConverter.convertToFieldValuesMap(configurationModel.getCopyOfFieldList());
+
+            updateMapWithMissingField(AzureBoardsDescriptor.KEY_ACCESS_TOKEN, existingFields, keyToValues);
+            updateMapWithMissingField(AzureBoardsDescriptor.KEY_REFRESH_TOKEN, existingFields, keyToValues);
+            updateMapWithMissingField(AzureBoardsDescriptor.KEY_TOKEN_EXPIRATION_MILLIS, existingFields, keyToValues);
+            updateMapWithMissingField(AzureBoardsDescriptor.KEY_OAUTH_USER_EMAIL, existingFields, keyToValues);
+        }
+
+        return new FieldModel(fieldModel.getDescriptorName(), fieldModel.getContext(), fieldModel.getCreatedAt(), fieldModel.getLastUpdated(), keyToValues);
+    }
+
+    private void updateMapWithMissingField(String key, Map<String, FieldValueModel> databaseFields, Map<String, FieldValueModel> fieldModelFields) {
+        if (databaseFields.containsKey(key)) {
+            fieldModelFields.put(key, databaseFields.get(key));
+        }
+    }
+}

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/actions/AzureBoardsGlobalApiAction.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/actions/AzureBoardsGlobalApiAction.java
@@ -83,6 +83,7 @@ public class AzureBoardsGlobalApiAction extends ApiAction {
             ConfigurationModel configurationModel = existingConfig.get();
             Map<String, FieldValueModel> existingFields = fieldModelConverter.convertToFieldValuesMap(configurationModel.getCopyOfFieldList());
 
+            // These fields are saved in the OAuth callback controller so we need to preserve their values on a save or an update.
             updateMapWithMissingField(AzureBoardsDescriptor.KEY_ACCESS_TOKEN, existingFields, keyToValues);
             updateMapWithMissingField(AzureBoardsDescriptor.KEY_REFRESH_TOKEN, existingFields, keyToValues);
             updateMapWithMissingField(AzureBoardsDescriptor.KEY_TOKEN_EXPIRATION_MILLIS, existingFields, keyToValues);

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/descriptor/AzureBoardsGlobalUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/descriptor/AzureBoardsGlobalUIConfig.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.synopsys.integration.alert.channel.azure.boards.oauth.AzureOAuthAuthenticateValidator;
 import com.synopsys.integration.alert.common.descriptor.config.field.ConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.PasswordConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.field.TextInputConfigField;
@@ -51,11 +52,13 @@ public class AzureBoardsGlobalUIConfig extends UIConfig {
     public static final String BUTTON_LABEL_OAUTH = "Authenticate";
 
     private final EncryptionValidator encryptionValidator;
+    private final AzureOAuthAuthenticateValidator azureOAuthAuthenticateValidator;
 
     @Autowired
-    public AzureBoardsGlobalUIConfig(EncryptionValidator encryptionValidator) {
+    public AzureBoardsGlobalUIConfig(EncryptionValidator encryptionValidator, AzureOAuthAuthenticateValidator azureOAuthAuthenticateValidator) {
         super(AzureBoardsDescriptor.AZURE_BOARDS_LABEL, AzureBoardsDescriptor.AZURE_BOARDS_DESCRIPTION, AzureBoardsDescriptor.AZURE_BOARDS_URL);
         this.encryptionValidator = encryptionValidator;
+        this.azureOAuthAuthenticateValidator = azureOAuthAuthenticateValidator;
     }
 
     @Override
@@ -67,7 +70,8 @@ public class AzureBoardsGlobalUIConfig extends UIConfig {
         ConfigField configureOAuth = new OAuthEndpointButtonField(AzureBoardsDescriptor.KEY_OAUTH, LABEL_OAUTH, DESCRIPTION_OAUTH, BUTTON_LABEL_OAUTH)
                                          .applyRequestedDataFieldKey(AzureBoardsDescriptor.KEY_ORGANIZATION_NAME)
                                          .applyRequestedDataFieldKey(AzureBoardsDescriptor.KEY_CLIENT_ID)
-                                         .applyRequestedDataFieldKey(AzureBoardsDescriptor.KEY_CLIENT_SECRET);
+                                         .applyRequestedDataFieldKey(AzureBoardsDescriptor.KEY_CLIENT_SECRET)
+                                         .applyValidationFunctions(azureOAuthAuthenticateValidator);
         return List.of(organizationName, clientId, clientSecret, configureOAuth);
     }
 

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/AzureOAuthAuthenticateValidator.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/AzureOAuthAuthenticateValidator.java
@@ -1,0 +1,27 @@
+package com.synopsys.integration.alert.channel.azure.boards.oauth;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ConfigValidationFunction;
+import com.synopsys.integration.alert.common.descriptor.config.field.validators.ValidationResult;
+import com.synopsys.integration.alert.common.rest.model.FieldModel;
+import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
+
+@Component
+public class AzureOAuthAuthenticateValidator implements ConfigValidationFunction {
+    private OAuthRequestValidator oAuthRequestValidator;
+
+    @Autowired
+    public AzureOAuthAuthenticateValidator(OAuthRequestValidator oAuthRequestValidator) {
+        this.oAuthRequestValidator = oAuthRequestValidator;
+    }
+
+    @Override
+    public ValidationResult apply(FieldValueModel fieldValueModel, FieldModel fieldModel) {
+        if (oAuthRequestValidator.hasRequests()) {
+            return ValidationResult.errors("Authentication in Progress cannot perform current action.");
+        }
+        return ValidationResult.success();
+    }
+}

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/AzureOAuthAuthenticateValidator.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/AzureOAuthAuthenticateValidator.java
@@ -1,3 +1,25 @@
+/**
+ * blackduck-alert
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.synopsys.integration.alert.channel.azure.boards.oauth;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidator.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidator.java
@@ -60,6 +60,10 @@ public class OAuthRequestValidator {
         return requestMap.containsKey(requestKey);
     }
 
+    public boolean hasRequests() {
+        return !requestMap.isEmpty();
+    }
+
     public void removeAllRequests() {
         // NOTE: If there are multiple OAuth clients make sure removeAllRequests is used correctly.
         // Do not want to remove requests for other OAuth clients inadvertently.

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/web/AzureBoardsCustomEndpoint.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/web/AzureBoardsCustomEndpoint.java
@@ -109,6 +109,12 @@ public class AzureBoardsCustomEndpoint extends OAuthCustomEndpoint {
                 logger.debug("Azure OAuth callback user does not have permission to call the controller.");
                 return new OAuthEndpointResponse(HttpStatus.FORBIDDEN.value(), false, "", ResponseFactory.UNAUTHORIZED_REQUEST_MESSAGE);
             }
+            String requestKey = createRequestKey();
+            // since we have only one OAuth channel now remove all other requests.
+            // if we have more OAuth clients then the removeAllRequests will have to be removed from here.
+            // beginning authentication process create the request id at the start.
+            oAuthRequestValidator.removeAllRequests();
+            oAuthRequestValidator.addAuthorizationRequest(requestKey);
             Optional<FieldModel> savedFieldModel = saveIfValid(fieldModel);
             if (!savedFieldModel.isPresent()) {
                 return new OAuthEndpointResponse(HttpStatus.BAD_REQUEST.value(), false, "", "");
@@ -116,22 +122,20 @@ public class AzureBoardsCustomEndpoint extends OAuthCustomEndpoint {
             FieldAccessor fieldAccessor = createFieldAccessor(savedFieldModel.get());
             Optional<String> clientId = fieldAccessor.getString(AzureBoardsDescriptor.KEY_CLIENT_ID);
             if (!clientId.isPresent()) {
+                oAuthRequestValidator.removeAllRequests();
                 return new OAuthEndpointResponse(HttpStatus.BAD_REQUEST.value(), false, "", "client id not found.");
             }
             Optional<String> alertServerUrl = alertProperties.getServerUrl();
 
             if (!alertServerUrl.isPresent()) {
+                oAuthRequestValidator.removeAllRequests();
                 return new OAuthEndpointResponse(HttpStatus.BAD_REQUEST.value(), false, "", "Could not determine the alert server url for the callback.");
             }
-            String requestKey = createRequestKey();
-            // since we have only one OAuth channel now remove all other requests.
-            // if we have more OAuth clients then the removeAllRequests will have to be removed from here.
-            oAuthRequestValidator.removeAllRequests();
-            oAuthRequestValidator.addAuthorizationRequest(requestKey);
+
             logger.info("OAuth authorization request created: {}", requestKey);
             String authUrl = createAuthURL(clientId.get(), requestKey);
             logger.debug("Authenticating Azure OAuth URL: " + authUrl);
-            return new OAuthEndpointResponse(HttpStatus.OK.value(), isAuthenticated(fieldAccessor), authUrl, "");
+            return new OAuthEndpointResponse(HttpStatus.OK.value(), isAuthenticated(fieldAccessor), authUrl, "Authenticating...");
 
         } catch (AlertFieldException ex) {
             logger.error("Error activating Azure Boards", ex);
@@ -141,10 +145,12 @@ public class AzureBoardsCustomEndpoint extends OAuthCustomEndpoint {
                                      .collect(Collectors.toSet());
             String errorMessage = String.format(
                 "The configuration is invalid. Please test the configuration. Details: %s", StringUtils.join(errors, ","));
+            oAuthRequestValidator.removeAllRequests();
             return new OAuthEndpointResponse(HttpStatus.BAD_REQUEST.value(), false, "", errorMessage);
 
         } catch (Exception ex) {
             logger.error("Error activating Azure Boards", ex);
+            oAuthRequestValidator.removeAllRequests();
             return new OAuthEndpointResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), false, "", "Error activating azure oauth.");
         }
     }

--- a/src/main/js/field/OAuthEndpointButtonField.js
+++ b/src/main/js/field/OAuthEndpointButtonField.js
@@ -8,7 +8,6 @@ import { createNewConfigurationRequest } from 'util/configurationRequestBuilder'
 import { connect } from 'react-redux';
 import StatusMessage from 'field/StatusMessage';
 import * as HTTPErrorUtils from 'util/httpErrorUtilities';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 class OAuthEndpointButtonField extends Component {
     constructor(props) {
@@ -70,7 +69,8 @@ class OAuthEndpointButtonField extends Component {
                     this.setState({
                         fieldError: {
                             severity: 'ERROR',
-                            fieldMessage: message
+                            fieldMessage: message,
+                            progress: false
                         }
                     });
                 }
@@ -106,9 +106,6 @@ class OAuthEndpointButtonField extends Component {
                     performingAction={progress}
                 >{buttonLabel}
                 </GeneralButton>
-                {authenticated &&
-                <FontAwesomeIcon icon="check" className="alert-icon synopsysGreen" size="2x"
-                                 title="authenticated" />}
                 {success &&
                 <StatusMessage id={`${fieldKey}-status-message`} actionMessage={statusMessage} />
                 }

--- a/src/main/js/field/OAuthEndpointButtonField.js
+++ b/src/main/js/field/OAuthEndpointButtonField.js
@@ -50,10 +50,6 @@ class OAuthEndpointButtonField extends Component {
         const mergedData = popupData ? FieldModelUtilities.combineFieldModels(newFieldModel, popupData) : newFieldModel;
         const request = createNewConfigurationRequest(`/alert${endpoint}/${fieldKey}`, csrfToken, mergedData);
         request.then((response) => {
-            this.setState({
-                progress: false
-            });
-
             response.json()
             .then((data) => {
                 const { httpStatus, authenticated, authorizationUrl, message } = data;
@@ -65,7 +61,6 @@ class OAuthEndpointButtonField extends Component {
                 onChange({ target });
                 const okRequest = HTTPErrorUtils.isOk(httpStatus);
                 this.setState({
-                    success: okRequest,
                     authenticated
                 });
                 if (okRequest) {


### PR DESCRIPTION
Fix issues with clicking save and test while authentication is happening.  Also fixed an issue where test fails after clicking save.

Test would fail because none of the token fields that are saved in the controller are preserved in the new configuration that is saved.  Read those existing fields and save them.

Fixed an issue with JPA batch update errors.  Needed to flush repositories.
Added a validator to see if authentication was in process.