### PR TITLE
Make sure testIntegrations and testAll run after copyToTemplates.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,6 +171,9 @@ tasks.helmPushChart.mustRunAfter(helmValidation)
 
 tasks.build.mustRunAfter(copyToTemplates)
 tasks.runServer.dependsOn copyToTemplates
+tasks.testIntegration.dependsOn copyToTemplates
+tasks.testAll.dependsOn copyToTemplates
+
 
 task all(dependsOn: [copyToTemplates, build, helmValidation, createDeploymentZip, dockerLogin, buildDockerImage, pushImage]) {
     helmValidation.mustRunAfter build


### PR DESCRIPTION
The HomeControllerTestIT checks if the index url of "/" returns ok.  That uses Thymeleaf to load the index.html page which is compiled by npm and copied by the copyToTemplates gradle task.  Change testIntegration and testAll to depend on the copyToTemplates task.