### PR TITLE
Removing incorrect logging from BlackDuckAccumulator

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/task/ScheduledTask.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/task/ScheduledTask.java
@@ -120,6 +120,7 @@ public abstract class ScheduledTask implements Runnable {
         if (future != null) {
             future.cancel(false);
         }
+        future = null;
     }
 
     public Optional<Long> getMillisecondsToNextRun() {

--- a/src/main/java/com/synopsys/integration/alert/provider/blackduck/tasks/BlackDuckAccumulator.java
+++ b/src/main/java/com/synopsys/integration/alert/provider/blackduck/tasks/BlackDuckAccumulator.java
@@ -28,7 +28,6 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -99,12 +98,6 @@ public class BlackDuckAccumulator extends ProviderTask {
             saveNextSearchStart(nextSearchStartString);
         } catch (AlertDatabaseConstraintException e) {
             logger.error("Error occurred accumulating data! ", e);
-        } finally {
-            Optional<Long> nextRun = getMillisecondsToNextRun();
-            if (nextRun.isPresent()) {
-                Long seconds = TimeUnit.MILLISECONDS.toSeconds(nextRun.get());
-                logger.debug("Accumulator next run: {} seconds", seconds);
-            }
         }
     }
 

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/tasks/BlackDuckAccumulatorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/tasks/BlackDuckAccumulatorTest.java
@@ -231,14 +231,6 @@ public class BlackDuckAccumulatorTest {
     }
 
     @Test
-    public void testAccumulateNextRunEmpty() {
-        BlackDuckAccumulator notificationAccumulator = createAccumulator(testBlackDuckProperties);
-        BlackDuckAccumulator spiedAccumulator = Mockito.spy(notificationAccumulator);
-        spiedAccumulator.accumulate();
-        Mockito.verify(spiedAccumulator).getMillisecondsToNextRun();
-    }
-
-    @Test
     public void testRead() throws Exception {
         BlackDuckHttpClient blackDuckHttpClient = Mockito.mock(BlackDuckHttpClient.class);
         BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);


### PR DESCRIPTION
While investigating the error message returning next accumulator run time as either 0 or a negative time we discovered that the logging does not reflect the correct results. This feature appears to not have been working as intended or correctly since before 5.3.0. Because future is currently referring to the running instance of the accumulator we are getting a negative run time as the time is actually reflecting the time since it last ran the accumulator. In the cases of it reporting 0 or -1 this is due to a rounding error as the message would be generated in about 500-900ms or occasionally just over 1000ms. When debugging, this time would reflect the amount of time since the accumulator first ran and would therefore be several seconds or minutes depending on how long you stop the execution for.

The next run time is still working successfully in the task view but since it does not operate the way its intended in the BlackDuckAccumulator we have removed that logging as well as the test. The only change we made here was setting future to null when unscheduling the task as there was nothing previously setting it to null.