### PR TITLE
Fixing NPE issue when trying to create work items while the Azure global config is missing.

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsProperties.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsProperties.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.NTCredentials;
@@ -51,6 +52,7 @@ import com.google.gson.Gson;
 import com.synopsys.integration.alert.channel.azure.boards.descriptor.AzureBoardsDescriptor;
 import com.synopsys.integration.alert.channel.azure.boards.oauth.storage.AzureBoardsCredentialDataStoreFactory;
 import com.synopsys.integration.alert.common.channel.issuetracker.config.IssueTrackerServiceConfig;
+import com.synopsys.integration.alert.common.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldAccessor;
 import com.synopsys.integration.azure.boards.common.http.AzureHttpService;
@@ -106,6 +108,15 @@ public class AzureBoardsProperties implements IssueTrackerServiceConfig {
 
     public List<String> getScopes() {
         return scopes;
+    }
+
+    public void validateProperties() throws AlertConfigurationException {
+        if (StringUtils.isBlank(organizationName) || StringUtils.isBlank(clientId) || StringUtils.isBlank(clientSecret)) {
+            throw new AlertConfigurationException("The global configuration for Azure is missing required information.");
+        }
+        if (StringUtils.isBlank(oauthUserId)) {
+            throw new AlertConfigurationException("The Azure connection was not authenticated properly. Please go to the Azure global configuration to authenticate the connection.");
+        }
     }
 
     public AzureHttpService createAzureHttpService(ProxyInfo proxy, Gson gson, String authorizationCode) throws AlertException {

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsProperties.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsProperties.java
@@ -114,9 +114,6 @@ public class AzureBoardsProperties implements IssueTrackerServiceConfig {
         if (StringUtils.isBlank(organizationName) || StringUtils.isBlank(clientId) || StringUtils.isBlank(clientSecret)) {
             throw new AlertConfigurationException("The global configuration for Azure is missing required information.");
         }
-        if (StringUtils.isBlank(oauthUserId)) {
-            throw new AlertConfigurationException("The Azure connection was not authenticated properly. Please go to the Azure global configuration to authenticate the connection.");
-        }
     }
 
     public AzureHttpService createAzureHttpService(ProxyInfo proxy, Gson gson, String authorizationCode) throws AlertException {

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsRequestDelegator.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsRequestDelegator.java
@@ -69,8 +69,6 @@ public class AzureBoardsRequestDelegator {
         Credential oAuthCredential = retrieveOAuthCredential(azureBoardsProperties, httpTransport);
         AzureHttpService azureHttpService = AzureHttpServiceFactory.withCredential(httpTransport, oAuthCredential, gson);
 
-        // TODO validate configuration
-
         AzureProjectService azureProjectService = new AzureProjectService(azureHttpService);
         AzureProcessService azureProcessService = new AzureProcessService(azureHttpService);
 

--- a/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsRequestDelegator.java
+++ b/src/main/java/com/synopsys/integration/alert/channel/azure/boards/service/AzureBoardsRequestDelegator.java
@@ -63,6 +63,7 @@ public class AzureBoardsRequestDelegator {
     public IssueTrackerResponse sendRequests(List<IssueTrackerRequest> requests) throws IntegrationException {
         IssueConfig azureIssueConfig = context.getIssueConfig();
         AzureBoardsProperties azureBoardsProperties = context.getIssueTrackerConfig();
+        azureBoardsProperties.validateProperties();
 
         HttpTransport httpTransport = azureBoardsProperties.createHttpTransport(proxyManager.createProxyInfo());
         Credential oAuthCredential = retrieveOAuthCredential(azureBoardsProperties, httpTransport);


### PR DESCRIPTION
Validate the Azure properties before attempting to create an issue in order to avoid a NPE when the global configuration is missing.
