### PR TITLE
 validation fix

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/action/ValidationActionResponse.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/action/ValidationActionResponse.java
@@ -41,6 +41,11 @@ public class ValidationActionResponse extends ActionResponse<ValidationResponseM
         return new ValidationActionResponse(HttpStatus.valueOf(integrationRestException.getHttpStatusCode()), ValidationResponseModel.withoutFieldStatuses(message));
     }
 
+    public static ValidationActionResponse createOKResponseWithContent(ValidationActionResponse response) {
+        // TODO A better API for validation. Validation response should not be null.
+        return new ValidationActionResponse(HttpStatus.OK, response.getContent().orElse(null));
+    }
+
     public ValidationActionResponse(HttpStatus httpStatus, ValidationResponseModel content) {
         super(httpStatus, null, content);
     }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/action/api/AbstractConfigResourceActions.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/action/api/AbstractConfigResourceActions.java
@@ -156,9 +156,10 @@ public abstract class AbstractConfigResourceActions implements LongResourceActio
         }
         ValidationActionResponse validationResponse = validateAfterChecks(resource);
         if (validationResponse.isError()) {
-            return validationResponse;
+            return ValidationActionResponse.createOKResponseWithContent(validationResponse);
         }
-        return testAfterChecks(resource);
+        ValidationActionResponse response = testAfterChecks(resource);
+        return ValidationActionResponse.createOKResponseWithContent(response);
     }
 
     @Override
@@ -167,7 +168,8 @@ public abstract class AbstractConfigResourceActions implements LongResourceActio
             ValidationResponseModel responseModel = ValidationResponseModel.withoutFieldStatuses(ActionResponse.FORBIDDEN_MESSAGE);
             return new ValidationActionResponse(HttpStatus.FORBIDDEN, responseModel);
         }
-        return validateAfterChecks(resource);
+        ValidationActionResponse response = validateAfterChecks(resource);
+        return ValidationActionResponse.createOKResponseWithContent(response);
     }
 
     public AuthorizationManager getAuthorizationManager() {

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/action/api/AbstractJobResourceActions.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/action/api/AbstractJobResourceActions.java
@@ -180,9 +180,10 @@ public abstract class AbstractJobResourceActions implements JobResourceActions, 
         }
         ValidationActionResponse validationResponse = validateAfterChecks(resource);
         if (validationResponse.isError()) {
-            return validationResponse;
+            return ValidationActionResponse.createOKResponseWithContent(validationResponse);
         }
-        return testAfterChecks(resource);
+        ValidationActionResponse response = testAfterChecks(resource);
+        return ValidationActionResponse.createOKResponseWithContent(response);
     }
 
     @Override
@@ -197,7 +198,8 @@ public abstract class AbstractJobResourceActions implements JobResourceActions, 
             ValidationResponseModel responseModel = ValidationResponseModel.withoutFieldStatuses(ActionResponse.FORBIDDEN_MESSAGE);
             return new ValidationActionResponse(HttpStatus.FORBIDDEN, responseModel);
         }
-        return validateAfterChecks(resource);
+        ValidationActionResponse response = validateAfterChecks(resource);
+        return ValidationActionResponse.createOKResponseWithContent(response);
     }
 
     public AuthorizationManager getAuthorizationManager() {

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/action/api/AbstractResourceActions.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/action/api/AbstractResourceActions.java
@@ -138,9 +138,10 @@ public abstract class AbstractResourceActions<T> implements LongResourceActions<
         }
         ValidationActionResponse validationResponse = validateAfterChecks(resource);
         if (validationResponse.isError()) {
-            return validationResponse;
+            return ValidationActionResponse.createOKResponseWithContent(validationResponse);
         }
-        return testAfterChecks(resource);
+        ValidationActionResponse response = testAfterChecks(resource);
+        return ValidationActionResponse.createOKResponseWithContent(response);
     }
 
     @Override
@@ -149,6 +150,7 @@ public abstract class AbstractResourceActions<T> implements LongResourceActions<
             ValidationResponseModel responseModel = ValidationResponseModel.withoutFieldStatuses(ActionResponse.FORBIDDEN_MESSAGE);
             return new ValidationActionResponse(HttpStatus.FORBIDDEN, responseModel);
         }
-        return validateAfterChecks(resource);
+        ValidationActionResponse response = validateAfterChecks(resource);
+        return ValidationActionResponse.createOKResponseWithContent(response);
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/web/api/certificate/CertificatesController.java
+++ b/src/main/java/com/synopsys/integration/alert/web/api/certificate/CertificatesController.java
@@ -25,11 +25,9 @@ package com.synopsys.integration.alert.web.api.certificate;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.synopsys.integration.alert.common.action.ValidationActionResponse;
 import com.synopsys.integration.alert.common.rest.ResponseFactory;
 import com.synopsys.integration.alert.common.rest.api.BaseResourceController;
 import com.synopsys.integration.alert.common.rest.api.ReadAllController;
@@ -75,8 +73,6 @@ public class CertificatesController implements ReadAllController<CertificateMode
 
     @Override
     public ValidationResponseModel validate(CertificateModel requestBody) {
-        ValidationActionResponse response = actions.validate(requestBody);
-        // TODO A better API for validation. Validation response should not be null.
-        return ResponseFactory.createContentResponseFromAction(new ValidationActionResponse(HttpStatus.OK, response.getContent().orElse(null)));
+        return ResponseFactory.createContentResponseFromAction(actions.validate(requestBody));
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/web/api/config/ConfigController.java
+++ b/src/main/java/com/synopsys/integration/alert/web/api/config/ConfigController.java
@@ -25,13 +25,11 @@ package com.synopsys.integration.alert.web.api.config;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.synopsys.integration.alert.common.action.ValidationActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.rest.ResponseFactory;
 import com.synopsys.integration.alert.common.rest.api.ConfigResourceController;
@@ -74,11 +72,9 @@ public class ConfigController implements ConfigResourceController, TestControlle
 
     @Override
     public ValidationResponseModel validate(FieldModel requestBody) {
-        ValidationActionResponse response = configActions.validate(requestBody);
-        // TODO A better API for validation. Validation response should not be null.
-        return ResponseFactory.createContentResponseFromAction(new ValidationActionResponse(HttpStatus.OK, response.getContent().orElse(null)));
+        return ResponseFactory.createContentResponseFromAction(configActions.validate(requestBody));
     }
-
+    
     @Override
     public void delete(Long id) {
         ResponseFactory.createContentResponseFromAction(configActions.delete(id));
@@ -86,7 +82,6 @@ public class ConfigController implements ConfigResourceController, TestControlle
 
     @Override
     public ValidationResponseModel test(FieldModel resource) {
-        ValidationActionResponse response = configActions.test(resource);
-        return ResponseFactory.createContentResponseFromAction(new ValidationActionResponse(HttpStatus.OK, response.getContent().orElse(null)));
+        return ResponseFactory.createContentResponseFromAction(configActions.test(resource));
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigController.java
+++ b/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigController.java
@@ -26,14 +26,12 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.synopsys.integration.alert.common.action.ValidationActionResponse;
 import com.synopsys.integration.alert.common.rest.ResponseFactory;
 import com.synopsys.integration.alert.common.rest.api.BaseJobResourceController;
 import com.synopsys.integration.alert.common.rest.api.ReadAllController;
@@ -93,14 +91,11 @@ public class JobConfigController implements BaseJobResourceController, ReadAllCo
 
     @Override
     public ValidationResponseModel validate(JobFieldModel requestBody) {
-        ValidationActionResponse response = jobConfigActions.validate(requestBody);
-        // TODO A better API for validation. Validation response should not be null.
-        return ResponseFactory.createContentResponseFromAction(new ValidationActionResponse(HttpStatus.OK, response.getContent().orElse(null)));
+        return ResponseFactory.createContentResponseFromAction(jobConfigActions.validate(requestBody));
     }
 
     @Override
     public ValidationResponseModel test(JobFieldModel resource) {
-        ValidationActionResponse response = jobConfigActions.test(resource);
-        return ResponseFactory.createContentResponseFromAction(new ValidationActionResponse(HttpStatus.OK, response.getContent().orElse(null)));
+        return ResponseFactory.createContentResponseFromAction(jobConfigActions.test(resource));
     }
 }

--- a/src/main/js/store/actions/distributions.js
+++ b/src/main/js/store/actions/distributions.js
@@ -153,19 +153,19 @@ export function deleteDistributionJob(job) {
         errorHandlers.push(HTTPErrorUtils.createForbiddenHandler(() => jobDeleteError(HTTPErrorUtils.MESSAGES.FORBIDDEN_ACTION)));
         const request = ConfigRequestBuilder.createDeleteRequest(ConfigRequestBuilder.JOB_API_URL, csrfToken, jobId);
         request.then((response) => {
-            response.json()
-                .then((responseData) => {
-                    if (response.ok) {
-                        dispatch(deletingJobConfigSuccess(jobId));
-                    } else {
+            if (response.ok) {
+                dispatch(deletingJobConfigSuccess(jobId));
+            } else {
+                response.json()
+                    .then((responseData) => {
                         const deleteMessageHandler = () => jobDeleteError(responseData.message);
                         errorHandlers.push(HTTPErrorUtils.createBadRequestHandler(deleteMessageHandler));
                         errorHandlers.push(HTTPErrorUtils.createPreconditionFailedHandler(deleteMessageHandler));
                         errorHandlers.push(HTTPErrorUtils.createDefaultHandler(() => jobDeleteError(responseData.message, null)));
                         const handler = HTTPErrorUtils.createHttpErrorHandler(errorHandlers);
                         dispatch(handler(response.status));
-                    }
-                });
+                    });
+            }
         }).catch(console.error);
     };
 }


### PR DESCRIPTION
Make sure forbidden messages propagate for test and validate calls.  Before we would return OK status responses and we might leak information.

Simplify the controller to just process the content result and move the transformation of the result into the actions.