### PR TITLE
Fix(CSS): Set overflow-y to inherit on expandableContainer

### DIFF
--- a/src/main/css/table.scss
+++ b/src/main/css/table.scss
@@ -124,7 +124,7 @@
   border-radius: $border-radius;
   border: 1px solid $border-color;
   background-color: $synopsys-color-section-background;
-  overflow-y: scroll !important;
+  overflow-y: inherit !important;
   padding-top: 15px;
 }
 


### PR DESCRIPTION
This prevents overriding the page size dropdown from being visible above the container.