### PR TITLE
ldap improvements

### DIFF
--- a/src/main/java/com/synopsys/integration/alert/component/authentication/descriptor/AuthenticationUIConfig.java
+++ b/src/main/java/com/synopsys/integration/alert/component/authentication/descriptor/AuthenticationUIConfig.java
@@ -107,6 +107,7 @@ public class AuthenticationUIConfig extends UIConfig {
     private static final String TEST_FIELD_KEY_SAML_INFORMATION = "test.field.saml.no.input";
     private static final String TEST_FIELD_LABEL_SAML = "No Input Required";
     private static final String TEST_FIELD_DESCRIPTION_SAML = "No input required here. SAML metadata fields will be tested by the server.";
+    private static final String DEFAULT_GROUP_SEARCH_FILTER = "uniqueMember={0}";
 
     private final EncryptionSettingsValidator encryptionValidator;
     private final FilePersistenceUtil filePersistenceUtil;
@@ -148,7 +149,8 @@ public class AuthenticationUIConfig extends UIConfig {
         ConfigField ldapUserDNPatterns = new TextInputConfigField(AuthenticationDescriptor.KEY_LDAP_USER_DN_PATTERNS, LABEL_LDAP_USER_DN_PATTERNS, AUTHENTICATION_LDAP_USER_DN_PATTERNS_DESCRIPTION);
         ConfigField ldapUserAttributes = new TextInputConfigField(AuthenticationDescriptor.KEY_LDAP_USER_ATTRIBUTES, LABEL_LDAP_USER_ATTRIBUTES, AUTHENTICATION_LDAP_USER_ATTRIBUTES_DESCRIPTION);
         ConfigField ldapGroupSearchBase = new TextInputConfigField(AuthenticationDescriptor.KEY_LDAP_GROUP_SEARCH_BASE, LABEL_LDAP_GROUP_SEARCH_BASE, AUTHENTICATION_LDAP_GROUP_SEARCH_BASE_DESCRIPTION);
-        ConfigField ldapGroupSearchFilter = new TextInputConfigField(AuthenticationDescriptor.KEY_LDAP_GROUP_SEARCH_FILTER, LABEL_LDAP_GROUP_SEARCH_FILTER, AUTHENTICATION_LDAP_GROUP_SEARCH_FILTER_DESCRIPTION);
+        ConfigField ldapGroupSearchFilter = new TextInputConfigField(AuthenticationDescriptor.KEY_LDAP_GROUP_SEARCH_FILTER, LABEL_LDAP_GROUP_SEARCH_FILTER, AUTHENTICATION_LDAP_GROUP_SEARCH_FILTER_DESCRIPTION)
+                                                .applyDefaultValue(DEFAULT_GROUP_SEARCH_FILTER);
         ConfigField ldapGroupRoleAttribute = new TextInputConfigField(AuthenticationDescriptor.KEY_LDAP_GROUP_ROLE_ATTRIBUTE, LABEL_LDAP_GROUP_ROLE_ATTRIBUTE, AUTHENTICATION_LDAP_GROUP_ROLE_ATTRIBUTE_DESCRIPTION);
         ConfigField ldapEnabled = new CheckboxConfigField(AuthenticationDescriptor.KEY_LDAP_ENABLED, LABEL_LDAP_ENABLED, AUTHENTICATION_LDAP_ENABLED_DESCRIPTION)
                                       .applyRequiredRelatedField(ldapServer.getKey())

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/ldap/MappingLdapAuthoritiesPopulator.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/ldap/MappingLdapAuthoritiesPopulator.java
@@ -51,7 +51,7 @@ public class MappingLdapAuthoritiesPopulator extends DefaultLdapAuthoritiesPopul
         try {
             grantedAuthorities.addAll(super.getGroupMembershipRoles(userDn, userName));
         } catch (Exception ex) {
-            logger.error("Error determining LDAP group membership", ex);
+            logger.error("Error determining LDAP group membership.", ex);
         }
         return grantedAuthorities;
     }

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/ldap/MappingLdapAuthoritiesPopulator.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/ldap/MappingLdapAuthoritiesPopulator.java
@@ -24,6 +24,8 @@ package com.synopsys.integration.alert.web.security.authentication.ldap;
 
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.ldap.core.ContextSource;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.ldap.userdetails.DefaultLdapAuthoritiesPopulator;
@@ -31,6 +33,7 @@ import org.springframework.security.ldap.userdetails.DefaultLdapAuthoritiesPopul
 import com.synopsys.integration.alert.web.security.authentication.UserManagementAuthoritiesPopulator;
 
 public class MappingLdapAuthoritiesPopulator extends DefaultLdapAuthoritiesPopulator {
+    private final Logger logger = LoggerFactory.getLogger(MappingLdapAuthoritiesPopulator.class);
     private final UserManagementAuthoritiesPopulator authoritiesPopulator;
 
     public MappingLdapAuthoritiesPopulator(ContextSource contextSource, String groupSearchBase, UserManagementAuthoritiesPopulator authoritiesPopulator) {
@@ -40,6 +43,12 @@ public class MappingLdapAuthoritiesPopulator extends DefaultLdapAuthoritiesPopul
 
     @Override
     public Set<GrantedAuthority> getGroupMembershipRoles(String userDn, String userName) {
-        return authoritiesPopulator.addAdditionalRoles(userName, super.getGroupMembershipRoles(userDn, userName));
+        Set<GrantedAuthority> grantedAuthorities = Set.of();
+        try {
+            grantedAuthorities = super.getGroupMembershipRoles(userDn, userName);
+        } catch (Exception ex) {
+            logger.error("Error determining LDAP group membership", ex);
+        }
+        return authoritiesPopulator.addAdditionalRoles(userName, grantedAuthorities);
     }
 }

--- a/src/main/java/com/synopsys/integration/alert/web/security/authentication/ldap/MappingLdapAuthoritiesPopulator.java
+++ b/src/main/java/com/synopsys/integration/alert/web/security/authentication/ldap/MappingLdapAuthoritiesPopulator.java
@@ -45,8 +45,10 @@ public class MappingLdapAuthoritiesPopulator extends DefaultLdapAuthoritiesPopul
 
     @Override
     public Set<GrantedAuthority> getGroupMembershipRoles(String userDn, String userName) {
-        //The parent class adds the additional roles to the set of roles returned by this method.
-        // therefore it needs to return a mutable set.
+        /*
+            The parent class adds the additional roles to the set of roles returned by this method.
+            It needs to return a mutable set.
+         */
         Set<GrantedAuthority> grantedAuthorities = new LinkedHashSet<>();
         try {
             grantedAuthorities.addAll(super.getGroupMembershipRoles(userDn, userName));

--- a/src/test/java/com/synopsys/integration/alert/web/security/authentication/ldap/MappingLdapAuthoritiesPopulatorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/security/authentication/ldap/MappingLdapAuthoritiesPopulatorTest.java
@@ -1,15 +1,22 @@
 package com.synopsys.integration.alert.web.security.authentication.ldap;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.JUnitException;
 import org.mockito.Mockito;
 import org.springframework.ldap.core.ContextSource;
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.ldap.SpringSecurityLdapTemplate;
 
+import com.synopsys.integration.alert.common.enumeration.DefaultUserRole;
 import com.synopsys.integration.alert.web.security.authentication.UserManagementAuthoritiesPopulator;
 
 public class MappingLdapAuthoritiesPopulatorTest {
@@ -24,13 +31,41 @@ public class MappingLdapAuthoritiesPopulatorTest {
     }
 
     @Test
+    public void testExceptionGroupMembershipRoles() {
+        UserManagementAuthoritiesPopulator authoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
+        ContextSource contextSource = Mockito.mock(ContextSource.class);
+        SpringSecurityLdapTemplate ldapTemplate = new SpringSecurityLdapTemplate(contextSource) {
+            @Override
+            public Set<Map<String, List<String>>> searchForMultipleAttributeValues(String base, String filter, Object[] params, String[] attributeNames) {
+                throw new JUnitException("Group Membership Roles Test Exception");
+            }
+        };
+        MappingLdapAuthoritiesPopulator ldapAuthoritiesPopulator = new MappingLdapAuthoritiesPopulator(contextSource, "searchbase={0}", authoritiesPopulator) {
+            @Override
+            protected SpringSecurityLdapTemplate getLdapTemplate() {
+                return ldapTemplate;
+            }
+        };
+        Set<GrantedAuthority> actualRoles = ldapAuthoritiesPopulator.getGroupMembershipRoles(null, null);
+        assertTrue(actualRoles.isEmpty());
+    }
+
+    @Test
     public void testEmptyAdditionalRoles() {
         UserManagementAuthoritiesPopulator authoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
+        Mockito.doReturn(Set.of(new SimpleGrantedAuthority(DefaultUserRole.ALERT_USER.name())))
+            .when(authoritiesPopulator).addAdditionalRoles(Mockito.anyString(), Mockito.anySet());
         ContextSource contextSource = Mockito.mock(ContextSource.class);
         DirContextOperations user = Mockito.mock(DirContextOperations.class);
         MappingLdapAuthoritiesPopulator ldapAuthoritiesPopulator = new MappingLdapAuthoritiesPopulator(contextSource, null, authoritiesPopulator);
         Set<GrantedAuthority> actualRoles = ldapAuthoritiesPopulator.getAdditionalRoles(user, "");
-        assertTrue(actualRoles.isEmpty());
+        boolean hasAlertUserRole = actualRoles.stream()
+                                       .map(GrantedAuthority::getAuthority)
+                                       .allMatch(roleName -> DefaultUserRole.ALERT_USER.name().equals(roleName));
+
+        Mockito.verify(authoritiesPopulator).addAdditionalRoles(Mockito.anyString(), Mockito.anySet());
+        assertFalse(actualRoles.isEmpty());
+        assertTrue(hasAlertUserRole);
     }
 
 }

--- a/src/test/java/com/synopsys/integration/alert/web/security/authentication/ldap/MappingLdapAuthoritiesPopulatorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/security/authentication/ldap/MappingLdapAuthoritiesPopulatorTest.java
@@ -1,0 +1,36 @@
+package com.synopsys.integration.alert.web.security.authentication.ldap;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.ldap.core.ContextSource;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.security.core.GrantedAuthority;
+
+import com.synopsys.integration.alert.web.security.authentication.UserManagementAuthoritiesPopulator;
+
+public class MappingLdapAuthoritiesPopulatorTest {
+
+    @Test
+    public void testEmptyGroupSearchBase() {
+        UserManagementAuthoritiesPopulator authoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
+        ContextSource contextSource = Mockito.mock(ContextSource.class);
+        MappingLdapAuthoritiesPopulator ldapAuthoritiesPopulator = new MappingLdapAuthoritiesPopulator(contextSource, null, authoritiesPopulator);
+        Set<GrantedAuthority> actualRoles = ldapAuthoritiesPopulator.getGroupMembershipRoles("", "");
+        assertTrue(actualRoles.isEmpty());
+    }
+
+    @Test
+    public void testEmptyAdditionalRoles() {
+        UserManagementAuthoritiesPopulator authoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
+        ContextSource contextSource = Mockito.mock(ContextSource.class);
+        DirContextOperations user = Mockito.mock(DirContextOperations.class);
+        MappingLdapAuthoritiesPopulator ldapAuthoritiesPopulator = new MappingLdapAuthoritiesPopulator(contextSource, null, authoritiesPopulator);
+        Set<GrantedAuthority> actualRoles = ldapAuthoritiesPopulator.getAdditionalRoles(user, "");
+        assertTrue(actualRoles.isEmpty());
+    }
+
+}


### PR DESCRIPTION
Update the LDAP handling to deal with exceptions if the search group is wrong and read the roles from the database and add them to the existing set of roles.  If the group search base is null an empty set is returned and the database roles are added.  This resolves the issues for customers who to not have LDAP groups configured for their users.