### PR TITLE
Update to jira common 2.0.0

### DIFF
--- a/channel/build.gradle
+++ b/channel/build.gradle
@@ -3,6 +3,6 @@ ext.moduleName = 'com.synopsys.integration.alert.channel'
 dependencies {
     implementation project(':alert-common')
     implementation project(':azure-boards-common')
-    implementation 'com.synopsys.integration:int-jira-common:1.1.0'
+    implementation 'com.synopsys.integration:int-jira-common:2.0.0'
     api 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
 }

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/util/JiraCloudIssueHandler.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/util/JiraCloudIssueHandler.java
@@ -27,11 +27,11 @@ import java.util.List;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.channel.jira.cloud.JiraCloudProperties;
-import com.synopsys.integration.alert.channel.jira.common.util.JiraIssueHandler;
 import com.synopsys.integration.alert.channel.jira.cloud.descriptor.JiraCloudDescriptor;
 import com.synopsys.integration.alert.channel.jira.common.JiraIssueSearchProperties;
 import com.synopsys.integration.alert.channel.jira.common.util.JiraCallbackUtils;
 import com.synopsys.integration.alert.channel.jira.common.util.JiraContentValidator;
+import com.synopsys.integration.alert.channel.jira.common.util.JiraIssueHandler;
 import com.synopsys.integration.alert.common.channel.issuetracker.config.IssueConfig;
 import com.synopsys.integration.alert.common.channel.issuetracker.enumeration.IssueOperation;
 import com.synopsys.integration.alert.common.channel.issuetracker.message.AlertIssueOrigin;
@@ -43,6 +43,7 @@ import com.synopsys.integration.jira.common.cloud.model.IssueSearchResponseModel
 import com.synopsys.integration.jira.common.cloud.service.IssueService;
 import com.synopsys.integration.jira.common.model.request.IssueCommentRequestModel;
 import com.synopsys.integration.jira.common.model.request.builder.IssueRequestModelFieldsMapBuilder;
+import com.synopsys.integration.jira.common.model.response.IssueCreationResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssueResponseModel;
 
 public class JiraCloudIssueHandler extends JiraIssueHandler {
@@ -60,7 +61,8 @@ public class JiraCloudIssueHandler extends JiraIssueHandler {
 
     @Override
     public IssueResponseModel createIssue(String issueCreator, String issueType, String projectName, IssueRequestModelFieldsMapBuilder fieldsBuilder) throws IntegrationException {
-        return issueService.createIssue(new IssueCreationRequestModel(issueCreator, issueType, projectName, fieldsBuilder, Collections.emptyList()));
+        IssueCreationResponseModel issueCreationResponseModel = issueService.createIssue(new IssueCreationRequestModel(issueCreator, issueType, projectName, fieldsBuilder, Collections.emptyList()));
+        return issueService.getIssue(issueCreationResponseModel.getKey());
     }
 
     @Override

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/jira/server/util/JiraServerIssueHandler.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/jira/server/util/JiraServerIssueHandler.java
@@ -30,10 +30,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
-import com.synopsys.integration.alert.channel.jira.common.util.JiraIssueHandler;
 import com.synopsys.integration.alert.channel.jira.common.JiraIssueSearchProperties;
 import com.synopsys.integration.alert.channel.jira.common.util.JiraCallbackUtils;
 import com.synopsys.integration.alert.channel.jira.common.util.JiraContentValidator;
+import com.synopsys.integration.alert.channel.jira.common.util.JiraIssueHandler;
 import com.synopsys.integration.alert.channel.jira.server.JiraServerProperties;
 import com.synopsys.integration.alert.channel.jira.server.descriptor.JiraServerDescriptor;
 import com.synopsys.integration.alert.common.channel.issuetracker.config.IssueConfig;
@@ -44,6 +44,7 @@ import com.synopsys.integration.alert.common.channel.issuetracker.message.IssueT
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.jira.common.model.request.IssueCommentRequestModel;
 import com.synopsys.integration.jira.common.model.request.builder.IssueRequestModelFieldsMapBuilder;
+import com.synopsys.integration.jira.common.model.response.IssueCreationResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssueResponseModel;
 import com.synopsys.integration.jira.common.server.model.IssueCreationRequestModel;
 import com.synopsys.integration.jira.common.server.model.IssueSearchIssueComponent;
@@ -68,7 +69,8 @@ public class JiraServerIssueHandler extends JiraIssueHandler {
 
     @Override
     public IssueResponseModel createIssue(String issueCreator, String issueType, String projectName, IssueRequestModelFieldsMapBuilder fieldsBuilder) throws IntegrationException {
-        return issueService.createIssue(new IssueCreationRequestModel(issueCreator, issueType, projectName, fieldsBuilder));
+        IssueCreationResponseModel issueCreationResponseModel = issueService.createIssue(new IssueCreationRequestModel(issueCreator, issueType, projectName, fieldsBuilder));
+        return issueService.getIssue(issueCreationResponseModel.getKey());
     }
 
     @Override

--- a/channel/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/JiraCloudRequestDelegatorTest.java
+++ b/channel/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/JiraCloudRequestDelegatorTest.java
@@ -40,6 +40,7 @@ import com.synopsys.integration.jira.common.cloud.service.UserSearchService;
 import com.synopsys.integration.jira.common.model.components.IdComponent;
 import com.synopsys.integration.jira.common.model.components.ProjectComponent;
 import com.synopsys.integration.jira.common.model.components.StatusDetailsComponent;
+import com.synopsys.integration.jira.common.model.response.IssueCreationResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssueResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssueTypeResponseModel;
 import com.synopsys.integration.jira.common.model.response.PageOfProjectsResponseModel;
@@ -147,8 +148,10 @@ public class JiraCloudRequestDelegatorTest {
         List<IssueResponseModel> issues = new ArrayList<>();
         searchResponseModel.setIssues(issues);
         Mockito.when(issueSearchService.queryForIssues(Mockito.anyString())).thenReturn(searchResponseModel);
+        IssueCreationResponseModel issueCreationResponseModel = new IssueCreationResponseModel("id", "se;lf", "key");
+        Mockito.when(issueService.createIssue(Mockito.any(IssueCreationRequestModel.class))).thenReturn(issueCreationResponseModel);
         IssueResponseModel issue = createIssueResponse();
-        Mockito.when(issueService.createIssue(Mockito.any(IssueCreationRequestModel.class))).thenReturn(issue);
+        Mockito.when(issueService.getIssue(Mockito.anyString())).thenReturn(issue);
 
         JiraCloudRequestDelegator service = new JiraCloudRequestDelegator(gson, createContext());
         List<IssueTrackerRequest> requests = new ArrayList<>();

--- a/channel/src/test/java/com/synopsys/integration/alert/channel/jira/server/JiraServerRequestDelegatorTest.java
+++ b/channel/src/test/java/com/synopsys/integration/alert/channel/jira/server/JiraServerRequestDelegatorTest.java
@@ -35,6 +35,7 @@ import com.synopsys.integration.alert.common.channel.issuetracker.message.IssueT
 import com.synopsys.integration.jira.common.model.components.IdComponent;
 import com.synopsys.integration.jira.common.model.components.ProjectComponent;
 import com.synopsys.integration.jira.common.model.components.StatusDetailsComponent;
+import com.synopsys.integration.jira.common.model.response.IssueCreationResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssueResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssueTypeResponseModel;
 import com.synopsys.integration.jira.common.model.response.TransitionsResponseModel;
@@ -146,8 +147,10 @@ public class JiraServerRequestDelegatorTest {
         List<IssueSearchIssueComponent> issues = new ArrayList<>();
         IssueSearchResponseModel searchResponseModel = new IssueSearchResponseModel("", issues);
         Mockito.when(issueSearchService.queryForIssues(Mockito.anyString())).thenReturn(searchResponseModel);
+        IssueCreationResponseModel issueCreationResponseModel = new IssueCreationResponseModel("id", "se;lf", "key");
+        Mockito.when(issueService.createIssue(Mockito.any(IssueCreationRequestModel.class))).thenReturn(issueCreationResponseModel);
         IssueResponseModel issue = createIssueResponse();
-        Mockito.when(issueService.createIssue(Mockito.any(IssueCreationRequestModel.class))).thenReturn(issue);
+        Mockito.when(issueService.getIssue(Mockito.anyString())).thenReturn(issue);
 
         JiraServerRequestDelegator service = new JiraServerRequestDelegator(gson, createContext());
         List<IssueTrackerRequest> requests = new ArrayList<>();


### PR DESCRIPTION
The biggest change is the issue creation returns a new object that more accurately represents the data returned. Use this returned data to then retrieve all the data about the newly created response object.