### PR TITLE
Fix all field error messages not displaying on distribution test configuration error

### DIFF
--- a/web/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigActions.java
+++ b/web/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigActions.java
@@ -231,15 +231,14 @@ public class JobConfigActions extends AbstractJobResourceActions {
         }
     }
 
-    private List<AlertFieldStatus> validateJobNameUnique(@Nullable UUID currentJobId, JobFieldModel jobFieldModel) {
-        List<AlertFieldStatus> fieldStatuses = new ArrayList<>();
+    private Optional<AlertFieldStatus> validateJobNameUnique(@Nullable UUID currentJobId, JobFieldModel jobFieldModel) {
         for (FieldModel fieldModel : jobFieldModel.getFieldModels()) {
             Optional<AlertFieldStatus> fieldStatus = validateJobNameUnique(currentJobId, fieldModel);
             if (fieldStatus.isPresent()) {
-                fieldStatuses.add(fieldStatus.get());
+                return fieldStatus;
             }
         }
-        return fieldStatuses;
+        return Optional.empty();
     }
 
     private Optional<AlertFieldStatus> validateJobNameUnique(@Nullable UUID currentJobId, FieldModel fieldModel) {
@@ -285,7 +284,8 @@ public class JobConfigActions extends AbstractJobResourceActions {
             jobId = UUID.fromString(resource.getJobId());
         }
         List<AlertFieldStatus> fieldStatuses = new ArrayList<>();
-        fieldStatuses.addAll(validateJobNameUnique(jobId, resource));
+
+        validateJobNameUnique(jobId, resource).ifPresent(fieldStatuses::add);
         fieldStatuses.addAll(fieldModelProcessor.validateJobFieldModel(resource));
 
         if (!fieldStatuses.isEmpty()) {


### PR DESCRIPTION
In 6.3.0 we split up the validation step and had a case where if the name was missing it wouldn't get the field status messages for the other fields. This changes the name validation to also return a fieldstatus and correctly display all of the errors in the UI.