### PR TITLE
Fix distribution test configuration to display warnings as successes

### DIFF
--- a/ui/src/main/js/dynamic/DistributionConfiguration.js
+++ b/ui/src/main/js/dynamic/DistributionConfiguration.js
@@ -1,13 +1,15 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {connect} from 'react-redux';
+import { connect } from 'react-redux';
 import * as FieldModelUtilities from 'util/fieldModelUtilities';
 import * as DescriptorUtilities from 'util/descriptorUtilities';
-import {OPERATIONS} from 'util/descriptorUtilities';
+import { OPERATIONS } from 'util/descriptorUtilities';
 import FieldsPanel from 'field/FieldsPanel';
-import {checkDescriptorForGlobalConfig, getDistributionJob, saveDistributionJob, testDistributionJob, updateDistributionJob, validateDistributionJob} from 'store/actions/distributionConfigs';
+import {
+    checkDescriptorForGlobalConfig, getDistributionJob, saveDistributionJob, testDistributionJob, updateDistributionJob, validateDistributionJob
+} from 'store/actions/distributionConfigs';
 import ConfigButtons from 'component/common/ConfigButtons';
-import {Modal} from 'react-bootstrap';
+import { Modal } from 'react-bootstrap';
 import JobCustomMessageModal from 'dynamic/JobCustomMessageModal';
 import StatusMessage from 'field/StatusMessage';
 
@@ -32,9 +34,9 @@ class DistributionConfiguration extends Component {
         this.handleTestSubmit = this.handleTestSubmit.bind(this);
         this.setSendMessageVisible = this.setSendMessageVisible.bind(this);
 
-        const {descriptors, validateDescriptorForGlobalConfig} = props;
+        const { descriptors, validateDescriptorForGlobalConfig } = props;
         const defaultDescriptor = descriptors.find((descriptor) => descriptor.type === DescriptorUtilities.DESCRIPTOR_TYPE.CHANNEL && descriptor.context === DescriptorUtilities.CONTEXT_TYPE.DISTRIBUTION);
-        const {fields, context, name} = defaultDescriptor;
+        const { fields, context, name } = defaultDescriptor;
         validateDescriptorForGlobalConfig(KEY_CHANNEL_NAME, name);
         const emptyFieldModel = FieldModelUtilities.createFieldModelWithDefaults(fields, context, name);
         const channelFieldModel = FieldModelUtilities.updateFieldModelSingleValue(emptyFieldModel, KEY_CHANNEL_NAME, name);
@@ -50,7 +52,7 @@ class DistributionConfiguration extends Component {
     }
 
     componentDidMount() {
-        const {jobId, getDistribution} = this.props;
+        const { jobId, getDistribution } = this.props;
         getDistribution(jobId);
         if (jobId) {
             this.loading = true;
@@ -62,7 +64,7 @@ class DistributionConfiguration extends Component {
             success, onSave, onModalClose, fetching, inProgress, job, descriptors, validateDescriptorForGlobalConfig, status, isUpdatingJob, jobId, saveDistribution, updateDistribution
         } = this.props;
         if (prevProps.saving && success) {
-            this.setState({show: false});
+            this.setState({ show: false });
             onSave(this.state);
             onModalClose();
         }
@@ -89,7 +91,7 @@ class DistributionConfiguration extends Component {
             }
         }
 
-        const {channelConfig, currentChannel, currentProvider} = this.state;
+        const { channelConfig, currentChannel, currentProvider } = this.state;
 
         const selectedChannelOption = FieldModelUtilities.getFieldModelSingleValue(channelConfig, KEY_CHANNEL_NAME);
         const prevChannelName = currentChannel ? currentChannel.name : '';
@@ -97,7 +99,7 @@ class DistributionConfiguration extends Component {
         if (selectedChannelOption && prevChannelName !== selectedChannelOption) {
             const newChannel = descriptors.find((descriptor) => descriptor.name === selectedChannelOption && descriptor.context === DescriptorUtilities.CONTEXT_TYPE.DISTRIBUTION);
             const emptyChannelConfig = FieldModelUtilities.createFieldModelWithDefaults(newChannel.fields, newChannel.context, newChannel.name);
-            const updatedChannelConfig = {...FieldModelUtilities.updateFieldModelSingleValue(emptyChannelConfig, KEY_CHANNEL_NAME, selectedChannelOption)};
+            const updatedChannelConfig = { ...FieldModelUtilities.updateFieldModelSingleValue(emptyChannelConfig, KEY_CHANNEL_NAME, selectedChannelOption) };
             const name = FieldModelUtilities.getFieldModelSingleValue(channelConfig, KEY_NAME) || '';
             const frequency = FieldModelUtilities.getFieldModelSingleValue(channelConfig, KEY_FREQUENCY) || '';
             const provider = FieldModelUtilities.getFieldModelSingleValue(channelConfig, KEY_PROVIDER_NAME) || '';
@@ -142,14 +144,14 @@ class DistributionConfiguration extends Component {
 
     handleTestSubmit(event) {
         event.preventDefault();
-        const {testDistribution} = this.props;
+        const { testDistribution } = this.props;
         const jsonBody = this.buildJsonBody();
         testDistribution(jsonBody);
     }
 
     buildJsonBody() {
-        const {channelConfig, providerConfig} = this.state;
-        const {jobId} = this.props;
+        const { channelConfig, providerConfig } = this.state;
+        const { jobId } = this.props;
         return {
             jobId,
             fieldModels: [
@@ -160,15 +162,15 @@ class DistributionConfiguration extends Component {
     }
 
     handleClose() {
-        const {onModalClose, handleCancel} = this.props;
-        this.setState({show: false});
+        const { onModalClose, handleCancel } = this.props;
+        this.setState({ show: false });
         onModalClose();
         handleCancel();
     }
 
     handleSubmit(event) {
         event.preventDefault();
-        const {validateDistribution} = this.props;
+        const { validateDistribution } = this.props;
 
         const jsonBody = this.buildJsonBody();
         validateDistribution(jsonBody);
@@ -180,13 +182,13 @@ class DistributionConfiguration extends Component {
         const {
             providerConfig, channelConfig, currentProvider
         } = this.state;
-        const {fieldErrors} = this.props;
+        const { fieldErrors } = this.props;
         const configNameFields = currentProvider.fields.filter((field) => field.key === KEY_PROVIDER_CONFIG_ID);
         return (
             <div>
                 <FieldsPanel
                     descriptorFields={configNameFields}
-                    metadata={{additionalFields: channelConfig.keyToValues}}
+                    metadata={{ additionalFields: channelConfig.keyToValues }}
                     currentConfig={providerConfig}
                     fieldErrors={fieldErrors}
                     self={this}
@@ -211,7 +213,7 @@ class DistributionConfiguration extends Component {
             <div>
                 <FieldsPanel
                     descriptorFields={providerFields}
-                    metadata={{additionalFields: channelConfig.keyToValues}}
+                    metadata={{ additionalFields: channelConfig.keyToValues }}
                     currentConfig={providerConfig}
                     fieldErrors={fieldErrors}
                     self={this}
@@ -265,7 +267,7 @@ class DistributionConfiguration extends Component {
         const {
             providerConfig, channelConfig, currentProvider, currentChannel, show
         } = this.state;
-        const {job, isUpdatingJob, fieldErrors} = this.props;
+        const { job, isUpdatingJob, fieldErrors } = this.props;
         const selectedProvider = (currentProvider) ? currentProvider.name : null;
 
         let jobAction = 'New';
@@ -302,7 +304,7 @@ class DistributionConfiguration extends Component {
                             && (
                                 <FieldsPanel
                                     descriptorFields={channelFields}
-                                    metadata={{additionalFields: providerConfig.keyToValues}}
+                                    metadata={{ additionalFields: providerConfig.keyToValues }}
                                     currentConfig={channelConfig}
                                     fieldErrors={fieldErrors}
                                     self={this}

--- a/ui/src/main/js/dynamic/DistributionConfiguration.js
+++ b/ui/src/main/js/dynamic/DistributionConfiguration.js
@@ -1,15 +1,13 @@
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import {connect} from 'react-redux';
 import * as FieldModelUtilities from 'util/fieldModelUtilities';
 import * as DescriptorUtilities from 'util/descriptorUtilities';
-import { OPERATIONS } from 'util/descriptorUtilities';
+import {OPERATIONS} from 'util/descriptorUtilities';
 import FieldsPanel from 'field/FieldsPanel';
-import {
-    checkDescriptorForGlobalConfig, getDistributionJob, saveDistributionJob, testDistributionJob, updateDistributionJob, validateDistributionJob
-} from 'store/actions/distributionConfigs';
+import {checkDescriptorForGlobalConfig, getDistributionJob, saveDistributionJob, testDistributionJob, updateDistributionJob, validateDistributionJob} from 'store/actions/distributionConfigs';
 import ConfigButtons from 'component/common/ConfigButtons';
-import { Modal } from 'react-bootstrap';
+import {Modal} from 'react-bootstrap';
 import JobCustomMessageModal from 'dynamic/JobCustomMessageModal';
 import StatusMessage from 'field/StatusMessage';
 
@@ -34,9 +32,9 @@ class DistributionConfiguration extends Component {
         this.handleTestSubmit = this.handleTestSubmit.bind(this);
         this.setSendMessageVisible = this.setSendMessageVisible.bind(this);
 
-        const { descriptors, validateDescriptorForGlobalConfig } = props;
+        const {descriptors, validateDescriptorForGlobalConfig} = props;
         const defaultDescriptor = descriptors.find((descriptor) => descriptor.type === DescriptorUtilities.DESCRIPTOR_TYPE.CHANNEL && descriptor.context === DescriptorUtilities.CONTEXT_TYPE.DISTRIBUTION);
-        const { fields, context, name } = defaultDescriptor;
+        const {fields, context, name} = defaultDescriptor;
         validateDescriptorForGlobalConfig(KEY_CHANNEL_NAME, name);
         const emptyFieldModel = FieldModelUtilities.createFieldModelWithDefaults(fields, context, name);
         const channelFieldModel = FieldModelUtilities.updateFieldModelSingleValue(emptyFieldModel, KEY_CHANNEL_NAME, name);
@@ -52,7 +50,7 @@ class DistributionConfiguration extends Component {
     }
 
     componentDidMount() {
-        const { jobId, getDistribution } = this.props;
+        const {jobId, getDistribution} = this.props;
         getDistribution(jobId);
         if (jobId) {
             this.loading = true;
@@ -64,7 +62,7 @@ class DistributionConfiguration extends Component {
             success, onSave, onModalClose, fetching, inProgress, job, descriptors, validateDescriptorForGlobalConfig, status, isUpdatingJob, jobId, saveDistribution, updateDistribution
         } = this.props;
         if (prevProps.saving && success) {
-            this.setState({ show: false });
+            this.setState({show: false});
             onSave(this.state);
             onModalClose();
         }
@@ -91,7 +89,7 @@ class DistributionConfiguration extends Component {
             }
         }
 
-        const { channelConfig, currentChannel, currentProvider } = this.state;
+        const {channelConfig, currentChannel, currentProvider} = this.state;
 
         const selectedChannelOption = FieldModelUtilities.getFieldModelSingleValue(channelConfig, KEY_CHANNEL_NAME);
         const prevChannelName = currentChannel ? currentChannel.name : '';
@@ -99,7 +97,7 @@ class DistributionConfiguration extends Component {
         if (selectedChannelOption && prevChannelName !== selectedChannelOption) {
             const newChannel = descriptors.find((descriptor) => descriptor.name === selectedChannelOption && descriptor.context === DescriptorUtilities.CONTEXT_TYPE.DISTRIBUTION);
             const emptyChannelConfig = FieldModelUtilities.createFieldModelWithDefaults(newChannel.fields, newChannel.context, newChannel.name);
-            const updatedChannelConfig = { ...FieldModelUtilities.updateFieldModelSingleValue(emptyChannelConfig, KEY_CHANNEL_NAME, selectedChannelOption) };
+            const updatedChannelConfig = {...FieldModelUtilities.updateFieldModelSingleValue(emptyChannelConfig, KEY_CHANNEL_NAME, selectedChannelOption)};
             const name = FieldModelUtilities.getFieldModelSingleValue(channelConfig, KEY_NAME) || '';
             const frequency = FieldModelUtilities.getFieldModelSingleValue(channelConfig, KEY_FREQUENCY) || '';
             const provider = FieldModelUtilities.getFieldModelSingleValue(channelConfig, KEY_PROVIDER_NAME) || '';
@@ -144,14 +142,14 @@ class DistributionConfiguration extends Component {
 
     handleTestSubmit(event) {
         event.preventDefault();
-        const { testDistribution } = this.props;
+        const {testDistribution} = this.props;
         const jsonBody = this.buildJsonBody();
         testDistribution(jsonBody);
     }
 
     buildJsonBody() {
-        const { channelConfig, providerConfig } = this.state;
-        const { jobId } = this.props;
+        const {channelConfig, providerConfig} = this.state;
+        const {jobId} = this.props;
         return {
             jobId,
             fieldModels: [
@@ -162,15 +160,15 @@ class DistributionConfiguration extends Component {
     }
 
     handleClose() {
-        const { onModalClose, handleCancel } = this.props;
-        this.setState({ show: false });
+        const {onModalClose, handleCancel} = this.props;
+        this.setState({show: false});
         onModalClose();
         handleCancel();
     }
 
     handleSubmit(event) {
         event.preventDefault();
-        const { validateDistribution } = this.props;
+        const {validateDistribution} = this.props;
 
         const jsonBody = this.buildJsonBody();
         validateDistribution(jsonBody);
@@ -182,13 +180,13 @@ class DistributionConfiguration extends Component {
         const {
             providerConfig, channelConfig, currentProvider
         } = this.state;
-        const { fieldErrors } = this.props;
+        const {fieldErrors} = this.props;
         const configNameFields = currentProvider.fields.filter((field) => field.key === KEY_PROVIDER_CONFIG_ID);
         return (
             <div>
                 <FieldsPanel
                     descriptorFields={configNameFields}
-                    metadata={{ additionalFields: channelConfig.keyToValues }}
+                    metadata={{additionalFields: channelConfig.keyToValues}}
                     currentConfig={providerConfig}
                     fieldErrors={fieldErrors}
                     self={this}
@@ -213,7 +211,7 @@ class DistributionConfiguration extends Component {
             <div>
                 <FieldsPanel
                     descriptorFields={providerFields}
-                    metadata={{ additionalFields: channelConfig.keyToValues }}
+                    metadata={{additionalFields: channelConfig.keyToValues}}
                     currentConfig={providerConfig}
                     fieldErrors={fieldErrors}
                     self={this}
@@ -267,7 +265,7 @@ class DistributionConfiguration extends Component {
         const {
             providerConfig, channelConfig, currentProvider, currentChannel, show
         } = this.state;
-        const { job, isUpdatingJob, fieldErrors } = this.props;
+        const {job, isUpdatingJob, fieldErrors} = this.props;
         const selectedProvider = (currentProvider) ? currentProvider.name : null;
 
         let jobAction = 'New';
@@ -304,7 +302,7 @@ class DistributionConfiguration extends Component {
                             && (
                                 <FieldsPanel
                                     descriptorFields={channelFields}
-                                    metadata={{ additionalFields: providerConfig.keyToValues }}
+                                    metadata={{additionalFields: providerConfig.keyToValues}}
                                     currentConfig={channelConfig}
                                     fieldErrors={fieldErrors}
                                     self={this}

--- a/ui/src/main/js/store/actions/distributionConfigs.js
+++ b/ui/src/main/js/store/actions/distributionConfigs.js
@@ -18,7 +18,7 @@ import {
     DISTRIBUTION_JOB_VALIDATED,
     DISTRIBUTION_JOB_VALIDATING
 } from 'store/actions/types';
-import {unauthorized} from 'store/actions/session';
+import { unauthorized } from 'store/actions/session';
 import * as ConfigRequestBuilder from 'util/configurationRequestBuilder';
 import * as HTTPErrorUtils from 'util/httpErrorUtilities';
 import HeaderUtilities from 'util/HeaderUtilities';
@@ -116,7 +116,7 @@ function validatedJob() {
     };
 }
 
-function validateJobError({message, errors}) {
+function validateJobError({ message, errors }) {
     return {
         type: DISTRIBUTION_JOB_VALIDATE_ERROR,
         message,
@@ -137,7 +137,7 @@ function checkingDescriptorGlobalConfigFailure(errorFieldName, response) {
     };
 }
 
-function jobError({type = '', message, errors}) {
+function jobError({ type = '', message, errors }) {
     return {
         type,
         message,
@@ -148,7 +148,7 @@ function jobError({type = '', message, errors}) {
 function createErrorHandler(type, defaultHandler) {
     const errorHandlers = [];
     errorHandlers.push(HTTPErrorUtils.createUnauthorizedHandler(unauthorized));
-    errorHandlers.push(HTTPErrorUtils.createForbiddenHandler(() => jobError({type, message: HTTPErrorUtils.MESSAGES.FORBIDDEN_ACTION})));
+    errorHandlers.push(HTTPErrorUtils.createForbiddenHandler(() => jobError({ type, message: HTTPErrorUtils.MESSAGES.FORBIDDEN_ACTION })));
     errorHandlers.push(HTTPErrorUtils.createBadRequestHandler(defaultHandler));
     errorHandlers.push(HTTPErrorUtils.createPreconditionFailedHandler(defaultHandler));
     errorHandlers.push(HTTPErrorUtils.createDefaultHandler(defaultHandler));
@@ -158,7 +158,7 @@ function createErrorHandler(type, defaultHandler) {
 export function getDistributionJob(jobId) {
     return (dispatch, getState) => {
         dispatch(fetchingJob());
-        const {csrfToken} = getState().session;
+        const { csrfToken } = getState().session;
         const errorHandlers = [];
         errorHandlers.push(HTTPErrorUtils.createUnauthorizedHandler(unauthorized));
         errorHandlers.push(HTTPErrorUtils.createForbiddenHandler(() => jobFetchErrorMessage(HTTPErrorUtils.MESSAGES.FORBIDDEN_READ)));
@@ -189,7 +189,7 @@ export function getDistributionJob(jobId) {
 export function saveDistributionJob(config) {
     return (dispatch, getState) => {
         dispatch(savingJobConfig());
-        const {csrfToken} = getState().session;
+        const { csrfToken } = getState().session;
         const request = ConfigRequestBuilder.createNewConfigurationRequest(ConfigRequestBuilder.JOB_API_URL, csrfToken, config);
         request.then((response) => {
             response.json()
@@ -212,7 +212,7 @@ export function saveDistributionJob(config) {
 export function updateDistributionJob(config) {
     return (dispatch, getState) => {
         dispatch(updatingJobConfig());
-        const {csrfToken} = getState().session;
+        const { csrfToken } = getState().session;
         const request = ConfigRequestBuilder.createUpdateRequest(ConfigRequestBuilder.JOB_API_URL, csrfToken, config.jobId, config);
         request.then((response) => {
             if (response.ok) {
@@ -235,7 +235,7 @@ export function updateDistributionJob(config) {
 export function testDistributionJob(config) {
     return (dispatch, getState) => {
         dispatch(testingJobConfig());
-        const {csrfToken} = getState().session;
+        const { csrfToken } = getState().session;
         const request = ConfigRequestBuilder.createTestRequest(ConfigRequestBuilder.JOB_API_URL, csrfToken, config);
         request.then((response) => {
             response.json()
@@ -261,7 +261,7 @@ export function testDistributionJob(config) {
 export function checkDescriptorForGlobalConfig(errorFieldName, descriptorName) {
     return (dispatch, getState) => {
         dispatch(checkingDescriptorGlobalConfig());
-        const {csrfToken} = getState().session;
+        const { csrfToken } = getState().session;
         const url = `${ConfigRequestBuilder.JOB_API_URL}/descriptorCheck`;
         const headersUtil = new HeaderUtilities();
         headersUtil.addApplicationJsonContentType();
@@ -287,7 +287,7 @@ export function checkDescriptorForGlobalConfig(errorFieldName, descriptorName) {
 export function validateDistributionJob(config) {
     return (dispatch, getState) => {
         dispatch(validatingJob());
-        const {csrfToken} = getState().session;
+        const { csrfToken } = getState().session;
         const request = ConfigRequestBuilder.createValidateRequest(ConfigRequestBuilder.JOB_API_URL, csrfToken, config);
         request.then((response) => {
             response.json()

--- a/ui/src/main/js/store/reducers/distributionConfigs.js
+++ b/ui/src/main/js/store/reducers/distributionConfigs.js
@@ -142,7 +142,7 @@ const config = (state = initialState, action) => {
                 success: true,
                 testingConfig: true,
                 configurationMessage: action.configurationMessage,
-                error: HTTPErrorUtils.createEmptyErrorObject(),
+                error: HTTPErrorUtils.createErrorObject(action),
                 status: 'TESTED'
             };
 
@@ -159,7 +159,7 @@ const config = (state = initialState, action) => {
                 status: 'ERROR'
             };
         case DISTRIBUTION_JOB_CHECK_DESCRIPTOR:
-            return { ...state, inProgress: true };
+            return {...state, inProgress: true};
         case DISTRIBUTION_JOB_CHECK_DESCRIPTOR_SUCCESS:
             return {
                 ...state,

--- a/ui/src/main/js/store/reducers/distributionConfigs.js
+++ b/ui/src/main/js/store/reducers/distributionConfigs.js
@@ -159,7 +159,7 @@ const config = (state = initialState, action) => {
                 status: 'ERROR'
             };
         case DISTRIBUTION_JOB_CHECK_DESCRIPTOR:
-            return {...state, inProgress: true};
+            return { ...state, inProgress: true };
         case DISTRIBUTION_JOB_CHECK_DESCRIPTOR_SUCCESS:
             return {
                 ...state,

--- a/ui/src/main/js/util/httpErrorUtilities.js
+++ b/ui/src/main/js/util/httpErrorUtilities.js
@@ -46,6 +46,14 @@ export function combineErrorObjects(errorObject1, errorObject2) {
     };
 }
 
+export function hasErrors(errorObject) {
+    if (!errorObject) {
+        return false;
+    }
+    const keys = Object.keys(errorObject);
+    return keys.some((key) => errorObject[key].severity === 'ERROR');
+}
+
 export function createStatusCodeHandler(statusCode, callback) {
     return {
         statusCode,


### PR DESCRIPTION
Due to our changes around fieldStatuses, warnings were coming up in the UI as errors but containing a success message and a successful response. This change makes it so that we will check for a severity of ERROR first to determine if we should throw an error status in the UI and allow warnings to continue as a success status.

As a side note, my save actions were messing with the formatting removing spaces in several areas. I tried to play around with this and fix it but the save actions would overwrite it each time. If anyone thinks its incorrect, please let me know how you modified it in your save actions so I can try to fix it.