### PR TITLE
Remove default value handling from DefaultNotificationAccessor

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/ReadPageController.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/ReadPageController.java
@@ -28,10 +28,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 
 public interface ReadPageController<P extends AlertPagedModel<?>> {
+    String DEFAULT_PAGE_NUMBER = "0";
+    String DEFAULT_PAGE_SIZE = "10";
+    
     @GetMapping
     P getPage(
-        @RequestParam(defaultValue = AlertPagedModel.DEFAULT_PAGE_NUMBER_STRING) Integer pageNumber,
-        @RequestParam(defaultValue = AlertPagedModel.DEFAULT_PAGE_SIZE_STRING) Integer pageSize,
+        @RequestParam(defaultValue = DEFAULT_PAGE_NUMBER) Integer pageNumber,
+        @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) Integer pageSize,
         @RequestParam(required = false) String searchTerm
     );
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/ReadPageController.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/ReadPageController.java
@@ -30,8 +30,8 @@ import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 public interface ReadPageController<P extends AlertPagedModel<?>> {
     @GetMapping
     P getPage(
-        @RequestParam(defaultValue = AlertPagedModel.DEFAULT_PAGE_NUMBER) Integer pageNumber,
-        @RequestParam(defaultValue = AlertPagedModel.DEFAULT_PAGE_SIZE) Integer pageSize,
+        @RequestParam(defaultValue = AlertPagedModel.DEFAULT_PAGE_NUMBER_STRING) Integer pageNumber,
+        @RequestParam(defaultValue = AlertPagedModel.DEFAULT_PAGE_SIZE_STRING) Integer pageSize,
         @RequestParam(required = false) String searchTerm
     );
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/model/AlertPagedModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/model/AlertPagedModel.java
@@ -24,11 +24,13 @@ package com.synopsys.integration.alert.common.rest.model;
 
 import java.util.List;
 
+import com.synopsys.integration.alert.common.rest.api.ReadPageController;
+
 import net.minidev.json.annotate.JsonIgnore;
 
 public class AlertPagedModel<M extends AlertSerializableModel> extends AlertSerializableModel {
-    public static final Integer DEFAULT_PAGE_NUMBER = 0;
-    public static final Integer DEFAULT_PAGE_SIZE = 10;
+    public static final Integer DEFAULT_PAGE_NUMBER = Integer.valueOf(ReadPageController.DEFAULT_PAGE_NUMBER);
+    public static final Integer DEFAULT_PAGE_SIZE = Integer.valueOf(ReadPageController.DEFAULT_PAGE_SIZE);
 
     // FIXME we should use terminology based on "offset" and "limit" which are standard REST API paging terms
     private final int totalPages;

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/model/AlertPagedModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/model/AlertPagedModel.java
@@ -29,8 +29,6 @@ import net.minidev.json.annotate.JsonIgnore;
 public class AlertPagedModel<M extends AlertSerializableModel> extends AlertSerializableModel {
     public static final Integer DEFAULT_PAGE_NUMBER = 0;
     public static final Integer DEFAULT_PAGE_SIZE = 10;
-    public static final String DEFAULT_PAGE_NUMBER_STRING = "0";
-    public static final String DEFAULT_PAGE_SIZE_STRING = "10";
 
     // FIXME we should use terminology based on "offset" and "limit" which are standard REST API paging terms
     private final int totalPages;

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/model/AlertPagedModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/model/AlertPagedModel.java
@@ -27,8 +27,10 @@ import java.util.List;
 import net.minidev.json.annotate.JsonIgnore;
 
 public class AlertPagedModel<M extends AlertSerializableModel> extends AlertSerializableModel {
-    public static final String DEFAULT_PAGE_NUMBER = "0";
-    public static final String DEFAULT_PAGE_SIZE = "10";
+    public static final Integer DEFAULT_PAGE_NUMBER = 0;
+    public static final Integer DEFAULT_PAGE_SIZE = 10;
+    public static final String DEFAULT_PAGE_NUMBER_STRING = "0";
+    public static final String DEFAULT_PAGE_SIZE_STRING = "10";
 
     // FIXME we should use terminology based on "offset" and "limit" which are standard REST API paging terms
     private final int totalPages;

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultNotificationAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultNotificationAccessor.java
@@ -29,7 +29,6 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -168,12 +167,7 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
         notificationContentRepository.deleteById(notification.getId());
     }
 
-    public PageRequest getPageRequestForNotifications(@Nullable Integer pageNumber, @Nullable Integer pageSize, @Nullable String sortField, @Nullable String sortOrder) {
-        // FIXME Integer.MAX_VALUE does not seem like an appropriate default
-        //  Because this is an internal API, we should not expect pageNumber and pageSize to be @Nullable
-        //  Default values should be handled at the public API level
-        Integer page = ObjectUtils.defaultIfNull(pageNumber, 0);
-        Integer size = ObjectUtils.defaultIfNull(pageSize, Integer.MAX_VALUE);
+    public PageRequest getPageRequestForNotifications(Integer pageNumber, Integer pageSize, @Nullable String sortField, @Nullable String sortOrder) {
         boolean sortQuery = false;
         String sortingField = "createdAt";
         // We can only modify the query for the fields that exist in NotificationContent
@@ -189,7 +183,7 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
         if (StringUtils.isNotBlank(sortOrder) && sortQuery && Sort.Direction.ASC.name().equalsIgnoreCase(sortOrder)) {
             sortingOrder = Sort.Order.asc(sortingField);
         }
-        return PageRequest.of(page, size, Sort.by(sortingOrder));
+        return PageRequest.of(pageNumber, pageSize, Sort.by(sortingOrder));
     }
 
     private void deleteAuditEntries(Long notificationId) {

--- a/component/src/main/java/com/synopsys/integration/alert/component/audit/web/AuditEntryActions.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/audit/web/AuditEntryActions.java
@@ -22,9 +22,6 @@
  */
 package com.synopsys.integration.alert.component.audit.web;
 
-import static com.synopsys.integration.alert.common.rest.model.AlertPagedModel.DEFAULT_PAGE_NUMBER;
-import static com.synopsys.integration.alert.common.rest.model.AlertPagedModel.DEFAULT_PAGE_SIZE;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +48,7 @@ import com.synopsys.integration.alert.common.persistence.model.AuditEntryPageMod
 import com.synopsys.integration.alert.common.persistence.model.AuditJobStatusModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationJobModel;
 import com.synopsys.integration.alert.common.rest.model.AlertNotificationModel;
+import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
 import com.synopsys.integration.alert.common.workflow.processor.notification.NotificationProcessor;
 import com.synopsys.integration.alert.component.audit.AuditDescriptorKey;
@@ -95,8 +93,8 @@ public class AuditEntryActions {
         if (!authorizationManager.hasReadPermission(ConfigContextEnum.GLOBAL, descriptorKey)) {
             return new ActionResponse<>(HttpStatus.FORBIDDEN, ActionResponse.FORBIDDEN_MESSAGE);
         }
-        Integer page = ObjectUtils.defaultIfNull(pageNumber, DEFAULT_PAGE_NUMBER);
-        Integer size = ObjectUtils.defaultIfNull(pageSize, DEFAULT_PAGE_SIZE);
+        Integer page = ObjectUtils.defaultIfNull(pageNumber, AlertPagedModel.DEFAULT_PAGE_NUMBER);
+        Integer size = ObjectUtils.defaultIfNull(pageSize, AlertPagedModel.DEFAULT_PAGE_SIZE);
         AuditEntryPageModel pagedRestModel = auditAccessor.getPageOfAuditEntries(page, size, searchTerm, sortField, sortOrder, onlyShowSentNotifications, auditAccessor::convertToAuditEntryModelFromNotification);
         logger.debug("Paged Audit Entry Rest Model: {}", pagedRestModel);
         return new ActionResponse<>(HttpStatus.OK, pagedRestModel);

--- a/component/src/main/java/com/synopsys/integration/alert/component/audit/web/AuditEntryActions.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/audit/web/AuditEntryActions.java
@@ -22,6 +22,9 @@
  */
 package com.synopsys.integration.alert.component.audit.web;
 
+import static com.synopsys.integration.alert.common.rest.model.AlertPagedModel.DEFAULT_PAGE_NUMBER;
+import static com.synopsys.integration.alert.common.rest.model.AlertPagedModel.DEFAULT_PAGE_SIZE;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,8 +95,8 @@ public class AuditEntryActions {
         if (!authorizationManager.hasReadPermission(ConfigContextEnum.GLOBAL, descriptorKey)) {
             return new ActionResponse<>(HttpStatus.FORBIDDEN, ActionResponse.FORBIDDEN_MESSAGE);
         }
-        Integer page = ObjectUtils.defaultIfNull(pageNumber, 0);
-        Integer size = ObjectUtils.defaultIfNull(pageSize, 100);
+        Integer page = ObjectUtils.defaultIfNull(pageNumber, DEFAULT_PAGE_NUMBER);
+        Integer size = ObjectUtils.defaultIfNull(pageSize, DEFAULT_PAGE_SIZE);
         AuditEntryPageModel pagedRestModel = auditAccessor.getPageOfAuditEntries(page, size, searchTerm, sortField, sortOrder, onlyShowSentNotifications, auditAccessor::convertToAuditEntryModelFromNotification);
         logger.debug("Paged Audit Entry Rest Model: {}", pagedRestModel);
         return new ActionResponse<>(HttpStatus.OK, pagedRestModel);

--- a/component/src/main/java/com/synopsys/integration/alert/component/audit/web/AuditEntryActions.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/audit/web/AuditEntryActions.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -88,10 +89,12 @@ public class AuditEntryActions {
     }
 
     public ActionResponse<AuditEntryPageModel> get(Integer pageNumber, Integer pageSize, String searchTerm, String sortField, String sortOrder, boolean onlyShowSentNotifications) {
+        Integer page = ObjectUtils.defaultIfNull(pageNumber, 0);
+        Integer size = ObjectUtils.defaultIfNull(pageSize, Integer.MAX_VALUE);
         if (!authorizationManager.hasReadPermission(ConfigContextEnum.GLOBAL, descriptorKey)) {
             return new ActionResponse<>(HttpStatus.FORBIDDEN, ActionResponse.FORBIDDEN_MESSAGE);
         }
-        AuditEntryPageModel pagedRestModel = auditAccessor.getPageOfAuditEntries(pageNumber, pageSize, searchTerm, sortField, sortOrder, onlyShowSentNotifications, auditAccessor::convertToAuditEntryModelFromNotification);
+        AuditEntryPageModel pagedRestModel = auditAccessor.getPageOfAuditEntries(page, size, searchTerm, sortField, sortOrder, onlyShowSentNotifications, auditAccessor::convertToAuditEntryModelFromNotification);
         logger.debug("Paged Audit Entry Rest Model: {}", pagedRestModel);
         return new ActionResponse<>(HttpStatus.OK, pagedRestModel);
     }

--- a/component/src/main/java/com/synopsys/integration/alert/component/audit/web/AuditEntryActions.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/audit/web/AuditEntryActions.java
@@ -89,11 +89,11 @@ public class AuditEntryActions {
     }
 
     public ActionResponse<AuditEntryPageModel> get(Integer pageNumber, Integer pageSize, String searchTerm, String sortField, String sortOrder, boolean onlyShowSentNotifications) {
-        Integer page = ObjectUtils.defaultIfNull(pageNumber, 0);
-        Integer size = ObjectUtils.defaultIfNull(pageSize, 100);
         if (!authorizationManager.hasReadPermission(ConfigContextEnum.GLOBAL, descriptorKey)) {
             return new ActionResponse<>(HttpStatus.FORBIDDEN, ActionResponse.FORBIDDEN_MESSAGE);
         }
+        Integer page = ObjectUtils.defaultIfNull(pageNumber, 0);
+        Integer size = ObjectUtils.defaultIfNull(pageSize, 100);
         AuditEntryPageModel pagedRestModel = auditAccessor.getPageOfAuditEntries(page, size, searchTerm, sortField, sortOrder, onlyShowSentNotifications, auditAccessor::convertToAuditEntryModelFromNotification);
         logger.debug("Paged Audit Entry Rest Model: {}", pagedRestModel);
         return new ActionResponse<>(HttpStatus.OK, pagedRestModel);

--- a/component/src/main/java/com/synopsys/integration/alert/component/audit/web/AuditEntryActions.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/audit/web/AuditEntryActions.java
@@ -90,7 +90,7 @@ public class AuditEntryActions {
 
     public ActionResponse<AuditEntryPageModel> get(Integer pageNumber, Integer pageSize, String searchTerm, String sortField, String sortOrder, boolean onlyShowSentNotifications) {
         Integer page = ObjectUtils.defaultIfNull(pageNumber, 0);
-        Integer size = ObjectUtils.defaultIfNull(pageSize, Integer.MAX_VALUE);
+        Integer size = ObjectUtils.defaultIfNull(pageSize, 100);
         if (!authorizationManager.hasReadPermission(ConfigContextEnum.GLOBAL, descriptorKey)) {
             return new ActionResponse<>(HttpStatus.FORBIDDEN, ActionResponse.FORBIDDEN_MESSAGE);
         }


### PR DESCRIPTION
# Remove default value handling from DefaultNotificationAccessor

**Link to github issue (if applicable):**
Fixes IALERT-2008

**If nothing above, what is your reason for this pull request:**
In the method `DefaultNotificationAccessor::getPageRequestForNotifications` the paging parameters are `@Nullable`, this should not be the case and default value handling should happen at a higher level.

**Changes proposed in this pull request:**
- Move default value handling higher into the API
- Change default page size from `Integer.MAX_VALUE` to `10`. Uses the constant defined in `AuditEntryPageModel`.