### PR TITLE
On demand data

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/ProviderDataAccessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/ProviderDataAccessor.java
@@ -37,7 +37,7 @@ public interface ProviderDataAccessor {
 
     void deleteProjects(Collection<ProviderProject> providerProjects);
 
-    Set<String> getEmailAddressesForProjectHref(String projectHref);
+    Set<String> getEmailAddressesForProjectHref(Long providerConfigId, String projectHref);
 
     List<ProviderUserModel> getUsersByProviderConfigId(Long providerConfigId);
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/processor/notification/NotificationProcessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/processor/notification/NotificationProcessor.java
@@ -221,11 +221,11 @@ public class NotificationProcessor {
         return List.of();
     }
 
-    private Optional<ConfigurationModel> retrieveProviderConfig(Long providerConfigID) {
+    private Optional<ConfigurationModel> retrieveProviderConfig(Long providerConfigId) {
         try {
-            return configurationAccessor.getConfigurationById(providerConfigID);
+            return configurationAccessor.getConfigurationById(providerConfigId);
         } catch (AlertDatabaseConstraintException e) {
-            logger.error("Could not retrieve the provider config for ID: {}", providerConfigID);
+            logger.error("Could not retrieve the provider config for Id: {}", providerConfigId);
             logger.debug(e.getMessage(), e);
             return Optional.empty();
         }

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProviderDataAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProviderDataAccessor.java
@@ -41,7 +41,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.common.exception.AlertDatabaseConstraintException;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
-import com.synopsys.integration.alert.common.persistence.accessor.ProviderDataAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
 import com.synopsys.integration.alert.common.persistence.model.ProviderProject;
 import com.synopsys.integration.alert.common.persistence.model.ProviderUserModel;
@@ -54,7 +53,8 @@ import com.synopsys.integration.alert.database.provider.user.ProviderUserReposit
 
 @Component
 @Transactional
-public class DefaultProviderDataAccessor implements ProviderDataAccessor {
+public class DefaultProviderDataAccessor {
+    //implements ProviderDataAccessor {
     public static final int MAX_DESCRIPTION_LENGTH = 250;
     public static final int MAX_PROJECT_NAME_LENGTH = 507;
 
@@ -73,7 +73,7 @@ public class DefaultProviderDataAccessor implements ProviderDataAccessor {
         this.configurationAccessor = configurationAccessor;
     }
 
-    @Override
+    //    @Override
     @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
     public List<ProviderProject> getProjectsByProviderConfigName(String providerConfigName) {
         try {
@@ -91,7 +91,7 @@ public class DefaultProviderDataAccessor implements ProviderDataAccessor {
         return List.of();
     }
 
-    @Override
+    //    @Override
     @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
     public List<ProviderProject> getProjectsByProviderConfigId(Long providerConfigId) {
         return providerProjectRepository.findByProviderConfigId(providerConfigId)
@@ -100,12 +100,12 @@ public class DefaultProviderDataAccessor implements ProviderDataAccessor {
                    .collect(Collectors.toList());
     }
 
-    @Override
+    //    @Override
     public void deleteProjects(Collection<ProviderProject> providerProjects) {
         providerProjects.forEach(project -> providerProjectRepository.deleteByHref(project.getHref()));
     }
 
-    @Override
+    //    @Override
     @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
     public Set<String> getEmailAddressesForProjectHref(String projectHref) {
         Optional<Long> projectId = providerProjectRepository.findFirstByHref(projectHref).map(ProviderProjectEntity::getId);
@@ -122,7 +122,7 @@ public class DefaultProviderDataAccessor implements ProviderDataAccessor {
         return Set.of();
     }
 
-    @Override
+    //    @Override
     @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
     public List<ProviderUserModel> getUsersByProviderConfigId(Long providerConfigId) {
         if (null == providerConfigId) {
@@ -134,7 +134,7 @@ public class DefaultProviderDataAccessor implements ProviderDataAccessor {
                    .collect(Collectors.toList());
     }
 
-    @Override
+    //    @Override
     public List<ProviderUserModel> getUsersByProviderConfigName(String providerConfigName) {
         if (StringUtils.isBlank(providerConfigName)) {
             return List.of();
@@ -151,7 +151,7 @@ public class DefaultProviderDataAccessor implements ProviderDataAccessor {
         return List.of();
     }
 
-    @Override
+    //    @Override
     public void updateProjectAndUserData(Long providerConfigId, Map<ProviderProject, Set<String>> projectToUserData, Set<String> additionalRelevantUsers) {
         updateProjectDB(providerConfigId, projectToUserData.keySet());
         Set<String> userData = projectToUserData.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProviderDataAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProviderDataAccessor.java
@@ -35,7 +35,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,7 +50,6 @@ import com.synopsys.integration.alert.database.provider.project.ProviderUserProj
 import com.synopsys.integration.alert.database.provider.user.ProviderUserEntity;
 import com.synopsys.integration.alert.database.provider.user.ProviderUserRepository;
 
-@Component
 @Transactional
 public class DefaultProviderDataAccessor {
     //implements ProviderDataAccessor {
@@ -73,7 +71,6 @@ public class DefaultProviderDataAccessor {
         this.configurationAccessor = configurationAccessor;
     }
 
-    //    @Override
     @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
     public List<ProviderProject> getProjectsByProviderConfigName(String providerConfigName) {
         try {
@@ -91,7 +88,6 @@ public class DefaultProviderDataAccessor {
         return List.of();
     }
 
-    //    @Override
     @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
     public List<ProviderProject> getProjectsByProviderConfigId(Long providerConfigId) {
         return providerProjectRepository.findByProviderConfigId(providerConfigId)
@@ -100,14 +96,12 @@ public class DefaultProviderDataAccessor {
                    .collect(Collectors.toList());
     }
 
-    //    @Override
     public void deleteProjects(Collection<ProviderProject> providerProjects) {
         providerProjects.forEach(project -> providerProjectRepository.deleteByHref(project.getHref()));
     }
 
-    //    @Override
     @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
-    public Set<String> getEmailAddressesForProjectHref(String projectHref) {
+    public Set<String> getEmailAddressesForProjectHref(Long providerConfigId, String projectHref) {
         Optional<Long> projectId = providerProjectRepository.findFirstByHref(projectHref).map(ProviderProjectEntity::getId);
         if (projectId.isPresent()) {
             Set<Long> userIds = providerUserProjectRelationRepository.findByProviderProjectId(projectId.get())
@@ -122,7 +116,6 @@ public class DefaultProviderDataAccessor {
         return Set.of();
     }
 
-    //    @Override
     @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
     public List<ProviderUserModel> getUsersByProviderConfigId(Long providerConfigId) {
         if (null == providerConfigId) {
@@ -134,7 +127,6 @@ public class DefaultProviderDataAccessor {
                    .collect(Collectors.toList());
     }
 
-    //    @Override
     public List<ProviderUserModel> getUsersByProviderConfigName(String providerConfigName) {
         if (StringUtils.isBlank(providerConfigName)) {
             return List.of();
@@ -151,7 +143,6 @@ public class DefaultProviderDataAccessor {
         return List.of();
     }
 
-    //    @Override
     public void updateProjectAndUserData(Long providerConfigId, Map<ProviderProject, Set<String>> projectToUserData, Set<String> additionalRelevantUsers) {
         updateProjectDB(providerConfigId, projectToUserData.keySet());
         Set<String> userData = projectToUserData.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProviderDataAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProviderDataAccessor.java
@@ -50,6 +50,7 @@ import com.synopsys.integration.alert.database.provider.project.ProviderUserProj
 import com.synopsys.integration.alert.database.provider.user.ProviderUserEntity;
 import com.synopsys.integration.alert.database.provider.user.ProviderUserRepository;
 
+@Deprecated(since = "6.4.0")
 @Transactional
 public class DefaultProviderDataAccessor {
     //implements ProviderDataAccessor {

--- a/alert-database/src/test/java/com/synopsys/integration/alert/database/api/DefaultProviderDataAccessorTest.java
+++ b/alert-database/src/test/java/com/synopsys/integration/alert/database/api/DefaultProviderDataAccessorTest.java
@@ -115,7 +115,7 @@ public class DefaultProviderDataAccessorTest {
         Mockito.when(providerUserRepository.findAllById(Mockito.any())).thenReturn(List.of(providerUserEntity));
 
         DefaultProviderDataAccessor providerDataAccessor = new DefaultProviderDataAccessor(providerProjectRepository, providerUserProjectRelationRepository, providerUserRepository, null);
-        Set<String> emailAddresses = providerDataAccessor.getEmailAddressesForProjectHref(href);
+        Set<String> emailAddresses = providerDataAccessor.getEmailAddressesForProjectHref(null, href);
 
         assertEquals(1, emailAddresses.size());
         assertTrue(emailAddresses.contains(projectOwnerEmail));
@@ -128,7 +128,7 @@ public class DefaultProviderDataAccessorTest {
         Mockito.when(providerProjectRepository.findFirstByHref(Mockito.any())).thenReturn(Optional.empty());
 
         DefaultProviderDataAccessor providerDataAccessor = new DefaultProviderDataAccessor(providerProjectRepository, null, null, null);
-        Set<String> emailAddresses = providerDataAccessor.getEmailAddressesForProjectHref("test-href");
+        Set<String> emailAddresses = providerDataAccessor.getEmailAddressesForProjectHref(null, "test-href");
 
         assertTrue(emailAddresses.isEmpty());
     }

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/email/EmailAddressHandler.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/email/EmailAddressHandler.java
@@ -93,7 +93,7 @@ public class EmailAddressHandler {
         return new FieldUtility(fieldMap);
     }
 
-    public Set<String> getEmailAddressesForProject(ProviderProject project, boolean projectOwnerOnly) {
+    public Set<String> getEmailAddressesForProject(Long providerConfigID, ProviderProject project, boolean projectOwnerOnly) {
         Set<String> emailAddresses;
         if (projectOwnerOnly) {
             String projectOwnerEmail = project.getProjectOwnerEmail();
@@ -103,7 +103,7 @@ public class EmailAddressHandler {
                 emailAddresses = Set.of();
             }
         } else {
-            emailAddresses = providerDataAccessor.getEmailAddressesForProjectHref(project.getHref());
+            emailAddresses = providerDataAccessor.getEmailAddressesForProjectHref(providerConfigID, project.getHref());
         }
         if (emailAddresses.isEmpty()) {
             logger.error("Could not find any email addresses for project: {}", project.getName());
@@ -131,7 +131,7 @@ public class EmailAddressHandler {
                                                         .filter(project -> project.getHref().equals(projectHref))
                                                         .findFirst();
         if (optionalProject.isPresent()) {
-            return getEmailAddressesForProject(optionalProject.get(), projectOwnerOnly);
+            return getEmailAddressesForProject(providerConfigId, optionalProject.get(), projectOwnerOnly);
         }
         return Set.of();
     }

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/email/EmailAddressHandler.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/email/EmailAddressHandler.java
@@ -93,7 +93,7 @@ public class EmailAddressHandler {
         return new FieldUtility(fieldMap);
     }
 
-    public Set<String> getEmailAddressesForProject(Long providerConfigID, ProviderProject project, boolean projectOwnerOnly) {
+    public Set<String> getEmailAddressesForProject(Long providerConfigId, ProviderProject project, boolean projectOwnerOnly) {
         Set<String> emailAddresses;
         if (projectOwnerOnly) {
             String projectOwnerEmail = project.getProjectOwnerEmail();
@@ -103,7 +103,7 @@ public class EmailAddressHandler {
                 emailAddresses = Set.of();
             }
         } else {
-            emailAddresses = providerDataAccessor.getEmailAddressesForProjectHref(providerConfigID, project.getHref());
+            emailAddresses = providerDataAccessor.getEmailAddressesForProjectHref(providerConfigId, project.getHref());
         }
         if (emailAddresses.isEmpty()) {
             logger.error("Could not find any email addresses for project: {}", project.getName());

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/email/actions/EmailActionHelper.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/email/actions/EmailActionHelper.java
@@ -32,8 +32,8 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
-import com.synopsys.integration.alert.channel.email.descriptor.EmailDescriptor;
 import com.synopsys.integration.alert.channel.email.EmailAddressHandler;
+import com.synopsys.integration.alert.channel.email.descriptor.EmailDescriptor;
 import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
 import com.synopsys.integration.alert.common.descriptor.config.ui.ProviderDistributionUIConfig;
 import com.synopsys.integration.alert.common.exception.AlertFieldException;
@@ -66,7 +66,7 @@ public class EmailActionHelper {
         if (null != providerConfigId && !onlyAdditionalEmails) {
             Set<ProviderProject> providerProjects = retrieveProviderProjects(fieldUtility, filterByProject, providerConfigId);
             if (null != providerProjects) {
-                Set<String> providerEmailAddresses = addEmailAddresses(providerProjects, fieldUtility);
+                Set<String> providerEmailAddresses = addEmailAddresses(providerConfigId, providerProjects, fieldUtility);
                 emailAddresses.addAll(providerEmailAddresses);
             }
         }
@@ -98,13 +98,13 @@ public class EmailActionHelper {
         return new HashSet<>(providerProjects);
     }
 
-    private Set<String> addEmailAddresses(Set<ProviderProject> providerProjects, FieldUtility fieldUtility) throws AlertFieldException {
+    private Set<String> addEmailAddresses(Long providerConfigId, Set<ProviderProject> providerProjects, FieldUtility fieldUtility) throws AlertFieldException {
         boolean projectOwnerOnly = fieldUtility.getBoolean(EmailDescriptor.KEY_PROJECT_OWNER_ONLY).orElse(false);
 
         Set<String> emailAddresses = new HashSet<>();
         Set<String> projectsWithoutEmails = new HashSet<>();
         for (ProviderProject project : providerProjects) {
-            Set<String> emailsForProject = emailAddressHandler.getEmailAddressesForProject(project, projectOwnerOnly);
+            Set<String> emailsForProject = emailAddressHandler.getEmailAddressesForProject(providerConfigId, project, projectOwnerOnly);
             if (emailsForProject.isEmpty()) {
                 projectsWithoutEmails.add(project.getName());
             }

--- a/provider/src/main/java/com/synopsys/integration/alert/database/api/BlackDuckProviderDataAccessor.java
+++ b/provider/src/main/java/com/synopsys/integration/alert/database/api/BlackDuckProviderDataAccessor.java
@@ -1,0 +1,223 @@
+/**
+ * provider
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.alert.database.api;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
+import com.synopsys.integration.alert.common.persistence.accessor.ProviderDataAccessor;
+import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
+import com.synopsys.integration.alert.common.persistence.model.ProviderProject;
+import com.synopsys.integration.alert.common.persistence.model.ProviderUserModel;
+import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
+import com.synopsys.integration.alert.provider.blackduck.factory.BlackDuckPropertiesFactory;
+import com.synopsys.integration.blackduck.api.generated.discovery.ApiDiscovery;
+import com.synopsys.integration.blackduck.api.generated.view.ProjectView;
+import com.synopsys.integration.blackduck.api.generated.view.UserView;
+import com.synopsys.integration.blackduck.http.client.BlackDuckHttpClient;
+import com.synopsys.integration.blackduck.service.BlackDuckService;
+import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
+import com.synopsys.integration.blackduck.service.dataservice.ProjectService;
+import com.synopsys.integration.blackduck.service.dataservice.ProjectUsersService;
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.log.IntLogger;
+import com.synopsys.integration.log.Slf4jIntLogger;
+import com.synopsys.integration.rest.HttpUrl;
+
+@Component
+public class BlackDuckProviderDataAccessor implements ProviderDataAccessor {
+    public static final int MAX_DESCRIPTION_LENGTH = 250;
+    public static final int MAX_PROJECT_NAME_LENGTH = 507;
+
+    private final IntLogger logger = new Slf4jIntLogger(LoggerFactory.getLogger(BlackDuckProviderDataAccessor.class));
+    private final ConfigurationAccessor configurationAccessor;
+    private final BlackDuckPropertiesFactory blackDuckPropertiesFactory;
+
+    @Autowired
+    public BlackDuckProviderDataAccessor(ConfigurationAccessor configurationAccessor, BlackDuckPropertiesFactory blackDuckPropertiesFactory) {
+        this.configurationAccessor = configurationAccessor;
+        this.blackDuckPropertiesFactory = blackDuckPropertiesFactory;
+    }
+
+    @Override
+    public List<ProviderProject> getProjectsByProviderConfigName(String providerConfigName) {
+        try {
+            Optional<ConfigurationModel> providerConfigOptional = configurationAccessor.getProviderConfigurationByName(providerConfigName);
+            if (providerConfigOptional.isPresent()) {
+                return getProjectsForProvider(providerConfigOptional.get());
+            }
+        } catch (IntegrationException e) {
+            logger.error(String.format("Could not get the project for the provider '%s'. %s", providerConfigName, e.getMessage()));
+            logger.debug(e.getMessage(), e);
+        }
+        return List.of();
+    }
+
+    @Override
+    public List<ProviderProject> getProjectsByProviderConfigId(Long providerConfigId) {
+        try {
+            Optional<ConfigurationModel> providerConfigOptional = configurationAccessor.getConfigurationById(providerConfigId);
+            if (providerConfigOptional.isPresent()) {
+                return getProjectsForProvider(providerConfigOptional.get());
+            }
+        } catch (IntegrationException e) {
+            logger.error(String.format("Could not get the project for the provider with id '%s'. %s", providerConfigId, e.getMessage()));
+            logger.debug(e.getMessage(), e);
+        }
+        return List.of();
+    }
+
+    private List<ProviderProject> getProjectsForProvider(ConfigurationModel blackDuckConfigurationModel) throws IntegrationException {
+        BlackDuckProperties properties = blackDuckPropertiesFactory.createProperties(blackDuckConfigurationModel);
+        BlackDuckHttpClient blackDuckHttpClient = properties.createBlackDuckHttpClient(logger);
+        BlackDuckServicesFactory blackDuckServicesFactory = properties.createBlackDuckServicesFactory(blackDuckHttpClient, logger);
+        ProjectService projectService = blackDuckServicesFactory.createProjectService();
+        List<ProjectView> allProjects = projectService.getAllProjects();
+        return convertBlackDuckProjects(allProjects, blackDuckServicesFactory.getBlackDuckService());
+    }
+
+    @Override
+    public void deleteProjects(Collection<ProviderProject> providerProjects) {
+        //ignored since we are not using the database
+    }
+
+    @Override
+    public Set<String> getEmailAddressesForProjectHref(Long providerConfigId, String projectHref) {
+        try {
+            Optional<ConfigurationModel> providerConfigOptional = configurationAccessor.getConfigurationById(providerConfigId);
+            if (providerConfigOptional.isPresent()) {
+                BlackDuckProperties properties = blackDuckPropertiesFactory.createProperties(providerConfigOptional.get());
+                BlackDuckHttpClient blackDuckHttpClient = properties.createBlackDuckHttpClient(logger);
+                BlackDuckServicesFactory blackDuckServicesFactory = properties.createBlackDuckServicesFactory(blackDuckHttpClient, logger);
+                BlackDuckService blackDuckService = blackDuckServicesFactory.getBlackDuckService();
+                ProjectView projectView = blackDuckService.getResponse(new HttpUrl(projectHref), ProjectView.class);
+                return getEmailAddressesForProject(projectView, blackDuckServicesFactory.createProjectUsersService());
+            }
+        } catch (IntegrationException e) {
+            logger.error(String.format("Could not get the project for the provider with id '%s'. %s", providerConfigId, e.getMessage()));
+            logger.debug(e.getMessage(), e);
+        }
+        return Set.of();
+    }
+
+    @Override
+    public List<ProviderUserModel> getUsersByProviderConfigId(Long providerConfigId) {
+        if (null == providerConfigId) {
+            return List.of();
+        }
+        try {
+            Optional<ConfigurationModel> providerConfigOptional = configurationAccessor.getConfigurationById(providerConfigId);
+            if (providerConfigOptional.isPresent()) {
+                return getEmailAddressesByProvider(providerConfigOptional.get());
+            }
+        } catch (IntegrationException e) {
+            logger.error(String.format("Could not get the project for the provider with id '%s'. %s", providerConfigId, e.getMessage()));
+            logger.debug(e.getMessage(), e);
+        }
+        return List.of();
+    }
+
+    @Override
+    public List<ProviderUserModel> getUsersByProviderConfigName(String providerConfigName) {
+        if (StringUtils.isBlank(providerConfigName)) {
+            return List.of();
+        }
+        try {
+            Optional<ConfigurationModel> providerConfigOptional = configurationAccessor.getProviderConfigurationByName(providerConfigName);
+            if (providerConfigOptional.isPresent()) {
+                return getEmailAddressesByProvider(providerConfigOptional.get());
+            }
+        } catch (IntegrationException e) {
+            logger.error(String.format("Could not get the project for the provider '%s'. %s", providerConfigName, e.getMessage()));
+            logger.debug(e.getMessage(), e);
+        }
+        return List.of();
+    }
+
+    private List<ProviderUserModel> getEmailAddressesByProvider(ConfigurationModel blackDuckConfiguration) throws IntegrationException {
+        BlackDuckProperties properties = blackDuckPropertiesFactory.createProperties(blackDuckConfiguration);
+        BlackDuckHttpClient blackDuckHttpClient = properties.createBlackDuckHttpClient(logger);
+        BlackDuckServicesFactory blackDuckServicesFactory = properties.createBlackDuckServicesFactory(blackDuckHttpClient, logger);
+        BlackDuckService blackDuckService = blackDuckServicesFactory.getBlackDuckService();
+        Set<String> allActiveBlackDuckUserEmailAddresses = getAllActiveBlackDuckUserEmailAddresses(blackDuckService);
+        return allActiveBlackDuckUserEmailAddresses.stream()
+                   .map(emailAddress -> new ProviderUserModel(emailAddress, false))
+                   .collect(Collectors.toList());
+    }
+
+    @Override
+    public void updateProjectAndUserData(Long providerConfigId, Map<ProviderProject, Set<String>> projectToUserData, Set<String> additionalRelevantUsers) {
+        //ignored since are not updating the database
+    }
+
+    private List<ProviderProject> convertBlackDuckProjects(List<ProjectView> projectViews, BlackDuckService blackDuckService) {
+        List<ProviderProject> providerProjects = new ArrayList<>();
+        projectViews
+            .parallelStream()
+            .forEach(projectView -> {
+                String projectOwnerEmail = null;
+                if (StringUtils.isNotBlank(projectView.getProjectOwner())) {
+                    try {
+                        HttpUrl projectOwnerHttpUrl = new HttpUrl(projectView.getProjectOwner());
+                        UserView projectOwner = blackDuckService.getResponse(projectOwnerHttpUrl, UserView.class);
+                        projectOwnerEmail = projectOwner.getEmail();
+                    } catch (IntegrationException e) {
+                        logger.error(String.format("Could not get the project owner for Project: %s. Error: %s", projectView.getName(), e.getMessage()), e);
+                    }
+                }
+                providerProjects.add(new ProviderProject(projectView.getName(), StringUtils.trimToEmpty(projectView.getDescription()), projectView.getMeta().getHref().toString(), projectOwnerEmail));
+            });
+        return providerProjects;
+    }
+
+    private Set<String> getEmailAddressesForProject(ProjectView projectView, ProjectUsersService projectUsersService) throws IntegrationException {
+        return projectUsersService.getAllActiveUsersForProject(projectView)
+                   .stream()
+                   .filter(UserView::getActive)
+                   .map(UserView::getEmail)
+                   .filter(StringUtils::isNotBlank)
+                   .collect(Collectors.toSet());
+
+    }
+
+    private Set<String> getAllActiveBlackDuckUserEmailAddresses(BlackDuckService blackDuckService) throws IntegrationException {
+        return blackDuckService.getAllResponses(ApiDiscovery.USERS_LINK_RESPONSE)
+                   .stream()
+                   .filter(UserView::getActive)
+                   .map(UserView::getEmail)
+                   .filter(StringUtils::isNotBlank)
+                   .collect(Collectors.toSet());
+    }
+
+}

--- a/provider/src/main/java/com/synopsys/integration/alert/database/api/BlackDuckProviderDataAccessor.java
+++ b/provider/src/main/java/com/synopsys/integration/alert/database/api/BlackDuckProviderDataAccessor.java
@@ -57,9 +57,6 @@ import com.synopsys.integration.rest.HttpUrl;
 
 @Component
 public class BlackDuckProviderDataAccessor implements ProviderDataAccessor {
-    public static final int MAX_DESCRIPTION_LENGTH = 250;
-    public static final int MAX_PROJECT_NAME_LENGTH = 507;
-
     private final IntLogger logger = new Slf4jIntLogger(LoggerFactory.getLogger(BlackDuckProviderDataAccessor.class));
     private final ConfigurationAccessor configurationAccessor;
     private final BlackDuckPropertiesFactory blackDuckPropertiesFactory;

--- a/provider/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckProviderDataAccessor.java
+++ b/provider/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckProviderDataAccessor.java
@@ -20,7 +20,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.synopsys.integration.alert.database.api;
+package com.synopsys.integration.alert.provider.blackduck;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,7 +40,6 @@ import com.synopsys.integration.alert.common.persistence.accessor.ProviderDataAc
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
 import com.synopsys.integration.alert.common.persistence.model.ProviderProject;
 import com.synopsys.integration.alert.common.persistence.model.ProviderUserModel;
-import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
 import com.synopsys.integration.alert.provider.blackduck.factory.BlackDuckPropertiesFactory;
 import com.synopsys.integration.blackduck.api.generated.discovery.ApiDiscovery;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectView;

--- a/provider/src/test/java/com/synopsys/integration/alert/provider/blackduck/mock/MockProviderDataAccessor.java
+++ b/provider/src/test/java/com/synopsys/integration/alert/provider/blackduck/mock/MockProviderDataAccessor.java
@@ -68,7 +68,7 @@ public final class MockProviderDataAccessor implements ProviderDataAccessor {
     }
 
     @Override
-    public Set<String> getEmailAddressesForProjectHref(String href) {
+    public Set<String> getEmailAddressesForProjectHref(Long providerConfigId, String href) {
         // This will just be gotten/set by tests
         return expectedEmailAddresses;
     }

--- a/src/test/java/com/synopsys/integration/alert/channel/email/EmailChannelChannelDescriptorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/email/EmailChannelChannelDescriptorTestIT.java
@@ -39,6 +39,7 @@ import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.common.message.model.MessageContentGroup;
 import com.synopsys.integration.alert.common.message.model.ProviderMessageContent;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldUtility;
+import com.synopsys.integration.alert.common.persistence.accessor.ProviderDataAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
 import com.synopsys.integration.alert.common.persistence.model.DefinedFieldModel;
@@ -71,7 +72,7 @@ public class EmailChannelChannelDescriptorTestIT extends ChannelDescriptorTestIT
     public static final String UNIT_TEST_PROJECT_NAME = "TestProject1";
     private static final String EMAIL_TEST_PROVIDER_CONFIG_NAME = "emailTestProviderConfig";
     @Autowired
-    private DefaultProviderDataAccessor providerDataAccessor;
+    private ProviderDataAccessor providerDataAccessor;
     @Autowired
     private ProviderProjectRepository providerProjectRepository;
     @Autowired

--- a/src/test/java/com/synopsys/integration/alert/channel/email/EmailChannelTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/email/EmailChannelTestIT.java
@@ -26,9 +26,9 @@ import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.common.message.model.MessageContentGroup;
 import com.synopsys.integration.alert.common.message.model.ProviderMessageContent;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldUtility;
+import com.synopsys.integration.alert.common.persistence.accessor.ProviderDataAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.database.api.DefaultAuditAccessor;
-import com.synopsys.integration.alert.database.api.DefaultProviderDataAccessor;
 import com.synopsys.integration.alert.descriptor.api.BlackDuckProviderKey;
 import com.synopsys.integration.alert.descriptor.api.EmailChannelKey;
 import com.synopsys.integration.alert.util.TestAlertProperties;
@@ -46,7 +46,7 @@ public class EmailChannelTestIT extends AbstractChannelTest {
     public void sendEmailTest() throws Exception {
         DefaultAuditAccessor auditUtility = Mockito.mock(DefaultAuditAccessor.class);
         TestAlertProperties testAlertProperties = new TestAlertProperties();
-        EmailAddressHandler emailAddressHandler = new EmailAddressHandler(Mockito.mock(DefaultProviderDataAccessor.class));
+        EmailAddressHandler emailAddressHandler = new EmailAddressHandler(Mockito.mock(ProviderDataAccessor.class));
 
         FreemarkerTemplatingService freemarkerTemplatingService = new FreemarkerTemplatingService();
         EmailChannelMessageParser emailChannelMessageParser = new EmailChannelMessageParser();

--- a/src/test/java/com/synopsys/integration/alert/channel/email/EmailGlobalTestActionTest.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/email/EmailGlobalTestActionTest.java
@@ -37,13 +37,13 @@ import com.synopsys.integration.alert.common.enumeration.EmailPropertyKeys;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.common.message.model.MessageContentGroup;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldUtility;
+import com.synopsys.integration.alert.common.persistence.accessor.ProviderDataAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
 import com.synopsys.integration.alert.common.security.EncryptionUtility;
 import com.synopsys.integration.alert.common.util.DataStructureUtils;
 import com.synopsys.integration.alert.database.api.DefaultAuditAccessor;
-import com.synopsys.integration.alert.database.api.DefaultProviderDataAccessor;
 import com.synopsys.integration.alert.descriptor.api.EmailChannelKey;
 import com.synopsys.integration.alert.util.TestAlertProperties;
 import com.synopsys.integration.alert.util.TestProperties;
@@ -188,7 +188,7 @@ public class EmailGlobalTestActionTest {
 
         TestAlertProperties testAlertProperties = new TestAlertProperties();
 
-        EmailAddressHandler emailAddressHandler = new EmailAddressHandler(Mockito.mock(DefaultProviderDataAccessor.class));
+        EmailAddressHandler emailAddressHandler = new EmailAddressHandler(Mockito.mock(ProviderDataAccessor.class));
         FreemarkerTemplatingService freemarkerTemplatingService = new FreemarkerTemplatingService();
         EmailChannelMessageParser emailChannelMessageParser = new EmailChannelMessageParser();
 

--- a/src/test/java/com/synopsys/integration/alert/database/api/ProviderDataAccessorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/database/api/ProviderDataAccessorTestIT.java
@@ -50,6 +50,7 @@ public class ProviderDataAccessorTestIT extends AlertIntegrationTest {
         return new ProviderKey(key, key);
     }
 
+    //TODO delete this test
     @Test
     public void deleteAndSaveAllProjectsTest() {
         Long providerConfigId = 10000L;
@@ -90,6 +91,7 @@ public class ProviderDataAccessorTestIT extends AlertIntegrationTest {
         assertEquals(2, savedEntities.size());
     }
 
+    //TODO update this test to use the new BlackDuckProviderDataAccessor
     @Test
     public void getEmailAddressesForProjectHrefTest() {
         Long providerConfigId = 10000L;
@@ -116,20 +118,22 @@ public class ProviderDataAccessorTestIT extends AlertIntegrationTest {
         providerUserProjectRelationRepository.save(new ProviderUserProjectRelation(savedUser4.getId(), projectId));
 
         DefaultProviderDataAccessor providerDataAccessor = new DefaultProviderDataAccessor(providerProjectRepository, providerUserProjectRelationRepository, providerUserRepository, configurationAccessor);
-        Set<String> foundEmailAddresses = providerDataAccessor.getEmailAddressesForProjectHref(href);
+        Set<String> foundEmailAddresses = providerDataAccessor.getEmailAddressesForProjectHref(null, href);
         assertEquals(3, foundEmailAddresses.size());
         assertTrue(foundEmailAddresses.contains(emailAddress1), "Expected email address was missing: " + emailAddress1);
         assertTrue(foundEmailAddresses.contains(emailAddress2), "Expected email address was missing: " + emailAddress1);
         assertTrue(foundEmailAddresses.contains(emailAddress3), "Expected email address was missing: " + emailAddress1);
     }
 
+    //TODO update this test to use the new BlackDuckProviderDataAccessor
     @Test
     public void getEmailAddressesForNonExistentProjectHrefTest() {
         DefaultProviderDataAccessor providerDataAccessor = new DefaultProviderDataAccessor(providerProjectRepository, providerUserProjectRelationRepository, providerUserRepository, configurationAccessor);
-        Set<String> foundEmailAddresses = providerDataAccessor.getEmailAddressesForProjectHref("expecting no results");
+        Set<String> foundEmailAddresses = providerDataAccessor.getEmailAddressesForProjectHref(null, "expecting no results");
         assertEquals(0, foundEmailAddresses.size());
     }
 
+    //TODO update this test to use the new BlackDuckProviderDataAccessor
     @Test
     public void getAllUsersTest() {
         Long providerConfigId = 10000L;
@@ -148,6 +152,7 @@ public class ProviderDataAccessorTestIT extends AlertIntegrationTest {
         assertEquals(3, allProviderUsers.size());
     }
 
+    //TODO update this test to use the new BlackDuckProviderDataAccessor
     @Test
     public void deleteAndSaveAllUsersTest() {
         Long providerConfigId = 10000L;


### PR DESCRIPTION
- Retrieve the Black Duck data on demand, instead of syncing the Black Duck data with the Alert database

**Changes proposed in this pull request:**

* Leave the old DefaultProviderDataAccessor in place in case we need to switch back to it
* Add a new BlackDuckProviderDataAccessor to replace the DefaultProviderDataAccessor
* The BlackDuckProviderDataAccessor will retrieve the Project and User data from Black Duck as needed