### PR TITLE
Fix back-end errors coming up as success messages in the UI

### DIFF
--- a/ui/src/main/js/store/actions/distributionConfigs.js
+++ b/ui/src/main/js/store/actions/distributionConfigs.js
@@ -245,8 +245,8 @@ export function testDistributionJob(config) {
                         ...responseData
                     });
                     const handler = createErrorHandler(DISTRIBUTION_JOB_TEST_FAILURE, defaultHandler);
-                    const containsErrors = HTTPErrorUtils.hasErrors(responseData.errors);
-                    if (!containsErrors) {
+                    const hasErrors = HTTPErrorUtils.containsErrors(responseData);
+                    if (!hasErrors) {
                         dispatch(testJobSuccess(responseData));
                     } else if (!response.ok) {
                         dispatch(handler(response.status));

--- a/ui/src/main/js/util/httpErrorUtilities.js
+++ b/ui/src/main/js/util/httpErrorUtilities.js
@@ -46,12 +46,20 @@ export function combineErrorObjects(errorObject1, errorObject2) {
     };
 }
 
-export function hasErrors(errorObject) {
-    if (!errorObject) {
+export function containsErrors(responseObject) {
+    if (!responseObject) {
         return false;
     }
-    const keys = Object.keys(errorObject);
-    return keys.some((key) => errorObject[key].severity === 'ERROR');
+    const { hasErrors, errors } = responseObject;
+
+    if (hasErrors) {
+        const keys = Object.keys(errors);
+        // Test that the error object isn't empty and contains at least one error
+        if (keys && keys.length > 0) {
+            return keys.some((key) => errors[key].severity === 'ERROR');
+        }
+    }
+    return hasErrors;
 }
 
 export function createStatusCodeHandler(statusCode, callback) {


### PR DESCRIPTION
containsErrors now checks to see if there are errors in the list and modifies the hasErrors field from the response object. This way it will throw an error message if at least one of the messages has a severity of error. Likewise, if there are no severities as in the case of a backend test message it will continue to return the hasErrors field. I've also verified this is working correctly in the case of an error and warning produced at the same time.