### PR TITLE
Fix unauthorized users logging into Alert

### DIFF
--- a/component/src/main/java/com/synopsys/integration/alert/component/authentication/web/AuthenticationActions.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/authentication/web/AuthenticationActions.java
@@ -46,7 +46,7 @@ import com.synopsys.integration.alert.component.authentication.security.AlertAut
 
 @Component
 public class AuthenticationActions {
-    private Logger logger = LoggerFactory.getLogger(AuthenticationActions.class);
+    private final Logger logger = LoggerFactory.getLogger(AuthenticationActions.class);
     private final AlertAuthenticationProvider authenticationProvider;
     private final PasswordResetService passwordResetService;
     private final CsrfTokenRepository csrfTokenRepository;
@@ -70,6 +70,8 @@ public class AuthenticationActions {
                 csrfTokenRepository.saveToken(token, servletRequest, servletResponse);
                 servletResponse.setHeader(token.getHeaderName(), token.getToken());
                 response = new ActionResponse<>(HttpStatus.NO_CONTENT);
+            } else {
+                servletRequest.getSession().invalidate();
             }
         } catch (AuthenticationException ex) {
             logger.error("Error Authenticating user.", ex);

--- a/web/src/main/java/com/synopsys/integration/alert/web/api/home/HomeActions.java
+++ b/web/src/main/java/com/synopsys/integration/alert/web/api/home/HomeActions.java
@@ -55,7 +55,7 @@ public class HomeActions {
         boolean isAnonymous = authentication.getAuthorities().stream()
                                   .map(GrantedAuthority::getAuthority)
                                   .anyMatch(authority -> authority.equals(ROLE_ANONYMOUS));
-        boolean authorized = authentication.isAuthenticated() && !isAnonymous && csrfToken != null;
+        boolean authorized = authentication.isAuthenticated() && !isAnonymous && csrfToken != null && !authentication.getAuthorities().isEmpty();
 
         if (!authorized) {
             servletRequest.getSession().invalidate();


### PR DESCRIPTION
Fixed an issue where users who do not have a role set are able to still log into Alert by refreshing the page.  We have validated this for regular alert users as well as SAML and LDAP.