### PR TITLE
Change ConfigurationFieldModelConverter to throw a Runtime exception

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/util/ConfigurationFieldModelConverter.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/util/ConfigurationFieldModelConverter.java
@@ -168,16 +168,14 @@ public class ConfigurationFieldModelConverter {
     }
 
     private String getDescriptorName(ConfigurationModel configurationModel) {
-        String descriptorName;
         try {
-            descriptorName = descriptorAccessor.getRegisteredDescriptorById(configurationModel.getDescriptorId())
-                                 .map(RegisteredDescriptorModel::getName)
-                                 .orElseThrow(() -> new AlertRuntimeException(MISSING_REGISTERED_DESCRIPTOR_MESSAGE));
+            return descriptorAccessor.getRegisteredDescriptorById(configurationModel.getDescriptorId())
+                       .map(RegisteredDescriptorModel::getName)
+                       .orElseThrow(() -> new AlertRuntimeException(MISSING_REGISTERED_DESCRIPTOR_MESSAGE));
         } catch (AlertDatabaseConstraintException e) {
             logger.debug(e.getMessage());
             throw new AlertRuntimeException(MISSING_REGISTERED_DESCRIPTOR_MESSAGE);
         }
-        return descriptorName;
     }
 
 }

--- a/src/test/java/com/synopsys/integration/alert/web/api/job/JobConfigActionsTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/api/job/JobConfigActionsTest.java
@@ -152,7 +152,7 @@ public class JobConfigActionsTest {
         int pageSize = 10;
         RegisteredDescriptorModel registeredDescriptorModel = new RegisteredDescriptorModel(1L, "descriptorName", descriptorType.name());
         AlertPagedModel<ConfigurationJobModel> pageOfJobs = new AlertPagedModel(totalPages, pageNumber, pageSize, List.of(configurationJobModel));
-        
+
         Mockito.when(descriptorAccessor.getRegisteredDescriptors()).thenReturn(List.of(registeredDescriptorModel));
         Mockito.when(jobAccessor.getPageOfJobs(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyCollection())).thenReturn(pageOfJobs);
         Mockito.when(configurationFieldModelConverter.convertToFieldModel(Mockito.any())).thenReturn(fieldModel);
@@ -162,25 +162,6 @@ public class JobConfigActionsTest {
         assertTrue(jobPagedModelActionResponse.isSuccessful());
         assertTrue(jobPagedModelActionResponse.hasContent());
         assertEquals(HttpStatus.OK, jobPagedModelActionResponse.getHttpStatus());
-    }
-
-    @Test
-    public void getPageServerErrorTest() throws Exception {
-        int totalPages = 1;
-        int pageNumber = 0;
-        int pageSize = 10;
-        RegisteredDescriptorModel registeredDescriptorModel = new RegisteredDescriptorModel(1L, "descriptorName", descriptorType.name());
-        AlertPagedModel<ConfigurationJobModel> pageOfJobs = new AlertPagedModel(totalPages, pageNumber, pageSize, List.of(configurationJobModel));
-
-        Mockito.when(descriptorAccessor.getRegisteredDescriptors()).thenReturn(List.of(registeredDescriptorModel));
-        Mockito.when(jobAccessor.getPageOfJobs(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyCollection())).thenReturn(pageOfJobs);
-        Mockito.doThrow(new AlertDatabaseConstraintException("Exception for Alert tests")).when(configurationFieldModelConverter).convertToFieldModel(Mockito.any());
-
-        ActionResponse<JobPagedModel> jobPagedModelActionResponse = jobConfigActions.getPage(pageNumber, pageSize, "");
-
-        assertTrue(jobPagedModelActionResponse.isError());
-        assertFalse(jobPagedModelActionResponse.hasContent());
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, jobPagedModelActionResponse.getHttpStatus());
     }
 
     @Test
@@ -197,7 +178,7 @@ public class JobConfigActionsTest {
     @Test
     public void getOneErrorTest() throws Exception {
         Mockito.when(jobAccessor.getJobById(Mockito.any())).thenReturn(Optional.of(configurationJobModel));
-        Mockito.doThrow(new AlertDatabaseConstraintException("Exception for Alert")).when(configurationFieldModelConverter).convertToFieldModel(Mockito.any());
+        Mockito.doThrow(new AlertException("Exception for Alert")).when(fieldModelProcessor).performAfterReadAction(Mockito.any());
 
         ActionResponse<JobFieldModel> jobFieldModelActionResponse = jobConfigActions.getOne(jobId);
 
@@ -545,7 +526,7 @@ public class JobConfigActionsTest {
         Mockito.when(authorizationManager.anyReadPermission(Mockito.any())).thenReturn(true);
         Mockito.when(jobAccessor.getJobsById(Mockito.any())).thenReturn(List.of(configurationJobModel));
 
-        Mockito.doThrow(new AlertDatabaseConstraintException("Exception for Alert test")).when(configurationFieldModelConverter).convertToFieldModel(Mockito.any());
+        Mockito.doThrow(new AlertException("Exception for Alert test")).when(fieldModelProcessor).performAfterReadAction(Mockito.any());
 
         ActionResponse<List<JobFieldStatuses>> actionResponse = jobConfigActions.validateJobsById(jobIdsValidationRequestModel);
 

--- a/web/src/main/java/com/synopsys/integration/alert/web/api/config/ConfigActions.java
+++ b/web/src/main/java/com/synopsys/integration/alert/web/api/config/ConfigActions.java
@@ -112,12 +112,8 @@ public class ConfigActions extends AbstractConfigResourceActions {
         List<FieldModel> fieldModelList = new LinkedList<>();
         if (null != configurationModels) {
             for (ConfigurationModel configurationModel : configurationModels) {
-                try {
-                    FieldModel fieldModel = modelConverter.convertToFieldModel(configurationModel);
-                    fieldModelList.add(fieldModel);
-                } catch (AlertDatabaseConstraintException ex) {
-                    logger.error("Error converting to field model", ex);
-                }
+                FieldModel fieldModel = modelConverter.convertToFieldModel(configurationModel);
+                fieldModelList.add(fieldModel);
             }
         }
         if (fieldModelList.isEmpty()) {

--- a/web/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigActions.java
+++ b/web/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigActions.java
@@ -118,21 +118,16 @@ public class JobConfigActions extends AbstractJobResourceActions {
 
     @Override
     public final ActionResponse<JobPagedModel> readPageWithoutChecks(Integer pageNumber, Integer pageSize, String searchTerm, Collection<String> permittedDescriptorsForSession) {
-        try {
-            AlertPagedModel<ConfigurationJobModel> pageOfJobs = jobAccessor.getPageOfJobs(pageNumber, pageSize, searchTerm, permittedDescriptorsForSession);
-            List<ConfigurationJobModel> pageOfJobsModels = pageOfJobs.getModels();
-            List<JobFieldModel> jobFieldModels = new ArrayList<>(pageOfJobsModels.size());
-            for (ConfigurationJobModel configJobModel : pageOfJobsModels) {
-                JobFieldModel jobFieldModel = convertToJobFieldModel(configJobModel);
-                jobFieldModels.add(jobFieldModel);
-            }
-
-            JobPagedModel jobPagedModel = new JobPagedModel(pageOfJobs.getTotalPages(), pageOfJobs.getCurrentPage(), pageOfJobs.getPageSize(), jobFieldModels);
-            return new ActionResponse<>(HttpStatus.OK, jobPagedModel);
-        } catch (AlertDatabaseConstraintException e) {
-            logger.error("Failed to get a page of jobs", e);
-            return new ActionResponse<>(HttpStatus.INTERNAL_SERVER_ERROR, "There was a problem retrieving the jobs from the database");
+        AlertPagedModel<ConfigurationJobModel> pageOfJobs = jobAccessor.getPageOfJobs(pageNumber, pageSize, searchTerm, permittedDescriptorsForSession);
+        List<ConfigurationJobModel> pageOfJobsModels = pageOfJobs.getModels();
+        List<JobFieldModel> jobFieldModels = new ArrayList<>(pageOfJobsModels.size());
+        for (ConfigurationJobModel configJobModel : pageOfJobsModels) {
+            JobFieldModel jobFieldModel = convertToJobFieldModel(configJobModel);
+            jobFieldModels.add(jobFieldModel);
         }
+
+        JobPagedModel jobPagedModel = new JobPagedModel(pageOfJobs.getTotalPages(), pageOfJobs.getCurrentPage(), pageOfJobs.getPageSize(), jobFieldModels);
+        return new ActionResponse<>(HttpStatus.OK, jobPagedModel);
     }
 
     @Override
@@ -465,7 +460,7 @@ public class JobConfigActions extends AbstractJobResourceActions {
         return new MessageResult("Provider Config Valid");
     }
 
-    private JobFieldModel convertToJobFieldModel(ConfigurationJobModel configurationJobModel) throws AlertDatabaseConstraintException {
+    private JobFieldModel convertToJobFieldModel(ConfigurationJobModel configurationJobModel) {
         Set<FieldModel> constructedFieldModels = new HashSet<>();
         for (ConfigurationModel configurationModel : configurationJobModel.getCopyOfConfigurations()) {
             constructedFieldModels.add(modelConverter.convertToFieldModel(configurationModel));


### PR DESCRIPTION
Per IALERT-2011, we want to change ConfigurationFieldModelConverter.getDescriptorName to throw a runtime exception rather than an AlertDatabaseConstraintException. We do not want this exception because if we trace it up to where the ConfigurationModel that is being passed in comes from, it will come from a database read where an option check has already been performed (in DefaultDescriptorGlobalConfigUtility). 
