### PR TITLE
Include href in provider projects table (hidden)

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/endpoint/table/TableSelectColumn.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/endpoint/table/TableSelectColumn.java
@@ -25,16 +25,26 @@ package com.synopsys.integration.alert.common.descriptor.config.field.endpoint.t
 import com.synopsys.integration.alert.common.rest.model.AlertSerializableModelComponent;
 
 public class TableSelectColumn extends AlertSerializableModelComponent {
-    private String header;
-    private String headerLabel;
-    private boolean isKey;
-    private boolean sortBy;
+    private final String header;
+    private final String headerLabel;
+    private final boolean isKey;
+    private final boolean sortBy;
+    private final boolean hidden;
 
-    public TableSelectColumn(String header, String headerLabel, boolean isKey, boolean sortBy) {
+    public static TableSelectColumn visible(String header, String headerLabel, boolean isKey, boolean sortBy) {
+        return new TableSelectColumn(header, headerLabel, isKey, sortBy, false);
+    }
+
+    public static TableSelectColumn hidden(String header, String headerLabel, boolean isKey, boolean sortBy) {
+        return new TableSelectColumn(header, headerLabel, isKey, sortBy, true);
+    }
+
+    public TableSelectColumn(String header, String headerLabel, boolean isKey, boolean sortBy, boolean hidden) {
         this.header = header;
         this.headerLabel = headerLabel;
         this.isKey = isKey;
         this.sortBy = sortBy;
+        this.hidden = hidden;
     }
 
     public String getHeader() {
@@ -51,6 +61,10 @@ public class TableSelectColumn extends AlertSerializableModelComponent {
 
     public boolean isSortBy() {
         return sortBy;
+    }
+
+    public boolean isHidden() {
+        return hidden;
     }
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/endpoint/table/model/ProviderProjectSelectOption.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/field/endpoint/table/model/ProviderProjectSelectOption.java
@@ -26,15 +26,21 @@ import com.synopsys.integration.alert.common.rest.model.AlertSerializableModel;
 
 public class ProviderProjectSelectOption extends AlertSerializableModel {
     private final String name;
+    private final String href;
     private final String description;
 
-    public ProviderProjectSelectOption(String name, String description) {
+    public ProviderProjectSelectOption(String name, String href, String description) {
         this.name = name;
+        this.href = href;
         this.description = description;
     }
 
     public String getName() {
         return name;
+    }
+
+    public String getHref() {
+        return href;
     }
 
     public String getDescription() {

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderDistributionUIConfig.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ui/ProviderDistributionUIConfig.java
@@ -111,8 +111,9 @@ public abstract class ProviderDistributionUIConfig extends UIConfig {
         ConfigField configuredProject = new EndpointTableSelectField(KEY_CONFIGURED_PROJECT, LABEL_PROJECTS, DESCRIPTION_PROJECTS)
                                             .applyPaged(true)
                                             .applySearchable(true)
-                                            .applyColumn(new TableSelectColumn("name", "Project Name", true, true))
-                                            .applyColumn(new TableSelectColumn("description", "Project Description", false, false))
+                                            .applyColumn(TableSelectColumn.visible("name", "Project Name", true, true))
+                                            .applyColumn(TableSelectColumn.hidden("href", "Project URL", false, false))
+                                            .applyColumn(TableSelectColumn.visible("description", "Project Description", false, false))
                                             .applyRequiredRelatedField(ChannelDistributionUIConfig.KEY_PROVIDER_NAME)
                                             .applyRequiredRelatedField(ProviderDescriptor.KEY_PROVIDER_CONFIG_ID)
                                             .applyValidationFunctions(this::validateConfiguredProject);

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/email/descriptor/EmailDistributionUIConfig.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/email/descriptor/EmailDistributionUIConfig.java
@@ -67,7 +67,7 @@ public class EmailDistributionUIConfig extends ChannelDistributionUIConfig {
     public List<ConfigField> createChannelDistributionFields() {
         ConfigField subjectLine = new TextInputConfigField(EmailDescriptor.KEY_SUBJECT_LINE, LABEL_SUBJECT_LINE, DESCRIPTION_EMAIL_SUBJECT_LINE);
         ConfigField additionalEmailAddresses = new EndpointTableSelectField(EmailDescriptor.KEY_EMAIL_ADDITIONAL_ADDRESSES, LABEL_ADDITIONAL_ADDRESSES, DESCRIPTION_ADDITIONAL_ADDRESSES)
-                                                   .applyColumn(new TableSelectColumn("emailAddress", "Email Address", true, true))
+                                                   .applyColumn(TableSelectColumn.visible("emailAddress", "Email Address", true, true))
                                                    .applySearchable(true)
                                                    .applyPaged(true)
                                                    .applyRequiredRelatedField(ChannelDistributionUIConfig.KEY_PROVIDER_NAME)

--- a/provider/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckDistributionUIConfig.java
+++ b/provider/src/main/java/com/synopsys/integration/alert/provider/blackduck/descriptor/BlackDuckDistributionUIConfig.java
@@ -55,7 +55,7 @@ public class BlackDuckDistributionUIConfig extends ProviderDistributionUIConfig 
     public List<ConfigField> createProviderDistributionFields() {
         ConfigField policyNotificationTypeFilter = new EndpointTableSelectField(BlackDuckDescriptor.KEY_BLACKDUCK_POLICY_NOTIFICATION_TYPE_FILTER, LABEL_BLACKDUCK_POLICY_NOTIFICATION_TYPE_FILTER,
             DESCRIPTION_BLACKDUCK_POLICY_NOTIFICATION_TYPE_FILTER)
-                                                       .applyColumn(new TableSelectColumn("name", "Name", true, true))
+                                                       .applyColumn(TableSelectColumn.visible("name", "Name", true, true))
                                                        .applyPaged(true)
                                                        .applyRequiredRelatedField(ProviderDistributionUIConfig.KEY_NOTIFICATION_TYPES)
                                                        .applyRequiredRelatedField(ChannelDistributionUIConfig.KEY_PROVIDER_NAME)

--- a/ui/src/main/js/field/input/TableSelectInput.js
+++ b/ui/src/main/js/field/input/TableSelectInput.js
@@ -332,6 +332,7 @@ class TableSelectInput extends Component {
                 columnClassName="tableCell"
                 tdStyle={{ whiteSpace: 'normal' }}
                 dataFormat={assignDataFormat}
+                hidden={column.hidden}
             >
                 {column.headerLabel}
             </TableHeaderColumn>

--- a/web/src/main/java/com/synopsys/integration/alert/web/api/provider/project/ProviderProjectCustomFunctionAction.java
+++ b/web/src/main/java/com/synopsys/integration/alert/web/api/provider/project/ProviderProjectCustomFunctionAction.java
@@ -76,7 +76,7 @@ public class ProviderProjectCustomFunctionAction extends PagedCustomFunctionActi
         AlertPagedModel<ProviderProject> providerProjectsPage = providerDataAccessor.getProjectsByProviderConfigId(blackDuckGlobalConfigId, pageNumber, pageSize, searchTerm);
         List<ProviderProjectSelectOption> options = providerProjectsPage.getModels()
                                                         .stream()
-                                                        .map(project -> new ProviderProjectSelectOption(project.getName(), project.getDescription()))
+                                                        .map(project -> new ProviderProjectSelectOption(project.getName(), project.getHref(), project.getDescription()))
                                                         .collect(Collectors.toList());
         return new ActionResponse<>(HttpStatus.OK, new ProviderProjectOptions(providerProjectsPage.getTotalPages(), providerProjectsPage.getCurrentPage(), providerProjectsPage.getPageSize(), options));
     }


### PR DESCRIPTION
Allow hidden columns to be defined through code and add hidden href column for provider projects.

This is a prelude to saving the href on the back-end.