### PR TITLE
Request all job-audit data at once

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/accessor/AuditAccessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/accessor/AuditAccessor.java
@@ -23,6 +23,7 @@
 package com.synopsys.integration.alert.common.descriptor.accessor;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -39,6 +40,8 @@ public interface AuditAccessor {
 
     Optional<AuditJobStatusModel> findFirstByJobId(UUID jobId);
 
+    List<AuditJobStatusModel> findByJobIds(Collection<UUID> jobIds);
+
     AuditEntryPageModel getPageOfAuditEntries(Integer pageNumber, Integer pageSize, String searchTerm, String sortField, String sortOrder, boolean onlyShowSentNotifications,
         Function<AlertNotificationModel, AuditEntryModel> notificationToAuditEntryConverter);
 
@@ -49,4 +52,5 @@ public interface AuditAccessor {
     void setAuditEntryFailure(Collection<Long> auditEntryIds, String errorMessage, Throwable t);
 
     AuditEntryModel convertToAuditEntryModelFromNotification(AlertNotificationModel notificationContentEntry);
+
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/AuditJobStatusModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/AuditJobStatusModel.java
@@ -22,9 +22,12 @@
  */
 package com.synopsys.integration.alert.common.persistence.model;
 
+import java.util.UUID;
+
 import com.synopsys.integration.alert.common.rest.model.AlertSerializableModel;
 
 public class AuditJobStatusModel extends AlertSerializableModel {
+    private UUID jobId;
     private String timeAuditCreated;
     private String timeLastSent;
     private String status;
@@ -32,10 +35,15 @@ public class AuditJobStatusModel extends AlertSerializableModel {
     public AuditJobStatusModel() {
     }
 
-    public AuditJobStatusModel(String timeAuditCreated, String timeLastSent, String status) {
+    public AuditJobStatusModel(UUID jobId, String timeAuditCreated, String timeLastSent, String status) {
+        this.jobId = jobId;
         this.timeAuditCreated = timeAuditCreated;
         this.timeLastSent = timeLastSent;
         this.status = status;
+    }
+
+    public UUID getJobId() {
+        return jobId;
     }
 
     public String getTimeAuditCreated() {

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/model/AuditJobStatusesModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/model/AuditJobStatusesModel.java
@@ -1,0 +1,45 @@
+/**
+ * alert-common
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.alert.common.rest.model;
+
+import java.util.List;
+
+import com.synopsys.integration.alert.common.persistence.model.AuditJobStatusModel;
+
+public class AuditJobStatusesModel extends AlertSerializableModel {
+    private final List<AuditJobStatusModel> statuses;
+
+    public AuditJobStatusesModel() {
+        // For serialization
+        this.statuses = List.of();
+    }
+
+    public AuditJobStatusesModel(List<AuditJobStatusModel> statuses) {
+        this.statuses = statuses;
+    }
+
+    public List<AuditJobStatusModel> getStatuses() {
+        return statuses;
+    }
+
+}

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/model/JobIdsRequestModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/model/JobIdsRequestModel.java
@@ -25,14 +25,14 @@ package com.synopsys.integration.alert.common.rest.model;
 import java.util.List;
 import java.util.UUID;
 
-public class JobIdsValidationRequestModel extends AlertSerializableModel {
+public class JobIdsRequestModel extends AlertSerializableModel {
     private List<UUID> jobIds;
 
-    public JobIdsValidationRequestModel() {
+    public JobIdsRequestModel() {
         // For serialization
     }
 
-    public JobIdsValidationRequestModel(List<UUID> jobIds) {
+    public JobIdsRequestModel(List<UUID> jobIds) {
         this.jobIds = jobIds;
     }
 

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultAuditAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultAuditAccessor.java
@@ -39,13 +39,13 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.jetbrains.annotations.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -106,6 +106,15 @@ public class DefaultAuditAccessor implements AuditAccessor {
     public Optional<AuditJobStatusModel> findFirstByJobId(UUID jobId) {
         Optional<AuditEntryEntity> auditEntryEntity = auditEntryRepository.findFirstByCommonConfigIdOrderByTimeLastSentDesc(jobId);
         return auditEntryEntity.map(this::convertToJobStatusModel);
+    }
+
+    @Override
+    @Transactional
+    public List<AuditJobStatusModel> findByJobIds(Collection<UUID> jobIds) {
+        return auditEntryRepository.findAllByCommonConfigIdInOrderByTimeLastSentDesc(jobIds)
+                   .stream()
+                   .map(this::convertToJobStatusModel)
+                   .collect(Collectors.toList());
     }
 
     @Override
@@ -226,14 +235,14 @@ public class DefaultAuditAccessor implements AuditAccessor {
         OffsetDateTime timeLastSentOffsetDateTime = null;
         List<JobAuditModel> jobAuditModels = new ArrayList<>();
         for (AuditEntryEntity auditEntryEntity : auditEntryEntities) {
-            UUID commonConfigId = auditEntryEntity.getCommonConfigId();
+            UUID jobId = auditEntryEntity.getCommonConfigId();
 
             if (null != auditEntryEntity.getTimeLastSent() && (null == timeLastSentOffsetDateTime || timeLastSentOffsetDateTime.isBefore(auditEntryEntity.getTimeLastSent()))) {
                 timeLastSentOffsetDateTime = auditEntryEntity.getTimeLastSent();
                 timeLastSent = formatAuditDate(timeLastSentOffsetDateTime);
             }
             String id = contentConverter.getStringValue(auditEntryEntity.getId());
-            String configId = contentConverter.getStringValue(commonConfigId);
+            String configId = contentConverter.getStringValue(jobId);
             String timeCreated = formatAuditDate(auditEntryEntity.getTimeCreated());
 
             AuditEntryStatus status = null;
@@ -245,7 +254,7 @@ public class DefaultAuditAccessor implements AuditAccessor {
             String errorMessage = auditEntryEntity.getErrorMessage();
             String errorStackTrace = auditEntryEntity.getErrorStackTrace();
 
-            Optional<ConfigurationJobModel> commonConfig = jobAccessor.getJobById(commonConfigId);
+            Optional<ConfigurationJobModel> commonConfig = jobAccessor.getJobById(jobId);
             String distributionConfigName = null;
             String eventType = null;
             if (commonConfig.isPresent()) {
@@ -257,7 +266,7 @@ public class DefaultAuditAccessor implements AuditAccessor {
             if (null != status) {
                 statusDisplayName = status.getDisplayName();
             }
-            AuditJobStatusModel auditJobStatusModel = new AuditJobStatusModel(timeCreated, timeLastSent, statusDisplayName);
+            AuditJobStatusModel auditJobStatusModel = new AuditJobStatusModel(jobId, timeCreated, timeLastSent, statusDisplayName);
             jobAuditModels.add(new JobAuditModel(id, configId, distributionConfigName, eventType, auditJobStatusModel, errorMessage, errorStackTrace));
         }
         String id = contentConverter.getStringValue(notificationContentEntry.getId());
@@ -318,7 +327,7 @@ public class DefaultAuditAccessor implements AuditAccessor {
         if (null != auditEntryEntity.getStatus()) {
             status = AuditEntryStatus.valueOf(auditEntryEntity.getStatus()).getDisplayName();
         }
-        return new AuditJobStatusModel(timeCreated, timeLastSent, status);
+        return new AuditJobStatusModel(auditEntryEntity.getCommonConfigId(), timeCreated, timeLastSent, status);
     }
 
     private Page<AlertNotificationModel> getPageOfNotifications(String sortField, String sortOrder, String searchTerm, Integer pageNumber, Integer pageSize, boolean onlyShowSentNotifications) {

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/audit/AuditEntryEntity.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/audit/AuditEntryEntity.java
@@ -50,6 +50,8 @@ public class AuditEntryEntity extends BaseEntity implements DatabaseEntity {
     @SequenceGenerator(name = "alert.audit_entries_id_seq_generator", sequenceName = "alert.audit_entries_id_seq")
     @Column(name = "id")
     private Long id;
+
+    // TODO rename to jobId
     @Column(name = "common_config_id")
     private UUID commonConfigId;
 

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/audit/AuditEntryRepository.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/audit/AuditEntryRepository.java
@@ -22,6 +22,8 @@
  */
 package com.synopsys.integration.alert.database.audit;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -29,7 +31,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface AuditEntryRepository extends JpaRepository<AuditEntryEntity, Long> {
-    Optional<AuditEntryEntity> findFirstByCommonConfigIdOrderByTimeLastSentDesc(final UUID commonConfigId);
+    List<AuditEntryEntity> findAllByCommonConfigIdInOrderByTimeLastSentDesc(Collection<UUID> commonConfigIds);
+
+    Optional<AuditEntryEntity> findFirstByCommonConfigIdOrderByTimeLastSentDesc(UUID commonConfigId);
 
     @Query(value = "SELECT entity FROM AuditEntryEntity entity INNER JOIN entity.auditNotificationRelations relation ON entity.id = relation.auditEntryId WHERE entity.commonConfigId = ?2 AND relation.notificationContent.id = ?1")
     Optional<AuditEntryEntity> findMatchingAudit(Long notificationId, UUID commonConfigId);

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/audit/AuditEntryRepository.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/audit/AuditEntryRepository.java
@@ -22,8 +22,6 @@
  */
 package com.synopsys.integration.alert.database.audit;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -31,8 +29,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface AuditEntryRepository extends JpaRepository<AuditEntryEntity, Long> {
-    List<AuditEntryEntity> findAllByCommonConfigIdInOrderByTimeLastSentDesc(Collection<UUID> commonConfigIds);
-
     Optional<AuditEntryEntity> findFirstByCommonConfigIdOrderByTimeLastSentDesc(UUID commonConfigId);
 
     @Query(value = "SELECT entity FROM AuditEntryEntity entity INNER JOIN entity.auditNotificationRelations relation ON entity.id = relation.auditEntryId WHERE entity.commonConfigId = ?2 AND relation.notificationContent.id = ?1")

--- a/component/src/main/java/com/synopsys/integration/alert/component/audit/web/AuditEntryActions.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/audit/web/AuditEntryActions.java
@@ -49,6 +49,8 @@ import com.synopsys.integration.alert.common.persistence.model.AuditJobStatusMod
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationJobModel;
 import com.synopsys.integration.alert.common.rest.model.AlertNotificationModel;
 import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
+import com.synopsys.integration.alert.common.rest.model.AuditJobStatusesModel;
+import com.synopsys.integration.alert.common.rest.model.JobIdsRequestModel;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
 import com.synopsys.integration.alert.common.workflow.processor.notification.NotificationProcessor;
 import com.synopsys.integration.alert.component.audit.AuditDescriptorKey;
@@ -121,6 +123,22 @@ public class AuditEntryActions {
             return new ActionResponse<>(HttpStatus.OK, auditJobStatusModel.get());
         }
         return new ActionResponse<>(HttpStatus.GONE, "The Audit information could not be found for this job.");
+    }
+
+    public ActionResponse<AuditJobStatusesModel> queryForAuditInfoInJobs(JobIdsRequestModel queryRequestModel) {
+        if (!authorizationManager.hasReadPermission(ConfigContextEnum.GLOBAL, descriptorKey)) {
+            return new ActionResponse<>(HttpStatus.FORBIDDEN, ActionResponse.FORBIDDEN_MESSAGE);
+        }
+
+        List<UUID> jobIds = queryRequestModel.getJobIds();
+        for (UUID jobId : jobIds) {
+            if (null == jobId) {
+                return new ActionResponse<>(HttpStatus.BAD_REQUEST, "The field 'jobIds' cannot contain null values");
+            }
+        }
+
+        List<AuditJobStatusModel> auditJobStatusModels = auditAccessor.findByJobIds(jobIds);
+        return new ActionResponse<>(HttpStatus.OK, new AuditJobStatusesModel(auditJobStatusModels));
     }
 
     public ActionResponse<AuditEntryPageModel> resendNotification(Long notificationId, UUID commonConfigId) {

--- a/component/src/main/java/com/synopsys/integration/alert/component/audit/web/AuditEntryController.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/audit/web/AuditEntryController.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,6 +41,8 @@ import com.synopsys.integration.alert.common.persistence.model.AuditJobStatusMod
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.rest.ResponseFactory;
 import com.synopsys.integration.alert.common.rest.api.BaseController;
+import com.synopsys.integration.alert.common.rest.model.AuditJobStatusesModel;
+import com.synopsys.integration.alert.common.rest.model.JobIdsRequestModel;
 
 @RestController
 @RequestMapping(AuditEntryController.AUDIT_BASE_PATH)
@@ -71,6 +74,11 @@ public class AuditEntryController extends BaseController {
         return ResponseFactory.createContentResponseFromAction(auditEntryActions.getAuditInfoForJob(jobId));
     }
 
+    @PostMapping(value = "/job")
+    public AuditJobStatusesModel queryForJobAuditInfoInJobs(@RequestBody JobIdsRequestModel queryRequestModel) {
+        return ResponseFactory.createContentResponseFromAction(auditEntryActions.queryForAuditInfoInJobs(queryRequestModel));
+    }
+
     @PostMapping(value = "/resend/{id}/")
     // TODO returning something other than the resource being interacted with is considered bad practice
     public AuditEntryPageModel resendById(@PathVariable(value = "id") Long notificationId) {
@@ -82,4 +90,5 @@ public class AuditEntryController extends BaseController {
     public AuditEntryPageModel resendByIdAndJobId(@PathVariable(value = "id") Long notificationId, @PathVariable(value = "jobId") UUID jobId) {
         return ResponseFactory.createContentResponseFromAction(auditEntryActions.resendNotification(notificationId, jobId));
     }
+
 }

--- a/src/test/java/com/synopsys/integration/alert/component/audit/JobAuditModelTest.java
+++ b/src/test/java/com/synopsys/integration/alert/component/audit/JobAuditModelTest.java
@@ -3,6 +3,7 @@ package com.synopsys.integration.alert.component.audit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Date;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
@@ -11,7 +12,6 @@ import com.synopsys.integration.alert.common.persistence.model.AuditJobStatusMod
 import com.synopsys.integration.alert.common.rest.model.JobAuditModel;
 
 public class JobAuditModelTest {
-
     @Test
     public void testModel() {
         String id = "1";
@@ -23,7 +23,7 @@ public class JobAuditModelTest {
         String status = AuditEntryStatus.SUCCESS.name();
         String errorMessage = "errorMessage";
         String errorStackTrace = "errorStackTrace";
-        AuditJobStatusModel auditJobStatusModel = new AuditJobStatusModel(timeAuditCreated, timeLastSent, status);
+        AuditJobStatusModel auditJobStatusModel = new AuditJobStatusModel(UUID.randomUUID(), timeAuditCreated, timeLastSent, status);
 
         JobAuditModel restModel = new JobAuditModel(id, configId, name, eventType, auditJobStatusModel, errorMessage, errorStackTrace);
 

--- a/src/test/java/com/synopsys/integration/alert/component/audit/mock/MockAuditJobStatusModel.java
+++ b/src/test/java/com/synopsys/integration/alert/component/audit/mock/MockAuditJobStatusModel.java
@@ -1,6 +1,7 @@
 package com.synopsys.integration.alert.component.audit.mock;
 
 import java.util.Date;
+import java.util.UUID;
 
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
@@ -13,16 +14,18 @@ import com.synopsys.integration.alert.common.persistence.model.AuditJobStatusMod
 
 public class MockAuditJobStatusModel {
     private final Gson gson = new Gson();
+    private final UUID jobId = UUID.randomUUID();
     private final String timeAuditCreated = new Date(400).toString();
     private final String timeLastSent = new Date(500).toString();
     private final String status = AuditEntryStatus.SUCCESS.name();
 
     public AuditJobStatusModel createRestModel() {
-        return new AuditJobStatusModel(timeAuditCreated, timeLastSent, status);
+        return new AuditJobStatusModel(jobId, timeAuditCreated, timeLastSent, status);
     }
 
     public String getRestModelJson() {
-        final JsonObject json = new JsonObject();
+        JsonObject json = new JsonObject();
+        json.addProperty("jobId", jobId.toString());
         json.addProperty("timeAuditCreated", timeAuditCreated);
         json.addProperty("timeLastSent", timeLastSent);
         json.addProperty("status", status);
@@ -31,8 +34,8 @@ public class MockAuditJobStatusModel {
     }
 
     public void verifyRestModel() throws JSONException {
-        final String restModel = gson.toJson(createRestModel());
-        final String json = getRestModelJson();
+        String restModel = gson.toJson(createRestModel());
+        String json = getRestModelJson();
         JSONAssert.assertEquals(restModel, json, false);
     }
 

--- a/src/test/java/com/synopsys/integration/alert/web/api/job/JobConfigActionsTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/api/job/JobConfigActionsTest.java
@@ -50,7 +50,7 @@ import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
 import com.synopsys.integration.alert.common.rest.model.JobFieldModel;
 import com.synopsys.integration.alert.common.rest.model.JobFieldStatuses;
-import com.synopsys.integration.alert.common.rest.model.JobIdsValidationRequestModel;
+import com.synopsys.integration.alert.common.rest.model.JobIdsRequestModel;
 import com.synopsys.integration.alert.common.rest.model.JobPagedModel;
 import com.synopsys.integration.alert.common.rest.model.ValidationResponseModel;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
@@ -461,7 +461,7 @@ public class JobConfigActionsTest {
 
     @Test
     public void validateJobsByIdTest() throws Exception {
-        JobIdsValidationRequestModel jobIdsValidationRequestModel = new JobIdsValidationRequestModel(List.of(jobId));
+        JobIdsRequestModel jobIdsRequestModel = new JobIdsRequestModel(List.of(jobId));
         DescriptorKey descriptorKey = createDescriptorKey();
         Descriptor descriptor = createDescriptor(descriptorType);
 
@@ -474,7 +474,7 @@ public class JobConfigActionsTest {
         AlertFieldStatus alertFieldStatus = AlertFieldStatus.error("fieldNameTest", "Alert Error Message");
         Mockito.when(fieldModelProcessor.validateJobFieldModel(Mockito.any())).thenReturn(List.of(alertFieldStatus));
 
-        ActionResponse<List<JobFieldStatuses>> actionResponse = jobConfigActions.validateJobsById(jobIdsValidationRequestModel);
+        ActionResponse<List<JobFieldStatuses>> actionResponse = jobConfigActions.validateJobsById(jobIdsRequestModel);
 
         assertTrue(actionResponse.isSuccessful());
         assertEquals(HttpStatus.OK, actionResponse.getHttpStatus());
@@ -483,14 +483,14 @@ public class JobConfigActionsTest {
 
     @Test
     public void validateJobsByIdForbiddenTest() {
-        JobIdsValidationRequestModel jobIdsValidationRequestModel = new JobIdsValidationRequestModel(List.of(jobId));
+        JobIdsRequestModel jobIdsRequestModel = new JobIdsRequestModel(List.of(jobId));
         DescriptorKey descriptorKey = createDescriptorKey();
         Descriptor descriptor = createDescriptor(descriptorType);
 
         Mockito.when(descriptorMap.getDescriptorMap()).thenReturn(Map.of(descriptorKey, descriptor));
         Mockito.when(authorizationManager.anyReadPermission(Mockito.any())).thenReturn(false);
 
-        ActionResponse<List<JobFieldStatuses>> actionResponse = jobConfigActions.validateJobsById(jobIdsValidationRequestModel);
+        ActionResponse<List<JobFieldStatuses>> actionResponse = jobConfigActions.validateJobsById(jobIdsRequestModel);
 
         assertTrue(actionResponse.isError());
         assertEquals(HttpStatus.FORBIDDEN, actionResponse.getHttpStatus());
@@ -499,7 +499,7 @@ public class JobConfigActionsTest {
 
     @Test
     public void validateJobsByIdEmptyListTest() {
-        JobIdsValidationRequestModel jobIdsValidationRequestModel = new JobIdsValidationRequestModel(List.of());
+        JobIdsRequestModel jobIdsRequestModel = new JobIdsRequestModel(List.of());
         DescriptorKey descriptorKey = createDescriptorKey();
         Descriptor descriptor = createDescriptor(descriptorType);
 
@@ -509,7 +509,7 @@ public class JobConfigActionsTest {
         AlertFieldStatus alertFieldStatus = AlertFieldStatus.error("fieldNameTest", "Alert Error Message");
         Mockito.when(fieldModelProcessor.validateJobFieldModel(Mockito.any())).thenReturn(List.of(alertFieldStatus));
 
-        ActionResponse<List<JobFieldStatuses>> actionResponse = jobConfigActions.validateJobsById(jobIdsValidationRequestModel);
+        ActionResponse<List<JobFieldStatuses>> actionResponse = jobConfigActions.validateJobsById(jobIdsRequestModel);
 
         assertTrue(actionResponse.isSuccessful());
         assertEquals(HttpStatus.OK, actionResponse.getHttpStatus());
@@ -518,7 +518,7 @@ public class JobConfigActionsTest {
 
     @Test
     public void validateJobsByIdInternalServerErrorTest() throws Exception {
-        JobIdsValidationRequestModel jobIdsValidationRequestModel = new JobIdsValidationRequestModel(List.of(jobId));
+        JobIdsRequestModel jobIdsRequestModel = new JobIdsRequestModel(List.of(jobId));
         DescriptorKey descriptorKey = createDescriptorKey();
         Descriptor descriptor = createDescriptor(descriptorType);
 
@@ -528,7 +528,7 @@ public class JobConfigActionsTest {
 
         Mockito.doThrow(new AlertException("Exception for Alert test")).when(fieldModelProcessor).performAfterReadAction(Mockito.any());
 
-        ActionResponse<List<JobFieldStatuses>> actionResponse = jobConfigActions.validateJobsById(jobIdsValidationRequestModel);
+        ActionResponse<List<JobFieldStatuses>> actionResponse = jobConfigActions.validateJobsById(jobIdsRequestModel);
 
         assertTrue(actionResponse.isError());
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, actionResponse.getHttpStatus());

--- a/web/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigActions.java
+++ b/web/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigActions.java
@@ -73,7 +73,7 @@ import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
 import com.synopsys.integration.alert.common.rest.model.JobFieldModel;
 import com.synopsys.integration.alert.common.rest.model.JobFieldStatuses;
-import com.synopsys.integration.alert.common.rest.model.JobIdsValidationRequestModel;
+import com.synopsys.integration.alert.common.rest.model.JobIdsRequestModel;
 import com.synopsys.integration.alert.common.rest.model.JobPagedModel;
 import com.synopsys.integration.alert.common.rest.model.ValidationResponseModel;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
@@ -298,7 +298,7 @@ public class JobConfigActions extends AbstractJobResourceActions {
         return new ValidationActionResponse(HttpStatus.OK, responseModel);
     }
 
-    public ActionResponse<List<JobFieldStatuses>> validateJobsById(JobIdsValidationRequestModel jobIdsValidationModel) {
+    public ActionResponse<List<JobFieldStatuses>> validateJobsById(JobIdsRequestModel jobIdsValidationModel) {
         List<PermissionKey> keys = new LinkedList<>();
         for (Descriptor descriptor : getDescriptorMap().getDescriptorMap().values()) {
             DescriptorKey descriptorKey = descriptor.getDescriptorKey();

--- a/web/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigController.java
+++ b/web/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigController.java
@@ -39,7 +39,7 @@ import com.synopsys.integration.alert.common.rest.api.TestController;
 import com.synopsys.integration.alert.common.rest.api.ValidateController;
 import com.synopsys.integration.alert.common.rest.model.JobFieldModel;
 import com.synopsys.integration.alert.common.rest.model.JobFieldStatuses;
-import com.synopsys.integration.alert.common.rest.model.JobIdsValidationRequestModel;
+import com.synopsys.integration.alert.common.rest.model.JobIdsRequestModel;
 import com.synopsys.integration.alert.common.rest.model.JobPagedModel;
 import com.synopsys.integration.alert.common.rest.model.ValidationResponseModel;
 
@@ -55,7 +55,7 @@ public class JobConfigController implements BaseJobResourceController, ReadPageC
     }
 
     @PostMapping("/validateJobsById")
-    public List<JobFieldStatuses> getValidationResultsForJobs(@RequestBody JobIdsValidationRequestModel validationModel) {
+    public List<JobFieldStatuses> getValidationResultsForJobs(@RequestBody JobIdsRequestModel validationModel) {
         return ResponseFactory.createContentResponseFromAction(jobConfigActions.validateJobsById(validationModel));
     }
 


### PR DESCRIPTION
This is to minimize network latency and remove the odd-looking loading of one row at a time.