### PR TITLE
Jm job accessor refactor

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/JobAccessorV2.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/JobAccessorV2.java
@@ -49,8 +49,6 @@ public interface JobAccessorV2 {
 
     Optional<DistributionJobModel> getJobByName(String jobName);
 
-    List<DistributionJobModel> getJobsByFrequency(FrequencyType frequency);
-
     DistributionJobModel createJob(Collection<String> descriptorNames, Collection<ConfigurationFieldModel> configuredFields) throws AlertDatabaseConstraintException;
 
     DistributionJobModel updateJob(UUID jobId, Collection<String> descriptorNames, Collection<ConfigurationFieldModel> configuredFields) throws AlertDatabaseConstraintException;

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/JobAccessorV2.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/JobAccessorV2.java
@@ -29,8 +29,8 @@ import java.util.UUID;
 
 import com.synopsys.integration.alert.common.enumeration.FrequencyType;
 import com.synopsys.integration.alert.common.exception.AlertDatabaseConstraintException;
-import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobModel;
+import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobRequestModel;
 import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 import com.synopsys.integration.blackduck.api.manual.enumeration.NotificationType;
 
@@ -49,9 +49,9 @@ public interface JobAccessorV2 {
 
     Optional<DistributionJobModel> getJobByName(String jobName);
 
-    DistributionJobModel createJob(Collection<String> descriptorNames, Collection<ConfigurationFieldModel> configuredFields) throws AlertDatabaseConstraintException;
+    DistributionJobModel createJob(DistributionJobRequestModel requestModel) throws AlertDatabaseConstraintException;
 
-    DistributionJobModel updateJob(UUID jobId, Collection<String> descriptorNames, Collection<ConfigurationFieldModel> configuredFields) throws AlertDatabaseConstraintException;
+    DistributionJobModel updateJob(UUID jobId, DistributionJobRequestModel requestModel) throws AlertDatabaseConstraintException;
 
     void deleteJob(UUID jobId) throws AlertDatabaseConstraintException;
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/JobAccessorV2.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/JobAccessorV2.java
@@ -1,0 +1,60 @@
+/**
+ * alert-common
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.alert.common.persistence.accessor;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.synopsys.integration.alert.common.enumeration.FrequencyType;
+import com.synopsys.integration.alert.common.exception.AlertDatabaseConstraintException;
+import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
+import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobModel;
+import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
+import com.synopsys.integration.blackduck.api.manual.enumeration.NotificationType;
+
+public interface JobAccessorV2 {
+    List<DistributionJobModel> getMatchingEnabledJobs(FrequencyType frequency, Long providerConfigId, NotificationType notificationType);
+
+    List<DistributionJobModel> getMatchingEnabledJobs(Long providerConfigId, NotificationType notificationType);
+
+    List<DistributionJobModel> getJobsById(Collection<UUID> jobIds);
+
+    AlertPagedModel<DistributionJobModel> getPageOfJobs(int pageOffset, int pageLimit);
+
+    AlertPagedModel<DistributionJobModel> getPageOfJobs(int pageOffset, int pageLimit, String searchTerm, Collection<String> descriptorsNamesToInclude);
+
+    Optional<DistributionJobModel> getJobById(UUID jobId);
+
+    Optional<DistributionJobModel> getJobByName(String jobName);
+
+    List<DistributionJobModel> getJobsByFrequency(FrequencyType frequency);
+
+    DistributionJobModel createJob(Collection<String> descriptorNames, Collection<ConfigurationFieldModel> configuredFields) throws AlertDatabaseConstraintException;
+
+    DistributionJobModel updateJob(UUID jobId, Collection<String> descriptorNames, Collection<ConfigurationFieldModel> configuredFields) throws AlertDatabaseConstraintException;
+
+    void deleteJob(UUID jobId) throws AlertDatabaseConstraintException;
+
+}

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/DistributionJobModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/DistributionJobModel.java
@@ -32,28 +32,11 @@ import org.jetbrains.annotations.Nullable;
 import com.synopsys.integration.alert.common.enumeration.FrequencyType;
 import com.synopsys.integration.alert.common.enumeration.ProcessingType;
 import com.synopsys.integration.alert.common.persistence.model.job.details.DistributionJobDetailsModel;
-import com.synopsys.integration.alert.common.rest.model.AlertSerializableModel;
 
-public class DistributionJobModel extends AlertSerializableModel {
+public class DistributionJobModel extends DistributionJobModelData {
     private final UUID jobId;
-    private final boolean enabled;
-    private final String name;
-    private final FrequencyType distributionFrequency;
-    private final ProcessingType processingType;
-    private final String channelDescriptorName;
     private final OffsetDateTime createdAt;
     private final OffsetDateTime lastUpdated;
-
-    // Black Duck fields will be common as long as it is the only provider
-    private final Long blackDuckGlobalConfigId;
-    private final boolean filterByProject;
-    private final String projectNamePattern;
-    private final List<String> notificationTypes;
-    private final List<String> projectFilterProjectNames;
-    private final List<String> policyFilterPolicyNames;
-    private final List<String> vulnerabilityFilterSeverityNames;
-
-    private final DistributionJobDetailsModel distributionJobDetails;
 
     public static DistributionJobModelBuilder builder() {
         return new DistributionJobModelBuilder();
@@ -77,47 +60,29 @@ public class DistributionJobModel extends AlertSerializableModel {
         List<String> vulnerabilityFilterSeverityNames,
         DistributionJobDetailsModel distributionJobDetails
     ) {
+        super(
+            enabled,
+            name,
+            distributionFrequency,
+            processingType,
+            channelDescriptorName,
+            blackDuckGlobalConfigId,
+            filterByProject,
+            projectNamePattern,
+            notificationTypes,
+            projectFilterProjectNames,
+            policyFilterPolicyNames,
+            vulnerabilityFilterSeverityNames,
+            distributionJobDetails
+        );
         this.jobId = jobId;
-        this.enabled = enabled;
-        this.name = name;
-        this.distributionFrequency = distributionFrequency;
-        this.processingType = processingType;
-        this.channelDescriptorName = channelDescriptorName;
         this.createdAt = createdAt;
         this.lastUpdated = lastUpdated;
-        this.blackDuckGlobalConfigId = blackDuckGlobalConfigId;
-        this.filterByProject = filterByProject;
-        this.projectNamePattern = projectNamePattern;
-        this.notificationTypes = notificationTypes;
-        this.projectFilterProjectNames = projectFilterProjectNames;
-        this.policyFilterPolicyNames = policyFilterPolicyNames;
-        this.vulnerabilityFilterSeverityNames = vulnerabilityFilterSeverityNames;
-        this.distributionJobDetails = distributionJobDetails;
     }
 
     @Nullable
     public UUID getJobId() {
         return jobId;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public FrequencyType getDistributionFrequency() {
-        return distributionFrequency;
-    }
-
-    public ProcessingType getProcessingType() {
-        return processingType;
-    }
-
-    public String getChannelDescriptorName() {
-        return channelDescriptorName;
     }
 
     public OffsetDateTime getCreatedAt() {
@@ -127,37 +92,4 @@ public class DistributionJobModel extends AlertSerializableModel {
     public Optional<OffsetDateTime> getLastUpdated() {
         return Optional.ofNullable(lastUpdated);
     }
-
-    public Long getBlackDuckGlobalConfigId() {
-        return blackDuckGlobalConfigId;
-    }
-
-    public boolean isFilterByProject() {
-        return filterByProject;
-    }
-
-    public Optional<String> getProjectNamePattern() {
-        return Optional.ofNullable(projectNamePattern);
-    }
-
-    public List<String> getNotificationTypes() {
-        return notificationTypes;
-    }
-
-    public List<String> getProjectFilterProjectNames() {
-        return projectFilterProjectNames;
-    }
-
-    public List<String> getPolicyFilterPolicyNames() {
-        return policyFilterPolicyNames;
-    }
-
-    public List<String> getVulnerabilityFilterSeverityNames() {
-        return vulnerabilityFilterSeverityNames;
-    }
-
-    public DistributionJobDetailsModel getDistributionJobDetails() {
-        return distributionJobDetails;
-    }
-
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/DistributionJobModelData.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/DistributionJobModelData.java
@@ -1,0 +1,135 @@
+/**
+ * alert-common
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.alert.common.persistence.model.job;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
+
+import com.synopsys.integration.alert.common.enumeration.FrequencyType;
+import com.synopsys.integration.alert.common.enumeration.ProcessingType;
+import com.synopsys.integration.alert.common.persistence.model.job.details.DistributionJobDetailsModel;
+import com.synopsys.integration.alert.common.rest.model.AlertSerializableModel;
+
+public abstract class DistributionJobModelData extends AlertSerializableModel {
+    private final boolean enabled;
+    private final String name;
+    private final FrequencyType distributionFrequency;
+    private final ProcessingType processingType;
+    private final String channelDescriptorName;
+
+    // Black Duck fields will be common as long as it is the only provider
+    private final Long blackDuckGlobalConfigId;
+    private final boolean filterByProject;
+    @Nullable
+    private final String projectNamePattern;
+    private final List<String> notificationTypes;
+    private final List<String> projectFilterProjectNames;
+    private final List<String> policyFilterPolicyNames;
+    private final List<String> vulnerabilityFilterSeverityNames;
+
+    private final DistributionJobDetailsModel distributionJobDetails;
+
+    public DistributionJobModelData(
+        boolean enabled,
+        String name,
+        FrequencyType distributionFrequency,
+        ProcessingType processingType,
+        String channelDescriptorName,
+        Long blackDuckGlobalConfigId,
+        boolean filterByProject,
+        @Nullable String projectNamePattern,
+        List<String> notificationTypes,
+        List<String> projectFilterProjectNames,
+        List<String> policyFilterPolicyNames,
+        List<String> vulnerabilityFilterSeverityNames,
+        DistributionJobDetailsModel distributionJobDetails
+    ) {
+        this.enabled = enabled;
+        this.name = name;
+        this.distributionFrequency = distributionFrequency;
+        this.processingType = processingType;
+        this.channelDescriptorName = channelDescriptorName;
+        this.blackDuckGlobalConfigId = blackDuckGlobalConfigId;
+        this.filterByProject = filterByProject;
+        this.projectNamePattern = projectNamePattern;
+        this.notificationTypes = notificationTypes;
+        this.projectFilterProjectNames = projectFilterProjectNames;
+        this.policyFilterPolicyNames = policyFilterPolicyNames;
+        this.vulnerabilityFilterSeverityNames = vulnerabilityFilterSeverityNames;
+        this.distributionJobDetails = distributionJobDetails;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public FrequencyType getDistributionFrequency() {
+        return distributionFrequency;
+    }
+
+    public ProcessingType getProcessingType() {
+        return processingType;
+    }
+
+    public String getChannelDescriptorName() {
+        return channelDescriptorName;
+    }
+
+    public Long getBlackDuckGlobalConfigId() {
+        return blackDuckGlobalConfigId;
+    }
+
+    public boolean isFilterByProject() {
+        return filterByProject;
+    }
+
+    public Optional<String> getProjectNamePattern() {
+        return Optional.ofNullable(projectNamePattern);
+    }
+
+    public List<String> getNotificationTypes() {
+        return notificationTypes;
+    }
+
+    public List<String> getProjectFilterProjectNames() {
+        return projectFilterProjectNames;
+    }
+
+    public List<String> getPolicyFilterPolicyNames() {
+        return policyFilterPolicyNames;
+    }
+
+    public List<String> getVulnerabilityFilterSeverityNames() {
+        return vulnerabilityFilterSeverityNames;
+    }
+
+    public DistributionJobDetailsModel getDistributionJobDetails() {
+        return distributionJobDetails;
+    }
+}

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/DistributionJobRequestModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/DistributionJobRequestModel.java
@@ -1,0 +1,112 @@
+package com.synopsys.integration.alert.common.persistence.model.job;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
+
+import com.synopsys.integration.alert.common.enumeration.FrequencyType;
+import com.synopsys.integration.alert.common.enumeration.ProcessingType;
+import com.synopsys.integration.alert.common.persistence.model.job.details.DistributionJobDetailsModel;
+
+public class DistributionJobRequestModel {
+    private final boolean enabled;
+    private final String name;
+    private final FrequencyType distributionFrequency;
+    private final ProcessingType processingType;
+    private final String channelDescriptorName;
+
+    // Black Duck fields will be common as long as it is the only provider
+    private final Long blackDuckGlobalConfigId;
+    private final boolean filterByProject;
+    @Nullable
+    private final String projectNamePattern;
+    private final List<String> notificationTypes;
+    private final List<String> projectFilterProjectNames;
+    private final List<String> policyFilterPolicyNames;
+    private final List<String> vulnerabilityFilterSeverityNames;
+
+    private final DistributionJobDetailsModel distributionJobDetails;
+
+    public DistributionJobRequestModel(
+        boolean enabled,
+        String name,
+        FrequencyType distributionFrequency,
+        ProcessingType processingType,
+        String channelDescriptorName,
+        Long blackDuckGlobalConfigId,
+        boolean filterByProject,
+        @Nullable String projectNamePattern,
+        List<String> notificationTypes,
+        List<String> projectFilterProjectNames,
+        List<String> policyFilterPolicyNames,
+        List<String> vulnerabilityFilterSeverityNames,
+        DistributionJobDetailsModel distributionJobDetails
+    ) {
+        this.enabled = enabled;
+        this.name = name;
+        this.distributionFrequency = distributionFrequency;
+        this.processingType = processingType;
+        this.channelDescriptorName = channelDescriptorName;
+        this.blackDuckGlobalConfigId = blackDuckGlobalConfigId;
+        this.filterByProject = filterByProject;
+        this.projectNamePattern = projectNamePattern;
+        this.notificationTypes = notificationTypes;
+        this.projectFilterProjectNames = projectFilterProjectNames;
+        this.policyFilterPolicyNames = policyFilterPolicyNames;
+        this.vulnerabilityFilterSeverityNames = vulnerabilityFilterSeverityNames;
+        this.distributionJobDetails = distributionJobDetails;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public FrequencyType getDistributionFrequency() {
+        return distributionFrequency;
+    }
+
+    public ProcessingType getProcessingType() {
+        return processingType;
+    }
+
+    public String getChannelDescriptorName() {
+        return channelDescriptorName;
+    }
+
+    public Long getBlackDuckGlobalConfigId() {
+        return blackDuckGlobalConfigId;
+    }
+
+    public boolean isFilterByProject() {
+        return filterByProject;
+    }
+
+    public Optional<String> getProjectNamePattern() {
+        return Optional.ofNullable(projectNamePattern);
+    }
+
+    public List<String> getNotificationTypes() {
+        return notificationTypes;
+    }
+
+    public List<String> getProjectFilterProjectNames() {
+        return projectFilterProjectNames;
+    }
+
+    public List<String> getPolicyFilterPolicyNames() {
+        return policyFilterPolicyNames;
+    }
+
+    public List<String> getVulnerabilityFilterSeverityNames() {
+        return vulnerabilityFilterSeverityNames;
+    }
+
+    public DistributionJobDetailsModel getDistributionJobDetails() {
+        return distributionJobDetails;
+    }
+}

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/DistributionJobRequestModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/DistributionJobRequestModel.java
@@ -23,7 +23,6 @@
 package com.synopsys.integration.alert.common.persistence.model.job;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -31,25 +30,7 @@ import com.synopsys.integration.alert.common.enumeration.FrequencyType;
 import com.synopsys.integration.alert.common.enumeration.ProcessingType;
 import com.synopsys.integration.alert.common.persistence.model.job.details.DistributionJobDetailsModel;
 
-public class DistributionJobRequestModel {
-    private final boolean enabled;
-    private final String name;
-    private final FrequencyType distributionFrequency;
-    private final ProcessingType processingType;
-    private final String channelDescriptorName;
-
-    // Black Duck fields will be common as long as it is the only provider
-    private final Long blackDuckGlobalConfigId;
-    private final boolean filterByProject;
-    @Nullable
-    private final String projectNamePattern;
-    private final List<String> notificationTypes;
-    private final List<String> projectFilterProjectNames;
-    private final List<String> policyFilterPolicyNames;
-    private final List<String> vulnerabilityFilterSeverityNames;
-
-    private final DistributionJobDetailsModel distributionJobDetails;
-
+public class DistributionJobRequestModel extends DistributionJobModelData {
     public DistributionJobRequestModel(
         boolean enabled,
         String name,
@@ -65,70 +46,7 @@ public class DistributionJobRequestModel {
         List<String> vulnerabilityFilterSeverityNames,
         DistributionJobDetailsModel distributionJobDetails
     ) {
-        this.enabled = enabled;
-        this.name = name;
-        this.distributionFrequency = distributionFrequency;
-        this.processingType = processingType;
-        this.channelDescriptorName = channelDescriptorName;
-        this.blackDuckGlobalConfigId = blackDuckGlobalConfigId;
-        this.filterByProject = filterByProject;
-        this.projectNamePattern = projectNamePattern;
-        this.notificationTypes = notificationTypes;
-        this.projectFilterProjectNames = projectFilterProjectNames;
-        this.policyFilterPolicyNames = policyFilterPolicyNames;
-        this.vulnerabilityFilterSeverityNames = vulnerabilityFilterSeverityNames;
-        this.distributionJobDetails = distributionJobDetails;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public FrequencyType getDistributionFrequency() {
-        return distributionFrequency;
-    }
-
-    public ProcessingType getProcessingType() {
-        return processingType;
-    }
-
-    public String getChannelDescriptorName() {
-        return channelDescriptorName;
-    }
-
-    public Long getBlackDuckGlobalConfigId() {
-        return blackDuckGlobalConfigId;
-    }
-
-    public boolean isFilterByProject() {
-        return filterByProject;
-    }
-
-    public Optional<String> getProjectNamePattern() {
-        return Optional.ofNullable(projectNamePattern);
-    }
-
-    public List<String> getNotificationTypes() {
-        return notificationTypes;
-    }
-
-    public List<String> getProjectFilterProjectNames() {
-        return projectFilterProjectNames;
-    }
-
-    public List<String> getPolicyFilterPolicyNames() {
-        return policyFilterPolicyNames;
-    }
-
-    public List<String> getVulnerabilityFilterSeverityNames() {
-        return vulnerabilityFilterSeverityNames;
-    }
-
-    public DistributionJobDetailsModel getDistributionJobDetails() {
-        return distributionJobDetails;
+        super(enabled, name, distributionFrequency, processingType, channelDescriptorName, blackDuckGlobalConfigId, filterByProject, projectNamePattern, notificationTypes, projectFilterProjectNames, policyFilterPolicyNames,
+            vulnerabilityFilterSeverityNames, distributionJobDetails);
     }
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/DistributionJobRequestModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/DistributionJobRequestModel.java
@@ -1,3 +1,25 @@
+/**
+ * alert-common
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.synopsys.integration.alert.common.persistence.model.job;
 
 import java.util.List;

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/StaticJobAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/StaticJobAccessor.java
@@ -50,6 +50,7 @@ import com.synopsys.integration.alert.common.persistence.model.ConfigurationFiel
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationJobModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
 import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobModel;
+import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobRequestModel;
 import com.synopsys.integration.alert.common.persistence.model.job.details.DistributionJobDetailsModel;
 import com.synopsys.integration.alert.common.persistence.model.mutable.ConfigurationModelMutable;
 import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
@@ -286,7 +287,23 @@ public class StaticJobAccessor implements JobAccessor {
         DistributionJobEntity savedJobEntity = distributionJobRepository.save(jobToSave);
         UUID savedJobId = savedJobEntity.getJobId();
 
-        BlackDuckJobDetailsEntity savedBlackDuckJobDetails = blackDuckJobDetailsAccessor.saveBlackDuckJobDetails(savedJobId, distributionJobModel);
+        DistributionJobRequestModel requestModel = new DistributionJobRequestModel(
+            distributionJobModel.isEnabled(),
+            distributionJobModel.getName(),
+            distributionJobModel.getDistributionFrequency(),
+            distributionJobModel.getProcessingType(),
+            distributionJobModel.getChannelDescriptorName(),
+            distributionJobModel.getBlackDuckGlobalConfigId(),
+            distributionJobModel.isFilterByProject(),
+            distributionJobModel.getProjectNamePattern().orElse(null),
+            distributionJobModel.getNotificationTypes(),
+            distributionJobModel.getProjectFilterProjectNames(),
+            distributionJobModel.getPolicyFilterPolicyNames(),
+            distributionJobModel.getVulnerabilityFilterSeverityNames(),
+            distributionJobModel.getDistributionJobDetails()
+        );
+
+        BlackDuckJobDetailsEntity savedBlackDuckJobDetails = blackDuckJobDetailsAccessor.saveBlackDuckJobDetails(savedJobId, requestModel);
         savedJobEntity.setBlackDuckJobDetails(savedBlackDuckJobDetails);
 
         DistributionJobDetailsModel distributionJobDetails = distributionJobModel.getDistributionJobDetails();

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/StaticJobAccessorV2.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/StaticJobAccessorV2.java
@@ -160,12 +160,14 @@ public class StaticJobAccessorV2 implements JobAccessorV2 {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<DistributionJobModel> getMatchingEnabledJobs(FrequencyType frequency, Long providerConfigId, NotificationType notificationType) {
         // TODO change this to return a page of jobs
         return getMatchingEnabledJobs(() -> distributionJobRepository.findMatchingEnabledJob(frequency.name(), providerConfigId, notificationType.name()));
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<DistributionJobModel> getMatchingEnabledJobs(Long providerConfigId, NotificationType notificationType) {
         // TODO change this to return a page of jobs
         return getMatchingEnabledJobs(() -> distributionJobRepository.findMatchingEnabledJob(providerConfigId, notificationType.name()));

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/StaticJobAccessorV2.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/StaticJobAccessorV2.java
@@ -203,6 +203,48 @@ public class StaticJobAccessorV2 implements JobAccessorV2 {
         distributionJobRepository.deleteById(jobId);
     }
 
+    private DistributionJobModel createJobWithId(UUID jobId, DistributionJobRequestModel requestModel, OffsetDateTime createdAt, @Nullable OffsetDateTime lastUpdated) {
+        String channelDescriptorName = requestModel.getChannelDescriptorName();
+        DistributionJobEntity jobToSave = new DistributionJobEntity(
+            jobId,
+            requestModel.getName(),
+            requestModel.isEnabled(),
+            requestModel.getDistributionFrequency().name(),
+            requestModel.getProcessingType().name(),
+            channelDescriptorName,
+            createdAt,
+            lastUpdated
+        );
+        DistributionJobEntity savedJobEntity = distributionJobRepository.save(jobToSave);
+        UUID savedJobId = savedJobEntity.getJobId();
+
+        BlackDuckJobDetailsEntity savedBlackDuckJobDetails = blackDuckJobDetailsAccessor.saveBlackDuckJobDetails(savedJobId, requestModel);
+        savedJobEntity.setBlackDuckJobDetails(savedBlackDuckJobDetails);
+
+        DistributionJobDetailsModel distributionJobDetails = requestModel.getDistributionJobDetails();
+        if (distributionJobDetails.isAzureBoardsDetails()) {
+            AzureBoardsJobDetailsEntity savedAzureBoardsJobDetails = azureBoardsJobDetailsAccessor.saveAzureBoardsJobDetails(savedJobId, distributionJobDetails.getAsAzureBoardsJobDetails());
+            savedJobEntity.setAzureBoardsJobDetails(savedAzureBoardsJobDetails);
+        } else if (distributionJobDetails.isEmailDetails()) {
+            EmailJobDetailsEntity savedEmailJobDetails = emailJobDetailsAccessor.saveEmailJobDetails(savedJobId, distributionJobDetails.getAsEmailJobDetails());
+            savedJobEntity.setEmailJobDetails(savedEmailJobDetails);
+        } else if (distributionJobDetails.isJiraCloudDetails()) {
+            JiraCloudJobDetailsEntity savedJiraCloudJobDetails = jiraCloudJobDetailsAccessor.saveJiraCloudJobDetails(savedJobId, distributionJobDetails.getAsJiraCouldJobDetails());
+            savedJobEntity.setJiraCloudJobDetails(savedJiraCloudJobDetails);
+        } else if (distributionJobDetails.isJiraServerDetails()) {
+            JiraServerJobDetailsEntity savedJiraServerJobDetails = jiraServerJobDetailsAccessor.saveJiraServerJobDetails(savedJobId, distributionJobDetails.getAsJiraServerJobDetails());
+            savedJobEntity.setJiraServerJobDetails(savedJiraServerJobDetails);
+        } else if (distributionJobDetails.isMSTeamsDetails()) {
+            MSTeamsJobDetailsEntity savedMSTeamsJobDetails = msTeamsJobDetailsAccessor.saveMSTeamsJobDetails(savedJobId, distributionJobDetails.getAsMSTeamsJobDetails());
+            savedJobEntity.setMsTeamsJobDetails(savedMSTeamsJobDetails);
+        } else if (distributionJobDetails.isSlackDetails()) {
+            SlackJobDetailsEntity savedSlackJobDetails = slackJobDetailsAccessor.saveSlackJobDetails(savedJobId, distributionJobDetails.getAsSlackJobDetails());
+            savedJobEntity.setSlackJobDetails(savedSlackJobDetails);
+        }
+
+        return convertToDistributionJobModel(savedJobEntity);
+    }
+
     private DistributionJobModel convertToDistributionJobModel(DistributionJobEntity jobEntity) {
         DistributionJobDetailsModel distributionJobDetailsModel = null;
         String channelDescriptorName = jobEntity.getChannelDescriptorName();
@@ -269,48 +311,6 @@ public class StaticJobAccessorV2 implements JobAccessorV2 {
                    .blackDuckGlobalConfigId(jobEntity.getBlackDuckJobDetails().getGlobalConfigId())
                    .distributionJobDetails(distributionJobDetailsModel)
                    .build();
-    }
-
-    private DistributionJobModel createJobWithId(UUID jobId, DistributionJobRequestModel requestModel, OffsetDateTime createdAt, @Nullable OffsetDateTime lastUpdated) {
-        String channelDescriptorName = requestModel.getChannelDescriptorName();
-        DistributionJobEntity jobToSave = new DistributionJobEntity(
-            jobId,
-            requestModel.getName(),
-            requestModel.isEnabled(),
-            requestModel.getDistributionFrequency().name(),
-            requestModel.getProcessingType().name(),
-            channelDescriptorName,
-            createdAt,
-            lastUpdated
-        );
-        DistributionJobEntity savedJobEntity = distributionJobRepository.save(jobToSave);
-        UUID savedJobId = savedJobEntity.getJobId();
-
-        BlackDuckJobDetailsEntity savedBlackDuckJobDetails = blackDuckJobDetailsAccessor.saveBlackDuckJobDetails(savedJobId, requestModel);
-        savedJobEntity.setBlackDuckJobDetails(savedBlackDuckJobDetails);
-
-        DistributionJobDetailsModel distributionJobDetails = requestModel.getDistributionJobDetails();
-        if (distributionJobDetails.isAzureBoardsDetails()) {
-            AzureBoardsJobDetailsEntity savedAzureBoardsJobDetails = azureBoardsJobDetailsAccessor.saveAzureBoardsJobDetails(savedJobId, distributionJobDetails.getAsAzureBoardsJobDetails());
-            savedJobEntity.setAzureBoardsJobDetails(savedAzureBoardsJobDetails);
-        } else if (distributionJobDetails.isEmailDetails()) {
-            EmailJobDetailsEntity savedEmailJobDetails = emailJobDetailsAccessor.saveEmailJobDetails(savedJobId, distributionJobDetails.getAsEmailJobDetails());
-            savedJobEntity.setEmailJobDetails(savedEmailJobDetails);
-        } else if (distributionJobDetails.isJiraCloudDetails()) {
-            JiraCloudJobDetailsEntity savedJiraCloudJobDetails = jiraCloudJobDetailsAccessor.saveJiraCloudJobDetails(savedJobId, distributionJobDetails.getAsJiraCouldJobDetails());
-            savedJobEntity.setJiraCloudJobDetails(savedJiraCloudJobDetails);
-        } else if (distributionJobDetails.isJiraServerDetails()) {
-            JiraServerJobDetailsEntity savedJiraServerJobDetails = jiraServerJobDetailsAccessor.saveJiraServerJobDetails(savedJobId, distributionJobDetails.getAsJiraServerJobDetails());
-            savedJobEntity.setJiraServerJobDetails(savedJiraServerJobDetails);
-        } else if (distributionJobDetails.isMSTeamsDetails()) {
-            MSTeamsJobDetailsEntity savedMSTeamsJobDetails = msTeamsJobDetailsAccessor.saveMSTeamsJobDetails(savedJobId, distributionJobDetails.getAsMSTeamsJobDetails());
-            savedJobEntity.setMsTeamsJobDetails(savedMSTeamsJobDetails);
-        } else if (distributionJobDetails.isSlackDetails()) {
-            SlackJobDetailsEntity savedSlackJobDetails = slackJobDetailsAccessor.saveSlackJobDetails(savedJobId, distributionJobDetails.getAsSlackJobDetails());
-            savedJobEntity.setSlackJobDetails(savedSlackJobDetails);
-        }
-
-        return convertToDistributionJobModel(savedJobEntity);
     }
 
 }

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/StaticJobAccessorV2.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/StaticJobAccessorV2.java
@@ -1,0 +1,225 @@
+/**
+ * alert-database
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.alert.database.api;
+
+import java.time.OffsetDateTime;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.enumeration.FrequencyType;
+import com.synopsys.integration.alert.common.exception.AlertDatabaseConstraintException;
+import com.synopsys.integration.alert.common.exception.AlertRuntimeException;
+import com.synopsys.integration.alert.common.persistence.accessor.JobAccessorV2;
+import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
+import com.synopsys.integration.alert.common.persistence.model.ConfigurationJobModel;
+import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
+import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobModel;
+import com.synopsys.integration.alert.common.persistence.model.mutable.ConfigurationModelMutable;
+import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
+import com.synopsys.integration.alert.common.util.DateUtils;
+import com.synopsys.integration.alert.database.configuration.RegisteredDescriptorEntity;
+import com.synopsys.integration.alert.database.configuration.repository.RegisteredDescriptorRepository;
+import com.synopsys.integration.alert.database.job.DistributionJobEntity;
+import com.synopsys.integration.alert.database.job.DistributionJobRepository;
+import com.synopsys.integration.alert.database.job.JobConfigurationModelFieldExtractorUtils;
+import com.synopsys.integration.alert.database.job.JobConfigurationModelFieldPopulationUtility;
+import com.synopsys.integration.alert.descriptor.api.model.ProviderKey;
+import com.synopsys.integration.blackduck.api.manual.enumeration.NotificationType;
+
+@Component
+public class StaticJobAccessorV2 implements JobAccessorV2 {
+    private final DistributionJobRepository distributionJobRepository;
+
+    // Temporary until all three tiers of the application have been updated to new Job models
+    private final JobConfigurationModelFieldPopulationUtility jobConfigurationModelFieldPopulationUtility;
+    private final RegisteredDescriptorRepository registeredDescriptorRepository;
+    // BlackDuck is currently the only provider, so this is safe in the short-term while we transition to new models
+    private final ProviderKey blackDuckProviderKey;
+
+    @Autowired
+    public StaticJobAccessorV2(
+        DistributionJobRepository distributionJobRepository,
+        JobConfigurationModelFieldPopulationUtility jobConfigurationModelFieldPopulationUtility,
+        RegisteredDescriptorRepository registeredDescriptorRepository,
+        ProviderKey blackDuckProviderKey
+    ) {
+        this.distributionJobRepository = distributionJobRepository;
+        this.jobConfigurationModelFieldPopulationUtility = jobConfigurationModelFieldPopulationUtility;
+        this.registeredDescriptorRepository = registeredDescriptorRepository;
+        this.blackDuckProviderKey = blackDuckProviderKey;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<DistributionJobModel> getJobsById(Collection<UUID> jobIds) {
+        return distributionJobRepository.findAllById(jobIds)
+                   .stream()
+                   .map(this::convertToDistributionJobModel)
+                   .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AlertPagedModel<DistributionJobModel> getPageOfJobs(int pageNumber, int pageLimit) {
+        PageRequest pageRequest = PageRequest.of(pageNumber, pageLimit);
+        Page<DistributionJobModel> pageOfJobsWithDescriptorNames = distributionJobRepository.findAll(pageRequest).map(this::convertToDistributionJobModel);
+        return new AlertPagedModel<>(pageOfJobsWithDescriptorNames.getTotalPages(), pageNumber, pageLimit, pageOfJobsWithDescriptorNames.getContent());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AlertPagedModel<DistributionJobModel> getPageOfJobs(int pageNumber, int pageLimit, String searchTerm, Collection<String> descriptorsNamesToInclude) {
+        if (!descriptorsNamesToInclude.contains(blackDuckProviderKey.getUniversalKey())) {
+            return new AlertPagedModel<>(0, pageNumber, pageLimit, List.of());
+        }
+
+        PageRequest pageRequest = PageRequest.of(pageNumber, pageLimit);
+        Page<DistributionJobEntity> pageOfJobsWithDescriptorNames;
+        if (StringUtils.isBlank(searchTerm)) {
+            pageOfJobsWithDescriptorNames = distributionJobRepository.findByChannelDescriptorNameIn(descriptorsNamesToInclude, pageRequest);
+        } else {
+            pageOfJobsWithDescriptorNames = distributionJobRepository.findByChannelDescriptorNamesAndSearchTerm(descriptorsNamesToInclude, searchTerm, pageRequest);
+        }
+
+        List<DistributionJobModel> configurationJobModels = pageOfJobsWithDescriptorNames.map(this::convertToDistributionJobModel).getContent();
+        return new AlertPagedModel<>(pageOfJobsWithDescriptorNames.getTotalPages(), pageNumber, pageLimit, configurationJobModels);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<DistributionJobModel> getJobById(UUID jobId) {
+        return distributionJobRepository.findById(jobId).map(this::convertToDistributionJobModel);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<DistributionJobModel> getJobByName(String jobName) {
+        return distributionJobRepository.findByName(jobName)
+                   .map(this::convertToDistributionJobModel);
+    }
+
+    @Override
+    public List<DistributionJobModel> getMatchingEnabledJobs(FrequencyType frequency, Long providerConfigId, NotificationType notificationType) {
+        // TODO change this to return a page of jobs
+        return getMatchingEnabledJobs(() -> distributionJobRepository.findMatchingEnabledJob(frequency.name(), providerConfigId, notificationType.name()));
+    }
+
+    @Override
+    public List<DistributionJobModel> getMatchingEnabledJobs(Long providerConfigId, NotificationType notificationType) {
+        // TODO change this to return a page of jobs
+        return getMatchingEnabledJobs(() -> distributionJobRepository.findMatchingEnabledJob(providerConfigId, notificationType.name()));
+    }
+
+    private List<DistributionJobModel> getMatchingEnabledJobs(Supplier<List<DistributionJobEntity>> getJobs) {
+        // TODO change this to return a page of jobs
+        List<DistributionJobEntity> matchingEnabledJob = getJobs.get();
+        return matchingEnabledJob
+                   .stream()
+                   .map(this::convertToDistributionJobModel)
+                   .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public DistributionJobModel createJob(Collection<String> descriptorNames, Collection<ConfigurationFieldModel> configuredFields) {
+        return createJobWithId(null, configuredFields, DateUtils.createCurrentDateTimestamp(), null);
+    }
+
+    @Override
+    @Transactional
+    public DistributionJobModel updateJob(UUID jobId, Collection<String> descriptorNames, Collection<ConfigurationFieldModel> configuredFields) throws AlertDatabaseConstraintException {
+        DistributionJobEntity jobEntity = distributionJobRepository.findById(jobId)
+                                              .orElseThrow(() -> new AlertDatabaseConstraintException(String.format("No job exists with the id [%s]", jobId.toString())));
+        OffsetDateTime createdAt = jobEntity.getCreatedAt();
+
+        deleteJob(jobId);
+        return createJobWithId(jobId, configuredFields, createdAt, DateUtils.createCurrentDateTimestamp());
+    }
+
+    @Override
+    @Transactional
+    public void deleteJob(UUID jobId) {
+        distributionJobRepository.deleteById(jobId);
+    }
+
+    private DistributionJobModel convertToDistributionJobModel(DistributionJobEntity jobEntity) {
+        ConfigurationJobModel configurationJobModel = convertToConfigurationJobModel(jobEntity);
+        Map<String, ConfigurationFieldModel> fields = configurationJobModel.getFieldUtility().getFields();
+        return JobConfigurationModelFieldExtractorUtils.convertToDistributionJobModel(configurationJobModel.getJobId(), fields, jobEntity.getCreatedAt(), jobEntity.getLastUpdated());
+    }
+
+    private ConfigurationJobModel convertToConfigurationJobModel(DistributionJobEntity jobEntity) {
+        Set<ConfigurationModel> configurationModels = new LinkedHashSet<>();
+
+        String createdAtDateTime = DateUtils.formatDate(jobEntity.getCreatedAt(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE);
+        String updatedAtDateTime = Optional.ofNullable(jobEntity.getLastUpdated())
+                                       .map(date -> DateUtils.formatDate(date, DateUtils.UTC_DATE_FORMAT_TO_MINUTE))
+                                       .orElse(null);
+
+        String providerUniversalKey = blackDuckProviderKey.getUniversalKey();
+        Long blackDuckDescriptorId = getDescriptorId(providerUniversalKey);
+
+        ConfigurationModelMutable blackDuckConfigurationModel = new ConfigurationModelMutable(blackDuckDescriptorId, -1L, createdAtDateTime, updatedAtDateTime, ConfigContextEnum.DISTRIBUTION);
+        jobConfigurationModelFieldPopulationUtility.populateBlackDuckConfigurationModelFields(jobEntity, blackDuckConfigurationModel);
+        configurationModels.add(blackDuckConfigurationModel);
+
+        Long channelDescriptorId = getDescriptorId(jobEntity.getChannelDescriptorName());
+        ConfigurationModelMutable channelConfigurationModel = new ConfigurationModelMutable(channelDescriptorId, -1L, createdAtDateTime, updatedAtDateTime, ConfigContextEnum.DISTRIBUTION);
+        channelConfigurationModel.put(jobConfigurationModelFieldPopulationUtility.createConfigFieldModel("channel.common.provider.name", providerUniversalKey));
+        jobConfigurationModelFieldPopulationUtility.populateChannelConfigurationModelFields(jobEntity, channelConfigurationModel);
+        configurationModels.add(channelConfigurationModel);
+
+        return new ConfigurationJobModel(jobEntity.getJobId(), configurationModels);
+    }
+
+    private Long getDescriptorId(String descriptorUniversalKey) {
+        return registeredDescriptorRepository.findFirstByName(descriptorUniversalKey)
+                   .map(RegisteredDescriptorEntity::getId)
+                   .orElseThrow(() -> new AlertRuntimeException("A descriptor is missing from the database"));
+    }
+
+    private DistributionJobModel createJobWithId(UUID jobId, Collection<ConfigurationFieldModel> configuredFields, OffsetDateTime createdAt, OffsetDateTime lastUpdated) {
+        Map<String, ConfigurationFieldModel> configuredFieldsMap = configuredFields
+                                                                       .stream()
+                                                                       .collect(Collectors.toMap(ConfigurationFieldModel::getFieldKey, Function.identity()));
+
+        return JobConfigurationModelFieldExtractorUtils.convertToDistributionJobModel(jobId, configuredFieldsMap, createdAt, lastUpdated);
+    }
+
+}

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/StaticJobAccessorV2.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/StaticJobAccessorV2.java
@@ -271,28 +271,7 @@ public class StaticJobAccessorV2 implements JobAccessorV2 {
                    .build();
     }
 
-    private DistributionJobModel createJobWithId(UUID jobId, DistributionJobRequestModel requestModel, OffsetDateTime createdAt, OffsetDateTime lastUpdated) {
-        return new DistributionJobModelBuilder()
-                   .jobId(jobId)
-                   .createdAt(createdAt)
-                   .lastUpdated(lastUpdated)
-                   .enabled(requestModel.isEnabled())
-                   .name(requestModel.getName())
-                   .distributionFrequency(requestModel.getDistributionFrequency())
-                   .processingType(requestModel.getProcessingType())
-                   .channelDescriptorName(requestModel.getChannelDescriptorName())
-                   .blackDuckGlobalConfigId(requestModel.getBlackDuckGlobalConfigId())
-                   .filterByProject(requestModel.isFilterByProject())
-                   .projectNamePattern(requestModel.getProjectNamePattern().orElse(null))
-                   .notificationTypes(requestModel.getNotificationTypes())
-                   .projectFilterProjectNames(requestModel.getProjectFilterProjectNames())
-                   .policyFilterPolicyNames(requestModel.getPolicyFilterPolicyNames())
-                   .vulnerabilityFilterSeverityNames(requestModel.getVulnerabilityFilterSeverityNames())
-                   .distributionJobDetails(requestModel.getDistributionJobDetails())
-                   .build();
-    }
-
-    private DistributionJobModel createJob(UUID jobId, DistributionJobRequestModel requestModel, OffsetDateTime createdAt, @Nullable OffsetDateTime lastUpdated) {
+    private DistributionJobModel createJobWithId(UUID jobId, DistributionJobRequestModel requestModel, OffsetDateTime createdAt, @Nullable OffsetDateTime lastUpdated) {
         String channelDescriptorName = requestModel.getChannelDescriptorName();
         DistributionJobEntity jobToSave = new DistributionJobEntity(
             jobId,

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/StaticJobAccessorV2.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/StaticJobAccessorV2.java
@@ -171,15 +171,6 @@ public class StaticJobAccessorV2 implements JobAccessorV2 {
         return getMatchingEnabledJobs(() -> distributionJobRepository.findMatchingEnabledJob(providerConfigId, notificationType.name()));
     }
 
-    private List<DistributionJobModel> getMatchingEnabledJobs(Supplier<List<DistributionJobEntity>> getJobs) {
-        // TODO change this to return a page of jobs
-        List<DistributionJobEntity> matchingEnabledJob = getJobs.get();
-        return matchingEnabledJob
-                   .stream()
-                   .map(this::convertToDistributionJobModel)
-                   .collect(Collectors.toList());
-    }
-
     @Override
     @Transactional
     public DistributionJobModel createJob(DistributionJobRequestModel requestModel) {
@@ -201,6 +192,15 @@ public class StaticJobAccessorV2 implements JobAccessorV2 {
     @Transactional
     public void deleteJob(UUID jobId) {
         distributionJobRepository.deleteById(jobId);
+    }
+
+    private List<DistributionJobModel> getMatchingEnabledJobs(Supplier<List<DistributionJobEntity>> getJobs) {
+        // TODO change this to return a page of jobs
+        List<DistributionJobEntity> matchingEnabledJob = getJobs.get();
+        return matchingEnabledJob
+                   .stream()
+                   .map(this::convertToDistributionJobModel)
+                   .collect(Collectors.toList());
     }
 
     private DistributionJobModel createJobWithId(UUID jobId, DistributionJobRequestModel requestModel, OffsetDateTime createdAt, @Nullable OffsetDateTime lastUpdated) {

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/job/blackduck/BlackDuckJobDetailsAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/job/blackduck/BlackDuckJobDetailsAccessor.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobModel;
+import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobRequestModel;
 import com.synopsys.integration.alert.database.job.blackduck.notification.BlackDuckJobNotificationTypeEntity;
 import com.synopsys.integration.alert.database.job.blackduck.notification.BlackDuckJobNotificationTypeRepository;
 import com.synopsys.integration.alert.database.job.blackduck.policy.BlackDuckJobPolicyFilterEntity;
@@ -65,37 +65,37 @@ public class BlackDuckJobDetailsAccessor {
     }
 
     @Transactional(propagation = Propagation.REQUIRED)
-    public BlackDuckJobDetailsEntity saveBlackDuckJobDetails(UUID jobId, DistributionJobModel distributionJobModel) {
+    public BlackDuckJobDetailsEntity saveBlackDuckJobDetails(UUID jobId, DistributionJobRequestModel requestModel) {
         BlackDuckJobDetailsEntity blackDuckJobDetailsToSave = new BlackDuckJobDetailsEntity(
             jobId,
-            distributionJobModel.getBlackDuckGlobalConfigId(),
-            distributionJobModel.isFilterByProject(),
-            distributionJobModel.getProjectNamePattern().orElse(null)
+            requestModel.getBlackDuckGlobalConfigId(),
+            requestModel.isFilterByProject(),
+            requestModel.getProjectNamePattern().orElse(null)
         );
         BlackDuckJobDetailsEntity savedBlackDuckJobDetails = blackDuckJobDetailsRepository.save(blackDuckJobDetailsToSave);
 
-        List<BlackDuckJobNotificationTypeEntity> notificationTypesToSave = distributionJobModel.getNotificationTypes()
+        List<BlackDuckJobNotificationTypeEntity> notificationTypesToSave = requestModel.getNotificationTypes()
                                                                                .stream()
                                                                                .map(notificationType -> new BlackDuckJobNotificationTypeEntity(jobId, notificationType))
                                                                                .collect(Collectors.toList());
         List<BlackDuckJobNotificationTypeEntity> savedNotificationTypes = blackDuckJobNotificationTypeRepository.saveAll(notificationTypesToSave);
         savedBlackDuckJobDetails.setBlackDuckJobNotificationTypes(savedNotificationTypes);
 
-        List<BlackDuckJobProjectEntity> ProjectFiltersToSave = distributionJobModel.getProjectFilterProjectNames()
+        List<BlackDuckJobProjectEntity> ProjectFiltersToSave = requestModel.getProjectFilterProjectNames()
                                                                    .stream()
                                                                    .map(projectName -> new BlackDuckJobProjectEntity(jobId, projectName))
                                                                    .collect(Collectors.toList());
         List<BlackDuckJobProjectEntity> savedProjectFilters = blackDuckJobProjectRepository.saveAll(ProjectFiltersToSave);
         savedBlackDuckJobDetails.setBlackDuckJobProjects(savedProjectFilters);
 
-        List<BlackDuckJobPolicyFilterEntity> policyFiltersToSave = distributionJobModel.getPolicyFilterPolicyNames()
+        List<BlackDuckJobPolicyFilterEntity> policyFiltersToSave = requestModel.getPolicyFilterPolicyNames()
                                                                        .stream()
                                                                        .map(policyName -> new BlackDuckJobPolicyFilterEntity(jobId, policyName))
                                                                        .collect(Collectors.toList());
         List<BlackDuckJobPolicyFilterEntity> savedPolicyFilters = blackDuckJobPolicyFilterRepository.saveAll(policyFiltersToSave);
         savedBlackDuckJobDetails.setBlackDuckJobPolicyFilters(savedPolicyFilters);
 
-        List<BlackDuckJobVulnerabilitySeverityFilterEntity> vulnerabilitySeverityFiltersToSave = distributionJobModel.getVulnerabilityFilterSeverityNames()
+        List<BlackDuckJobVulnerabilitySeverityFilterEntity> vulnerabilitySeverityFiltersToSave = requestModel.getVulnerabilityFilterSeverityNames()
                                                                                                      .stream()
                                                                                                      .map(severityName -> new BlackDuckJobVulnerabilitySeverityFilterEntity(jobId, severityName))
                                                                                                      .collect(Collectors.toList());


### PR DESCRIPTION
#### Create new `JobAccessor` to aid in the transition from `ConfigurationJobModel` to `DistributionJobModel`

**Changes proposed in this pull request:**

* Create new `JobAccessor` interface: `JobAccessorV2`
* Create new `JobAccessorV2` implementation: `StaticJobAccessorV2`
* Don't carry over `JobAccessor::getAllJobs` or `JobAccessor::getJobsByFrequency`

Classes that currently use `JobAccessor` will be incrementally updated in future PR's to utilize these new classes.