### PR TITLE
Fix the self-signed cert to be a root certificate with SAN values.

### DIFF
--- a/buildSrc/src/main/java/com/synopsys/integration/alert/build/CreateKeystoreTask.java
+++ b/buildSrc/src/main/java/com/synopsys/integration/alert/build/CreateKeystoreTask.java
@@ -30,11 +30,17 @@ public class CreateKeystoreTask extends Exec {
             "-storetype",
             "PKCS12",
             "-validity",
-            "3650",
+            "365",
             "-storepass",
             "changeit",
             "-dname",
-            "CN=localhost, OU=Engineering, O=Synopsys, C=US"
+            "CN=localhost, OU=Engineering, O=Synopsys, C=US",
+            "-ext",
+            "eku=sa,ca",
+            "-ext",
+            "BasicConstraints=ca:true",
+            "-ext",
+            "san=dns:localhost,dns:localhost.localdomain,dns:lvh.me,ip:127.0.0.1,ip:FE80:0:0:0:0:0:0:1"
         );
     }
 }


### PR DESCRIPTION
Makes the certificate a root certificate that is a CA.  Also added SubjectAlternativeName values.  This allows the certificate to be accepted by the chrome browser.  The MacOS would block the certificate with the Catalina OS update in a chrome browser.  This will give the option to accept the certificate.