### PR TITLE
Ignore remediation data from Blackduck 2020.10.*+

### DIFF
--- a/provider/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/builder/VulnerabilityNotificationMessageBuilder.java
+++ b/provider/src/main/java/com/synopsys/integration/alert/provider/blackduck/collector/builder/VulnerabilityNotificationMessageBuilder.java
@@ -63,6 +63,7 @@ import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
 import com.synopsys.integration.blackduck.service.bucket.BlackDuckBucket;
 import com.synopsys.integration.blackduck.service.bucket.BlackDuckBucketService;
 import com.synopsys.integration.blackduck.service.dataservice.ComponentService;
+import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.rest.HttpUrl;
 
 @Component
@@ -132,12 +133,14 @@ public class VulnerabilityNotificationMessageBuilder extends BlackDuckMessageBui
                 componentAttributes.addAll(ComponentBuilderUtil.getUsageLinkableItems(bomComponent));
             }
 
+            String componentName = content.getComponentName();
+            String componentVersionName = content.getVersionName();
+            String componentVersionUrl = content.getComponentVersion();
+            String projectVersionUrl = affectedProjectVersion.getProjectVersion();
+            ComponentData componentData = new ComponentData(componentName, componentVersionName, projectVersionUrl, ProjectVersionView.VULNERABLE_COMPONENTS_LINK);
+            //TODO 2020.10.* deprecated GET /api/components/{componentId}/versions/{componentVersionId}/remediating
+            // For now, we will be ignoring remediation data
             try {
-                String componentName = content.getComponentName();
-                String componentVersionName = content.getVersionName();
-                String componentVersionUrl = content.getComponentVersion();
-                String projectVersionUrl = affectedProjectVersion.getProjectVersion();
-                ComponentData componentData = new ComponentData(componentName, componentVersionName, projectVersionUrl, ProjectVersionView.VULNERABLE_COMPONENTS_LINK);
                 if (addRemediationData && StringUtils.isNotBlank(componentVersionUrl)) {
                     HttpUrl componentVersionHttpUrl = new HttpUrl(componentVersionUrl);
                     ComponentVersionView componentVersionView = blackDuckService.getResponse(componentVersionHttpUrl, ComponentVersionView.class);
@@ -145,11 +148,17 @@ public class VulnerabilityNotificationMessageBuilder extends BlackDuckMessageBui
                     List<LinkableItem> remediationItems = VulnerabilityUtil.getRemediationItems(componentService, componentVersionView);
                     componentAttributes.addAll(remediationItems);
                 }
-                messageContentBuilder.applyAllComponentItems(
-                    createVulnerabilityItems(commonMessageData.getNotificationId(), itemOperation, componentData, componentItemCallbackInfo, componentAttributes, vulnerabilities, blackDuckResponseCache, vulnerabilityFilters));
+            } catch (IntegrationException e) {
+                logger.error("Could not get remediation data: {}", e.getMessage());
+                logger.debug(e.getMessage(), e);
+            }
+            messageContentBuilder.applyAllComponentItems(
+                createVulnerabilityItems(commonMessageData.getNotificationId(), itemOperation, componentData, componentItemCallbackInfo, componentAttributes, vulnerabilities, blackDuckResponseCache, vulnerabilityFilters));
+            try {
                 messageContents.add(messageContentBuilder.build());
-            } catch (Exception e) {
-                logger.error("Mishandled the expected type of a notification field", e);
+            } catch (AlertException e) {
+                logger.error("Could not construct the message: {}", e.getMessage());
+                logger.debug(e.getMessage(), e);
             }
         }
         return messageContents;


### PR DESCRIPTION
https://jira-sig.internal.synopsys.com/browse/IALERT-2083

This is a temporary work around to Blackduck 2020.10.0 removing the: 
GET /api/components/{componentId}/versions/{componentVersionId}/remediating endpoint. In this version calling the endpoint will return to the user a 410 GONE. 

In the future the blackduck api team recommends that we switch to:
GET /api/components/{componentId}/versions/{componentVersionId}/upgrade-guidance.

The purpose for this change is to still allow us to send messages even if remediation fails. Currently if that step fails, Alert will not send any notifications for vulnerabilities in 2020.10 or greater.