### PR TITLE
Update the ProvidersMissingTask validation

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/provider/lifecycle/ProvidersMissingTask.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/provider/lifecycle/ProvidersMissingTask.java
@@ -51,4 +51,8 @@ public class ProvidersMissingTask extends StartupScheduledTask {
         providerMissingValidator.validate();
     }
 
+    @Override
+    protected void postTaskStartup() {
+        runTask();
+    }
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/provider/lifecycle/ProvidersMissingTask.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/provider/lifecycle/ProvidersMissingTask.java
@@ -43,7 +43,7 @@ public class ProvidersMissingTask extends StartupScheduledTask {
 
     @Override
     public String scheduleCronExpression() {
-        return ScheduledTask.EVERY_MINUTE_CRON_EXPRESSION;
+        return ScheduledTask.EVERY_HOUR_CRON_EXPRESSION;
     }
 
     @Override

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/task/ScheduledTask.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/task/ScheduledTask.java
@@ -44,6 +44,7 @@ public abstract class ScheduledTask implements Runnable {
     public static final String STOP_SCHEDULE_EXPRESSION = "";
     //Spring Cron documentation  https://riptutorial.com/spring/example/21209/cron-expression
     public static final String EVERY_MINUTE_CRON_EXPRESSION = "0 0/1 * 1/1 * *";
+    public static final String EVERY_HOUR_CRON_EXPRESSION = "0 * * * * *";
     public static final String ONCE_DAILY_CRON_EXPRESSION = "0 0 0 * * *";
     public static final Long EVERY_MINUTE_SECONDS = 60L;
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/task/ScheduledTask.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/task/ScheduledTask.java
@@ -44,7 +44,7 @@ public abstract class ScheduledTask implements Runnable {
     public static final String STOP_SCHEDULE_EXPRESSION = "";
     //Spring Cron documentation  https://riptutorial.com/spring/example/21209/cron-expression
     public static final String EVERY_MINUTE_CRON_EXPRESSION = "0 0/1 * 1/1 * *";
-    public static final String EVERY_HOUR_CRON_EXPRESSION = "0 * * * * *";
+    public static final String EVERY_HOUR_CRON_EXPRESSION = "0 0 0/1 * * *";
     public static final String ONCE_DAILY_CRON_EXPRESSION = "0 0 0 * * *";
     public static final Long EVERY_MINUTE_SECONDS = 60L;
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/task/ScheduledTask.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/task/ScheduledTask.java
@@ -44,7 +44,7 @@ public abstract class ScheduledTask implements Runnable {
     public static final String STOP_SCHEDULE_EXPRESSION = "";
     //Spring Cron documentation  https://riptutorial.com/spring/example/21209/cron-expression
     public static final String EVERY_MINUTE_CRON_EXPRESSION = "0 0/1 * 1/1 * *";
-    public static final String EVERY_HOUR_CRON_EXPRESSION = "0 0 */1 * * *";
+    public static final String EVERY_HOUR_CRON_EXPRESSION = "0 0 0/1 * * *";
     public static final String ONCE_DAILY_CRON_EXPRESSION = "0 0 0 * * *";
     public static final Long EVERY_MINUTE_SECONDS = 60L;
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/task/ScheduledTask.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/task/ScheduledTask.java
@@ -44,7 +44,7 @@ public abstract class ScheduledTask implements Runnable {
     public static final String STOP_SCHEDULE_EXPRESSION = "";
     //Spring Cron documentation  https://riptutorial.com/spring/example/21209/cron-expression
     public static final String EVERY_MINUTE_CRON_EXPRESSION = "0 0/1 * 1/1 * *";
-    public static final String EVERY_HOUR_CRON_EXPRESSION = "0 0 0/1 * * *";
+    public static final String EVERY_HOUR_CRON_EXPRESSION = "0 0 */1 * * *";
     public static final String ONCE_DAILY_CRON_EXPRESSION = "0 0 0 * * *";
     public static final Long EVERY_MINUTE_SECONDS = 60L;
 


### PR DESCRIPTION
The desire was to have `ProvidersMissingTask` validate on startup and only validate every hour instead of every minute.
`ProvidersMissingTask` already extends `StartupScheduledTask` so the `StartupScheduledTask::postTaskStartup` needed to be implemented.