### PR TITLE
Add deserializer for DistributionJobDetailsModel

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/DistributionJobModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/DistributionJobModel.java
@@ -42,6 +42,12 @@ public class DistributionJobModel extends DistributionJobModelData {
         return new DistributionJobModelBuilder();
     }
 
+    /* package private */ DistributionJobModel() {
+        this.jobId = null;
+        this.createdAt = null;
+        this.lastUpdated = null;
+    }
+
     protected DistributionJobModel(
         UUID jobId,
         boolean enabled,

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/DistributionJobModelData.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/DistributionJobModelData.java
@@ -51,6 +51,22 @@ public abstract class DistributionJobModelData extends AlertSerializableModel {
 
     private final DistributionJobDetailsModel distributionJobDetails;
 
+    /* package private */ DistributionJobModelData() {
+        this.enabled = true;
+        this.name = null;
+        this.distributionFrequency = FrequencyType.REAL_TIME;
+        this.processingType = ProcessingType.DEFAULT;
+        this.channelDescriptorName = null;
+        this.blackDuckGlobalConfigId = null;
+        this.filterByProject = false;
+        this.projectNamePattern = null;
+        this.notificationTypes = List.of();
+        this.projectFilterDetails = List.of();
+        this.policyFilterPolicyNames = List.of();
+        this.vulnerabilityFilterSeverityNames = List.of();
+        this.distributionJobDetails = null;
+    }
+
     public DistributionJobModelData(
         boolean enabled,
         String name,

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/details/DistributionJobDetailsModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/details/DistributionJobDetailsModel.java
@@ -22,6 +22,7 @@
  */
 package com.synopsys.integration.alert.common.persistence.model.job.details;
 
+import com.google.gson.annotations.JsonAdapter;
 import com.synopsys.integration.alert.common.rest.model.AlertSerializableModel;
 import com.synopsys.integration.alert.descriptor.api.AzureBoardsChannelKey;
 import com.synopsys.integration.alert.descriptor.api.EmailChannelKey;
@@ -31,8 +32,13 @@ import com.synopsys.integration.alert.descriptor.api.MsTeamsKey;
 import com.synopsys.integration.alert.descriptor.api.SlackChannelKey;
 import com.synopsys.integration.alert.descriptor.api.model.ChannelKey;
 
+@JsonAdapter(DistributionJobDetailsModelDeserializer.class)
 public abstract class DistributionJobDetailsModel extends AlertSerializableModel {
     private final String channelDescriptorName;
+
+    /* package private */ DistributionJobDetailsModel() {
+        this.channelDescriptorName = null;
+    }
 
     /* package private */ DistributionJobDetailsModel(String channelDescriptorName) {
         this.channelDescriptorName = channelDescriptorName;

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/details/DistributionJobDetailsModelDeserializer.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/details/DistributionJobDetailsModelDeserializer.java
@@ -1,0 +1,57 @@
+/**
+ * alert-common
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.alert.common.persistence.model.job.details;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+
+public class DistributionJobDetailsModelDeserializer implements JsonDeserializer<DistributionJobDetailsModel> {
+    @Override
+    public DistributionJobDetailsModel deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext context) throws JsonParseException {
+        JsonObject jsonObject = jsonElement.getAsJsonObject();
+        JsonPrimitive channelDescriptorName = jsonObject.getAsJsonPrimitive("channelDescriptorName");
+        DistributionJobDetailsModel distributionJobDetailsModel = new DistributionJobDetailsModel(channelDescriptorName.getAsString()) {};
+        if (distributionJobDetailsModel.isAzureBoardsDetails()) {
+            return context.deserialize(jsonObject, AzureBoardsJobDetailsModel.class);
+        } else if (distributionJobDetailsModel.isEmailDetails()) {
+            return context.deserialize(jsonObject, EmailJobDetailsModel.class);
+        } else if (distributionJobDetailsModel.isJiraCloudDetails()) {
+            return context.deserialize(jsonObject, JiraCloudJobDetailsModel.class);
+        } else if (distributionJobDetailsModel.isJiraServerDetails()) {
+            return context.deserialize(jsonObject, JiraServerJobDetailsModel.class);
+        } else if (distributionJobDetailsModel.isMSTeamsDetails()) {
+            return context.deserialize(jsonObject, MSTeamsJobDetailsModel.class);
+        } else if (distributionJobDetailsModel.isSlackDetails()) {
+            return context.deserialize(jsonObject, SlackJobDetailsModel.class);
+        } else {
+            throw new JsonParseException("Could not determine an appropriate sub-class for " + type);
+        }
+    }
+
+}

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/persistence/model/job/details/DistributionJobDetailsModelDeserializerTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/persistence/model/job/details/DistributionJobDetailsModelDeserializerTest.java
@@ -1,0 +1,131 @@
+package com.synopsys.integration.alert.common.persistence.model.job.details;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+public class DistributionJobDetailsModelDeserializerTest {
+    private final Gson gson = new Gson();
+    private final JsonDeserializationContext jsonDeserializationContext = gson::fromJson;
+
+    @Test
+    public void deserializeAzureBoardsJobDetailsModelTest() {
+        AzureBoardsJobDetailsModel baseModel = new AzureBoardsJobDetailsModel(true, "project name", "task", "none", "alt");
+
+        DistributionJobDetailsModel deserializedModel = runDeserializerAndAssert(baseModel, DistributionJobDetailsModel::isAzureBoardsDetails);
+
+        AzureBoardsJobDetailsModel jobDetails = deserializedModel.getAsAzureBoardsJobDetails();
+        assertEquals(baseModel.isAddComments(), jobDetails.isAddComments());
+        assertEquals(baseModel.getProjectNameOrId(), jobDetails.getProjectNameOrId());
+        assertEquals(baseModel.getWorkItemType(), jobDetails.getWorkItemType());
+        assertEquals(baseModel.getWorkItemCompletedState(), jobDetails.getWorkItemCompletedState());
+        assertEquals(baseModel.getWorkItemReopenState(), jobDetails.getWorkItemReopenState());
+    }
+
+    @Test
+    public void deserializeEmailJobDetailsModelTest() {
+        EmailJobDetailsModel baseModel = new EmailJobDetailsModel("alert subject", false, true, null, List.of("email 1", "email 2"));
+
+        DistributionJobDetailsModel deserializedModel = runDeserializerAndAssert(baseModel, DistributionJobDetailsModel::isEmailDetails);
+
+        EmailJobDetailsModel jobDetails = deserializedModel.getAsEmailJobDetails();
+        assertEquals(baseModel.getSubjectLine(), jobDetails.getSubjectLine());
+        assertEquals(baseModel.isProjectOwnerOnly(), jobDetails.isProjectOwnerOnly());
+        assertEquals(baseModel.isAdditionalEmailAddressesOnly(), jobDetails.isAdditionalEmailAddressesOnly());
+        assertEquals(baseModel.getAttachmentFileType(), jobDetails.getAttachmentFileType());
+        assertEquals(baseModel.getAdditionalEmailAddresses(), jobDetails.getAdditionalEmailAddresses());
+    }
+
+    @Test
+    public void deserializeJiraCloudJobDetailsModelTest() {
+        JiraCloudJobDetailsModel baseModel = new JiraCloudJobDetailsModel(true, "unknown", "JIRA-X", "bug", "done", "undone");
+
+        DistributionJobDetailsModel deserializedModel = runDeserializerAndAssert(baseModel, DistributionJobDetailsModel::isJiraCloudDetails);
+
+        JiraCloudJobDetailsModel jobDetails = deserializedModel.getAsJiraCouldJobDetails();
+        assertEquals(baseModel.isAddComments(), jobDetails.isAddComments());
+        assertEquals(baseModel.getIssueCreatorEmail(), jobDetails.getIssueCreatorEmail());
+        assertEquals(baseModel.getProjectNameOrKey(), jobDetails.getProjectNameOrKey());
+        assertEquals(baseModel.getIssueType(), jobDetails.getIssueType());
+        assertEquals(baseModel.getResolveTransition(), jobDetails.getResolveTransition());
+        assertEquals(baseModel.getReopenTransition(), jobDetails.getReopenTransition());
+    }
+
+    @Test
+    public void deserializeJiraServerJobDetailsModelTest() {
+        JiraServerJobDetailsModel baseModel = new JiraServerJobDetailsModel(true, "user_name01", "JIRA-Y", "other", "finished", "unfinished");
+
+        DistributionJobDetailsModel deserializedModel = runDeserializerAndAssert(baseModel, DistributionJobDetailsModel::isJiraServerDetails);
+
+        JiraServerJobDetailsModel jobDetails = deserializedModel.getAsJiraServerJobDetails();
+        assertEquals(baseModel.isAddComments(), jobDetails.isAddComments());
+        assertEquals(baseModel.getIssueCreatorUsername(), jobDetails.getIssueCreatorUsername());
+        assertEquals(baseModel.getProjectNameOrKey(), jobDetails.getProjectNameOrKey());
+        assertEquals(baseModel.getIssueType(), jobDetails.getIssueType());
+        assertEquals(baseModel.getResolveTransition(), jobDetails.getResolveTransition());
+        assertEquals(baseModel.getReopenTransition(), jobDetails.getReopenTransition());
+    }
+
+    @Test
+    public void deserializeMSTeamsJobDetailsModelTest() {
+        MSTeamsJobDetailsModel baseModel = new MSTeamsJobDetailsModel("webhook_url");
+
+        DistributionJobDetailsModel deserializedModel = runDeserializerAndAssert(baseModel, DistributionJobDetailsModel::isMSTeamsDetails);
+
+        MSTeamsJobDetailsModel jobDetails = deserializedModel.getAsMSTeamsJobDetails();
+        assertEquals(baseModel.getWebhook(), jobDetails.getWebhook());
+    }
+
+    @Test
+    public void deserializeSlackJobDetailsModelTest() {
+        SlackJobDetailsModel baseModel = new SlackJobDetailsModel("slack_webhook_url", "a-cool-channel", "Channel Tester");
+
+        DistributionJobDetailsModel deserializedModel = runDeserializerAndAssert(baseModel, DistributionJobDetailsModel::isSlackDetails);
+
+        SlackJobDetailsModel jobDetails = deserializedModel.getAsSlackJobDetails();
+        assertEquals(baseModel.getWebhook(), jobDetails.getWebhook());
+        assertEquals(baseModel.getChannelName(), jobDetails.getChannelName());
+        assertEquals(baseModel.getChannelUsername(), jobDetails.getChannelUsername());
+    }
+
+    @Test
+    public void deserializeThrowsJsonParseExceptionTest() {
+        DistributionJobDetailsModel baseModel = new Test_DistributionJobDetailsModel();
+        JsonElement jsonElement = gson.toJsonTree(baseModel);
+        DistributionJobDetailsModelDeserializer deserializer = new DistributionJobDetailsModelDeserializer();
+
+        try {
+            deserializer.deserialize(jsonElement, DistributionJobDetailsModel.class, jsonDeserializationContext);
+            fail("Expected exception: " + JsonParseException.class);
+        } catch (JsonParseException e) {
+            // Success
+        }
+    }
+
+    private DistributionJobDetailsModel runDeserializerAndAssert(DistributionJobDetailsModel baseModel, Predicate<DistributionJobDetailsModel> isSpecifiedSubclass) {
+        JsonElement jsonElement = gson.toJsonTree(baseModel);
+        DistributionJobDetailsModelDeserializer deserializer = new DistributionJobDetailsModelDeserializer();
+        DistributionJobDetailsModel deserializedModel = deserializer.deserialize(jsonElement, DistributionJobDetailsModel.class, jsonDeserializationContext);
+        assertTrue(isSpecifiedSubclass.test(deserializedModel), "Expected to deserialize as " + baseModel.getClass().getSimpleName());
+        return deserializedModel;
+    }
+
+    private static class Test_DistributionJobDetailsModel extends DistributionJobDetailsModel {
+        public Test_DistributionJobDetailsModel() {
+            super("unknown_channel_name_" + RandomUtils.nextInt());
+        }
+
+    }
+
+}


### PR DESCRIPTION
- JMS uses Gson to serialize/deserialize
- DistributionJobDetailsModel is an abstract class, so it cannot be deserialized by Gson out of the box
- A custom type adapter allows abstract classes to be deserialized