### PR TITLE
Helm exposed Node port

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/AlertProperties.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/AlertProperties.java
@@ -61,6 +61,9 @@ public class AlertProperties {
     @Value("${server.port:}")
     private String serverPort;
 
+    @Value("${public.alert.webserver.port:}")
+    private String publicServerPort;
+
     @Value("${server.servlet.context-path:}")
     private String contextPath;
 
@@ -146,6 +149,10 @@ public class AlertProperties {
         return getOptionalString(serverPort);
     }
 
+    public Optional<String> getPublicServerPort() {
+        return getOptionalString(publicServerPort);
+    }
+
     public Optional<String> getContextPath() {
         return getOptionalString(contextPath);
     }
@@ -191,8 +198,8 @@ public class AlertProperties {
 
     public Optional<String> getServerUrl() {
         try {
-            String hostName = getAlertHostName().orElse(getAlertHostName().orElse("localhost"));
-            String port = getServerPort().orElse(getServerPort().orElse(getServerPort().orElse("")));
+            String hostName = getAlertHostName().orElse("localhost");
+            String port = getPublicServerPort().orElse(getServerPort().orElse(""));
             String path = getContextPath().orElse("");
             String protocol = "http";
             if (getSslEnabled()) {

--- a/deployment/helm/synopsys-alert/templates/_helpers.tpl
+++ b/deployment/helm/synopsys-alert/templates/_helpers.tpl
@@ -3,6 +3,15 @@
 _helpers.tpl - create helper functions for templating here...
 */}}
 
+{{/*
+Custom Node Port
+*/}}
+{{- define "customNodePort" -}}
+{{- if and .Values.exposedNodePort (eq .Values.exposedServiceType "NodePort") }}
+PUBLIC_ALERT_WEBSERVER_PORT: {{ quote .Values.exposedNodePort }}
+{{- end -}}
+{{- end -}}
+
 {{- define "alert.encryptionSecretEnvirons" -}}
 {{- if not (hasKey .Values.secretEnvirons "ALERT_ENCRYPTION_PASSWORD") }}
 ALERT_ENCRYPTION_PASSWORD: {{ required "must provide --set alertEncryptionPassword=\"\"" .Values.alertEncryptionPassword | b64enc }}

--- a/deployment/helm/synopsys-alert/templates/_helpers.tpl
+++ b/deployment/helm/synopsys-alert/templates/_helpers.tpl
@@ -3,15 +3,6 @@
 _helpers.tpl - create helper functions for templating here...
 */}}
 
-{{/*
-Custom Node Port
-*/}}
-{{- define "customNodePort" -}}
-{{- if and .Values.exposedNodePort (eq .Values.exposedServiceType "NodePort") }}
-PUBLIC_ALERT_WEBSERVER_PORT: {{ quote .Values.exposedNodePort }}
-{{- end -}}
-{{- end -}}
-
 {{- define "alert.encryptionSecretEnvirons" -}}
 {{- if not (hasKey .Values.secretEnvirons "ALERT_ENCRYPTION_PASSWORD") }}
 ALERT_ENCRYPTION_PASSWORD: {{ required "must provide --set alertEncryptionPassword=\"\"" .Values.alertEncryptionPassword | b64enc }}

--- a/deployment/helm/synopsys-alert/templates/alert-environ-configmap.yaml
+++ b/deployment/helm/synopsys-alert/templates/alert-environ-configmap.yaml
@@ -11,6 +11,9 @@ data:
   HUB_CFSSL_HOST: {{ .Release.Name }}-cfssl
   {{- end -}}
   {{- end -}}
+  {{- if and .Values.exposedNodePort (eq .Values.exposedServiceType "NodePort") }}
+  PUBLIC_ALERT_WEBSERVER_PORT: {{ quote .Values.exposedNodePort }}
+  {{- end -}}
   {{- if .Values.environs }}
   {{- include "alert.environs" . | nindent 2 }}
   {{- end }}


### PR DESCRIPTION
If the User manually configures the exposed Node port this change will allow us to grab that value by setting an environment variable and we can then use that when constructing the URL's that we expose in Alert. This addresses the issues with the links in the emails we send out, the callback URL for Azure, and the Swagger doc link.

Thank you Paulo for the assistance with these changes.