### PR TITLE
revise implementation to use updated blackduck-common

### DIFF
--- a/alert-platform/build.gradle
+++ b/alert-platform/build.gradle
@@ -13,9 +13,9 @@ dependencies {
         api 'com.sun.mail:javax.mail:1.6.2'
         api 'javax.mail:javax.mail-api:1.6.2'
 
-        api 'com.synopsys.integration:blackduck-common:50.3.0'
-        api 'com.synopsys.integration:integration-rest:6.1.2'
-        api 'com.synopsys.integration:integration-common:24.1.0'
+        api 'com.synopsys.integration:blackduck-common:51.0.0'
+        api 'com.synopsys.integration:integration-rest:7.0.0'
+        api 'com.synopsys.integration:integration-common:24.2.0'
 
         api 'org.springframework.security.extensions:spring-security-saml2-core:1.0.10.RELEASE'
 

--- a/provider/src/main/java/com/synopsys/integration/alert/provider/blackduck/issue/BlackDuckProviderIssueHandler.java
+++ b/provider/src/main/java/com/synopsys/integration/alert/provider/blackduck/issue/BlackDuckProviderIssueHandler.java
@@ -26,101 +26,79 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.BiFunction;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpHeaders;
 
 import com.google.gson.Gson;
-import com.synopsys.integration.blackduck.api.generated.view.IssueView;
+import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionIssuesView;
+import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionView;
+import com.synopsys.integration.blackduck.api.manual.temporary.component.IssueRequest;
 import com.synopsys.integration.blackduck.http.BlackDuckRequestBuilder;
-import com.synopsys.integration.blackduck.http.BlackDuckRequestFactory;
 import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
 import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.rest.HttpMethod;
 import com.synopsys.integration.rest.HttpUrl;
+import com.synopsys.integration.rest.body.StringBodyContent;
 import com.synopsys.integration.rest.request.Request;
 
 public class BlackDuckProviderIssueHandler {
     public static final String ISSUE_ENDPOINT_MEDIA_TYPE_V6 = "application/vnd.blackducksoftware.bill-of-materials-6+json";
     private final Gson gson;
     private final BlackDuckApiClient blackDuckApiClient;
-    private final BlackDuckRequestFactory blackDuckRequestFactory;
 
-    public BlackDuckProviderIssueHandler(Gson gson, BlackDuckApiClient blackDuckApiClient, BlackDuckRequestFactory blackDuckRequestFactory) {
+    public BlackDuckProviderIssueHandler(Gson gson, BlackDuckApiClient blackDuckApiClient) {
         this.gson = gson;
         this.blackDuckApiClient = blackDuckApiClient;
-        this.blackDuckRequestFactory = blackDuckRequestFactory;
     }
 
-    public void createOrUpdateBlackDuckIssue(String bomComponentVersionIssuesUrl, BlackDuckProviderIssueModel issueModel) throws IntegrationException {
-        Optional<IssueView> optionalExistingIssue = retrieveExistingIssue(bomComponentVersionIssuesUrl, issueModel.getKey());
+    public void createOrUpdateBlackDuckIssue(ProjectVersionView projectVersionView, String bomComponentVersionIssuesUrl, BlackDuckProviderIssueModel issueModel) throws IntegrationException {
+        Optional<ProjectVersionIssuesView> optionalExistingIssue = retrieveExistingIssue(projectVersionView, issueModel.getKey());
 
         Date currentDate = Date.from(Instant.now());
         HttpUrl requestUri = new HttpUrl(bomComponentVersionIssuesUrl);
-        IssueView issueRequestModel = createIssueRequestModel(issueModel);
+        IssueRequest issueRequestModel = createIssueRequestModel(issueModel);
 
-        BiFunction<HttpUrl, String, BlackDuckRequestBuilder> requestBuilderCreator;
+        HttpMethod httpMethod = HttpMethod.POST;
         if (optionalExistingIssue.isPresent()) {
-            IssueView existingIssue = optionalExistingIssue.get();
+            ProjectVersionIssuesView existingIssue = optionalExistingIssue.get();
             issueRequestModel.setIssueDescription(existingIssue.getIssueDescription());
             issueRequestModel.setIssueCreatedAt(existingIssue.getIssueCreatedAt());
             issueRequestModel.setIssueUpdatedAt(currentDate);
 
             // The request uri should point at the specific issue for PUT requests
-            requestUri = existingIssue.getMeta().getHref();
-            requestBuilderCreator = blackDuckRequestFactory::createCommonPutRequestBuilder;
+            httpMethod = HttpMethod.PUT;
+            requestUri = existingIssue.getHref();
         } else {
             issueRequestModel.setIssueCreatedAt(currentDate);
             issueRequestModel.setIssueUpdatedAt(null);
-            requestBuilderCreator = blackDuckRequestFactory::createCommonPostRequestBuilder;
         }
-        performRequest(requestUri, issueRequestModel, requestBuilderCreator);
+
+        performRequest(requestUri, httpMethod, issueRequestModel);
     }
 
-    // TODO fix this logic once the bomComponentVersionIssuesUrl supports GET requests directly
-    private Optional<IssueView> retrieveExistingIssue(String bomComponentVersionIssuesUrl, String issueKey) throws IntegrationException {
-        String issueLookupUrl = createIssueLookupUrl(bomComponentVersionIssuesUrl);
-        HttpUrl issueLookupHttpUrl = new HttpUrl(issueLookupUrl);
-        BlackDuckRequestBuilder requestBuilder = blackDuckRequestFactory.createCommonGetRequestBuilder(issueLookupHttpUrl)
-                                                     .addHeader(HttpHeaders.ACCEPT, ISSUE_ENDPOINT_MEDIA_TYPE_V6);
-
-        // This is really a List<BomComponentIssueView>, but BomComponentIssueView is not considered a BlackDuckResponse.
-        List<IssueView> bomComponentIssues = blackDuckApiClient.getAllResponses(requestBuilder, IssueView.class);
+    private Optional<ProjectVersionIssuesView> retrieveExistingIssue(ProjectVersionView projectVersionView, String issueKey) throws IntegrationException {
+        List<ProjectVersionIssuesView> bomComponentIssues = blackDuckApiClient.getAllResponses(projectVersionView, ProjectVersionView.ISSUES_LINK_RESPONSE);
         return bomComponentIssues
                    .stream()
                    .filter(issue -> issue.getIssueId().equals(issueKey))
                    .findAny();
     }
 
-    private void performRequest(HttpUrl httpUrl, IssueView requestModel, BiFunction<HttpUrl, String, BlackDuckRequestBuilder> requestBuilderCreator) throws IntegrationException {
-        String requestJson = gson.toJson(requestModel);
-        Request request = requestBuilderCreator.apply(httpUrl, requestJson)
-                              .addHeader(HttpHeaders.CONTENT_TYPE, ISSUE_ENDPOINT_MEDIA_TYPE_V6)
-                              .addHeader(HttpHeaders.ACCEPT, ISSUE_ENDPOINT_MEDIA_TYPE_V6)
+    private void performRequest(HttpUrl httpUrl, HttpMethod httpMethod, IssueRequest issueRequest) throws IntegrationException {
+        Request request = new BlackDuckRequestBuilder(new Request.Builder())
+                              .url(httpUrl)
+                              .method(httpMethod)
+                              .bodyContent(new StringBodyContent(gson.toJson(issueRequest)))
                               .build();
         blackDuckApiClient.execute(request);
     }
 
-    private IssueView createIssueRequestModel(BlackDuckProviderIssueModel issueModel) {
-        IssueView blackDuckIssueView = new IssueView();
-        blackDuckIssueView.setIssueId(issueModel.getKey());
-        blackDuckIssueView.setIssueLink(issueModel.getLink());
-        blackDuckIssueView.setIssueAssignee(issueModel.getAssignee());
-        blackDuckIssueView.setIssueStatus(issueModel.getStatus());
-        blackDuckIssueView.setIssueDescription(issueModel.getSummary());
-        return blackDuckIssueView;
-    }
-
-    /**
-     * @param bomComponentVersionIssuesUrl a string in the format of<br/>
-     *                                     {blackDuckUrl}/api/projects/{projectId}/versions/{projectVersionId}/components/{componentId}/issues<br/>
-     *                                     or<br/>
-     *                                     {blackDuckUrl}/api/projects/{projectId}/versions/{projectVersionId}/components/{componentId}/component-versions/{componentVersionId}/issues
-     * @return a string in the format of {blackDuckUrl}/api/projects/{projectId}/versions/{projectVersionId}/issues
-     */
-    private String createIssueLookupUrl(String bomComponentVersionIssuesUrl) {
-        String projectVersionUrl = StringUtils.substringBefore(bomComponentVersionIssuesUrl, "/components");
-        return projectVersionUrl + "/issues";
+    private IssueRequest createIssueRequestModel(BlackDuckProviderIssueModel issueModel) {
+        IssueRequest blackDuckIssueRequest = new IssueRequest();
+        blackDuckIssueRequest.setIssueId(issueModel.getKey());
+        blackDuckIssueRequest.setIssueLink(issueModel.getLink());
+        blackDuckIssueRequest.setIssueAssignee(issueModel.getAssignee());
+        blackDuckIssueRequest.setIssueStatus(issueModel.getStatus());
+        blackDuckIssueRequest.setIssueDescription(issueModel.getSummary());
+        return blackDuckIssueRequest;
     }
 
 }


### PR DESCRIPTION
***NOTE***
This does not compile. All I'm trying to show here is a different implementation based on an issue created by James related to this class. It adds a clearer dependency on ProjectVersionView, which should be possible to acquire and pass in. Once that is done, there may be other side effects of upgrading to 51.0.0.