### PR TITLE
Add content-security-policy header and allow inline script execution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ ext {
 }
 
 mainClassName = 'com.synopsys.integration.alert.Application'
-version = '6.3.1'
+version = '6.3.2-SNAPSHOT'
 
 apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'

--- a/component/src/main/java/com/synopsys/integration/alert/component/authentication/security/AuthenticationHandler.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/authentication/security/AuthenticationHandler.java
@@ -183,12 +183,14 @@ public class AuthenticationHandler extends WebSecurityConfigurerAdapter {
 
     private void configureHeaders(HttpSecurity http) throws Exception {
         http
+            //preserve default headers.
             .headers()
             .contentTypeOptions()
             .and().xssProtection()
             .and().cacheControl()
             .and().httpStrictTransportSecurity()
             .and().frameOptions()
+            // new header for Content Security Policy to allow the SAML auto-submit form for post binding.
             .and().addHeaderWriter(new StaticHeadersWriter("Content-Security-Policy", "script-src 'self' 'unsafe-inline'"));
     }
 

--- a/component/src/main/java/com/synopsys/integration/alert/component/authentication/security/AuthenticationHandler.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/authentication/security/AuthenticationHandler.java
@@ -87,6 +87,7 @@ import org.springframework.security.web.authentication.logout.SecurityContextLog
 import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.security.web.header.writers.StaticHeadersWriter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
@@ -149,6 +150,7 @@ public class AuthenticationHandler extends WebSecurityConfigurerAdapter {
         configureActiveMQProvider();
         configureWithSSL(http);
         configureH2Console(http);
+        configureHeaders(http);
         http.authorizeRequests()
             .requestMatchers(createAllowedPathMatchers()).permitAll()
             .and().authorizeRequests().anyRequest().authenticated()
@@ -177,6 +179,17 @@ public class AuthenticationHandler extends WebSecurityConfigurerAdapter {
             // nothing needed here if that provider does not exist
             logger.info("Alert Application Configuration: Bouncy Castle provider not found");
         }
+    }
+
+    private void configureHeaders(HttpSecurity http) throws Exception {
+        http
+            .headers()
+            .contentTypeOptions()
+            .and().xssProtection()
+            .and().cacheControl()
+            .and().httpStrictTransportSecurity()
+            .and().frameOptions()
+            .and().addHeaderWriter(new StaticHeadersWriter("Content-Security-Policy", "script-src 'self' 'unsafe-inline'"));
     }
 
     private void configureH2Console(HttpSecurity http) throws Exception {
@@ -246,6 +259,7 @@ public class AuthenticationHandler extends WebSecurityConfigurerAdapter {
     public SavedRequestAwareAuthenticationSuccessHandler successRedirectHandler() {
         SavedRequestAwareAuthenticationSuccessHandler redirectHandler = new SavedRequestAwareAuthenticationSuccessHandler();
         redirectHandler.setDefaultTargetUrl("/");
+        redirectHandler.setAlwaysUseDefaultTargetUrl(true);
         return redirectHandler;
     }
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "blackduck-alert",
-  "version": "6.3.1-SIGQA1",
+  "version": "6.3.2-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blackduck-alert",
-    "version": "6.3.1",
+    "version": "6.3.2-SNAPSHOT",
     "description": "Alert UI",
     "keywords": [
         "blackduck",


### PR DESCRIPTION
The SAML post binding uses an auto-submit form that requires inline javascript to be executed to communicate with the IDP as part of the SAML Login process.  Add the header to allow the inline execution of javascript for the auto-submit form to work for SAML IDP providers like Azure.