### PR TITLE
NotificationReciever timeout

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,7 +27,7 @@ spring.h2.console.path=/h2
 spring.h2.console.enabled=false
 # JMS
 spring.jms.template.qos-enabled=true
-spring.jms.template.time-to-live=120000ms
+spring.jms.template.time-to-live=14400000ms
 # SSL Properties
 server.ssl.enabled=true
 server.ssl.key-store=file:${SECURITY_DIR:/opt/blackduck/alert/security}/blackduck-alert.keystore


### PR DESCRIPTION
Per this mornings discussion, I've updated NotificationReciever to timeout after 2 hours of running. Also I've updated the time-to-live for the jms messages to now be 4 hours long.

I will add a new ticket to the 6.5.0 changes to change this timeout back to 2 minutes.