### PR TITLE
Add source for simple messages

### DIFF
--- a/processor-api/src/main/java/com/synopsys/integration/alert/processor/api/extract/model/SimpleMessage.java
+++ b/processor-api/src/main/java/com/synopsys/integration/alert/processor/api/extract/model/SimpleMessage.java
@@ -23,19 +23,34 @@
 package com.synopsys.integration.alert.processor.api.extract.model;
 
 import java.util.List;
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
 
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ProjectMessage;
 
 public class SimpleMessage extends ProviderMessage<SimpleMessage> {
     private final String summary;
     private final String description;
     private final List<LinkableItem> details;
 
-    public SimpleMessage(LinkableItem provider, String summary, String description, List<LinkableItem> details) {
+    private final ProjectMessage source;
+
+    public static SimpleMessage original(LinkableItem provider, String summary, String description, List<LinkableItem> details) {
+        return new SimpleMessage(provider, summary, description, details, null);
+    }
+
+    public static SimpleMessage derived(String summary, String description, List<LinkableItem> details, ProjectMessage source) {
+        return new SimpleMessage(source.getProvider(), summary, description, details, source);
+    }
+
+    private SimpleMessage(LinkableItem provider, String summary, String description, List<LinkableItem> details, @Nullable ProjectMessage source) {
         super(provider);
         this.summary = summary;
         this.description = description;
         this.details = details;
+        this.source = source;
     }
 
     public String getSummary() {
@@ -48,6 +63,10 @@ public class SimpleMessage extends ProviderMessage<SimpleMessage> {
 
     public List<LinkableItem> getDetails() {
         return details;
+    }
+
+    public Optional<ProjectMessage> getSource() {
+        return Optional.ofNullable(source);
     }
 
     @Override

--- a/processor-api/src/main/java/com/synopsys/integration/alert/processor/api/summarize/ProjectMessageSummarizer.java
+++ b/processor-api/src/main/java/com/synopsys/integration/alert/processor/api/summarize/ProjectMessageSummarizer.java
@@ -48,7 +48,7 @@ public class ProjectMessageSummarizer {
     public SimpleMessage summarize(ProjectMessage digestedProjectMessage) {
         Pair<String, String> summaryAndDescription = constructSummaryAndDescription(digestedProjectMessage);
         List<LinkableItem> details = constructMessageDetails(digestedProjectMessage);
-        return new SimpleMessage(digestedProjectMessage.getProvider(), summaryAndDescription.getLeft(), summaryAndDescription.getRight(), details);
+        return SimpleMessage.derived(summaryAndDescription.getLeft(), summaryAndDescription.getRight(), details, digestedProjectMessage);
     }
 
     private Pair<String, String> constructSummaryAndDescription(ProjectMessage projectMessage) {

--- a/processor-api/src/test/java/com/synopsys/integration/alert/processor/api/ProviderMessageHolderTest.java
+++ b/processor-api/src/test/java/com/synopsys/integration/alert/processor/api/ProviderMessageHolderTest.java
@@ -16,7 +16,7 @@ import com.synopsys.integration.alert.processor.api.extract.model.project.Projec
 
 public class ProviderMessageHolderTest {
     private static final LinkableItem PROVIDER = new LinkableItem("BlackDuck", "test-server01");
-    private static final SimpleMessage SIMPLE_MESSAGE = new SimpleMessage(PROVIDER, "Subject", "Description", List.of());
+    private static final SimpleMessage SIMPLE_MESSAGE = SimpleMessage.original(PROVIDER, "Subject", "Description", List.of());
     private static final ProjectMessage PROJECT_MESSAGE = ProjectMessage.projectStatusInfo(PROVIDER, new LinkableItem("Project", "My Project"), ProjectOperation.CREATE);
 
     @Test


### PR DESCRIPTION
If a `SimpleMessage` is derived, its source can be used by consumers to determine specific (strongly-typed) details about it.