### PR TITLE
Exclude snakeyaml

### DIFF
--- a/alert-database/build.gradle
+++ b/alert-database/build.gradle
@@ -32,7 +32,9 @@ dependencies {
     implementation 'org.hibernate:hibernate-core'
 
     runtimeOnly 'org.postgresql:postgresql'
-    runtimeOnly 'org.liquibase:liquibase-core'
+    runtimeOnly(group: 'org.liquibase', name: 'liquibase-core') {
+        exclude group: 'org.yaml', module: 'snakeyaml'
+    }
 
     // Connection Pool
     // https://www.baeldung.com/hibernate-c3p0

--- a/build.gradle
+++ b/build.gradle
@@ -159,7 +159,6 @@ distributions {
                 include 'liquibase-core*.jar'
                 include 'logback-*.jar'
                 include 'slf4j-api*.jar'
-                include 'snakeyaml*.jar'
                 into 'lib/liquibase'
             }
             from('src/main/resources/db/changelog-master.xml') { into 'upgradeResources' }

--- a/buildSrc/buildTasks.gradle
+++ b/buildSrc/buildTasks.gradle
@@ -8,7 +8,7 @@ def findJar(Object... prefixes) {
 }
 
 task copyToLib(type: Copy, dependsOn: [compileJava]) {
-    from findJar('h2', 'liquibase', 'logback-classic', 'logback-core', 'slf4j-api', 'snakeyaml')
+    from findJar('h2', 'liquibase', 'logback-classic', 'logback-core', 'slf4j-api')
     into "${project.buildDir}/libs/liquibase"
 }
 


### PR DESCRIPTION
We are not using snakeyaml and the version that is being dragged in transitively is vulnerable, so we should exclude it. Excluding it does not seem to have any impact at all. I have started Alert using the runServer task and everything seems to be working perfectly fine, there do not seem to be any issues with liquibase when excluding this. 
