### PR TITLE
Jm ms teams improvements

### DIFF
--- a/channel/src/main/java/com/synopsys/integration/alert/channel/msteams2/MSTeamsChannelMessageConverter.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/msteams2/MSTeamsChannelMessageConverter.java
@@ -56,14 +56,14 @@ public class MSTeamsChannelMessageConverter extends AbstractChannelMessageConver
         String provider = providerDetails.getProvider().getValue();
         String messageTitle = String.format("Received a message from %s", provider);
         List<MSTeamsChannelMessageSection> messageSections = createMessageSections(messageChunks);
-        MSTeamsChannelMessageModel messageModel = new MSTeamsChannelMessageModel(providerDetails, messageTitle, messageSections);
+        MSTeamsChannelMessageModel messageModel = new MSTeamsChannelMessageModel(messageTitle, messageSections);
         return List.of(messageModel);
     }
 
     private List<MSTeamsChannelMessageSection> createMessageSections(List<String> messageChunks) {
         List<MSTeamsChannelMessageSection> messageSections = new LinkedList<>();
         int messageChunksSize = messageChunks.size();
-        
+
         if (messageChunksSize > 1) {
             for (int i = 0; i < messageChunksSize; i++) {
                 String title = String.format("(%s/%s)", i + 1, messageChunksSize);

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/msteams2/MSTeamsChannelMessageConverter.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/msteams2/MSTeamsChannelMessageConverter.java
@@ -53,20 +53,29 @@ public class MSTeamsChannelMessageConverter extends AbstractChannelMessageConver
     }
 
     private List<MSTeamsChannelMessageModel> createMessageModel(ProviderDetails providerDetails, List<String> messageChunks) {
-        List<MSTeamsChannelMessageModel> messageModels = new LinkedList<>();
-        int messagesSize = messageChunks.size();
-        if (messagesSize > 1) {
-            for (int i = 0; i < messagesSize; i++) {
-                String title = String.format("(%s/%s)", i + 1, messagesSize);
-                messageModels.add(new MSTeamsChannelMessageModel(providerDetails, title, messageChunks.get(i)));
+        String provider = providerDetails.getProvider().getValue();
+        String messageTitle = String.format("Received a message from %s", provider);
+        List<MSTeamsChannelMessageSection> messageSections = createMessageSections(messageChunks);
+        MSTeamsChannelMessageModel messageModel = new MSTeamsChannelMessageModel(providerDetails, messageTitle, messageSections);
+        return List.of(messageModel);
+    }
+
+    private List<MSTeamsChannelMessageSection> createMessageSections(List<String> messageChunks) {
+        List<MSTeamsChannelMessageSection> messageSections = new LinkedList<>();
+        int messageChunksSize = messageChunks.size();
+        
+        if (messageChunksSize > 1) {
+            for (int i = 0; i < messageChunksSize; i++) {
+                String title = String.format("(%s/%s)", i + 1, messageChunksSize);
+                messageSections.add(new MSTeamsChannelMessageSection(title, messageChunks.get(i)));
             }
         } else {
             messageChunks.stream()
-                .map(messageContent -> new MSTeamsChannelMessageModel(providerDetails, StringUtils.EMPTY, messageContent))
-                .forEach(messageModels::add);
+                .map(messageContent -> new MSTeamsChannelMessageSection(StringUtils.EMPTY, messageContent))
+                .forEach(messageSections::add);
         }
 
-        return messageModels;
+        return messageSections;
     }
 
 }

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/msteams2/MSTeamsChannelMessageModel.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/msteams2/MSTeamsChannelMessageModel.java
@@ -25,21 +25,14 @@ package com.synopsys.integration.alert.channel.msteams2;
 import java.util.List;
 
 import com.synopsys.integration.alert.common.rest.model.AlertSerializableModel;
-import com.synopsys.integration.alert.processor.api.extract.model.ProviderDetails;
 
 public class MSTeamsChannelMessageModel extends AlertSerializableModel {
-    private final ProviderDetails providerDetails;
     private final String messageTitle;
     private final List<MSTeamsChannelMessageSection> messageSections;
 
-    public MSTeamsChannelMessageModel(ProviderDetails providerDetails, String messageTitle, List<MSTeamsChannelMessageSection> messageSections) {
-        this.providerDetails = providerDetails;
+    public MSTeamsChannelMessageModel(String messageTitle, List<MSTeamsChannelMessageSection> messageSections) {
         this.messageTitle = messageTitle;
         this.messageSections = messageSections;
-    }
-
-    public ProviderDetails getProviderDetails() {
-        return providerDetails;
     }
 
     public String getTitle() {

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/msteams2/MSTeamsChannelMessageModel.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/msteams2/MSTeamsChannelMessageModel.java
@@ -22,30 +22,32 @@
  */
 package com.synopsys.integration.alert.channel.msteams2;
 
+import java.util.List;
+
 import com.synopsys.integration.alert.common.rest.model.AlertSerializableModel;
 import com.synopsys.integration.alert.processor.api.extract.model.ProviderDetails;
 
 public class MSTeamsChannelMessageModel extends AlertSerializableModel {
     private final ProviderDetails providerDetails;
     private final String messageTitle;
-    private final String messageContent;
+    private final List<MSTeamsChannelMessageSection> messageSections;
 
-    public MSTeamsChannelMessageModel(ProviderDetails providerDetails, String messageTitle, String messageContent) {
+    public MSTeamsChannelMessageModel(ProviderDetails providerDetails, String messageTitle, List<MSTeamsChannelMessageSection> messageSections) {
         this.providerDetails = providerDetails;
         this.messageTitle = messageTitle;
-        this.messageContent = messageContent;
+        this.messageSections = messageSections;
     }
 
     public ProviderDetails getProviderDetails() {
         return providerDetails;
     }
 
-    public String getMessageTitle() {
+    public String getTitle() {
         return messageTitle;
     }
 
-    public String getMessageContent() {
-        return messageContent;
+    public List<MSTeamsChannelMessageSection> getSections() {
+        return messageSections;
     }
 
 }

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/msteams2/MSTeamsChannelMessageSection.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/msteams2/MSTeamsChannelMessageSection.java
@@ -1,3 +1,25 @@
+/*
+ * channel
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.synopsys.integration.alert.channel.msteams2;
 
 public class MSTeamsChannelMessageSection {

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/msteams2/MSTeamsChannelMessageSection.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/msteams2/MSTeamsChannelMessageSection.java
@@ -1,0 +1,20 @@
+package com.synopsys.integration.alert.channel.msteams2;
+
+public class MSTeamsChannelMessageSection {
+    private final String sectionTitle;
+    private final String content;
+
+    public MSTeamsChannelMessageSection(String sectionTitle, String content) {
+        this.sectionTitle = sectionTitle;
+        this.content = content;
+    }
+
+    public String getTitle() {
+        return sectionTitle;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+}

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/msteams2/MSTeamsChannelMessageSender.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/msteams2/MSTeamsChannelMessageSender.java
@@ -62,7 +62,7 @@ public class MSTeamsChannelMessageSender implements ChannelMessageSender<MSTeams
         requestHeaders.put("Content-Type", "application/json");
 
         List<Request> messageRequests = channelMessages.stream()
-                                            .map(it -> createRequestsForMessage(webhook, it, requestHeaders))
+                                            .map(it -> createRequestForMessage(webhook, it, requestHeaders))
                                             .collect(Collectors.toList());
 
         restChannelUtility.sendMessage(messageRequests, msTeamsKey.getUniversalKey());
@@ -70,7 +70,7 @@ public class MSTeamsChannelMessageSender implements ChannelMessageSender<MSTeams
         return new MessageResult(String.format("Successfully sent %d MSTeams message(s)", channelMessages.size()));
     }
 
-    private Request createRequestsForMessage(String webhook, MSTeamsChannelMessageModel messageModel, Map<String, String> requestHeaders) {
+    private Request createRequestForMessage(String webhook, MSTeamsChannelMessageModel messageModel, Map<String, String> requestHeaders) {
         String jsonString = createJsonString(messageModel);
         return restChannelUtility.createPostMessageRequest(webhook, requestHeaders, jsonString);
     }


### PR DESCRIPTION
An `MSTeamsChannelMessageModel` now contains message sections and titles. This allows the entire message to be constructed in `MSTeamsChannelMessageConverter` rather than partially in the `MSTeamsChannelMessageSender`.

This PR also removes the need to complete IALERT-2247 (Add provider field to ProviderMessageHolder) as the `ProviderDetails` are no longer needed in `MSTeamsChannelMessageSender`.