### PR TITLE
fix(notifications):  …

### DIFF
--- a/provider/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/util/BlackDuckMessageLinkUtils.java
+++ b/provider/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/util/BlackDuckMessageLinkUtils.java
@@ -7,6 +7,9 @@
  */
 package com.synopsys.integration.alert.provider.blackduck.processor.message.util;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.lang3.StringUtils;
 
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionComponentView;
@@ -27,7 +30,10 @@ public final class BlackDuckMessageLinkUtils {
 
     public static String createComponentQueryLink(ProjectVersionComponentView bomComponent) {
         String projectVersionComponentsLink = createProjectVersionComponentsLink(bomComponent);
-        return String.format("%s?q=%s:%s", projectVersionComponentsLink, QUERY_PARAM_COMPONENT_NAME, bomComponent.getComponentName());
+        String encodedQueryValue = URLEncoder.encode(bomComponent.getComponentName(), StandardCharsets.UTF_8);
+        // Encoding a space as a '+' is the standard (https://www.w3.org/TR/html4/references.html#ref-RFC1738). Black Duck does not decode the '+' as a space resulting in unsuccessful queries.
+        String blackDuckEncodedQueryValue = encodedQueryValue.replace("+", "%20");
+        return String.format("%s?q=%s:%s", projectVersionComponentsLink, QUERY_PARAM_COMPONENT_NAME, blackDuckEncodedQueryValue);
     }
 
     private BlackDuckMessageLinkUtils() {


### PR DESCRIPTION
Fixed links created by BlackDuckMessageLinkUtils not having a properly encoded query value. (IALERT-2325)

Not properly encoding the URL query value results in the url being invalid and displayed as plain text in message boards (probably elsewhere too).