### PR TITLE
Fix Issue-Tracker post-create comments being ignored

### DIFF
--- a/channel-api/src/main/java/com/synopsys/integration/alert/channel/api/issue/model/IssueCommentModel.java
+++ b/channel-api/src/main/java/com/synopsys/integration/alert/channel/api/issue/model/IssueCommentModel.java
@@ -9,6 +9,9 @@ package com.synopsys.integration.alert.channel.api.issue.model;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
 
 import com.synopsys.integration.alert.channel.api.issue.search.ExistingIssueDetails;
 import com.synopsys.integration.alert.common.rest.model.AlertSerializableModel;
@@ -16,10 +19,10 @@ import com.synopsys.integration.alert.common.rest.model.AlertSerializableModel;
 public class IssueCommentModel<T extends Serializable> extends AlertSerializableModel {
     private final ExistingIssueDetails<T> existingIssueDetails;
     private final List<String> comments;
-
+    @Nullable
     private final ProjectIssueModel source;
 
-    public IssueCommentModel(ExistingIssueDetails<T> existingIssueDetails, List<String> comments, ProjectIssueModel source) {
+    public IssueCommentModel(ExistingIssueDetails<T> existingIssueDetails, List<String> comments, @Nullable ProjectIssueModel source) {
         this.existingIssueDetails = existingIssueDetails;
         this.comments = comments;
         this.source = source;
@@ -33,8 +36,8 @@ public class IssueCommentModel<T extends Serializable> extends AlertSerializable
         return comments;
     }
 
-    public ProjectIssueModel getSource() {
-        return source;
+    public Optional<ProjectIssueModel> getSource() {
+        return Optional.ofNullable(source);
     }
 
 }

--- a/channel-api/src/main/java/com/synopsys/integration/alert/channel/api/issue/send/IssueTrackerIssueCommenter.java
+++ b/channel-api/src/main/java/com/synopsys/integration/alert/channel/api/issue/send/IssueTrackerIssueCommenter.java
@@ -10,6 +10,7 @@ package com.synopsys.integration.alert.channel.api.issue.send;
 import java.io.Serializable;
 import java.util.Optional;
 
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,13 +39,13 @@ public abstract class IssueTrackerIssueCommenter<T extends Serializable> {
         }
 
         addComments(issueCommentModel);
-        IssueTrackerIssueResponseModel<T> responseModel = issueResponseCreator.createIssueResponse(issueCommentModel.getSource(), issueCommentModel.getExistingIssueDetails(), IssueOperation.UPDATE);
+        IssueTrackerIssueResponseModel<T> responseModel = issueResponseCreator.createIssueResponse(issueCommentModel.getSource().orElse(null), issueCommentModel.getExistingIssueDetails(), IssueOperation.UPDATE);
         return Optional.of(responseModel);
     }
 
     protected abstract boolean isCommentingEnabled();
 
-    protected abstract void addComment(String comment, ExistingIssueDetails<T> existingIssueDetails, ProjectIssueModel source) throws AlertException;
+    protected abstract void addComment(String comment, ExistingIssueDetails<T> existingIssueDetails, @Nullable ProjectIssueModel source) throws AlertException;
 
     protected void addComments(IssueCommentModel<T> issueCommentModel) throws AlertException {
         if (!isCommentingEnabled()) {
@@ -53,7 +54,7 @@ public abstract class IssueTrackerIssueCommenter<T extends Serializable> {
         }
 
         for (String comment : issueCommentModel.getComments()) {
-            addComment(comment, issueCommentModel.getExistingIssueDetails(), issueCommentModel.getSource());
+            addComment(comment, issueCommentModel.getExistingIssueDetails(), issueCommentModel.getSource().orElse(null));
         }
     }
 

--- a/channel-api/src/main/java/com/synopsys/integration/alert/channel/api/issue/send/IssueTrackerIssueCreator.java
+++ b/channel-api/src/main/java/com/synopsys/integration/alert/channel/api/issue/send/IssueTrackerIssueCreator.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.Optional;
 
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,9 +60,9 @@ public abstract class IssueTrackerIssueCreator<T extends Serializable> {
         if (optionalSource.isPresent()) {
             ProjectIssueModel alertIssueSource = optionalSource.get();
             assignAlertSearchProperties(createdIssueDetails, alertIssueSource);
-            addPostCreateComments(createdIssueDetails, alertIssueCreationModel, alertIssueSource);
             callbackInfo = callbackInfoCreator.createCallbackInfo(alertIssueSource).orElse(null);
         }
+        addPostCreateComments(createdIssueDetails, alertIssueCreationModel, optionalSource.orElse(null));
 
         return new IssueTrackerIssueResponseModel<>(
             createdIssueDetails.getIssueId(),
@@ -77,7 +78,7 @@ public abstract class IssueTrackerIssueCreator<T extends Serializable> {
 
     protected abstract void assignAlertSearchProperties(ExistingIssueDetails<T> createdIssueDetails, ProjectIssueModel alertIssueSource) throws AlertException;
 
-    private void addPostCreateComments(ExistingIssueDetails<T> issueDetails, IssueCreationModel creationModel, ProjectIssueModel projectSource) throws AlertException {
+    private void addPostCreateComments(ExistingIssueDetails<T> issueDetails, IssueCreationModel creationModel, @Nullable ProjectIssueModel projectSource) throws AlertException {
         LinkedList<String> postCreateComments = new LinkedList<>(creationModel.getPostCreateComments());
         postCreateComments.addFirst("This issue was automatically created by Alert.");
 

--- a/channel-api/src/main/java/com/synopsys/integration/alert/channel/api/issue/send/IssueTrackerIssueResponseCreator.java
+++ b/channel-api/src/main/java/com/synopsys/integration/alert/channel/api/issue/send/IssueTrackerIssueResponseCreator.java
@@ -8,6 +8,9 @@
 package com.synopsys.integration.alert.channel.api.issue.send;
 
 import java.io.Serializable;
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
 
 import com.synopsys.integration.alert.channel.api.issue.callback.IssueTrackerCallbackInfoCreator;
 import com.synopsys.integration.alert.channel.api.issue.model.IssueTrackerIssueResponseModel;
@@ -23,8 +26,10 @@ public class IssueTrackerIssueResponseCreator {
         this.callbackInfoCreator = callbackInfoCreator;
     }
 
-    public final <T extends Serializable> IssueTrackerIssueResponseModel<T> createIssueResponse(ProjectIssueModel source, ExistingIssueDetails<T> existingIssueDetails, IssueOperation issueOperation) {
-        IssueTrackerCallbackInfo callbackInfo = callbackInfoCreator.createCallbackInfo(source).orElse(null);
+    public final <T extends Serializable> IssueTrackerIssueResponseModel<T> createIssueResponse(@Nullable ProjectIssueModel source, ExistingIssueDetails<T> existingIssueDetails, IssueOperation issueOperation) {
+        IssueTrackerCallbackInfo callbackInfo = Optional.ofNullable(source)
+                                                    .flatMap(callbackInfoCreator::createCallbackInfo)
+                                                    .orElse(null);
         return new IssueTrackerIssueResponseModel<>(
             existingIssueDetails.getIssueId(),
             existingIssueDetails.getIssueKey(),

--- a/channel-api/src/test/java/com/synopsys/integration/alert/channel/api/issue/IssueTrackerChannelTest.java
+++ b/channel-api/src/test/java/com/synopsys/integration/alert/channel/api/issue/IssueTrackerChannelTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.Serializable;
 import java.util.Optional;
 
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import com.synopsys.integration.alert.channel.api.issue.model.IssueCreationModel;
@@ -50,7 +51,7 @@ public class IssueTrackerChannelTest {
             }
 
             @Override
-            protected void addComment(String comment, ExistingIssueDetails<String> existingIssueDetails, ProjectIssueModel source) {
+            protected void addComment(String comment, ExistingIssueDetails<String> existingIssueDetails, @Nullable ProjectIssueModel source) {
             }
         };
         IssueTrackerIssueTransitioner<String> transitioner = new IssueTrackerIssueTransitioner<>(commenter, null) {

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/delegate/AzureBoardsIssueCommenter.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/delegate/AzureBoardsIssueCommenter.java
@@ -7,6 +7,8 @@
  */
 package com.synopsys.integration.alert.channel.azure.boards.distribution.delegate;
 
+import org.jetbrains.annotations.Nullable;
+
 import com.synopsys.integration.alert.channel.api.issue.model.ProjectIssueModel;
 import com.synopsys.integration.alert.channel.api.issue.search.ExistingIssueDetails;
 import com.synopsys.integration.alert.channel.api.issue.send.IssueTrackerIssueCommenter;
@@ -39,7 +41,7 @@ public class AzureBoardsIssueCommenter extends IssueTrackerIssueCommenter<Intege
     }
 
     @Override
-    protected void addComment(String comment, ExistingIssueDetails<Integer> existingIssueDetails, ProjectIssueModel source) throws AlertException {
+    protected void addComment(String comment, ExistingIssueDetails<Integer> existingIssueDetails, @Nullable ProjectIssueModel source) throws AlertException {
         try {
             commentService.addComment(organizationName, distributionDetails.getProjectNameOrId(), existingIssueDetails.getIssueId(), comment);
         } catch (HttpServiceException e) {

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/jira/common/distribution/delegate/JiraIssueCommenter.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/jira/common/distribution/delegate/JiraIssueCommenter.java
@@ -7,6 +7,8 @@
  */
 package com.synopsys.integration.alert.channel.jira.common.distribution.delegate;
 
+import org.jetbrains.annotations.Nullable;
+
 import com.synopsys.integration.alert.channel.api.issue.model.ProjectIssueModel;
 import com.synopsys.integration.alert.channel.api.issue.search.ExistingIssueDetails;
 import com.synopsys.integration.alert.channel.api.issue.send.IssueTrackerIssueCommenter;
@@ -22,7 +24,7 @@ public abstract class JiraIssueCommenter extends IssueTrackerIssueCommenter<Stri
     }
 
     @Override
-    protected final void addComment(String comment, ExistingIssueDetails<String> existingIssueDetails, ProjectIssueModel source) throws AlertException {
+    protected final void addComment(String comment, ExistingIssueDetails<String> existingIssueDetails, @Nullable ProjectIssueModel source) throws AlertException {
         try {
             IssueCommentRequestModel issueCommentRequestModel = new IssueCommentRequestModel(existingIssueDetails.getIssueKey(), comment);
             addComment(issueCommentRequestModel);


### PR DESCRIPTION
Issue-Tracker post-create comments are ignored if no "source" is present
Source should become optional (its usage in the commenter is to create the IssueTrackerIssueResponseModel in which it is optional).

IALERT-2337