### PR TITLE
Constrain MessageReceiver to AlertEvents

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/MessageReceiver.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/MessageReceiver.java
@@ -15,13 +15,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
+import com.synopsys.integration.alert.common.event.AlertEvent;
 
-public abstract class MessageReceiver<T> implements MessageListener {
+public abstract class MessageReceiver<T extends AlertEvent> implements MessageListener {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final Gson gson;
     private final Class<T> eventClass;
 
-    public MessageReceiver(Gson gson, Class<T> eventClass) {
+    protected MessageReceiver(Gson gson, Class<T> eventClass) {
         this.gson = gson;
         this.eventClass = eventClass;
     }
@@ -39,6 +40,7 @@ public abstract class MessageReceiver<T> implements MessageListener {
                 T event = gson.fromJson(textMessage.getText(), eventClass);
                 logger.trace("{} event {}", receiverClassName, event);
                 handleEvent(event);
+                logger.debug("Received Event ID: {}", event.getEventId());
             }
         } catch (Exception e) {
             logger.error(e.getMessage(), e);

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/MessageReceiver.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/workflow/MessageReceiver.java
@@ -39,8 +39,8 @@ public abstract class MessageReceiver<T extends AlertEvent> implements MessageLi
                 TextMessage textMessage = (TextMessage) message;
                 T event = gson.fromJson(textMessage.getText(), eventClass);
                 logger.trace("{} event {}", receiverClassName, event);
-                handleEvent(event);
                 logger.debug("Received Event ID: {}", event.getEventId());
+                handleEvent(event);
             }
         } catch (Exception e) {
             logger.error(e.getMessage(), e);


### PR DESCRIPTION
IALERT-2218
Constrained `MessageReceiver` to accept `AlertEvent`s to allow the EventID to be logged.
All usages of `MessageReceiver` currently pass in `AlertEvent`s.