### PR TITLE
Improve generic usage of configuration test actions

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/action/ConfigurationAction.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/action/ConfigurationAction.java
@@ -11,7 +11,7 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.Optional;
 
-import com.synopsys.integration.alert.common.channel.ChannelDistributionTestAction;
+import com.synopsys.integration.alert.common.channel.DistributionChannelTestAction;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.persistence.model.job.details.processor.JobDetailsExtractor;
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
@@ -23,7 +23,7 @@ public abstract class ConfigurationAction {
 
     // FIXME there needs to be a better distinction between a global TestAction and a distribution TestAction
     //  for 6.4.0, this will have to suffice to avoid additional scope-creep of re-architecting TestActions
-    private ChannelDistributionTestAction channelDistributionTestAction;
+    private DistributionChannelTestAction distributionChannelTestAction;
 
     // TODO This Should probably receive the same fix as the channelDistributionTestAction object as well.
     private JobDetailsExtractor jobDetailsExtractor;
@@ -52,8 +52,8 @@ public abstract class ConfigurationAction {
         testActionMap.put(ConfigContextEnum.DISTRIBUTION, testAction);
     }
 
-    public void addDistributionTestAction(ChannelDistributionTestAction testAction) {
-        channelDistributionTestAction = testAction;
+    public void addDistributionTestAction(DistributionChannelTestAction testAction) {
+        distributionChannelTestAction = testAction;
     }
 
     public ApiAction getApiAction(ConfigContextEnum context) {
@@ -72,8 +72,8 @@ public abstract class ConfigurationAction {
         return Optional.ofNullable(jobDetailsExtractor);
     }
 
-    public Optional<ChannelDistributionTestAction> getChannelDistributionTestAction() {
-        return Optional.ofNullable(channelDistributionTestAction);
+    public Optional<DistributionChannelTestAction> getChannelDistributionTestAction() {
+        return Optional.ofNullable(distributionChannelTestAction);
     }
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/action/ConfigurationAction.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/action/ConfigurationAction.java
@@ -11,7 +11,6 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.Optional;
 
-import com.synopsys.integration.alert.common.channel.DistributionChannelTestAction;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.persistence.model.job.details.processor.JobDetailsExtractor;
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
@@ -20,10 +19,6 @@ public abstract class ConfigurationAction {
     private final DescriptorKey descriptorKey;
     private final Map<ConfigContextEnum, ApiAction> apiActionMap = new EnumMap<>(ConfigContextEnum.class);
     private final Map<ConfigContextEnum, TestAction> testActionMap = new EnumMap<>(ConfigContextEnum.class);
-
-    // FIXME there needs to be a better distinction between a global TestAction and a distribution TestAction
-    //  for 6.4.0, this will have to suffice to avoid additional scope-creep of re-architecting TestActions
-    private DistributionChannelTestAction distributionChannelTestAction;
 
     // TODO This Should probably receive the same fix as the channelDistributionTestAction object as well.
     private JobDetailsExtractor jobDetailsExtractor;
@@ -52,10 +47,6 @@ public abstract class ConfigurationAction {
         testActionMap.put(ConfigContextEnum.DISTRIBUTION, testAction);
     }
 
-    public void addDistributionTestAction(DistributionChannelTestAction testAction) {
-        distributionChannelTestAction = testAction;
-    }
-
     public ApiAction getApiAction(ConfigContextEnum context) {
         return apiActionMap.get(context);
     }
@@ -70,10 +61,6 @@ public abstract class ConfigurationAction {
 
     public Optional<JobDetailsExtractor> getJobDetailsExtractor() {
         return Optional.ofNullable(jobDetailsExtractor);
-    }
-
-    public Optional<DistributionChannelTestAction> getChannelDistributionTestAction() {
-        return Optional.ofNullable(distributionChannelTestAction);
     }
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/channel/DistributionChannelTestAction.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/channel/DistributionChannelTestAction.java
@@ -13,9 +13,14 @@ import com.synopsys.integration.alert.common.descriptor.action.DescriptorAction;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.common.message.model.MessageResult;
 import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobModel;
+import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
 
-public interface DistributionChannelTestAction extends DescriptorAction {
-    MessageResult testConfig(
+public abstract class DistributionChannelTestAction extends DescriptorAction {
+    public DistributionChannelTestAction(DescriptorKey descriptorKey) {
+        super(descriptorKey);
+    }
+
+    public abstract MessageResult testConfig(
         DistributionJobModel distributionJobModel,
         @Nullable String customTopic,
         @Nullable String customMessage

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/channel/DistributionChannelTestAction.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/channel/DistributionChannelTestAction.java
@@ -9,16 +9,16 @@ package com.synopsys.integration.alert.common.channel;
 
 import org.jetbrains.annotations.Nullable;
 
+import com.synopsys.integration.alert.common.descriptor.action.DescriptorAction;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.common.message.model.MessageResult;
 import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobModel;
 
-public interface ChannelDistributionTestAction {
+public interface DistributionChannelTestAction extends DescriptorAction {
     MessageResult testConfig(
         DistributionJobModel distributionJobModel,
         @Nullable String customTopic,
-        @Nullable String customMessage,
-        @Nullable String destination
+        @Nullable String customMessage
     ) throws AlertException;
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/DescriptorProcessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/DescriptorProcessor.java
@@ -19,7 +19,6 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.common.action.ApiAction;
 import com.synopsys.integration.alert.common.action.ConfigurationAction;
 import com.synopsys.integration.alert.common.action.TestAction;
-import com.synopsys.integration.alert.common.channel.DistributionChannelTestAction;
 import com.synopsys.integration.alert.common.descriptor.config.field.ConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.ui.UIConfig;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
@@ -53,10 +52,6 @@ public class DescriptorProcessor {
 
     public Optional<TestAction> retrieveTestAction(String descriptorName, ConfigContextEnum context) {
         return retrieveConfigurationAction(descriptorName).map(configurationAction -> configurationAction.getTestAction(context));
-    }
-
-    public Optional<DistributionChannelTestAction> retrieveChannelDistributionTestAction(String descriptorName) {
-        return retrieveConfigurationAction(descriptorName).flatMap(ConfigurationAction::getChannelDistributionTestAction);
     }
 
     public Optional<Descriptor> retrieveDescriptor(String descriptorName) {

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/DescriptorProcessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/DescriptorProcessor.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.common.action.ApiAction;
 import com.synopsys.integration.alert.common.action.ConfigurationAction;
 import com.synopsys.integration.alert.common.action.TestAction;
-import com.synopsys.integration.alert.common.channel.ChannelDistributionTestAction;
+import com.synopsys.integration.alert.common.channel.DistributionChannelTestAction;
 import com.synopsys.integration.alert.common.descriptor.config.field.ConfigField;
 import com.synopsys.integration.alert.common.descriptor.config.ui.UIConfig;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
@@ -55,7 +55,7 @@ public class DescriptorProcessor {
         return retrieveConfigurationAction(descriptorName).map(configurationAction -> configurationAction.getTestAction(context));
     }
 
-    public Optional<ChannelDistributionTestAction> retrieveChannelDistributionTestAction(String descriptorName) {
+    public Optional<DistributionChannelTestAction> retrieveChannelDistributionTestAction(String descriptorName) {
         return retrieveConfigurationAction(descriptorName).flatMap(ConfigurationAction::getChannelDistributionTestAction);
     }
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/action/DescriptorAction.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/action/DescriptorAction.java
@@ -9,7 +9,15 @@ package com.synopsys.integration.alert.common.descriptor.action;
 
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
 
-public interface DescriptorAction {
-    DescriptorKey getDescriptorKey();
+public abstract class DescriptorAction {
+    private final DescriptorKey descriptorKey;
+
+    protected DescriptorAction(DescriptorKey descriptorKey) {
+        this.descriptorKey = descriptorKey;
+    }
+
+    public DescriptorKey getDescriptorKey() {
+        return descriptorKey;
+    }
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/action/DescriptorAction.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/action/DescriptorAction.java
@@ -1,0 +1,15 @@
+/*
+ * alert-common
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.alert.common.descriptor.action;
+
+import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
+
+public interface DescriptorAction {
+    DescriptorKey getDescriptorKey();
+
+}

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/action/DescriptorActionMap.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/action/DescriptorActionMap.java
@@ -1,0 +1,53 @@
+/*
+ * alert-common
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.alert.common.descriptor.action;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.synopsys.integration.alert.common.exception.AlertRuntimeException;
+import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
+
+public final class DescriptorActionMap<T extends DescriptorAction> {
+    private final Map<String, T> universalKeyToAction;
+
+    public DescriptorActionMap(Collection<T> descriptorActions) {
+        this.universalKeyToAction = initializeMap(descriptorActions);
+    }
+
+    public final T findRequiredAction(DescriptorKey descriptorKey) throws AlertRuntimeException {
+        return findRequiredAction(descriptorKey.getUniversalKey());
+    }
+
+    public final T findRequiredAction(String descriptorUniversalKey) throws AlertRuntimeException {
+        T foundAction = universalKeyToAction.get(descriptorUniversalKey);
+        if (null == foundAction) {
+            throw new AlertRuntimeException(String.format("Missing required action for descriptor: %s", descriptorUniversalKey));
+        }
+        return foundAction;
+    }
+
+    public final Optional<T> findOptionalAction(DescriptorKey descriptorKey) {
+        return findOptionalAction(descriptorKey.getUniversalKey());
+    }
+
+    public final Optional<T> findOptionalAction(String descriptorUniversalKey) {
+        T foundAction = universalKeyToAction.get(descriptorUniversalKey);
+        return Optional.ofNullable(foundAction);
+    }
+
+    private static <U extends DescriptorAction> Map<String, U> initializeMap(Collection<U> descriptorActions) {
+        return descriptorActions
+                   .stream()
+                   .collect(Collectors.toMap(action -> action.getDescriptorKey().getUniversalKey(), Function.identity()));
+    }
+
+}

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/action/DescriptorActionMap.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/action/DescriptorActionMap.java
@@ -28,11 +28,8 @@ public final class DescriptorActionMap<T extends DescriptorAction> {
     }
 
     public final T findRequiredAction(String descriptorUniversalKey) throws AlertRuntimeException {
-        T foundAction = universalKeyToAction.get(descriptorUniversalKey);
-        if (null == foundAction) {
-            throw new AlertRuntimeException(String.format("Missing required action for descriptor: %s", descriptorUniversalKey));
-        }
-        return foundAction;
+        return findOptionalAction(descriptorUniversalKey)
+                   .orElseThrow(() -> new AlertRuntimeException(String.format("Missing required action for descriptor: %s", descriptorUniversalKey)));
     }
 
     public final Optional<T> findOptionalAction(DescriptorKey descriptorKey) {

--- a/channel-api/src/main/java/com/synopsys/integration/alert/channel/api/action/DistributionChannelMessageTestAction.java
+++ b/channel-api/src/main/java/com/synopsys/integration/alert/channel/api/action/DistributionChannelMessageTestAction.java
@@ -24,19 +24,12 @@ import com.synopsys.integration.alert.processor.api.extract.model.ProviderDetail
 import com.synopsys.integration.alert.processor.api.extract.model.ProviderMessageHolder;
 import com.synopsys.integration.alert.processor.api.extract.model.SimpleMessage;
 
-public abstract class DistributionChannelMessageTestAction<D extends DistributionJobDetailsModel> implements DistributionChannelTestAction {
-    private final ChannelKey channelKey;
+public abstract class DistributionChannelMessageTestAction<D extends DistributionJobDetailsModel> extends DistributionChannelTestAction {
     private final DistributionChannelV2<D> distributionChannel;
 
     public DistributionChannelMessageTestAction(ChannelKey channelKey, DistributionChannelV2<D> distributionChannel) {
-        this.channelKey = channelKey;
+        super(channelKey);
         this.distributionChannel = distributionChannel;
-    }
-
-    @Override
-    @SuppressWarnings("SuspiciousGetterSetter")
-    public ChannelKey getDescriptorKey() {
-        return channelKey;
     }
 
     @Override

--- a/channel-api/src/main/java/com/synopsys/integration/alert/channel/api/action/DistributionChannelMessageTestAction.java
+++ b/channel-api/src/main/java/com/synopsys/integration/alert/channel/api/action/DistributionChannelMessageTestAction.java
@@ -13,34 +13,43 @@ import java.util.Optional;
 import org.jetbrains.annotations.Nullable;
 
 import com.synopsys.integration.alert.channel.api.DistributionChannelV2;
-import com.synopsys.integration.alert.common.channel.ChannelDistributionTestAction;
+import com.synopsys.integration.alert.common.channel.DistributionChannelTestAction;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.common.message.model.MessageResult;
 import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobModel;
 import com.synopsys.integration.alert.common.persistence.model.job.details.DistributionJobDetailsModel;
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKey;
 import com.synopsys.integration.alert.processor.api.extract.model.ProviderDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.ProviderMessageHolder;
 import com.synopsys.integration.alert.processor.api.extract.model.SimpleMessage;
 
-public abstract class DistributionChannelTestAction<D extends DistributionJobDetailsModel> implements ChannelDistributionTestAction {
+public abstract class DistributionChannelMessageTestAction<D extends DistributionJobDetailsModel> implements DistributionChannelTestAction {
+    private final ChannelKey channelKey;
     private final DistributionChannelV2<D> distributionChannel;
 
-    public DistributionChannelTestAction(DistributionChannelV2<D> distributionChannel) {
+    public DistributionChannelMessageTestAction(ChannelKey channelKey, DistributionChannelV2<D> distributionChannel) {
+        this.channelKey = channelKey;
         this.distributionChannel = distributionChannel;
     }
 
     @Override
-    public final MessageResult testConfig(DistributionJobModel testJobModel, @Nullable String customTopic, @Nullable String customMessage, @Nullable String destination) throws AlertException {
+    @SuppressWarnings("SuspiciousGetterSetter")
+    public ChannelKey getDescriptorKey() {
+        return channelKey;
+    }
+
+    @Override
+    public final MessageResult testConfig(DistributionJobModel testJobModel, @Nullable String customTopic, @Nullable String customMessage) throws AlertException {
         String topicString = Optional.ofNullable(customTopic).orElse("Alert Test Topic");
         String messageString = Optional.ofNullable(customMessage).orElse("Alert Test Message");
 
-        D distributionJobDetails = resolveTestDistributionDetails(testJobModel, destination);
+        D distributionJobDetails = resolveTestDistributionDetails(testJobModel);
         ProviderMessageHolder messages = createTestMessageHolder(testJobModel, topicString, messageString);
         return distributionChannel.distributeMessages(distributionJobDetails, messages);
     }
 
-    protected D resolveTestDistributionDetails(DistributionJobModel testJobModel, @Nullable String destination) throws AlertException {
+    protected D resolveTestDistributionDetails(DistributionJobModel testJobModel) throws AlertException {
         return (D) testJobModel.getDistributionJobDetails();
     }
 

--- a/channel-api/src/main/java/com/synopsys/integration/alert/channel/api/issue/action/IssueTrackerTestAction.java
+++ b/channel-api/src/main/java/com/synopsys/integration/alert/channel/api/issue/action/IssueTrackerTestAction.java
@@ -25,7 +25,7 @@ import com.synopsys.integration.alert.channel.api.issue.model.ProjectIssueModel;
 import com.synopsys.integration.alert.channel.api.issue.search.ExistingIssueDetails;
 import com.synopsys.integration.alert.channel.api.issue.send.IssueTrackerMessageSender;
 import com.synopsys.integration.alert.channel.api.issue.send.IssueTrackerMessageSenderFactory;
-import com.synopsys.integration.alert.common.channel.ChannelDistributionTestAction;
+import com.synopsys.integration.alert.common.channel.DistributionChannelTestAction;
 import com.synopsys.integration.alert.common.channel.issuetracker.enumeration.IssueOperation;
 import com.synopsys.integration.alert.common.channel.issuetracker.exception.IssueMissingTransitionException;
 import com.synopsys.integration.alert.common.exception.AlertException;
@@ -33,19 +33,28 @@ import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.common.message.model.MessageResult;
 import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobModel;
 import com.synopsys.integration.alert.common.persistence.model.job.details.DistributionJobDetailsModel;
+import com.synopsys.integration.alert.descriptor.api.model.IssueTrackerChannelKey;
 import com.synopsys.integration.alert.processor.api.extract.model.ProviderDetails;
 
-public abstract class IssueTrackerTestAction<D extends DistributionJobDetailsModel, T extends Serializable> implements ChannelDistributionTestAction {
+public abstract class IssueTrackerTestAction<D extends DistributionJobDetailsModel, T extends Serializable> implements DistributionChannelTestAction {
+    private final IssueTrackerChannelKey issueTrackerChannelKey;
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final IssueTrackerMessageSenderFactory<D, T> messageSenderFactory;
 
-    public IssueTrackerTestAction(IssueTrackerMessageSenderFactory<D, T> messageSenderFactory) {
+    public IssueTrackerTestAction(IssueTrackerChannelKey issueTrackerChannelKey, IssueTrackerMessageSenderFactory<D, T> messageSenderFactory) {
+        this.issueTrackerChannelKey = issueTrackerChannelKey;
         this.messageSenderFactory = messageSenderFactory;
     }
 
     @Override
-    public MessageResult testConfig(DistributionJobModel testJobModel, @Nullable String customTopic, @Nullable String customMessage, @Nullable String destination) throws AlertException {
+    @SuppressWarnings("SuspiciousGetterSetter")
+    public IssueTrackerChannelKey getDescriptorKey() {
+        return issueTrackerChannelKey;
+    }
+
+    @Override
+    public MessageResult testConfig(DistributionJobModel testJobModel, @Nullable String customTopic, @Nullable String customMessage) throws AlertException {
         D distributionDetails = (D) testJobModel.getDistributionJobDetails();
         IssueTrackerMessageSender<T> messageSender = messageSenderFactory.createMessageSender(distributionDetails);
 

--- a/channel-api/src/main/java/com/synopsys/integration/alert/channel/api/issue/action/IssueTrackerTestAction.java
+++ b/channel-api/src/main/java/com/synopsys/integration/alert/channel/api/issue/action/IssueTrackerTestAction.java
@@ -36,21 +36,14 @@ import com.synopsys.integration.alert.common.persistence.model.job.details.Distr
 import com.synopsys.integration.alert.descriptor.api.model.IssueTrackerChannelKey;
 import com.synopsys.integration.alert.processor.api.extract.model.ProviderDetails;
 
-public abstract class IssueTrackerTestAction<D extends DistributionJobDetailsModel, T extends Serializable> implements DistributionChannelTestAction {
-    private final IssueTrackerChannelKey issueTrackerChannelKey;
+public abstract class IssueTrackerTestAction<D extends DistributionJobDetailsModel, T extends Serializable> extends DistributionChannelTestAction {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final IssueTrackerMessageSenderFactory<D, T> messageSenderFactory;
 
     public IssueTrackerTestAction(IssueTrackerChannelKey issueTrackerChannelKey, IssueTrackerMessageSenderFactory<D, T> messageSenderFactory) {
-        this.issueTrackerChannelKey = issueTrackerChannelKey;
+        super(issueTrackerChannelKey);
         this.messageSenderFactory = messageSenderFactory;
-    }
-
-    @Override
-    @SuppressWarnings("SuspiciousGetterSetter")
-    public IssueTrackerChannelKey getDescriptorKey() {
-        return issueTrackerChannelKey;
     }
 
     @Override
@@ -97,12 +90,8 @@ public abstract class IssueTrackerTestAction<D extends DistributionJobDetailsMod
             return createSuccessMessageResult(existingIssueDetails);
         }
 
-        Optional<MessageResult> optionalReopenFailure = transitionTestIssueOrReturnFailureResult(messageSender, IssueOperation.OPEN, existingIssueDetails, testProjectIssueModel);
-        if (optionalReopenFailure.isPresent()) {
-            return optionalReopenFailure.get();
-        }
-
-        return transitionTestIssueOrReturnFailureResult(messageSender, IssueOperation.RESOLVE, existingIssueDetails, testProjectIssueModel).orElse(createSuccessMessageResult(existingIssueDetails));
+        return transitionTestIssueOrReturnFailureResult(messageSender, IssueOperation.OPEN, existingIssueDetails, testProjectIssueModel)
+                   .orElseGet(() -> transitionTestIssueOrReturnFailureResult(messageSender, IssueOperation.RESOLVE, existingIssueDetails, testProjectIssueModel).orElse(createSuccessMessageResult(existingIssueDetails)));
     }
 
     protected abstract boolean hasResolveTransition(D distributionDetails);

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsConfigurationAction.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsConfigurationAction.java
@@ -16,12 +16,10 @@ import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
 @Component
 public class AzureBoardsConfigurationAction extends ConfigurationAction {
     @Autowired
-    protected AzureBoardsConfigurationAction(AzureBoardsDistributionTestAction azureBoardsDistributionTestAction, AzureBoardsGlobalTestAction azureBoardsGlobalTestAction,
-        AzureBoardsGlobalApiAction azureBoardsGlobalApiAction, AzureBoardsJobDetailsExtractor azureBoardsJobDetailsExtractor) {
+    protected AzureBoardsConfigurationAction(AzureBoardsGlobalTestAction azureBoardsGlobalTestAction, AzureBoardsGlobalApiAction azureBoardsGlobalApiAction, AzureBoardsJobDetailsExtractor azureBoardsJobDetailsExtractor) {
         super(ChannelKeys.AZURE_BOARDS);
         addGlobalTestAction(azureBoardsGlobalTestAction);
         addGlobalApiAction(azureBoardsGlobalApiAction);
-        addDistributionTestAction(azureBoardsDistributionTestAction);
         addJobDetailsExtractor(azureBoardsJobDetailsExtractor);
     }
 

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsDistributionTestAction.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsDistributionTestAction.java
@@ -14,12 +14,13 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.channel.api.issue.action.IssueTrackerTestAction;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.AzureBoardsMessageSenderFactory;
 import com.synopsys.integration.alert.common.persistence.model.job.details.AzureBoardsJobDetailsModel;
+import com.synopsys.integration.alert.descriptor.api.AzureBoardsChannelKey;
 
 @Component
 public class AzureBoardsDistributionTestAction extends IssueTrackerTestAction<AzureBoardsJobDetailsModel, Integer> {
     @Autowired
-    public AzureBoardsDistributionTestAction(AzureBoardsMessageSenderFactory messageSenderFactory) {
-        super(messageSenderFactory);
+    public AzureBoardsDistributionTestAction(AzureBoardsChannelKey channelKey, AzureBoardsMessageSenderFactory messageSenderFactory) {
+        super(channelKey, messageSenderFactory);
     }
 
     @Override

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailConfigurationAction.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailConfigurationAction.java
@@ -16,10 +16,9 @@ import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
 @Component
 public class EmailConfigurationAction extends ConfigurationAction {
     @Autowired
-    protected EmailConfigurationAction(EmailGlobalTestAction emailGlobalTestAction, EmailDistributionTestAction emailDistributionTestAction, EmailJobDetailsExtractor emailJobDetailsExtractor) {
+    protected EmailConfigurationAction(EmailGlobalTestAction emailGlobalTestAction, EmailJobDetailsExtractor emailJobDetailsExtractor) {
         super(ChannelKeys.EMAIL);
         addGlobalTestAction(emailGlobalTestAction);
-        addDistributionTestAction(emailDistributionTestAction);
         addJobDetailsExtractor(emailJobDetailsExtractor);
     }
 

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailDistributionTestAction.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailDistributionTestAction.java
@@ -11,30 +11,30 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.jetbrains.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.synopsys.integration.alert.channel.api.action.DistributionChannelTestAction;
+import com.synopsys.integration.alert.channel.api.action.DistributionChannelMessageTestAction;
 import com.synopsys.integration.alert.channel.email.distribution.EmailChannelV2;
 import com.synopsys.integration.alert.common.exception.AlertException;
 import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobModel;
 import com.synopsys.integration.alert.common.persistence.model.job.details.DistributionJobDetailsModel;
 import com.synopsys.integration.alert.common.persistence.model.job.details.EmailJobDetailsModel;
+import com.synopsys.integration.alert.descriptor.api.EmailChannelKey;
 
 @Component
-public class EmailDistributionTestAction extends DistributionChannelTestAction<EmailJobDetailsModel> {
+public class EmailDistributionTestAction extends DistributionChannelMessageTestAction<EmailJobDetailsModel> {
     private final EmailTestActionHelper emailTestActionHelper;
 
     @Autowired
-    public EmailDistributionTestAction(EmailChannelV2 distributionChannel, EmailTestActionHelper emailTestActionHelper) {
-        super(distributionChannel);
+    public EmailDistributionTestAction(EmailChannelKey channelKey, EmailChannelV2 distributionChannel, EmailTestActionHelper emailTestActionHelper) {
+        super(channelKey, distributionChannel);
         this.emailTestActionHelper = emailTestActionHelper;
     }
 
     @Override
-    protected EmailJobDetailsModel resolveTestDistributionDetails(DistributionJobModel testJobModel, @Nullable String destination) throws AlertException {
-        Set<String> updateEmailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(testJobModel, destination);
+    protected EmailJobDetailsModel resolveTestDistributionDetails(DistributionJobModel testJobModel) throws AlertException {
+        Set<String> updateEmailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(testJobModel);
         EmailJobDetailsModel originalEmailJobDetails = testJobModel.getDistributionJobDetails().getAs(DistributionJobDetailsModel.EMAIL);
 
         // For testing configuration, just use additional email addresses field

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailTestActionHelper.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailTestActionHelper.java
@@ -14,7 +14,6 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -39,11 +38,8 @@ public class EmailTestActionHelper {
         this.providerDataAccessor = providerDataAccessor;
     }
 
-    public Set<String> createUpdatedEmailAddresses(DistributionJobModel distributionJobModel, @Nullable String destination) throws AlertException {
+    public Set<String> createUpdatedEmailAddresses(DistributionJobModel distributionJobModel) throws AlertException {
         Set<String> emailAddresses = new HashSet<>();
-        if (StringUtils.isNotBlank(destination)) {
-            emailAddresses.add(destination);
-        }
 
         DistributionJobDetailsModel distributionJobDetails = distributionJobModel.getDistributionJobDetails();
         EmailJobDetailsModel emailJobDetails = distributionJobDetails.getAs(DistributionJobDetailsModel.EMAIL);

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/action/JiraCloudConfigurationAction.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/action/JiraCloudConfigurationAction.java
@@ -16,10 +16,9 @@ import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
 @Component
 public class JiraCloudConfigurationAction extends ConfigurationAction {
     @Autowired
-    public JiraCloudConfigurationAction(JiraCloudGlobalTestAction globalTestAction, JiraCloudDistributionTestAction jiraDistributionTestAction, JiraCloudJobDetailsExtractor jiraCloudJobDetailsExtractor) {
+    public JiraCloudConfigurationAction(JiraCloudGlobalTestAction globalTestAction, JiraCloudJobDetailsExtractor jiraCloudJobDetailsExtractor) {
         super(ChannelKeys.JIRA_CLOUD);
         addGlobalTestAction(globalTestAction);
-        addDistributionTestAction(jiraDistributionTestAction);
         addJobDetailsExtractor(jiraCloudJobDetailsExtractor);
     }
 

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/action/JiraCloudDistributionTestAction.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/action/JiraCloudDistributionTestAction.java
@@ -10,15 +10,16 @@ package com.synopsys.integration.alert.channel.jira.cloud.action;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.synopsys.integration.alert.channel.api.action.DistributionChannelTestAction;
+import com.synopsys.integration.alert.channel.api.action.DistributionChannelMessageTestAction;
 import com.synopsys.integration.alert.channel.jira.cloud.distribution.JiraCloudChannel;
 import com.synopsys.integration.alert.common.persistence.model.job.details.JiraCloudJobDetailsModel;
+import com.synopsys.integration.alert.descriptor.api.JiraCloudChannelKey;
 
 @Component
-public class JiraCloudDistributionTestAction extends DistributionChannelTestAction<JiraCloudJobDetailsModel> {
+public class JiraCloudDistributionTestAction extends DistributionChannelMessageTestAction<JiraCloudJobDetailsModel> {
     @Autowired
-    public JiraCloudDistributionTestAction(JiraCloudChannel distributionChannel) {
-        super(distributionChannel);
+    public JiraCloudDistributionTestAction(JiraCloudChannelKey channelKey, JiraCloudChannel distributionChannel) {
+        super(channelKey, distributionChannel);
     }
 
 }

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/jira/server/action/JiraServerConfigurationAction.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/jira/server/action/JiraServerConfigurationAction.java
@@ -16,13 +16,8 @@ import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
 @Component
 public class JiraServerConfigurationAction extends ConfigurationAction {
     @Autowired
-    protected JiraServerConfigurationAction(
-        JiraServerDistributionTestAction jiraServerDistributionTestAction,
-        JiraServerGlobalTestAction jiraServerGlobalTestAction,
-        JiraServerJobDetailsExtractor jiraServerJobDetailsExtractor
-    ) {
+    protected JiraServerConfigurationAction(JiraServerGlobalTestAction jiraServerGlobalTestAction, JiraServerJobDetailsExtractor jiraServerJobDetailsExtractor) {
         super(ChannelKeys.JIRA_SERVER);
-        addDistributionTestAction(jiraServerDistributionTestAction);
         addGlobalTestAction(jiraServerGlobalTestAction);
         addJobDetailsExtractor(jiraServerJobDetailsExtractor);
     }

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/jira/server/action/JiraServerDistributionTestAction.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/jira/server/action/JiraServerDistributionTestAction.java
@@ -14,12 +14,13 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.channel.api.issue.action.IssueTrackerTestAction;
 import com.synopsys.integration.alert.channel.jira.server.distribution.JiraServerMessageSenderFactory;
 import com.synopsys.integration.alert.common.persistence.model.job.details.JiraServerJobDetailsModel;
+import com.synopsys.integration.alert.descriptor.api.JiraServerChannelKey;
 
 @Component
 public class JiraServerDistributionTestAction extends IssueTrackerTestAction<JiraServerJobDetailsModel, String> {
     @Autowired
-    public JiraServerDistributionTestAction(JiraServerMessageSenderFactory messageSenderFactory) {
-        super(messageSenderFactory);
+    public JiraServerDistributionTestAction(JiraServerChannelKey channelKey, JiraServerMessageSenderFactory messageSenderFactory) {
+        super(channelKey, messageSenderFactory);
     }
 
     @Override
@@ -31,4 +32,5 @@ public class JiraServerDistributionTestAction extends IssueTrackerTestAction<Jir
     protected boolean hasReopenTransition(JiraServerJobDetailsModel distributionDetails) {
         return StringUtils.isNotBlank(distributionDetails.getReopenTransition());
     }
+
 }

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/msteams/actions/MSTeamsDistributionTestAction.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/msteams/actions/MSTeamsDistributionTestAction.java
@@ -10,15 +10,16 @@ package com.synopsys.integration.alert.channel.msteams.actions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.synopsys.integration.alert.channel.api.action.DistributionChannelTestAction;
+import com.synopsys.integration.alert.channel.api.action.DistributionChannelMessageTestAction;
 import com.synopsys.integration.alert.channel.msteams.distribution.MSTeamsChannel;
 import com.synopsys.integration.alert.common.persistence.model.job.details.MSTeamsJobDetailsModel;
+import com.synopsys.integration.alert.descriptor.api.MsTeamsKey;
 
 @Component
-public class MSTeamsDistributionTestAction extends DistributionChannelTestAction<MSTeamsJobDetailsModel> {
+public class MSTeamsDistributionTestAction extends DistributionChannelMessageTestAction<MSTeamsJobDetailsModel> {
     @Autowired
-    public MSTeamsDistributionTestAction(MSTeamsChannel distributionChannel) {
-        super(distributionChannel);
+    public MSTeamsDistributionTestAction(MsTeamsKey channelKey, MSTeamsChannel distributionChannel) {
+        super(channelKey, distributionChannel);
     }
 
 }

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/msteams/actions/MsTeamsConfigurationAction.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/msteams/actions/MsTeamsConfigurationAction.java
@@ -16,10 +16,9 @@ import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
 @Component
 public class MsTeamsConfigurationAction extends ConfigurationAction {
     @Autowired
-    protected MsTeamsConfigurationAction(MsTeamsJobDetailsExtractor msTeamsJobDetailsExtractor, MSTeamsDistributionTestAction msTeamsDistributionTestAction) {
+    protected MsTeamsConfigurationAction(MsTeamsJobDetailsExtractor msTeamsJobDetailsExtractor) {
         super(ChannelKeys.MS_TEAMS);
         addJobDetailsExtractor(msTeamsJobDetailsExtractor);
-        addDistributionTestAction(msTeamsDistributionTestAction);
     }
 
 }

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/slack/action/SlackConfigurationAction.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/slack/action/SlackConfigurationAction.java
@@ -16,10 +16,9 @@ import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
 @Component
 public class SlackConfigurationAction extends ConfigurationAction {
     @Autowired
-    protected SlackConfigurationAction(SlackJobDetailsExtractor slackJobDetailsExtractor, SlackDistributionTestAction slackDistributionTestAction) {
+    protected SlackConfigurationAction(SlackJobDetailsExtractor slackJobDetailsExtractor) {
         super(ChannelKeys.SLACK);
         addJobDetailsExtractor(slackJobDetailsExtractor);
-        addDistributionTestAction(slackDistributionTestAction);
     }
 
 }

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/slack/action/SlackDistributionTestAction.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/slack/action/SlackDistributionTestAction.java
@@ -10,15 +10,16 @@ package com.synopsys.integration.alert.channel.slack.action;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.synopsys.integration.alert.channel.api.action.DistributionChannelTestAction;
+import com.synopsys.integration.alert.channel.api.action.DistributionChannelMessageTestAction;
 import com.synopsys.integration.alert.channel.slack.distribution.SlackChannel;
 import com.synopsys.integration.alert.common.persistence.model.job.details.SlackJobDetailsModel;
+import com.synopsys.integration.alert.descriptor.api.SlackChannelKey;
 
 @Component
-public class SlackDistributionTestAction extends DistributionChannelTestAction<SlackJobDetailsModel> {
+public class SlackDistributionTestAction extends DistributionChannelMessageTestAction<SlackJobDetailsModel> {
     @Autowired
-    public SlackDistributionTestAction(SlackChannel distributionChannel) {
-        super(distributionChannel);
+    public SlackDistributionTestAction(SlackChannelKey channelKey, SlackChannel distributionChannel) {
+        super(channelKey, distributionChannel);
     }
 
 }

--- a/src/test/java/com/synopsys/integration/alert/channel/ChannelDescriptorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/ChannelDescriptorTestIT.java
@@ -179,7 +179,7 @@ public abstract class ChannelDescriptorTestIT {
 
     public abstract TestAction getGlobalTestAction();
 
-    public abstract DistributionChannelTestAction getChannelDistributionTestAction();
+    public abstract DistributionChannelTestAction getDistributionChannelTestAction();
 
     protected ConfigurationModel saveProviderGlobalConfig() {
         return configurationAccessor.createConfiguration(providerKey, ConfigContextEnum.GLOBAL, List.of());
@@ -214,7 +214,7 @@ public abstract class ChannelDescriptorTestIT {
     @Test
     public void testDistributionConfig() {
         try {
-            DistributionChannelTestAction descriptorActionApi = getChannelDistributionTestAction();
+            DistributionChannelTestAction descriptorActionApi = getDistributionChannelTestAction();
             descriptorActionApi.testConfig(distributionJobModel, "Topic - Channel Descriptor Test IT", "Message - Channel Descriptor Test IT");
         } catch (IntegrationException e) {
             e.printStackTrace();

--- a/src/test/java/com/synopsys/integration/alert/channel/ChannelDescriptorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/ChannelDescriptorTestIT.java
@@ -22,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.common.ContentConverter;
 import com.synopsys.integration.alert.common.action.TestAction;
-import com.synopsys.integration.alert.common.channel.ChannelDistributionTestAction;
+import com.synopsys.integration.alert.common.channel.DistributionChannelTestAction;
 import com.synopsys.integration.alert.common.descriptor.ChannelDescriptor;
 import com.synopsys.integration.alert.common.descriptor.DescriptorProcessor;
 import com.synopsys.integration.alert.common.descriptor.config.field.ConfigField;
@@ -179,7 +179,7 @@ public abstract class ChannelDescriptorTestIT {
 
     public abstract TestAction getGlobalTestAction();
 
-    public abstract ChannelDistributionTestAction getChannelDistributionTestAction();
+    public abstract DistributionChannelTestAction getChannelDistributionTestAction();
 
     protected ConfigurationModel saveProviderGlobalConfig() {
         return configurationAccessor.createConfiguration(providerKey, ConfigContextEnum.GLOBAL, List.of());
@@ -214,8 +214,8 @@ public abstract class ChannelDescriptorTestIT {
     @Test
     public void testDistributionConfig() {
         try {
-            ChannelDistributionTestAction descriptorActionApi = getChannelDistributionTestAction();
-            descriptorActionApi.testConfig(distributionJobModel, "Topic - Channel Descriptor Test IT", "Message - Channel Descriptor Test IT", null);
+            DistributionChannelTestAction descriptorActionApi = getChannelDistributionTestAction();
+            descriptorActionApi.testConfig(distributionJobModel, "Topic - Channel Descriptor Test IT", "Message - Channel Descriptor Test IT");
         } catch (IntegrationException e) {
             e.printStackTrace();
             fail();

--- a/src/test/java/com/synopsys/integration/alert/channel/Channel_ComprehensiveRequirements_ITTest.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/Channel_ComprehensiveRequirements_ITTest.java
@@ -1,0 +1,83 @@
+package com.synopsys.integration.alert.channel;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.synopsys.integration.alert.channel.api.DistributionEventReceiver;
+import com.synopsys.integration.alert.channel.api.issue.action.IssueTrackerTestAction;
+import com.synopsys.integration.alert.common.channel.DistributionChannelTestAction;
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKey;
+import com.synopsys.integration.alert.descriptor.api.model.IssueTrackerChannelKey;
+import com.synopsys.integration.alert.util.AlertIntegrationTest;
+
+@AlertIntegrationTest
+public class Channel_ComprehensiveRequirements_ITTest {
+    private static final String COMPONENT_NAME_DISTRIBUTION_RECEIVER = DistributionEventReceiver.class.getSimpleName();
+    private static final String COMPONENT_NAME_DISTRIBUTION_TEST_ACTION = DistributionChannelTestAction.class.getSimpleName();
+    private static final String COMPONENT_NAME_ISSUE_TRACKER_TEST_ACTION = IssueTrackerTestAction.class.getSimpleName();
+
+    @Autowired
+    private List<ChannelKey> channelKeys;
+    @Autowired
+    private List<DistributionEventReceiver> distributionEventReceivers;
+    @Autowired
+    private List<DistributionChannelTestAction> distributionChannelTestActions;
+
+    @Test
+    public void checkIfChannelsHaveAllNecessarySpringComponents() {
+        List<String> channelFailureMessages = new LinkedList<>();
+        for (ChannelKey channelKey : channelKeys) {
+            List<String> missingComponents = findMissingComponents(channelKey);
+            if (!missingComponents.isEmpty()) {
+                String channelFailureMessage = createChannelFailureMessage(channelKey, missingComponents);
+                channelFailureMessages.add(channelFailureMessage);
+            }
+        }
+
+        if (!channelFailureMessages.isEmpty()) {
+            String failureMessage = StringUtils.join(channelFailureMessages, "\n\n");
+            fail(failureMessage);
+        }
+    }
+
+    private List<String> findMissingComponents(ChannelKey channelKey) {
+        List<String> missingComponents = new LinkedList<>();
+
+        // Distribution Event Receiver
+        boolean hasReceiver = distributionEventReceivers
+                                  .stream()
+                                  .anyMatch(receiver -> receiver.getDestinationName().equals(channelKey.getUniversalKey()));
+        if (!hasReceiver) {
+            missingComponents.add(COMPONENT_NAME_DISTRIBUTION_RECEIVER);
+        }
+
+        // Distribution Test Action
+        Optional<DistributionChannelTestAction> foundTestAction = distributionChannelTestActions
+                                                                      .stream()
+                                                                      .filter(testAction -> testAction.getDescriptorKey().equals(channelKey))
+                                                                      .findAny();
+        if (foundTestAction.isPresent()) {
+            DistributionChannelTestAction testAction = foundTestAction.get();
+            if (channelKey instanceof IssueTrackerChannelKey && !(testAction instanceof IssueTrackerTestAction)) {
+                missingComponents.add(COMPONENT_NAME_ISSUE_TRACKER_TEST_ACTION);
+            }
+        } else {
+            missingComponents.add(COMPONENT_NAME_DISTRIBUTION_TEST_ACTION);
+        }
+
+        return missingComponents;
+    }
+
+    private String createChannelFailureMessage(ChannelKey channelKey, List<String> missingComponents) {
+        String missingComponentsString = StringUtils.join(missingComponents, ", ");
+        return String.format("%s (%s) was missing the following components: %s", channelKey.getDisplayName(), channelKey.getUniversalKey(), missingComponentsString);
+    }
+
+}

--- a/src/test/java/com/synopsys/integration/alert/channel/Channel_ComprehensiveRequirements_TestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/Channel_ComprehensiveRequirements_TestIT.java
@@ -18,7 +18,7 @@ import com.synopsys.integration.alert.descriptor.api.model.IssueTrackerChannelKe
 import com.synopsys.integration.alert.util.AlertIntegrationTest;
 
 @AlertIntegrationTest
-public class Channel_ComprehensiveRequirements_ITTest {
+public class Channel_ComprehensiveRequirements_TestIT {
     private static final String COMPONENT_NAME_DISTRIBUTION_RECEIVER = DistributionEventReceiver.class.getSimpleName();
     private static final String COMPONENT_NAME_DISTRIBUTION_TEST_ACTION = DistributionChannelTestAction.class.getSimpleName();
     private static final String COMPONENT_NAME_ISSUE_TRACKER_TEST_ACTION = IssueTrackerTestAction.class.getSimpleName();
@@ -26,7 +26,7 @@ public class Channel_ComprehensiveRequirements_ITTest {
     @Autowired
     private List<ChannelKey> channelKeys;
     @Autowired
-    private List<DistributionEventReceiver> distributionEventReceivers;
+    private List<DistributionEventReceiver<?>> distributionEventReceivers;
     @Autowired
     private List<DistributionChannelTestAction> distributionChannelTestActions;
 

--- a/src/test/java/com/synopsys/integration/alert/channel/Channel_ComprehensiveRequirements_TestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/Channel_ComprehensiveRequirements_TestIT.java
@@ -19,6 +19,9 @@ import com.synopsys.integration.alert.descriptor.api.model.ChannelKey;
 import com.synopsys.integration.alert.descriptor.api.model.IssueTrackerChannelKey;
 import com.synopsys.integration.alert.util.AlertIntegrationTest;
 
+/*
+ * This class uses underscores to indicate that it does not reference one particular class and instead tests an Alert concept.
+ */
 @AlertIntegrationTest
 public class Channel_ComprehensiveRequirements_TestIT {
     private static final String COMPONENT_NAME_DISTRIBUTION_RECEIVER = DistributionEventReceiver.class.getSimpleName();

--- a/src/test/java/com/synopsys/integration/alert/channel/email/EmailChannelChannelDescriptorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/email/EmailChannelChannelDescriptorTestIT.java
@@ -25,7 +25,7 @@ import com.synopsys.integration.alert.channel.email.distribution.EmailChannelMes
 import com.synopsys.integration.alert.channel.email.distribution.EmailChannelMessageSender;
 import com.synopsys.integration.alert.channel.email.distribution.EmailChannelV2;
 import com.synopsys.integration.alert.common.action.TestAction;
-import com.synopsys.integration.alert.common.channel.ChannelDistributionTestAction;
+import com.synopsys.integration.alert.common.channel.DistributionChannelTestAction;
 import com.synopsys.integration.alert.common.channel.template.FreemarkerTemplatingService;
 import com.synopsys.integration.alert.common.descriptor.ChannelDescriptor;
 import com.synopsys.integration.alert.common.descriptor.ProviderDescriptor;
@@ -165,7 +165,7 @@ public class EmailChannelChannelDescriptorTestIT extends ChannelDescriptorTestIT
     }
 
     @Override
-    public ChannelDistributionTestAction getChannelDistributionTestAction() {
+    public DistributionChannelTestAction getChannelDistributionTestAction() {
         TestAlertProperties alertProperties = new TestAlertProperties();
         FreemarkerTemplatingService freemarkerTemplatingService = new FreemarkerTemplatingService();
         EmailAttachmentFileCreator emailAttachmentFileCreator = new EmailAttachmentFileCreator(alertProperties, new MessageContentGroupCsvCreator(), gson);
@@ -180,7 +180,7 @@ public class EmailChannelChannelDescriptorTestIT extends ChannelDescriptorTestIT
         EmailChannelMessageSender emailChannelMessageSender = new EmailChannelMessageSender(ChannelKeys.EMAIL, alertProperties, emailAddressGatherer, emailAttachmentFileCreator, freemarkerTemplatingService, mockConfigAccessor);
         EmailChannelV2 emailChannel = new EmailChannelV2(emailChannelMessageConverter, emailChannelMessageSender);
 
-        return new EmailDistributionTestAction(emailChannel, emailTestActionHelper);
+        return new EmailDistributionTestAction(ChannelKeys.EMAIL, emailChannel, emailTestActionHelper);
     }
 
     @Test

--- a/src/test/java/com/synopsys/integration/alert/channel/email/EmailChannelChannelDescriptorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/email/EmailChannelChannelDescriptorTestIT.java
@@ -165,7 +165,7 @@ public class EmailChannelChannelDescriptorTestIT extends ChannelDescriptorTestIT
     }
 
     @Override
-    public DistributionChannelTestAction getChannelDistributionTestAction() {
+    public DistributionChannelTestAction getDistributionChannelTestAction() {
         TestAlertProperties alertProperties = new TestAlertProperties();
         FreemarkerTemplatingService freemarkerTemplatingService = new FreemarkerTemplatingService();
         EmailAttachmentFileCreator emailAttachmentFileCreator = new EmailAttachmentFileCreator(alertProperties, new MessageContentGroupCsvCreator(), gson);

--- a/src/test/java/com/synopsys/integration/alert/channel/slack/SlackChannelChannelDescriptorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/slack/SlackChannelChannelDescriptorTestIT.java
@@ -14,7 +14,7 @@ import com.synopsys.integration.alert.channel.slack.action.SlackDistributionTest
 import com.synopsys.integration.alert.channel.slack.descriptor.SlackDescriptor;
 import com.synopsys.integration.alert.channel.slack.distribution.SlackChannel;
 import com.synopsys.integration.alert.common.action.TestAction;
-import com.synopsys.integration.alert.common.channel.ChannelDistributionTestAction;
+import com.synopsys.integration.alert.common.channel.DistributionChannelTestAction;
 import com.synopsys.integration.alert.common.descriptor.ChannelDescriptor;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
@@ -99,8 +99,8 @@ public class SlackChannelChannelDescriptorTestIT extends ChannelDescriptorTestIT
     }
 
     @Override
-    public ChannelDistributionTestAction getChannelDistributionTestAction() {
-        return new SlackDistributionTestAction(slackChannel) {};
+    public DistributionChannelTestAction getChannelDistributionTestAction() {
+        return new SlackDistributionTestAction(ChannelKeys.SLACK, slackChannel) {};
     }
 
     @Override

--- a/src/test/java/com/synopsys/integration/alert/channel/slack/SlackChannelChannelDescriptorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/slack/SlackChannelChannelDescriptorTestIT.java
@@ -99,7 +99,7 @@ public class SlackChannelChannelDescriptorTestIT extends ChannelDescriptorTestIT
     }
 
     @Override
-    public DistributionChannelTestAction getChannelDistributionTestAction() {
+    public DistributionChannelTestAction getDistributionChannelTestAction() {
         return new SlackDistributionTestAction(ChannelKeys.SLACK, slackChannel) {};
     }
 

--- a/src/test/java/com/synopsys/integration/alert/web/api/job/JobConfigActionsTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/api/job/JobConfigActionsTest.java
@@ -598,15 +598,10 @@ public class JobConfigActionsTest {
     }
 
     private DistributionChannelTestAction createChannelDistributionTestAction() {
-        return new DistributionChannelTestAction() {
+        return new DistributionChannelTestAction(createDescriptorKey()) {
             @Override
             public MessageResult testConfig(DistributionJobModel distributionJobModel, @Nullable String customTopic, @Nullable String customMessage) {
                 return new MessageResult("Test Status Message");
-            }
-
-            @Override
-            public DescriptorKey getDescriptorKey() {
-                return createDescriptorKey();
             }
         };
     }

--- a/src/test/java/com/synopsys/integration/alert/web/api/job/JobConfigActionsTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/api/job/JobConfigActionsTest.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -20,7 +21,7 @@ import org.springframework.http.HttpStatus;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.action.TestAction;
 import com.synopsys.integration.alert.common.action.ValidationActionResponse;
-import com.synopsys.integration.alert.common.channel.ChannelDistributionTestAction;
+import com.synopsys.integration.alert.common.channel.DistributionChannelTestAction;
 import com.synopsys.integration.alert.common.descriptor.Descriptor;
 import com.synopsys.integration.alert.common.descriptor.DescriptorMap;
 import com.synopsys.integration.alert.common.descriptor.DescriptorProcessor;
@@ -602,8 +603,18 @@ public class JobConfigActionsTest {
         return new ConfigurationModel(descriptorId, configurationId, createdAt, lastUpdated, configContextEnum, configuredFields);
     }
 
-    private ChannelDistributionTestAction createChannelDistributionTestAction() {
-        return (testJobModel, customTopic, customMessage, destination) -> new MessageResult("Test Status Message");
+    private DistributionChannelTestAction createChannelDistributionTestAction() {
+        return new DistributionChannelTestAction() {
+            @Override
+            public MessageResult testConfig(DistributionJobModel distributionJobModel, @Nullable String customTopic, @Nullable String customMessage) throws AlertException {
+                return new MessageResult("Test Status Message");
+            }
+
+            @Override
+            public DescriptorKey getDescriptorKey() {
+                return createChannelKey();
+            }
+        };
     }
 
     private JobDetailsExtractor createJobDetailsExtractor() {

--- a/src/test/java/com/synopsys/integration/alert/web/api/job/JobConfigActionsTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/api/job/JobConfigActionsTest.java
@@ -126,7 +126,8 @@ public class JobConfigActionsTest {
             globalConfigExistsValidator,
             pkixErrorResponseFactory,
             descriptorMap,
-            providerProjectExistencePopulator
+            providerProjectExistencePopulator,
+            List.of()
         );
 
         Mockito.when(authorizationManager.hasCreatePermission(Mockito.any(ConfigContextEnum.class), Mockito.any(DescriptorKey.class))).thenReturn(true);
@@ -270,6 +271,21 @@ public class JobConfigActionsTest {
 
     @Test
     public void testTest() throws Exception {
+        JobConfigActions jobConfigActionsForTest = new JobConfigActions(
+            authorizationManager,
+            descriptorAccessor,
+            configurationAccessor,
+            jobAccessor,
+            fieldModelProcessor,
+            descriptorProcessor,
+            configurationFieldModelConverter,
+            globalConfigExistsValidator,
+            pkixErrorResponseFactory,
+            descriptorMap,
+            null,
+            List.of(createChannelDistributionTestAction())
+        );
+
         fieldModel.setId("testID");
         Descriptor descriptor = createDescriptor(DescriptorType.CHANNEL);
 
@@ -277,11 +293,11 @@ public class JobConfigActionsTest {
         Mockito.when(descriptorProcessor.retrieveDescriptor(Mockito.any())).thenReturn(Optional.of(descriptor));
         Mockito.when(fieldModelProcessor.createCustomMessageFieldModel(Mockito.any())).thenReturn(fieldModel);
 
-        Mockito.when(descriptorProcessor.retrieveChannelDistributionTestAction(Mockito.any())).thenReturn(Optional.of(createChannelDistributionTestAction()));
+        // Mockito.when(descriptorProcessor.retrieveChannelDistributionTestAction(Mockito.any())).thenReturn(Optional.of(createChannelDistributionTestAction()));
         Mockito.when(descriptorProcessor.retrieveJobDetailsExtractor(Mockito.anyString())).thenReturn(Optional.of(createJobDetailsExtractor()));
         Mockito.when(configurationFieldModelConverter.convertToConfigurationFieldModelMap(Mockito.any())).thenReturn(Map.of("testKey", configurationFieldModel));
 
-        ValidationActionResponse validationActionResponse = jobConfigActions.test(jobFieldModel);
+        ValidationActionResponse validationActionResponse = jobConfigActionsForTest.test(jobFieldModel);
 
         assertTrue(validationActionResponse.isSuccessful(), "Validation response was not successful");
         assertEquals(HttpStatus.OK, validationActionResponse.getHttpStatus());
@@ -312,26 +328,6 @@ public class JobConfigActionsTest {
         assertTrue(validationActionResponse.hasContent(), "Expected response to have content");
         ValidationResponseModel validationResponseModel = validationActionResponse.getContent().get();
         assertTrue(validationResponseModel.hasErrors(), "Expected response to ");
-    }
-
-    @Test
-    public void testMethodNotAllowedTest() throws Exception {
-        fieldModel.setId("testID");
-        Descriptor descriptor = createDescriptor(DescriptorType.CHANNEL);
-
-        Mockito.when(fieldModelProcessor.validateJobFieldModel(Mockito.any())).thenReturn(List.of());
-        Mockito.when(descriptorProcessor.retrieveDescriptor(Mockito.any())).thenReturn(Optional.of(descriptor));
-        Mockito.when(fieldModelProcessor.createCustomMessageFieldModel(Mockito.any())).thenReturn(fieldModel);
-
-        Mockito.when(descriptorProcessor.retrieveTestAction(Mockito.any())).thenReturn(Optional.empty());
-
-        ValidationActionResponse validationActionResponse = jobConfigActions.test(jobFieldModel);
-
-        assertTrue(validationActionResponse.isError());
-        assertEquals(HttpStatus.METHOD_NOT_ALLOWED, validationActionResponse.getHttpStatus());
-        assertTrue(validationActionResponse.hasContent());
-        ValidationResponseModel validationResponseModel = validationActionResponse.getContent().get();
-        assertTrue(validationResponseModel.hasErrors());
     }
 
     @Test
@@ -606,13 +602,13 @@ public class JobConfigActionsTest {
     private DistributionChannelTestAction createChannelDistributionTestAction() {
         return new DistributionChannelTestAction() {
             @Override
-            public MessageResult testConfig(DistributionJobModel distributionJobModel, @Nullable String customTopic, @Nullable String customMessage) throws AlertException {
+            public MessageResult testConfig(DistributionJobModel distributionJobModel, @Nullable String customTopic, @Nullable String customMessage) {
                 return new MessageResult("Test Status Message");
             }
 
             @Override
             public DescriptorKey getDescriptorKey() {
-                return createChannelKey();
+                return createDescriptorKey();
             }
         };
     }

--- a/src/test/java/com/synopsys/integration/alert/web/api/job/JobConfigActionsTest.java
+++ b/src/test/java/com/synopsys/integration/alert/web/api/job/JobConfigActionsTest.java
@@ -317,7 +317,6 @@ public class JobConfigActionsTest {
         Mockito.when(fieldModelProcessor.createCustomMessageFieldModel(Mockito.any())).thenReturn(fieldModel);
 
         Mockito.when(descriptorProcessor.retrieveTestAction(Mockito.any())).thenReturn(Optional.of(createTestActionWithErrors()));
-        Mockito.when(descriptorProcessor.retrieveChannelDistributionTestAction(Mockito.any())).thenReturn(Optional.of(createChannelDistributionTestAction()));
         Mockito.when(configurationFieldModelConverter.convertToConfigurationFieldModelMap(Mockito.any())).thenReturn(Map.of(ChannelDistributionUIConfig.KEY_PROVIDER_NAME, configurationFieldModel));
         Mockito.when(descriptorProcessor.retrieveTestAction(Mockito.any(), Mockito.any())).thenReturn(Optional.of(createTestActionWithErrors()));
 
@@ -409,7 +408,6 @@ public class JobConfigActionsTest {
         Mockito.when(fieldModelProcessor.createCustomMessageFieldModel(Mockito.any())).thenReturn(fieldModel);
 
         Mockito.when(descriptorProcessor.retrieveTestAction(Mockito.any())).thenReturn(Optional.of(createTestActionWithErrors()));
-        Mockito.when(descriptorProcessor.retrieveChannelDistributionTestAction(Mockito.any())).thenReturn(Optional.of(createChannelDistributionTestAction()));
         Mockito.when(configurationFieldModelConverter.convertToConfigurationFieldModelMap(Mockito.any())).thenReturn(Map.of(ChannelDistributionUIConfig.KEY_PROVIDER_NAME, configurationFieldModel));
         Mockito.when(descriptorProcessor.retrieveTestAction(Mockito.any(), Mockito.any())).thenReturn(Optional.of(createTestActionWithIntegrationRestException()));
 

--- a/web/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigActions.java
+++ b/web/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigActions.java
@@ -37,6 +37,7 @@ import com.synopsys.integration.alert.common.channel.DistributionChannelTestActi
 import com.synopsys.integration.alert.common.descriptor.Descriptor;
 import com.synopsys.integration.alert.common.descriptor.DescriptorMap;
 import com.synopsys.integration.alert.common.descriptor.DescriptorProcessor;
+import com.synopsys.integration.alert.common.descriptor.action.DescriptorActionMap;
 import com.synopsys.integration.alert.common.descriptor.config.GlobalConfigExistsValidator;
 import com.synopsys.integration.alert.common.descriptor.config.field.errors.AlertFieldStatus;
 import com.synopsys.integration.alert.common.descriptor.config.ui.ChannelDistributionUIConfig;
@@ -79,6 +80,7 @@ import com.synopsys.integration.rest.exception.IntegrationRestException;
 @Component
 public class JobConfigActions extends AbstractJobResourceActions {
     private final Logger logger = LoggerFactory.getLogger(JobConfigActions.class);
+
     private final ConfigurationAccessor configurationAccessor;
     private final JobAccessor jobAccessor;
     private final FieldModelProcessor fieldModelProcessor;
@@ -86,6 +88,7 @@ public class JobConfigActions extends AbstractJobResourceActions {
     private final ConfigurationFieldModelConverter modelConverter;
     private final GlobalConfigExistsValidator globalConfigExistsValidator;
     private final PKIXErrorResponseFactory pkixErrorResponseFactory;
+    private final DescriptorActionMap<DistributionChannelTestAction> channelTestActionMap;
 
     private final ProviderProjectExistencePopulator providerProjectExistencePopulator;
 
@@ -101,7 +104,8 @@ public class JobConfigActions extends AbstractJobResourceActions {
         GlobalConfigExistsValidator globalConfigExistsValidator,
         PKIXErrorResponseFactory pkixErrorResponseFactory,
         DescriptorMap descriptorMap,
-        ProviderProjectExistencePopulator providerProjectExistencePopulator
+        ProviderProjectExistencePopulator providerProjectExistencePopulator,
+        List<DistributionChannelTestAction> channelTestActions
     ) {
         super(authorizationManager, descriptorAccessor, descriptorMap);
         this.configurationAccessor = configurationAccessor;
@@ -112,6 +116,7 @@ public class JobConfigActions extends AbstractJobResourceActions {
         this.pkixErrorResponseFactory = pkixErrorResponseFactory;
         this.jobAccessor = jobAccessor;
         this.providerProjectExistencePopulator = providerProjectExistencePopulator;
+        this.channelTestActionMap = new DescriptorActionMap<>(channelTestActions);
     }
 
     @Override
@@ -334,48 +339,40 @@ public class JobConfigActions extends AbstractJobResourceActions {
             FieldModel channelFieldModel = getChannelFieldModelAndPopulateOtherJobModels(resource, otherJobModels);
 
             if (null != channelFieldModel) {
-                String descriptorName = channelFieldModel.getDescriptorName();
-                Optional<DistributionChannelTestAction> optionalChannelDistributionTestAction = descriptorProcessor.retrieveChannelDistributionTestAction(descriptorName);
-                if (optionalChannelDistributionTestAction.isPresent()) {
-                    DistributionChannelTestAction distributionChannelTestAction = optionalChannelDistributionTestAction.get();
-                    Map<String, ConfigurationFieldModel> fields = createFieldsMap(channelFieldModel, otherJobModels);
-                    // The custom message fields are not written to the database or defined fields in the database.  Need to manually add them.
-                    // TODO Create a mechanism to create the field accessor with a combination of fields in the database and fields that are not.
-                    Optional<ConfigurationFieldModel> topicField = convertFieldToConfigurationField(channelFieldModel, TestAction.KEY_CUSTOM_TOPIC);
-                    Optional<ConfigurationFieldModel> messageField = convertFieldToConfigurationField(channelFieldModel, TestAction.KEY_CUSTOM_MESSAGE);
-                    Optional<ConfigurationFieldModel> destinationField = convertFieldToConfigurationField(channelFieldModel, TestAction.KEY_DESTINATION_NAME);
-                    topicField.ifPresent(model -> fields.put(TestAction.KEY_CUSTOM_TOPIC, model));
-                    messageField.ifPresent(model -> fields.put(TestAction.KEY_CUSTOM_MESSAGE, model));
-                    destinationField.ifPresent(model -> fields.put(TestAction.KEY_DESTINATION_NAME, model));
+                String channelDescriptorName = channelFieldModel.getDescriptorName();
 
-                    MessageResult providerTestResult = testProviderConfig(new FieldUtility(fields), jobIdString, channelFieldModel);
-                    if (providerTestResult.hasErrors() || providerTestResult.hasWarnings()) {
-                        responseModel = ValidationResponseModel.fromStatusCollection(providerTestResult.getStatusMessage(), providerTestResult.getFieldStatuses());
-                        return new ValidationActionResponse(HttpStatus.OK, responseModel);
-                    }
+                Map<String, ConfigurationFieldModel> fields = createFieldsMap(channelFieldModel, otherJobModels);
+                // The custom message fields are not written to the database or defined fields in the database.  Need to manually add them.
+                // TODO Create a mechanism to create the field accessor with a combination of fields in the database and fields that are not.
+                Optional<ConfigurationFieldModel> topicField = convertFieldToConfigurationField(channelFieldModel, TestAction.KEY_CUSTOM_TOPIC);
+                Optional<ConfigurationFieldModel> messageField = convertFieldToConfigurationField(channelFieldModel, TestAction.KEY_CUSTOM_MESSAGE);
+                topicField.ifPresent(model -> fields.put(TestAction.KEY_CUSTOM_TOPIC, model));
+                messageField.ifPresent(model -> fields.put(TestAction.KEY_CUSTOM_MESSAGE, model));
 
-                    List<BlackDuckProjectDetailsModel> projectFilterDetails = Optional.ofNullable(resource.getConfiguredProviderProjects())
-                                                                                  .orElse(List.of())
-                                                                                  .stream()
-                                                                                  .map(jobProject -> new BlackDuckProjectDetailsModel(jobProject.getName(), jobProject.getHref()))
-                                                                                  .collect(Collectors.toList());
-                    DistributionJobModel testJobModel = descriptorProcessor.retrieveJobDetailsExtractor(descriptorName)
-                                                            .map(JobDetailsExtractor -> JobDetailsExtractor.convertToJobModel(jobId, fields, DateUtils.createCurrentDateTimestamp(), null, projectFilterDetails))
-                                                            .orElseThrow(() -> new AlertException("This job should have an associated job details processor."));
-
-                    MessageResult testActionResult = distributionChannelTestAction.testConfig(
-                        testJobModel,
-                        topicField.flatMap(ConfigurationFieldModel::getFieldValue).orElse(null),
-                        messageField.flatMap(ConfigurationFieldModel::getFieldValue).orElse(null)
-                    );
-                    List<AlertFieldStatus> resultFieldStatuses = testActionResult.getFieldStatuses();
-                    responseModel = ValidationResponseModel.fromStatusCollection(testActionResult.getStatusMessage(), resultFieldStatuses);
+                MessageResult providerTestResult = testProviderConfig(new FieldUtility(fields), jobIdString, channelFieldModel);
+                if (providerTestResult.hasErrors() || providerTestResult.hasWarnings()) {
+                    responseModel = ValidationResponseModel.fromStatusCollection(providerTestResult.getStatusMessage(), providerTestResult.getFieldStatuses());
                     return new ValidationActionResponse(HttpStatus.OK, responseModel);
-                } else {
-                    logger.error("Test action did not exist: {}", descriptorName);
-                    responseModel = ValidationResponseModel.generalError("Test functionality not implemented for " + descriptorName);
-                    return new ValidationActionResponse(HttpStatus.METHOD_NOT_ALLOWED, responseModel);
                 }
+
+                List<BlackDuckProjectDetailsModel> projectFilterDetails = Optional.ofNullable(resource.getConfiguredProviderProjects())
+                                                                              .orElse(List.of())
+                                                                              .stream()
+                                                                              .map(jobProject -> new BlackDuckProjectDetailsModel(jobProject.getName(), jobProject.getHref()))
+                                                                              .collect(Collectors.toList());
+                DistributionJobModel testJobModel = descriptorProcessor.retrieveJobDetailsExtractor(channelDescriptorName)
+                                                        .map(JobDetailsExtractor -> JobDetailsExtractor.convertToJobModel(jobId, fields, DateUtils.createCurrentDateTimestamp(), null, projectFilterDetails))
+                                                        .orElseThrow(() -> new AlertException("This job should have an associated job details processor."));
+
+                DistributionChannelTestAction distributionChannelTestAction = channelTestActionMap.findRequiredAction(channelDescriptorName);
+                MessageResult testActionResult = distributionChannelTestAction.testConfig(
+                    testJobModel,
+                    topicField.flatMap(ConfigurationFieldModel::getFieldValue).orElse(null),
+                    messageField.flatMap(ConfigurationFieldModel::getFieldValue).orElse(null)
+                );
+                List<AlertFieldStatus> resultFieldStatuses = testActionResult.getFieldStatuses();
+                responseModel = ValidationResponseModel.fromStatusCollection(testActionResult.getStatusMessage(), resultFieldStatuses);
+                return new ValidationActionResponse(HttpStatus.OK, responseModel);
             }
             responseModel = ValidationResponseModel.generalError("No field model of type channel was was sent to test.");
             return new ValidationActionResponse(HttpStatus.BAD_REQUEST, responseModel);

--- a/web/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigActions.java
+++ b/web/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigActions.java
@@ -33,7 +33,7 @@ import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.action.TestAction;
 import com.synopsys.integration.alert.common.action.ValidationActionResponse;
 import com.synopsys.integration.alert.common.action.api.AbstractJobResourceActions;
-import com.synopsys.integration.alert.common.channel.ChannelDistributionTestAction;
+import com.synopsys.integration.alert.common.channel.DistributionChannelTestAction;
 import com.synopsys.integration.alert.common.descriptor.Descriptor;
 import com.synopsys.integration.alert.common.descriptor.DescriptorMap;
 import com.synopsys.integration.alert.common.descriptor.DescriptorProcessor;
@@ -335,9 +335,9 @@ public class JobConfigActions extends AbstractJobResourceActions {
 
             if (null != channelFieldModel) {
                 String descriptorName = channelFieldModel.getDescriptorName();
-                Optional<ChannelDistributionTestAction> optionalChannelDistributionTestAction = descriptorProcessor.retrieveChannelDistributionTestAction(descriptorName);
+                Optional<DistributionChannelTestAction> optionalChannelDistributionTestAction = descriptorProcessor.retrieveChannelDistributionTestAction(descriptorName);
                 if (optionalChannelDistributionTestAction.isPresent()) {
-                    ChannelDistributionTestAction channelDistributionTestAction = optionalChannelDistributionTestAction.get();
+                    DistributionChannelTestAction distributionChannelTestAction = optionalChannelDistributionTestAction.get();
                     Map<String, ConfigurationFieldModel> fields = createFieldsMap(channelFieldModel, otherJobModels);
                     // The custom message fields are not written to the database or defined fields in the database.  Need to manually add them.
                     // TODO Create a mechanism to create the field accessor with a combination of fields in the database and fields that are not.
@@ -363,11 +363,10 @@ public class JobConfigActions extends AbstractJobResourceActions {
                                                             .map(JobDetailsExtractor -> JobDetailsExtractor.convertToJobModel(jobId, fields, DateUtils.createCurrentDateTimestamp(), null, projectFilterDetails))
                                                             .orElseThrow(() -> new AlertException("This job should have an associated job details processor."));
 
-                    MessageResult testActionResult = channelDistributionTestAction.testConfig(
+                    MessageResult testActionResult = distributionChannelTestAction.testConfig(
                         testJobModel,
                         topicField.flatMap(ConfigurationFieldModel::getFieldValue).orElse(null),
-                        messageField.flatMap(ConfigurationFieldModel::getFieldValue).orElse(null),
-                        destinationField.flatMap(ConfigurationFieldModel::getFieldValue).orElse(null)
+                        messageField.flatMap(ConfigurationFieldModel::getFieldValue).orElse(null)
                     );
                     List<AlertFieldStatus> resultFieldStatuses = testActionResult.getFieldStatuses();
                     responseModel = ValidationResponseModel.fromStatusCollection(testActionResult.getStatusMessage(), resultFieldStatuses);


### PR DESCRIPTION
## Motivations: 
 - In 6.4.0, the introduction of concrete classes for Distribution Jobs created an opportunity for improving "TestActions". Up until this point, all TestActions took a FieldModel and FieldUtility as parameters, but now they could take in a DistributionJobModel. A separate class was created for Distribution TestActions (i.e. TestActions that distributed a message based on a Distribution Job's fields). 

 - The class ConfigurationAction used to manage all actions of a single "descriptor" and it did this with TestActions by putting them into a Map from Context to TestAction. With the introduction of a new class for Channel DistributionTestActions, the Map was no longer useful.


## Discoveries:
 - In making these changes, it became apparent that these classes existed primarily to serve the dynamic UI.

 - The class ConfigurationAction is abstract and implementations of it autowire TestActions to pass to it, then those implementations are autowired into a class called DescriptorProcessor, which is autowired into a class called FieldModelProcessor, which is finally autowired into the places we actually want to get the originally autowired TestActions.

 - These classes were autowired in more places (four places) than they were actually called (which was litetally one place)

 - This process, besides being incredibly convoluted, is totally unnecessary with because we can simply autowire the TestActions in the place we actually want them. The only problem is that they won't be in a Map.


 ## Solution:
 - Create a class that takes in a list of test actions and provides "lookup" functionality based on the channel name (like a map).

 - Remove all references to the new TestActions in ConfigurationAction, DescriptorProcessor, and FieldModelProcessor

 - Create an integration test that verifies whether a channel has declared all necessary Spring components required to work properly