### PR TITLE
Jm jira cloud test action

### DIFF
--- a/channel/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/action/JiraCloudDistributionTestAction.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/action/JiraCloudDistributionTestAction.java
@@ -7,18 +7,28 @@
  */
 package com.synopsys.integration.alert.channel.jira.cloud.action;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.synopsys.integration.alert.channel.api.action.DistributionChannelTestAction;
-import com.synopsys.integration.alert.channel.jira.cloud.distribution.JiraCloudChannel;
+import com.synopsys.integration.alert.channel.api.issue.action.IssueTrackerTestAction;
+import com.synopsys.integration.alert.channel.jira.cloud.distribution.JiraCloudMessageSenderFactory;
 import com.synopsys.integration.alert.common.persistence.model.job.details.JiraCloudJobDetailsModel;
 
 @Component
-public class JiraCloudDistributionTestAction extends DistributionChannelTestAction<JiraCloudJobDetailsModel> {
+public class JiraCloudDistributionTestAction extends IssueTrackerTestAction<JiraCloudJobDetailsModel, String> {
     @Autowired
-    public JiraCloudDistributionTestAction(JiraCloudChannel distributionChannel) {
-        super(distributionChannel);
+    public JiraCloudDistributionTestAction(JiraCloudMessageSenderFactory messageSenderFactory) {
+        super(messageSenderFactory);
     }
 
+    @Override
+    protected boolean hasResolveTransition(JiraCloudJobDetailsModel distributionDetails) {
+        return StringUtils.isNotBlank(distributionDetails.getResolveTransition());
+    }
+
+    @Override
+    protected boolean hasReopenTransition(JiraCloudJobDetailsModel distributionDetails) {
+        return StringUtils.isNotBlank(distributionDetails.getReopenTransition());
+    }
 }

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/action/JiraCloudDistributionTestAction.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/action/JiraCloudDistributionTestAction.java
@@ -14,12 +14,13 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.channel.api.issue.action.IssueTrackerTestAction;
 import com.synopsys.integration.alert.channel.jira.cloud.distribution.JiraCloudMessageSenderFactory;
 import com.synopsys.integration.alert.common.persistence.model.job.details.JiraCloudJobDetailsModel;
+import com.synopsys.integration.alert.descriptor.api.JiraCloudChannelKey;
 
 @Component
 public class JiraCloudDistributionTestAction extends IssueTrackerTestAction<JiraCloudJobDetailsModel, String> {
     @Autowired
-    public JiraCloudDistributionTestAction(JiraCloudMessageSenderFactory messageSenderFactory) {
-        super(messageSenderFactory);
+    public JiraCloudDistributionTestAction(JiraCloudChannelKey channelKey, JiraCloudMessageSenderFactory messageSenderFactory) {
+        super(channelKey, messageSenderFactory);
     }
 
     @Override

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/JiraCloudMessageSenderFactory.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/JiraCloudMessageSenderFactory.java
@@ -1,3 +1,10 @@
+/*
+ * channel
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.alert.channel.jira.cloud.distribution;
 
 import org.slf4j.Logger;

--- a/channel/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/JiraCloudMessageSenderFactory.java
+++ b/channel/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/JiraCloudMessageSenderFactory.java
@@ -1,0 +1,113 @@
+package com.synopsys.integration.alert.channel.jira.cloud.distribution;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.channel.api.issue.callback.IssueTrackerCallbackInfoCreator;
+import com.synopsys.integration.alert.channel.api.issue.send.IssueTrackerIssueResponseCreator;
+import com.synopsys.integration.alert.channel.api.issue.send.IssueTrackerMessageSender;
+import com.synopsys.integration.alert.channel.api.issue.send.IssueTrackerMessageSenderFactory;
+import com.synopsys.integration.alert.channel.jira.cloud.JiraCloudProperties;
+import com.synopsys.integration.alert.channel.jira.cloud.JiraCloudPropertiesFactory;
+import com.synopsys.integration.alert.channel.jira.cloud.distribution.delegate.JiraCloudIssueCommenter;
+import com.synopsys.integration.alert.channel.jira.cloud.distribution.delegate.JiraCloudIssueCreator;
+import com.synopsys.integration.alert.channel.jira.cloud.distribution.delegate.JiraCloudIssueTransitioner;
+import com.synopsys.integration.alert.channel.jira.common.distribution.JiraErrorMessageUtility;
+import com.synopsys.integration.alert.channel.jira.common.distribution.JiraIssueCreationRequestCreator;
+import com.synopsys.integration.alert.channel.jira.common.distribution.custom.JiraCustomFieldResolver;
+import com.synopsys.integration.alert.channel.jira.common.distribution.search.JiraIssueAlertPropertiesManager;
+import com.synopsys.integration.alert.common.exception.AlertException;
+import com.synopsys.integration.alert.common.persistence.model.job.details.JiraCloudJobDetailsModel;
+import com.synopsys.integration.alert.descriptor.api.JiraCloudChannelKey;
+import com.synopsys.integration.jira.common.cloud.service.FieldService;
+import com.synopsys.integration.jira.common.cloud.service.IssueService;
+import com.synopsys.integration.jira.common.cloud.service.JiraCloudServiceFactory;
+import com.synopsys.integration.jira.common.cloud.service.ProjectService;
+import com.synopsys.integration.jira.common.rest.service.IssuePropertyService;
+
+@Component
+public class JiraCloudMessageSenderFactory implements IssueTrackerMessageSenderFactory<JiraCloudJobDetailsModel, String> {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final Gson gson;
+    private final JiraCloudChannelKey channelKey;
+    private final JiraCloudPropertiesFactory jiraCloudPropertiesFactory;
+    private final IssueTrackerCallbackInfoCreator callbackInfoCreator;
+    private final JiraErrorMessageUtility jiraErrorMessageUtility;
+
+    @Autowired
+    public JiraCloudMessageSenderFactory(
+        Gson gson,
+        JiraCloudChannelKey channelKey,
+        JiraCloudPropertiesFactory jiraCloudPropertiesFactory,
+        IssueTrackerCallbackInfoCreator callbackInfoCreator,
+        JiraErrorMessageUtility jiraErrorMessageUtility
+    ) {
+        this.gson = gson;
+        this.channelKey = channelKey;
+        this.jiraCloudPropertiesFactory = jiraCloudPropertiesFactory;
+        this.callbackInfoCreator = callbackInfoCreator;
+        this.jiraErrorMessageUtility = jiraErrorMessageUtility;
+    }
+
+    @Override
+    public IssueTrackerMessageSender<String> createMessageSender(JiraCloudJobDetailsModel distributionDetails) throws AlertException {
+        JiraCloudProperties jiraCloudProperties = jiraCloudPropertiesFactory.createJiraProperties();
+        JiraCloudServiceFactory jiraCloudServiceFactory = jiraCloudProperties.createJiraServicesCloudFactory(logger, gson);
+
+        // Jira Services
+        IssueService issueService = jiraCloudServiceFactory.createIssueService();
+        IssuePropertyService issuePropertyService = jiraCloudServiceFactory.createIssuePropertyService();
+
+        // Common Helpers
+        JiraIssueAlertPropertiesManager issuePropertiesManager = new JiraIssueAlertPropertiesManager(gson, issuePropertyService);
+
+        return createMessageSender(issueService, distributionDetails, jiraCloudServiceFactory, issuePropertiesManager);
+    }
+
+    public IssueTrackerMessageSender<String> createMessageSender(
+        IssueService issueService,
+        JiraCloudJobDetailsModel distributionDetails,
+        JiraCloudServiceFactory jiraCloudServiceFactory,
+        JiraIssueAlertPropertiesManager issuePropertiesManager
+    ) {
+        // Jira Services
+        IssueTrackerIssueResponseCreator issueResponseCreator = new IssueTrackerIssueResponseCreator(callbackInfoCreator);
+
+        // Message Sender Requirements
+        JiraCloudIssueCommenter issueCommenter = new JiraCloudIssueCommenter(issueResponseCreator, issueService, distributionDetails);
+        JiraCloudIssueTransitioner issueTransitioner = new JiraCloudIssueTransitioner(issueCommenter, issueResponseCreator, distributionDetails, issueService);
+        JiraCloudIssueCreator issueCreator = createIssueCreator(distributionDetails, jiraCloudServiceFactory, issuePropertiesManager, issueService, issueCommenter);
+
+        return new IssueTrackerMessageSender<>(issueCreator, issueTransitioner, issueCommenter);
+    }
+
+    private JiraCloudIssueCreator createIssueCreator(
+        JiraCloudJobDetailsModel distributionDetails,
+        JiraCloudServiceFactory jiraCloudServiceFactory,
+        JiraIssueAlertPropertiesManager issuePropertiesManager,
+        IssueService issueService,
+        JiraCloudIssueCommenter issueCommenter
+    ) {
+        ProjectService projectService = jiraCloudServiceFactory.createProjectService();
+        FieldService fieldService = jiraCloudServiceFactory.createFieldService();
+
+        JiraCustomFieldResolver customFieldResolver = new JiraCustomFieldResolver(fieldService::getUserVisibleFields);
+        JiraIssueCreationRequestCreator issueCreationRequestCreator = new JiraIssueCreationRequestCreator(customFieldResolver);
+
+        return new JiraCloudIssueCreator(
+            channelKey,
+            issueCommenter,
+            callbackInfoCreator,
+            distributionDetails,
+            issueService,
+            projectService,
+            issueCreationRequestCreator,
+            issuePropertiesManager,
+            jiraErrorMessageUtility
+        );
+    }
+}


### PR DESCRIPTION
## Implement channel-api test-action for Jira Cloud
### IALERT-2340

- Created a `JiraCloudMessageSenderFactory` with code pulled from `JiraCloudProccesorFactory`
- Implemented the new `IssueTrackerTestAction`
- Added a no-args method for creating `JiraCloudProperties`