### PR TITLE
Remove BlackDuck ObjectMapper from Spring Components

### DIFF
--- a/provider/src/main/java/com/synopsys/integration/alert/provider/blackduck/factory/BlackDuckPropertiesFactory.java
+++ b/provider/src/main/java/com/synopsys/integration/alert/provider/blackduck/factory/BlackDuckPropertiesFactory.java
@@ -7,12 +7,9 @@
  */
 package com.synopsys.integration.alert.provider.blackduck.factory;
 
-import java.util.Optional;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
@@ -20,31 +17,25 @@ import com.synopsys.integration.alert.common.persistence.accessor.FieldUtility;
 import com.synopsys.integration.alert.common.provider.lifecycle.ProviderPropertiesFactory;
 import com.synopsys.integration.alert.common.rest.ProxyManager;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
+import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
 
 @Component
 public class BlackDuckPropertiesFactory extends ProviderPropertiesFactory<BlackDuckProperties> {
     private final Gson gson;
-    private final ObjectMapper objectMapper;
     private final AlertProperties alertProperties;
     private final ProxyManager proxyManager;
 
     @Autowired
-    public BlackDuckPropertiesFactory(ConfigurationAccessor configurationAccessor, Gson gson, ObjectMapper objectMapper, AlertProperties alertProperties, ProxyManager proxyManager) {
+    public BlackDuckPropertiesFactory(ConfigurationAccessor configurationAccessor, Gson gson, AlertProperties alertProperties, ProxyManager proxyManager) {
         super(configurationAccessor);
         this.gson = gson;
-        this.objectMapper = objectMapper;
         this.alertProperties = alertProperties;
         this.proxyManager = proxyManager;
     }
 
     @Override
     public BlackDuckProperties createProperties(Long blackDuckConfigId, FieldUtility fieldUtility) {
-        return new BlackDuckProperties(blackDuckConfigId, gson, objectMapper, alertProperties, proxyManager, fieldUtility);
-    }
-
-    // TODO remove duplicate method
-    public Optional<BlackDuckProperties> createPropertiesIfConfigExists(Long blackDuckConfigId) {
-        return createProperties(blackDuckConfigId);
+        return new BlackDuckProperties(blackDuckConfigId, gson, BlackDuckServicesFactory.createDefaultObjectMapper(), alertProperties, proxyManager, fieldUtility);
     }
 
 }

--- a/provider/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/NotificationExtractorBlackDuckServicesFactoryCache.java
+++ b/provider/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/NotificationExtractorBlackDuckServicesFactoryCache.java
@@ -51,7 +51,7 @@ public class NotificationExtractorBlackDuckServicesFactoryCache implements Notif
     }
 
     private BlackDuckServicesFactory createBlackDuckServicesFactory(Long blackDuckConfigId) throws AlertConfigurationException {
-        Optional<BlackDuckProperties> optionalProperties = blackDuckPropertiesFactory.createPropertiesIfConfigExists(blackDuckConfigId);
+        Optional<BlackDuckProperties> optionalProperties = blackDuckPropertiesFactory.createProperties(blackDuckConfigId);
         if (optionalProperties.isPresent()) {
             BlackDuckProperties blackDuckProperties = optionalProperties.get();
             Slf4jIntLogger intLogger = new Slf4jIntLogger(logger);

--- a/provider/src/main/java/com/synopsys/integration/alert/provider/blackduck/web/BlackDuckProjectCustomFunctionAction.java
+++ b/provider/src/main/java/com/synopsys/integration/alert/provider/blackduck/web/BlackDuckProjectCustomFunctionAction.java
@@ -72,7 +72,7 @@ public class BlackDuckProjectCustomFunctionAction extends PagedCustomFunctionAct
     }
 
     private void validateBlackDuckConfiguration(Long blackDuckConfigId) {
-        BlackDuckProperties blackDuckProperties = blackDuckPropertiesFactory.createPropertiesIfConfigExists(blackDuckConfigId)
+        BlackDuckProperties blackDuckProperties = blackDuckPropertiesFactory.createProperties(blackDuckConfigId)
                                                       .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "The BlackDuck configuration used in this Job does not exist"));
 
         BlackDuckApiTokenValidator blackDuckAPITokenValidator = new BlackDuckApiTokenValidator(blackDuckProperties);

--- a/src/main/java/com/synopsys/integration/alert/BlackDuckConfiguration.java
+++ b/src/main/java/com/synopsys/integration/alert/BlackDuckConfiguration.java
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.synopsys.integration.blackduck.http.transform.BlackDuckJsonTransformer;
 import com.synopsys.integration.blackduck.http.transform.subclass.BlackDuckResponseResolver;
@@ -30,18 +29,13 @@ public class BlackDuckConfiguration {
     }
 
     @Bean
-    public ObjectMapper objectMapper() {
-        return BlackDuckServicesFactory.createDefaultObjectMapper();
-    }
-
-    @Bean
     public BlackDuckResponseResolver blackDuckResponseResolver() {
         return new BlackDuckResponseResolver(gson());
     }
 
     @Bean
     public BlackDuckJsonTransformer blackDuckJsonTransformer() {
-        return new BlackDuckJsonTransformer(gson(), objectMapper(), blackDuckResponseResolver(), new Slf4jIntLogger(logger));
+        return new BlackDuckJsonTransformer(gson(), BlackDuckServicesFactory.createDefaultObjectMapper(), blackDuckResponseResolver(), new Slf4jIntLogger(logger));
     }
 
     @Bean

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/TestBlackDuckProperties.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/TestBlackDuckProperties.java
@@ -29,6 +29,7 @@ import com.synopsys.integration.alert.test.common.TestProperties;
 import com.synopsys.integration.alert.test.common.TestPropertyKey;
 import com.synopsys.integration.blackduck.configuration.BlackDuckServerConfig;
 import com.synopsys.integration.blackduck.http.client.BlackDuckHttpClient;
+import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
 import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.rest.proxy.ProxyInfo;
 
@@ -56,7 +57,7 @@ public class TestBlackDuckProperties extends BlackDuckProperties {
     }
 
     public TestBlackDuckProperties(MockAlertProperties alertProperties, ProxyManager proxyManager) {
-        this(new Gson(), new ObjectMapper(), alertProperties, new TestProperties(), proxyManager);
+        this(new Gson(), BlackDuckServicesFactory.createDefaultObjectMapper(), alertProperties, new TestProperties(), proxyManager);
     }
 
     public TestBlackDuckProperties(Gson gson, ObjectMapper objectMapper, MockAlertProperties alertProperties, TestProperties testProperties, ProxyManager proxyManager) {


### PR DESCRIPTION
It was conflicting with Spring's ObjectMapper for deserialization of REST requests.