### PR TITLE
Update test-common to use api depedencies

### DIFF
--- a/alert-common/build.gradle
+++ b/alert-common/build.gradle
@@ -27,6 +27,5 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
 
-    testImplementation 'org.mockito:mockito-core'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params'
+    testImplementation project(':test-common')
 }

--- a/alert-database/build.gradle
+++ b/alert-database/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     // Deprecated for removal in 8.0.0. We still need the h2 jar bundled for use in the docker-entrypoint to upgrade a pre 6.0.0 database.
     runtimeOnly 'com.h2database:h2'
 
-    testImplementation 'org.mockito:mockito-core'
+    testImplementation project(':test-common')
 }
 
 task dockerLogin(type: Exec) {

--- a/build.gradle
+++ b/build.gradle
@@ -134,15 +134,8 @@ dependencies {
         runtimeClasspath 'org.springframework.boot:spring-boot-devtools'
     }
 
-    testImplementation 'org.springframework:spring-test'
-    testImplementation 'org.springframework.security:spring-security-test'
-    testImplementation 'org.springframework.boot:spring-boot-test-autoconfigure'
     testImplementation 'org.springframework.security.extensions:spring-security-saml2-core'
     testImplementation 'org.springframework.security:spring-security-ldap'
-    testImplementation 'org.mockito:mockito-core'
-    testImplementation 'org.skyscreamer:jsonassert'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params'
-    testImplementation 'com.github.springtestdbunit:spring-test-dbunit'
     testImplementation 'jakarta.persistence:jakarta.persistence-api'
     testImplementation 'org.javassist:javassist'
     testImplementation 'javax.mail:javax.mail-api'

--- a/channel-api/build.gradle
+++ b/channel-api/build.gradle
@@ -12,6 +12,5 @@ dependencies {
     implementation 'org.springframework:spring-jms'
     implementation 'org.springframework:spring-context'
 
-    testImplementation 'org.mockito:mockito-core'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params'
+    testImplementation project(':test-common')
 }

--- a/channel/build.gradle
+++ b/channel/build.gradle
@@ -22,5 +22,4 @@ dependencies {
     implementation 'org.freemarker:freemarker'
 
     testImplementation project(':test-common')
-    testImplementation 'org.mockito:mockito-core'
 }

--- a/component/build.gradle
+++ b/component/build.gradle
@@ -30,5 +30,5 @@ dependencies {
 
     implementation 'org.springframework.security.extensions:spring-security-saml2-core'
 
-    testImplementation 'org.mockito:mockito-core'
+    testImplementation project(':test-common')
 }

--- a/processor-api/build.gradle
+++ b/processor-api/build.gradle
@@ -7,7 +7,4 @@ dependencies {
 
     implementation 'com.synopsys.integration:blackduck-common'
     implementation 'org.springframework:spring-context'
-
-    testImplementation 'org.mockito:mockito-core'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params'
 }

--- a/provider/build.gradle
+++ b/provider/build.gradle
@@ -15,5 +15,4 @@ dependencies {
     implementation 'com.synopsys.integration:blackduck-common', rootProject.ext.blackduckCommonExcludes
 
     testImplementation project(':test-common')
-    testImplementation 'org.mockito:mockito-core'
 }

--- a/test-common/build.gradle
+++ b/test-common/build.gradle
@@ -4,11 +4,11 @@ dependencies {
 
     implementation 'com.synopsys.integration:integration-common'
 
-    implementation 'org.springframework:spring-test'
-    implementation 'org.springframework.security:spring-security-test'
-    implementation 'org.springframework.boot:spring-boot-test-autoconfigure'
-    implementation 'org.junit.jupiter:junit-jupiter-params'
-    implementation 'com.github.springtestdbunit:spring-test-dbunit'
-    implementation 'org.mockito:mockito-core'
-    implementation 'org.skyscreamer:jsonassert'
+    api 'org.springframework:spring-test'
+    api 'org.springframework.security:spring-security-test'
+    api 'org.springframework.boot:spring-boot-test-autoconfigure'
+    api 'org.junit.jupiter:junit-jupiter-params'
+    api 'com.github.springtestdbunit:spring-test-dbunit'
+    api 'org.mockito:mockito-core'
+    api 'org.skyscreamer:jsonassert'
 }

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -30,7 +30,5 @@ dependencies {
     // Documentation
     implementation 'io.springfox:springfox-boot-starter'
 
-    testImplementation 'org.mockito:mockito-core'
-    testImplementation 'org.springframework:spring-test'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params'
+    testImplementation project(':test-common')
 }

--- a/workflow/build.gradle
+++ b/workflow/build.gradle
@@ -16,6 +16,5 @@ dependencies {
     implementation 'com.synopsys.integration:integration-common'
     implementation 'org.springframework.data:spring-data-jpa'
 
-    testImplementation 'org.mockito:mockito-core'
     testImplementation 'com.synopsys.integration:blackduck-common', rootProject.ext.blackduckCommonExcludes
 }


### PR DESCRIPTION
Changing dependencies in test-common from implementation to api in order to remove duplicate testImplementations in other sub projects.