### PR TITLE
Splitting the "all" task in to "buildAll" and "publishDockerImage".

### DIFF
--- a/alert-database/build.gradle
+++ b/alert-database/build.gradle
@@ -69,8 +69,11 @@ task pushImage(type: Exec, dependsOn: [buildDockerImage]) {
     commandLine "docker", "push", "blackducksoftware/${project.name}:${alertDatabaseDockerImageVersion}"
 }
 
-task all(dependsOn: [build, dockerLogin, buildDockerImage, pushImage]) {
-    dockerLogin.mustRunAfter build
-    buildDockerImage.mustRunAfter dockerLogin
+task buildAll(dependsOn: [build, buildDockerImage]) {
+    buildDockerImage.mustRunAfter build
+}
+
+task publishDockerImage(dependsOn: [dockerLogin, pushImage]) {
+    pushImage.mustRunAfter dockerLogin
     pushImage.mustRunAfter buildDockerImage
 }

--- a/build.gradle
+++ b/build.gradle
@@ -192,16 +192,17 @@ tasks.helmPushChart.mustRunAfter(helmValidation)
 tasks.build.mustRunAfter(copyToTemplates)
 tasks.runServer.dependsOn copyToTemplates
 tasks.buildDockerImage.dependsOn copyToTemplates
-tasks.testIntegration.dependsOn copyToTemplates
-tasks.testAll.dependsOn copyToTemplates
+tasks.test.dependsOn copyToTemplates
 
 
-task all(dependsOn: [copyToTemplates, build, helmValidation, createDeploymentZip, dockerLogin, buildDockerImage, pushImage]) {
+task buildAll(dependsOn: [copyToTemplates, build, helmValidation, createDeploymentZip, buildDockerImage]) {
     helmValidation.mustRunAfter build
     createDeploymentZip.mustRunAfter helmValidation
 
-    dockerLogin.mustRunAfter createDeploymentZip
-    buildDockerImage.mustRunAfter dockerLogin
+    buildDockerImage.mustRunAfter createDeploymentZip
+}
 
+task publishDockerImage(dependsOn: [dockerLogin, pushImage]) {
+    pushImage.mustRunAfter dockerLogin
     pushImage.mustRunAfter buildDockerImage
 }


### PR DESCRIPTION
For more flexibility we should split the all task into separate pieces, one to build and one to publish