### PR TITLE
Load test.properties from test-common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ classes/
 /src/main/resources/about.txt
 /src/test/resources/application.properties
 /src/test/resources/test.properties
+/test-common/src/main/resources/test.properties
 /activemq-data/
 *-lastrun.txt
 *-last-search.txt

--- a/src/test/java/com/synopsys/integration/alert/util/TestPropertiesFileGenerator.java
+++ b/src/test/java/com/synopsys/integration/alert/util/TestPropertiesFileGenerator.java
@@ -15,7 +15,7 @@ public class TestPropertiesFileGenerator {
     @Test
     @Disabled("This test is to generate the test.properties for new developers.")
     public void generatePropertiesFile() throws IOException {
-        String propertiesFileName = new File(TestResourceUtils.BASE_TEST_RESOURCE_DIR.getCanonicalFile(), TestResourceUtils.DEFAULT_PROPERTIES_FILE_LOCATION).getCanonicalPath();
+        String propertiesFileName = TestResourceUtils.createTestPropertiesCanonicalFilePath();
         System.out.println("Generating file: " + propertiesFileName + "..");
 
         File testPropertiesFile = new File(propertiesFileName);

--- a/src/test/java/com/synopsys/integration/alert/util/TestPropertiesFileGenerator.java
+++ b/src/test/java/com/synopsys/integration/alert/util/TestPropertiesFileGenerator.java
@@ -15,7 +15,7 @@ public class TestPropertiesFileGenerator {
     @Test
     @Disabled("This test is to generate the test.properties for new developers.")
     public void generatePropertiesFile() throws IOException {
-        String propertiesFileName = TestResourceUtils.BASE_TEST_RESOURCE_DIR + "/" + TestResourceUtils.DEFAULT_PROPERTIES_FILE_LOCATION;
+        String propertiesFileName = new File(TestResourceUtils.BASE_TEST_RESOURCE_DIR.getCanonicalFile(), TestResourceUtils.DEFAULT_PROPERTIES_FILE_LOCATION).getCanonicalPath();
         System.out.println("Generating file: " + propertiesFileName + "..");
 
         File testPropertiesFile = new File(propertiesFileName);

--- a/test-common/src/main/java/com/synopsys/integration/alert/test/common/TestProperties.java
+++ b/test-common/src/main/java/com/synopsys/integration/alert/test/common/TestProperties.java
@@ -7,7 +7,6 @@
  */
 package com.synopsys.integration.alert.test.common;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.Properties;
@@ -21,7 +20,7 @@ public class TestProperties {
 
     public TestProperties() {
         try {
-            propertiesLocation = new File(TestResourceUtils.BASE_TEST_RESOURCE_DIR.getCanonicalFile(), TestResourceUtils.DEFAULT_PROPERTIES_FILE_LOCATION).getCanonicalPath();
+            propertiesLocation = TestResourceUtils.createTestPropertiesCanonicalFilePath();
         } catch (IOException e) {
             propertiesLocation = TestResourceUtils.DEFAULT_PROPERTIES_FILE_LOCATION;
         }

--- a/test-common/src/main/java/com/synopsys/integration/alert/test/common/TestProperties.java
+++ b/test-common/src/main/java/com/synopsys/integration/alert/test/common/TestProperties.java
@@ -7,6 +7,8 @@
  */
 package com.synopsys.integration.alert.test.common;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -18,7 +20,11 @@ public class TestProperties {
     private String propertiesLocation;
 
     public TestProperties() {
-        propertiesLocation = TestResourceUtils.DEFAULT_PROPERTIES_FILE_LOCATION;
+        try {
+            propertiesLocation = new File(TestResourceUtils.BASE_TEST_RESOURCE_DIR.getCanonicalFile(), TestResourceUtils.DEFAULT_PROPERTIES_FILE_LOCATION).getCanonicalPath();
+        } catch (IOException e) {
+            propertiesLocation = TestResourceUtils.DEFAULT_PROPERTIES_FILE_LOCATION;
+        }
         loadProperties();
     }
 

--- a/test-common/src/main/java/com/synopsys/integration/alert/test/common/TestResourceUtils.java
+++ b/test-common/src/main/java/com/synopsys/integration/alert/test/common/TestResourceUtils.java
@@ -21,6 +21,10 @@ public final class TestResourceUtils {
     public static final String DEFAULT_PROPERTIES_FILE_LOCATION = "test.properties";
     public static final File BASE_TEST_RESOURCE_DIR = new File(TestResourceUtils.class.getProtectionDomain().getCodeSource().getLocation().getPath(), "../../../../src/main/resources/");
 
+    public static String createTestPropertiesCanonicalFilePath() throws IOException {
+        return new File(TestResourceUtils.BASE_TEST_RESOURCE_DIR.getCanonicalFile(), TestResourceUtils.DEFAULT_PROPERTIES_FILE_LOCATION).getCanonicalPath();
+    }
+
     /**
      * @param resourcePath The path to the file resource. For example: If the file is in src/test/resources/dir1/dir2/file.ext, then use "dir1/dir2/file.ext"
      * @return The file contents, never null

--- a/test-common/src/main/java/com/synopsys/integration/alert/test/common/TestResourceUtils.java
+++ b/test-common/src/main/java/com/synopsys/integration/alert/test/common/TestResourceUtils.java
@@ -8,6 +8,7 @@
 package com.synopsys.integration.alert.test.common;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -18,7 +19,7 @@ import org.springframework.core.io.ClassPathResource;
 
 public final class TestResourceUtils {
     public static final String DEFAULT_PROPERTIES_FILE_LOCATION = "test.properties";
-    public static final File BASE_TEST_RESOURCE_DIR = new File(TestResourceUtils.class.getProtectionDomain().getCodeSource().getLocation().getPath(), "../../../../src/test/resources/");
+    public static final File BASE_TEST_RESOURCE_DIR = new File(TestResourceUtils.class.getProtectionDomain().getCodeSource().getLocation().getPath(), "../../../../src/main/resources/");
 
     /**
      * @param resourcePath The path to the file resource. For example: If the file is in src/test/resources/dir1/dir2/file.ext, then use "dir1/dir2/file.ext"
@@ -33,11 +34,23 @@ public final class TestResourceUtils {
 
     public static Properties loadProperties(String resourceLocation) throws IOException {
         Properties properties = new Properties();
+
         ClassPathResource classPathResource = new ClassPathResource(resourceLocation);
-        try (InputStream iStream = classPathResource.getInputStream()) {
-            properties.load(iStream);
+        try (InputStream classPathInputStream = classPathResource.getInputStream()) {
+            properties.load(classPathInputStream);
+            return properties;
+        } catch (IOException ioException) {
+            System.out.printf("Failed to load [%s] from classpath%n", resourceLocation);
         }
-        return properties;
+
+        File fileResource = new File(resourceLocation);
+        try (FileInputStream fileInputStream = FileUtils.openInputStream(fileResource)) {
+            properties.load(fileInputStream);
+            return properties;
+        } catch (IOException ioException) {
+            System.out.printf("Failed to load [%s] as file%n", resourceLocation);
+            throw ioException;
+        }
     }
 
     private TestResourceUtils() {


### PR DESCRIPTION
# Note: Alert developers will need to put their `test.properties` file into _test-common/src/main/resources_. 
Notice this is a _main_ resource and not a _test_ resource. This is because _test-common_ is a library and not a set of actual tests.