### PR TITLE
Add policy description to issue tracker descriptions

### DIFF
--- a/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/convert/IssuePolicyDetailsConverter.java
+++ b/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/convert/IssuePolicyDetailsConverter.java
@@ -9,6 +9,7 @@ package com.synopsys.integration.alert.api.channel.issue.convert;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 import com.synopsys.integration.alert.api.channel.convert.ChannelMessageFormatter;
 import com.synopsys.integration.alert.api.channel.issue.model.IssueBomComponentDetails;
@@ -36,10 +37,9 @@ public class IssuePolicyDetailsConverter {
         policyDetailsSectionPieces.add(formatter.getLineSeparator());
         policyDetailsSectionPieces.add(formatter.encode(LABEL_SEVERITY));
         policyDetailsSectionPieces.add(formatter.encode(policyDetails.getSeverity().getPolicyLabel()));
-        //TODO: Change should go here
-        policyDetailsSectionPieces.add(formatter.encode(LABEL_DESCRIPTION));
-        //figure out how to manage a list of policies
-        policyDetailsSectionPieces.add(formatter.encode(bomComponentDetails.getComponentPolicies().get(0).getDescription()));
+
+        List<String> policyDescriptionSection = createPolicyDescription(bomComponentDetails, policyDetails);
+        policyDetailsSectionPieces.addAll(policyDescriptionSection);
 
         List<String> additionalPolicyDetailsSections = createAdditionalPolicyDetailsSections(bomComponentDetails, policyDetails);
         if (!additionalPolicyDetailsSections.isEmpty()) {
@@ -61,6 +61,29 @@ public class IssuePolicyDetailsConverter {
             return componentVulnerabilitiesConverter.createComponentVulnerabilitiesSectionPieces(bomComponentDetails.getComponentVulnerabilities());
         }
         return List.of();
+    }
+
+    private List<String> createPolicyDescription(IssueBomComponentDetails bomComponentDetails, IssuePolicyDetails policyDetails) {
+        List<ComponentPolicy> policies = bomComponentDetails.getComponentPolicies();
+        if (policies.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> policyDescriptionPieces = new LinkedList<>();
+
+        String policyName = policyDetails.getName();
+        for (ComponentPolicy policy : policies) {
+            if (policyName.equals(policy.getPolicyName())) {
+                Optional<String> description = policy.getDescription();
+                if (description.isPresent()) {
+                    policyDescriptionPieces.add(formatter.getLineSeparator());
+                    policyDescriptionPieces.add(formatter.encode(LABEL_DESCRIPTION));
+                    policyDescriptionPieces.add(formatter.encode(description.get()));
+                    return policyDescriptionPieces;
+                }
+            }
+        }
+        return policyDescriptionPieces;
     }
 
 }

--- a/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/convert/IssuePolicyDetailsConverter.java
+++ b/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/convert/IssuePolicyDetailsConverter.java
@@ -18,6 +18,7 @@ import com.synopsys.integration.alert.processor.api.extract.model.project.Compon
 public class IssuePolicyDetailsConverter {
     private static final String LABEL_POLICY = "Policy: ";
     private static final String LABEL_SEVERITY = "Severity: ";
+    private static final String LABEL_DESCRIPTION = "Policy Description: ";
 
     private final ChannelMessageFormatter formatter;
     private final ComponentVulnerabilitiesConverter componentVulnerabilitiesConverter;
@@ -35,6 +36,10 @@ public class IssuePolicyDetailsConverter {
         policyDetailsSectionPieces.add(formatter.getLineSeparator());
         policyDetailsSectionPieces.add(formatter.encode(LABEL_SEVERITY));
         policyDetailsSectionPieces.add(formatter.encode(policyDetails.getSeverity().getPolicyLabel()));
+        //TODO: Change should go here
+        policyDetailsSectionPieces.add(formatter.encode(LABEL_DESCRIPTION));
+        //figure out how to manage a list of policies
+        policyDetailsSectionPieces.add(formatter.encode(bomComponentDetails.getComponentPolicies().get(0).getDescription()));
 
         List<String> additionalPolicyDetailsSections = createAdditionalPolicyDetailsSections(bomComponentDetails, policyDetails);
         if (!additionalPolicyDetailsSections.isEmpty()) {

--- a/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/convert/IssuePolicyDetailsConverterTest.java
+++ b/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/convert/IssuePolicyDetailsConverterTest.java
@@ -17,17 +17,14 @@ import com.synopsys.integration.alert.processor.api.extract.model.project.Compon
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentVulnerabilities;
 
 public class IssuePolicyDetailsConverterTest {
-    private static final ComponentPolicy COMPONENT_POLICY = new ComponentPolicy(
-        "A vulnerability policy",
-        ComponentConcernSeverity.MINOR_MEDIUM,
-        false,
-        true
-    );
+    private static final ComponentPolicy COMPONENT_POLICY = createComponentPolicy("A vulnerability policy", "Description of a policy");
+    private static final ComponentPolicy COMPONENT_POLICY_NO_DESCRIPTION = createComponentPolicy("policy without description", null);
+
     private static final AbstractBomComponentDetails BOM_COMPONENT_DETAILS = new AbstractBomComponentDetails(
         new LinkableItem("Component", "A BOM component"),
         new LinkableItem("Component Version", "1.0.0-SNAPSHOT"),
         new ComponentVulnerabilities(List.of(), List.of(), List.of(), List.of()),
-        List.of(COMPONENT_POLICY),
+        List.of(COMPONENT_POLICY, COMPONENT_POLICY_NO_DESCRIPTION),
         new LinkableItem("License", "A software license", "https://license-url"),
         "Example Usage",
         List.of(),
@@ -37,6 +34,7 @@ public class IssuePolicyDetailsConverterTest {
 
     private static final IssuePolicyDetails POLICY_DETAILS_WITH_VULNERABILITY = new IssuePolicyDetails(COMPONENT_POLICY.getPolicyName(), ItemOperation.ADD, COMPONENT_POLICY.getSeverity());
     private static final IssuePolicyDetails POLICY_DETAILS_WITHOUT_VULNERABILITY = new IssuePolicyDetails("Normal Policy", ItemOperation.DELETE, ComponentConcernSeverity.TRIVIAL_LOW);
+    private static final IssuePolicyDetails POLICY_DETAILS_WITHOUT_DESCRIPTION = new IssuePolicyDetails(COMPONENT_POLICY_NO_DESCRIPTION.getPolicyName(), ItemOperation.DELETE, ComponentConcernSeverity.TRIVIAL_LOW);
 
     @Test
     public void createPolicyDetailsSectionPiecesWithVulnerabilityTest() {
@@ -64,10 +62,33 @@ public class IssuePolicyDetailsConverterTest {
         System.out.print(joinedSectionPieces);
     }
 
+    @Test
+    public void createPolicyDetailsSectionWithoutDescriptionTest() {
+        callCreatePolicyDetailsSectionPieces(POLICY_DETAILS_WITHOUT_DESCRIPTION);
+    }
+
+    @Disabled
+    @Test
+    public void previewFromattingWithoutDescription() {
+        List<String> sectionPieces = callCreatePolicyDetailsSectionPieces(POLICY_DETAILS_WITHOUT_DESCRIPTION);
+        String joinedSectionPieces = StringUtils.join(sectionPieces, "");
+        System.out.print(joinedSectionPieces);
+    }
+
     private List<String> callCreatePolicyDetailsSectionPieces(IssuePolicyDetails policyDetails) {
         MockIssueTrackerMessageFormatter formatter = MockIssueTrackerMessageFormatter.withIntegerMaxValueLength();
         IssuePolicyDetailsConverter converter = new IssuePolicyDetailsConverter(formatter);
         return converter.createPolicyDetailsSectionPieces(ISSUE_BOM_COMPONENT_DETAILS, policyDetails);
+    }
+
+    private static ComponentPolicy createComponentPolicy(String policyName, String description) {
+        return new ComponentPolicy(
+            policyName,
+            ComponentConcernSeverity.MINOR_MEDIUM,
+            false,
+            true,
+            description
+        );
     }
 
 }

--- a/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/convert/ProjectIssueModelConverterTest.java
+++ b/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/convert/ProjectIssueModelConverterTest.java
@@ -33,7 +33,7 @@ public class ProjectIssueModelConverterTest {
     private static final LinkableItem PROJECT_VERSION_ITEM = new LinkableItem("Project Version", "2.3.4-RC", "https://project-version-url");
     private static final LinkableItem COMPONENT_ITEM = new LinkableItem("Component", "A BOM component");
     private static final LinkableItem COMPONENT_VERSION_ITEM = new LinkableItem("Component Version", "1.0.0-SNAPSHOT");
-    private static final ComponentPolicy COMPONENT_POLICY = new ComponentPolicy("A policy", ComponentConcernSeverity.UNSPECIFIED_UNKNOWN, false, false);
+    private static final ComponentPolicy COMPONENT_POLICY = new ComponentPolicy("A policy", ComponentConcernSeverity.UNSPECIFIED_UNKNOWN, false, false, null);
     private static final ComponentVulnerabilities COMPONENT_VULNERABILITIES = new ComponentVulnerabilities(List.of(), List.of(), List.of(), List.of(new LinkableItem("Vulnerability", "CVE-007")));
     private static final AbstractBomComponentDetails BOM_COMPONENT_DETAILS = createBomComponentDetailsWithComponentVulnerabilities(COMPONENT_VULNERABILITIES);
     private static final IssueBomComponentDetails ISSUE_BOM_COMPONENT_DETAILS = IssueBomComponentDetails.fromBomComponentDetails(BOM_COMPONENT_DETAILS);

--- a/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/convert/ProjectMessageToIssueModelTransformerTest.java
+++ b/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/convert/ProjectMessageToIssueModelTransformerTest.java
@@ -49,8 +49,8 @@ public class ProjectMessageToIssueModelTransformerTest {
         List.of(VULNERABILITY_4, VULNERABILITY_5, VULNERABILITY_6)
     );
 
-    private static final ComponentPolicy COMPONENT_POLICY_1 = new ComponentPolicy("First Policy", ComponentConcernSeverity.MINOR_MEDIUM, false, true);
-    private static final ComponentPolicy COMPONENT_POLICY_2 = new ComponentPolicy("Second Policy", ComponentConcernSeverity.UNSPECIFIED_UNKNOWN, true, false);
+    private static final ComponentPolicy COMPONENT_POLICY_1 = new ComponentPolicy("First Policy", ComponentConcernSeverity.MINOR_MEDIUM, false, true, null);
+    private static final ComponentPolicy COMPONENT_POLICY_2 = new ComponentPolicy("Second Policy", ComponentConcernSeverity.UNSPECIFIED_UNKNOWN, true, false, null);
     private static final List<ComponentPolicy> COMPONENT_POLICIES = List.of(
         COMPONENT_POLICY_1,
         COMPONENT_POLICY_2

--- a/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/convert/BomComponentDetailConverterTest.java
+++ b/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/convert/BomComponentDetailConverterTest.java
@@ -60,8 +60,8 @@ public class BomComponentDetailConverterTest {
     }
 
     private static AbstractBomComponentDetails createBomComponentDetails() {
-        ComponentPolicy componentPolicy1 = new ComponentPolicy("A Black Duck Policy", ComponentConcernSeverity.MAJOR_HIGH, true, false);
-        ComponentPolicy componentPolicy2 = new ComponentPolicy("A Different Black Duck Policy", ComponentConcernSeverity.UNSPECIFIED_UNKNOWN, false, true);
+        ComponentPolicy componentPolicy1 = new ComponentPolicy("A Black Duck Policy", ComponentConcernSeverity.MAJOR_HIGH, true, false, null);
+        ComponentPolicy componentPolicy2 = new ComponentPolicy("A Different Black Duck Policy", ComponentConcernSeverity.UNSPECIFIED_UNKNOWN, false, true, null);
 
         LinkableItem attribute1 = new LinkableItem("Attribute", "Number 1");
         LinkableItem attribute2 = new LinkableItem("Attribute", "Number 2");

--- a/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/convert/ProjectMessageConverterTest.java
+++ b/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/convert/ProjectMessageConverterTest.java
@@ -71,8 +71,8 @@ public class ProjectMessageConverterTest {
     }
 
     private static BomComponentDetails createBomComponentDetails() {
-        ComponentPolicy componentPolicy1 = new ComponentPolicy("A component policy", ComponentConcernSeverity.UNSPECIFIED_UNKNOWN, true, false);
-        ComponentPolicy componentPolicy2 = new ComponentPolicy("A different policy", ComponentConcernSeverity.MAJOR_HIGH, false, true);
+        ComponentPolicy componentPolicy1 = new ComponentPolicy("A component policy", ComponentConcernSeverity.UNSPECIFIED_UNKNOWN, true, false, null);
+        ComponentPolicy componentPolicy2 = new ComponentPolicy("A different policy", ComponentConcernSeverity.MAJOR_HIGH, false, true, null);
 
         ComponentConcern policyConcern1 = ComponentConcern.policy(ItemOperation.DELETE, "A non-severe policy");
         ComponentConcern policyConcern2 = ComponentConcern.severePolicy(ItemOperation.ADD, "A severe policy", ComponentConcernSeverity.TRIVIAL_LOW);

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/extract/model/project/ComponentPolicy.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/extract/model/project/ComponentPolicy.java
@@ -14,12 +14,14 @@ public class ComponentPolicy extends AlertSerializableModel {
     private final ComponentConcernSeverity severity;
     private final boolean overridden;
     private final boolean vulnerabilityPolicy;
+    private final String description;
 
-    public ComponentPolicy(String policyName, ComponentConcernSeverity severity, boolean overridden, boolean vulnerabilityPolicy) {
+    public ComponentPolicy(String policyName, ComponentConcernSeverity severity, boolean overridden, boolean vulnerabilityPolicy, String description) {
         this.policyName = policyName;
         this.severity = severity;
         this.overridden = overridden;
         this.vulnerabilityPolicy = vulnerabilityPolicy;
+        this.description = description;
     }
 
     public String getPolicyName() {
@@ -38,4 +40,7 @@ public class ComponentPolicy extends AlertSerializableModel {
         return vulnerabilityPolicy;
     }
 
+    public String getDescription() {
+        return description;
+    }
 }

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/extract/model/project/ComponentPolicy.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/extract/model/project/ComponentPolicy.java
@@ -7,6 +7,10 @@
  */
 package com.synopsys.integration.alert.processor.api.extract.model.project;
 
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
+
 import com.synopsys.integration.alert.api.common.model.AlertSerializableModel;
 
 public class ComponentPolicy extends AlertSerializableModel {
@@ -16,7 +20,7 @@ public class ComponentPolicy extends AlertSerializableModel {
     private final boolean vulnerabilityPolicy;
     private final String description;
 
-    public ComponentPolicy(String policyName, ComponentConcernSeverity severity, boolean overridden, boolean vulnerabilityPolicy, String description) {
+    public ComponentPolicy(String policyName, ComponentConcernSeverity severity, boolean overridden, boolean vulnerabilityPolicy, @Nullable String description) {
         this.policyName = policyName;
         this.severity = severity;
         this.overridden = overridden;
@@ -40,7 +44,7 @@ public class ComponentPolicy extends AlertSerializableModel {
         return vulnerabilityPolicy;
     }
 
-    public String getDescription() {
-        return description;
+    public Optional<String> getDescription() {
+        return Optional.ofNullable(description);
     }
 }

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/distribution/search/AzureBoardsSearcherTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/distribution/search/AzureBoardsSearcherTest.java
@@ -35,7 +35,7 @@ public class AzureBoardsSearcherTest {
     private static final LinkableItem PROJECT_VERSION_ITEM = new LinkableItem("Project Version", "2.3.4-RC", "https://project-version-url");
     private static final LinkableItem COMPONENT_ITEM = new LinkableItem("Component", "A BOM component");
     private static final LinkableItem COMPONENT_VERSION_ITEM = new LinkableItem("Component Version", "1.0.0-SNAPSHOT");
-    private static final ComponentPolicy COMPONENT_POLICY = new ComponentPolicy("A policy", ComponentConcernSeverity.UNSPECIFIED_UNKNOWN, false, false);
+    private static final ComponentPolicy COMPONENT_POLICY = new ComponentPolicy("A policy", ComponentConcernSeverity.UNSPECIFIED_UNKNOWN, false, false, null);
     private static final ComponentVulnerabilities COMPONENT_VULNERABILITIES = new ComponentVulnerabilities(List.of(), List.of(), List.of(), List.of(new LinkableItem("Vulnerability", "CVE-007")));
     private static final AbstractBomComponentDetails BOM_COMPONENT_DETAILS = createBomComponentDetailsWithComponentVulnerabilities(COMPONENT_VULNERABILITIES);
     private static final IssueBomComponentDetails ISSUE_BOM_COMPONENT_DETAILS = IssueBomComponentDetails.fromBomComponentDetails(BOM_COMPONENT_DETAILS);

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/policy/BlackDuckComponentPolicyDetailsCreator.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/policy/BlackDuckComponentPolicyDetailsCreator.java
@@ -34,7 +34,7 @@ public class BlackDuckComponentPolicyDetailsCreator {
         ComponentConcernSeverity componentConcernSeverity = policySeverityConverter.toComponentConcernSeverity(componentPolicyRulesView.getSeverity().name());
         boolean overridden = ProjectVersionComponentPolicyStatusType.IN_VIOLATION_OVERRIDDEN.equals(componentPolicyRulesView.getPolicyApprovalStatus());
         boolean vulnerabilityPolicy = isVulnerabilityPolicy(componentPolicyRulesView);
-        return new ComponentPolicy(componentPolicyRulesView.getName(), componentConcernSeverity, overridden, vulnerabilityPolicy);
+        return new ComponentPolicy(componentPolicyRulesView.getName(), componentConcernSeverity, overridden, vulnerabilityPolicy, componentPolicyRulesView.getDescription());
     }
 
     private boolean isVulnerabilityPolicy(ComponentPolicyRulesView componentPolicyRulesView) {


### PR DESCRIPTION
Added a nullable field in ComponentPolicy for description to be used in IssuePolicyDetailsConverter.

If no description is provided in the blackduck policy, the description field will not be printed