### PR TITLE
Temporary fix for Users table delete

### DIFF
--- a/ui/src/main/js/common/table/TableDisplay.js
+++ b/ui/src/main/js/common/table/TableDisplay.js
@@ -335,6 +335,7 @@ const TableDisplay = ({
 
     const deleteItems = () => {
         onConfigDelete(rowsToDelete, closeDeleteModal);
+        setRowsToDelete([]);
     };
 
     const editButtonClicked = (selectedRow) => {

--- a/ui/src/main/js/page/user/UserTable.js
+++ b/ui/src/main/js/page/user/UserTable.js
@@ -4,13 +4,12 @@ import TableDisplay from 'common/table/TableDisplay';
 import TextInput from 'common/input/TextInput';
 import PasswordInput from 'common/input/PasswordInput';
 import { connect } from 'react-redux';
-import {
-    clearUserFieldErrors, deleteUser, fetchUsers, saveUser, validateUser
-} from 'store/actions/users';
+import { clearUserFieldErrors, deleteUser, fetchUsers, saveUser, validateUser } from 'store/actions/users';
 import DynamicSelectInput from 'common/input/DynamicSelectInput';
 import { fetchRoles } from 'store/actions/roles';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import * as HTTPErrorUtils from 'common/util/httpErrorUtilities';
+import StatusMessage from 'common/StatusMessage';
 
 const KEY_CONFIRM_PASSWORD_ERROR = 'confirmPasswordError';
 
@@ -34,13 +33,15 @@ class UserTable extends Component {
         this.state = {
             user: {},
             validateCallback: () => null,
-            saveCallback: () => null
+            saveCallback: () => null,
+            errorMessageState: null
         };
     }
 
     componentDidUpdate(prevProps) {
-        const { saveStatus } = this.props;
+        const { saveStatus, errorMessage, deleteStatus } = this.props;
         const { validateCallback, saveCallback } = this.state;
+
         if (prevProps.saveStatus === 'VALIDATING' && saveStatus === 'VALIDATED') {
             validateCallback(true);
         }
@@ -48,6 +49,11 @@ class UserTable extends Component {
             saveCallback(true);
         } else if (prevProps.saveStatus === 'SAVING' && saveStatus === 'ERROR') {
             saveCallback(false);
+        }
+        if (prevProps.deleteStatus === 'DELETING' && deleteStatus === 'ERROR') {
+            this.setState({
+                errorMessageState: errorMessage
+            });
         }
     }
 
@@ -91,6 +97,8 @@ class UserTable extends Component {
             user: selectedRow
         });
         callback();
+        const { clearFieldErrors } = this.props;
+        clearFieldErrors();
     }
 
     onCopy(selectedRow, callback) {
@@ -106,8 +114,11 @@ class UserTable extends Component {
         const { user } = this.state;
         if (user && Object.keys(user).length > 0) {
             this.setState({
-                user: {}
+                user: {},
+                errorMessageState: null
             });
+            const { clearFieldErrors } = this.props;
+            clearFieldErrors();
         }
     }
 
@@ -298,15 +309,19 @@ class UserTable extends Component {
 
     render() {
         const {
-            canCreate, canDelete, fieldErrors, errorMessage, inProgress, fetching, users, autoRefresh
+            canCreate, canDelete, fieldErrors, errorMessage, inProgress, users, autoRefresh
         } = this.props;
-        const { user } = this.state;
+        const { user, errorMessageState } = this.state;
         const fieldErrorKeys = Object.keys(fieldErrors);
         const hasErrors = (fieldErrorKeys && fieldErrorKeys.length > 0)
             || (user[KEY_CONFIRM_PASSWORD_ERROR] && user[KEY_CONFIRM_PASSWORD_ERROR].length > 0);
         return (
             <div>
                 <div>
+                    <StatusMessage
+                        id="$user-status-message"
+                        errorMessage={errorMessageState}
+                    />
                     <TableDisplay
                         id="users"
                         autoRefresh={autoRefresh}
@@ -326,7 +341,6 @@ class UserTable extends Component {
                         hasFieldErrors={hasErrors}
                         errorDialogMessage={errorMessage}
                         inProgress={inProgress}
-                        fetching={fetching}
                     />
                 </div>
             </div>
@@ -340,8 +354,8 @@ UserTable.defaultProps = {
     errorMessage: null,
     fieldErrors: {},
     inProgress: false,
-    fetching: false,
     saveStatus: null,
+    deleteStatus: null,
     users: [],
     roles: [],
     autoRefresh: true
@@ -359,8 +373,8 @@ UserTable.propTypes = {
     errorMessage: PropTypes.string,
     fieldErrors: PropTypes.object,
     inProgress: PropTypes.bool,
-    fetching: PropTypes.bool,
     saveStatus: PropTypes.string,
+    deleteStatus: PropTypes.string,
     users: PropTypes.array,
     roles: PropTypes.array,
     autoRefresh: PropTypes.bool
@@ -372,8 +386,8 @@ const mapStateToProps = (state) => ({
     errorMessage: state.users.error.message,
     fieldErrors: state.users.error.fieldErrors,
     inProgress: state.users.inProgress,
-    fetching: state.users.fetching,
     saveStatus: state.users.saveStatus,
+    deleteStatus: state.users.deleteStatus,
     autoRefresh: state.refresh.autoRefresh
 });
 

--- a/ui/src/main/js/store/reducers/users.js
+++ b/ui/src/main/js/store/reducers/users.js
@@ -24,7 +24,8 @@ const initialState = {
     userFetchError: '',
     error: HTTPErrorUtils.createEmptyErrorObject(),
     fieldErrors: {},
-    saveStatus: ''
+    saveStatus: '',
+    deleteStatus: ''
 };
 
 const users = (state = initialState, action) => {
@@ -36,7 +37,8 @@ const users = (state = initialState, action) => {
                 deleteSuccess: false,
                 error: HTTPErrorUtils.createErrorObject(action),
                 fieldErrors: action.errors || {},
-                saveStatus: ''
+                saveStatus: '',
+                deleteStatus: 'ERROR'
             };
         case USER_MANAGEMENT_USER_DELETED:
             return {
@@ -45,14 +47,16 @@ const users = (state = initialState, action) => {
                 deleteSuccess: true,
                 error: HTTPErrorUtils.createEmptyErrorObject(),
                 fieldErrors: {},
-                saveStatus: ''
+                saveStatus: '',
+                deleteStatus: 'DELETED'
             };
         case USER_MANAGEMENT_USER_DELETING:
             return {
                 ...state,
                 inProgress: true,
                 deleteSuccess: false,
-                saveStatus: ''
+                saveStatus: '',
+                deleteStatus: 'DELETING'
             };
         case USER_MANAGEMENT_USER_FETCH_ERROR_ALL:
             return {


### PR DESCRIPTION
Status wasn't showing why you couldn't delete the main users. Added a status bar to show this info.

This class needs to be rewritten with hooks and without the TableDisplay dependency.