### PR TITLE
Add missing builder method for ComponentItemBuilder

### DIFF
--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/distribution/ProjectMessageToMessageContentGroupConversionUtils.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/distribution/ProjectMessageToMessageContentGroupConversionUtils.java
@@ -13,11 +13,11 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.channel.email.attachment.compatibility.ComponentItem;
 import com.synopsys.integration.alert.channel.email.attachment.compatibility.MessageContentGroup;
 import com.synopsys.integration.alert.channel.email.attachment.compatibility.ProviderMessageContent;
 import com.synopsys.integration.alert.common.enumeration.ItemOperation;
-import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.processor.api.extract.model.project.BomComponentDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcern;
@@ -94,6 +94,7 @@ public final class ProjectMessageToMessageContentGroupConversionUtils {
             componentAttributes.add(usageItem);
 
             componentAttributes.addAll(bomComponent.getAdditionalAttributes());
+            componentItemBuilder.applyAllComponentAttributes(componentAttributes);
 
             try {
                 componentItems.add(componentItemBuilder.build());


### PR DESCRIPTION
While working on upgrade guidance changes I noticed that in the following code we were creating a List<LinkableItem>. componentAttributes but did nothing with this list. I believe this was overlooked and have added in the builder step to apply the componentAttributes.

This change impacts the email attachment json file where the attributes was previously left blank.