### PR TITLE
Create ComponentUpgradeGuidance and implement it as a custom field replacment

### DIFF
--- a/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/model/IssueBomComponentDetails.java
+++ b/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/model/IssueBomComponentDetails.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.Nullable;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.processor.api.extract.model.project.AbstractBomComponentDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentPolicy;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentVulnerabilities;
 
 public class IssueBomComponentDetails extends AbstractBomComponentDetails {
@@ -28,6 +29,7 @@ public class IssueBomComponentDetails extends AbstractBomComponentDetails {
             List.of(),
             UNKNOWN_LICENSE,
             UNKNOWN_USAGE,
+            ComponentUpgradeGuidance.none(),
             List.of(),
             ""
         );
@@ -41,6 +43,7 @@ public class IssueBomComponentDetails extends AbstractBomComponentDetails {
             bomComponentDetails.getComponentPolicies(),
             bomComponentDetails.getLicense(),
             bomComponentDetails.getUsage(),
+            bomComponentDetails.getComponentUpgradeGuidance(),
             bomComponentDetails.getAdditionalAttributes(),
             bomComponentDetails.getBlackDuckIssuesUrl()
         );
@@ -53,10 +56,11 @@ public class IssueBomComponentDetails extends AbstractBomComponentDetails {
         List<ComponentPolicy> componentPolicies,
         LinkableItem license,
         String usage,
+        ComponentUpgradeGuidance componentUpgradeGuidance,
         List<LinkableItem> additionalAttributes,
         String blackDuckIssuesUrl
     ) {
-        super(component, componentVersion, componentVulnerabilities, componentPolicies, license, usage, additionalAttributes, blackDuckIssuesUrl);
+        super(component, componentVersion, componentVulnerabilities, componentPolicies, license, usage, componentUpgradeGuidance, additionalAttributes, blackDuckIssuesUrl);
     }
 
 }

--- a/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/IssueTrackerModelExtractorTest.java
+++ b/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/IssueTrackerModelExtractorTest.java
@@ -29,6 +29,7 @@ import com.synopsys.integration.alert.processor.api.extract.model.SimpleMessage;
 import com.synopsys.integration.alert.processor.api.extract.model.project.AbstractBomComponentDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.BomComponentDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcernSeverity;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentVulnerabilities;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ProjectMessage;
 
@@ -44,7 +45,8 @@ public class IssueTrackerModelExtractorTest {
     private static final String USAGE = "Some generic usage";
     private static final String ISSUES_URL = "https://issues-url";
 
-    private static final AbstractBomComponentDetails BOM_COMPONENT_DETAILS = new BomComponentDetails(COMPONENT, COMPONENT_VERSION, ComponentVulnerabilities.none(), List.of(), List.of(), LICENSE, USAGE, List.of(), ISSUES_URL);
+    private static final AbstractBomComponentDetails BOM_COMPONENT_DETAILS = new BomComponentDetails(COMPONENT, COMPONENT_VERSION, ComponentVulnerabilities.none(), List.of(), List.of(), LICENSE, USAGE, ComponentUpgradeGuidance.none(),
+        List.of(), ISSUES_URL);
     private static final IssueBomComponentDetails ISSUE_BOM_COMPONENT_DETAILS = IssueBomComponentDetails.fromBomComponentDetails(BOM_COMPONENT_DETAILS);
 
     @Test

--- a/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/callback/IssueTrackerCallbackInfoCreatorTest.java
+++ b/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/callback/IssueTrackerCallbackInfoCreatorTest.java
@@ -14,6 +14,7 @@ import com.synopsys.integration.alert.common.channel.issuetracker.message.IssueT
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.processor.api.extract.model.ProviderDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.AbstractBomComponentDetails;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentVulnerabilities;
 
 public class IssueTrackerCallbackInfoCreatorTest {
@@ -25,6 +26,7 @@ public class IssueTrackerCallbackInfoCreatorTest {
         List.of(),
         TEST_ITEM,
         "Example Usage",
+        ComponentUpgradeGuidance.none(),
         List.of(),
         "https://issues-url"
     ) {};

--- a/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/convert/IssuePolicyDetailsConverterTest.java
+++ b/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/convert/IssuePolicyDetailsConverterTest.java
@@ -14,6 +14,7 @@ import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.processor.api.extract.model.project.AbstractBomComponentDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcernSeverity;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentPolicy;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentVulnerabilities;
 
 public class IssuePolicyDetailsConverterTest {
@@ -27,6 +28,7 @@ public class IssuePolicyDetailsConverterTest {
         List.of(COMPONENT_POLICY, COMPONENT_POLICY_NO_DESCRIPTION),
         new LinkableItem("License", "A software license", "https://license-url"),
         "Example Usage",
+        ComponentUpgradeGuidance.none(),
         List.of(),
         "https://issues-url"
     ) {};

--- a/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/convert/ProjectIssueModelConverterTest.java
+++ b/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/convert/ProjectIssueModelConverterTest.java
@@ -27,6 +27,7 @@ import com.synopsys.integration.alert.processor.api.extract.model.ProviderDetail
 import com.synopsys.integration.alert.processor.api.extract.model.project.AbstractBomComponentDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcernSeverity;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentPolicy;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentVulnerabilities;
 
 public class ProjectIssueModelConverterTest {
@@ -202,6 +203,7 @@ public class ProjectIssueModelConverterTest {
             List.of(COMPONENT_POLICY),
             new LinkableItem("License", "A software license", "https://license-url"),
             "Example Usage",
+            ComponentUpgradeGuidance.none(),
             List.of(
                 new LinkableItem("Attribute", "Example attribute")
             ),

--- a/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/convert/ProjectMessageToIssueModelTransformerTest.java
+++ b/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/convert/ProjectMessageToIssueModelTransformerTest.java
@@ -19,6 +19,7 @@ import com.synopsys.integration.alert.processor.api.extract.model.project.BomCom
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcern;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcernSeverity;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentPolicy;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentVulnerabilities;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ProjectMessage;
 
@@ -33,6 +34,9 @@ public class ProjectMessageToIssueModelTransformerTest {
     private static final LinkableItem COMPONENT_VERSION = new LinkableItem("Component Version", "0.8.7");
     private static final LinkableItem LICENSE = new LinkableItem("License", "A software license", "https://license-url");
     private static final String USAGE = "Some generic usage";
+    private static final LinkableItem SHORT_TERM_GUIDANCE = new LinkableItem("Upgrade Guidance - Short Term", "1.0");
+    private static final LinkableItem LONG_TERM_GUIDANCE = new LinkableItem("Upgrade Guidance - Long Term", "2.0");
+    private static final ComponentUpgradeGuidance UPGRADE_GUIDANCE = new ComponentUpgradeGuidance(SHORT_TERM_GUIDANCE, LONG_TERM_GUIDANCE);
     private static final LinkableItem ADDITIONAL_ATTRIBUTE = new LinkableItem("A Label", "An attribute value");
     private static final String ISSUES_URL = "https://issues-url";
 
@@ -130,6 +134,7 @@ public class ProjectMessageToIssueModelTransformerTest {
         assertEquals(LICENSE, issueBomComponentDetails.getLicense());
         assertEquals(USAGE, issueBomComponentDetails.getUsage());
         assertEquals(ISSUES_URL, issueBomComponentDetails.getBlackDuckIssuesUrl());
+        assertEquals(UPGRADE_GUIDANCE, issueBomComponentDetails.getComponentUpgradeGuidance());
         assertTrue(
             issueBomComponentDetails.getAdditionalAttributes().contains(ADDITIONAL_ATTRIBUTE),
             "Expected issue BOM component details to contain an additional attribute"
@@ -149,6 +154,7 @@ public class ProjectMessageToIssueModelTransformerTest {
             componentConcerns,
             LICENSE,
             USAGE,
+            UPGRADE_GUIDANCE,
             List.of(ADDITIONAL_ATTRIBUTE),
             ISSUES_URL
         );

--- a/api-channel-jira/src/main/java/com/synopsys/integration/alert/api/channel/jira/distribution/custom/MessageReplacementValues.java
+++ b/api-channel-jira/src/main/java/com/synopsys/integration/alert/api/channel/jira/distribution/custom/MessageReplacementValues.java
@@ -25,6 +25,8 @@ public class MessageReplacementValues {
     private final String componentLicense;
     private final String severity;
     private final String policyCategory;
+    private final String shortTermUpgradeGuidance;
+    private final String longTermUpgradeGuidance;
 
     private MessageReplacementValues(
         String providerName,
@@ -35,7 +37,9 @@ public class MessageReplacementValues {
         @Nullable String componentUsage,
         @Nullable String componentLicense,
         @Nullable String severity,
-        @Nullable String policyCategory
+        @Nullable String policyCategory,
+        @Nullable String shortTermUpgradeGuidance,
+        @Nullable String longTermUpgradeGuidance
     ) {
         this.providerName = providerName;
         this.projectName = projectName;
@@ -46,6 +50,8 @@ public class MessageReplacementValues {
         this.componentLicense = StringUtils.trimToNull(componentLicense);
         this.severity = StringUtils.trimToNull(severity);
         this.policyCategory = StringUtils.trimToNull(policyCategory);
+        this.shortTermUpgradeGuidance = StringUtils.trimToNull(shortTermUpgradeGuidance);
+        this.longTermUpgradeGuidance = StringUtils.trimToNull(longTermUpgradeGuidance);
     }
 
     public String getProviderName() {
@@ -84,6 +90,14 @@ public class MessageReplacementValues {
         return Optional.ofNullable(policyCategory);
     }
 
+    public Optional<String> getShortTermUpgradeGuidance() {
+        return Optional.ofNullable(shortTermUpgradeGuidance);
+    }
+
+    public Optional<String> getLongTermUpgradeGuidance() {
+        return Optional.ofNullable(longTermUpgradeGuidance);
+    }
+
     public static class Builder {
         private String providerName;
         private String projectName;
@@ -94,6 +108,8 @@ public class MessageReplacementValues {
         private String componentLicense;
         private String severity;
         private String policyCategory;
+        private String shortTermUpgradeGuidance;
+        private String longTermUpgradeGuidance;
 
         public Builder(String providerName, String projectName) {
             this.providerName = providerName;
@@ -110,7 +126,9 @@ public class MessageReplacementValues {
                 defaultIfBlank(componentUsage),
                 defaultIfBlank(componentLicense),
                 defaultIfBlank(severity),
-                defaultIfBlank(policyCategory)
+                defaultIfBlank(policyCategory),
+                defaultIfBlank(shortTermUpgradeGuidance),
+                defaultIfBlank(longTermUpgradeGuidance)
             );
         }
 
@@ -146,6 +164,16 @@ public class MessageReplacementValues {
 
         public Builder policyCategory(String policyCategory) {
             this.policyCategory = policyCategory;
+            return this;
+        }
+
+        public Builder shortTermUpgradeGuidance(String shortTermUpgradeGuidance) {
+            this.shortTermUpgradeGuidance = shortTermUpgradeGuidance;
+            return this;
+        }
+
+        public Builder longTermUpgradeGuidance(String longTermUpgradeGuidance) {
+            this.longTermUpgradeGuidance = longTermUpgradeGuidance;
             return this;
         }
 

--- a/api-channel-jira/src/main/java/com/synopsys/integration/alert/api/channel/jira/distribution/custom/MessageValueReplacementResolver.java
+++ b/api-channel-jira/src/main/java/com/synopsys/integration/alert/api/channel/jira/distribution/custom/MessageValueReplacementResolver.java
@@ -22,6 +22,8 @@ public final class MessageValueReplacementResolver {
     public static final String REPLACEMENT_COMPONENT_LICENSE = "{{componentLicense}}";
     public static final String REPLACEMENT_SEVERITY = "{{severity}}";
     public static final String REPLACEMENT_POLICY_CATEGORY = "{{policyCategory}}";
+    public static final String REPLAMCENT_SHORT_TERM_UPGRADE_GUIDANCE = "{{shortTermUpgradeGuidance}}";
+    public static final String REPLAMCENT_LONG_TERM_UPGRADE_GUIDANCE = "{{longTermUpgradeGuidance}}";
 
     private final MessageReplacementValues replacementValues;
 
@@ -40,6 +42,8 @@ public final class MessageValueReplacementResolver {
         modifiedFieldValue = replaceFieldValue(modifiedFieldValue, REPLACEMENT_COMPONENT_LICENSE, replacementValues::getComponentLicense);
         modifiedFieldValue = replaceFieldValue(modifiedFieldValue, REPLACEMENT_SEVERITY, replacementValues::getSeverity);
         modifiedFieldValue = replaceFieldValue(modifiedFieldValue, REPLACEMENT_POLICY_CATEGORY, replacementValues::getPolicyCategory);
+        modifiedFieldValue = replaceFieldValue(modifiedFieldValue, REPLAMCENT_SHORT_TERM_UPGRADE_GUIDANCE, replacementValues::getShortTermUpgradeGuidance);
+        modifiedFieldValue = replaceFieldValue(modifiedFieldValue, REPLAMCENT_LONG_TERM_UPGRADE_GUIDANCE, replacementValues::getLongTermUpgradeGuidance);
 
         return modifiedFieldValue;
     }

--- a/api-channel-jira/src/main/java/com/synopsys/integration/alert/api/channel/jira/distribution/delegate/JiraIssueCreator.java
+++ b/api-channel-jira/src/main/java/com/synopsys/integration/alert/api/channel/jira/distribution/delegate/JiraIssueCreator.java
@@ -36,6 +36,7 @@ import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.descriptor.api.model.IssueTrackerChannelKey;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcernType;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentPolicy;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.jira.common.exception.JiraPreconditionNotMetException;
 import com.synopsys.integration.jira.common.model.components.IssueFieldsComponent;
@@ -111,6 +112,7 @@ public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<Strin
 
     protected MessageReplacementValues createCustomFieldReplacementValues(ProjectIssueModel alertIssueSource) {
         IssueBomComponentDetails bomComponent = alertIssueSource.getBomComponentDetails();
+        ComponentUpgradeGuidance upgradeGuidance = bomComponent.getComponentUpgradeGuidance();
 
         Optional<String> severity = Optional.empty();
         Optional<String> policyCategory = Optional.empty();
@@ -136,6 +138,8 @@ public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<Strin
                    .componentLicense(bomComponent.getLicense().getValue())
                    .severity(severity.orElse(MessageReplacementValues.DEFAULT_NOTIFICATION_REPLACEMENT_VALUE))
                    .policyCategory(policyCategory.orElse(MessageReplacementValues.DEFAULT_NOTIFICATION_REPLACEMENT_VALUE))
+                   .shortTermUpgradeGuidance(upgradeGuidance.getShortTermUpgradeGuidance().map(LinkableItem::getLabel).orElse(MessageReplacementValues.DEFAULT_NOTIFICATION_REPLACEMENT_VALUE))
+                   .longTermUpgradeGuidance(upgradeGuidance.getLongTermUpgradeGuidance().map(LinkableItem::getLabel).orElse(MessageReplacementValues.DEFAULT_NOTIFICATION_REPLACEMENT_VALUE))
                    .build();
     }
 

--- a/api-channel-jira/src/main/java/com/synopsys/integration/alert/api/channel/jira/distribution/delegate/JiraIssueCreator.java
+++ b/api-channel-jira/src/main/java/com/synopsys/integration/alert/api/channel/jira/distribution/delegate/JiraIssueCreator.java
@@ -71,8 +71,8 @@ public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<Strin
     @Override
     protected final ExistingIssueDetails<String> createIssueAndExtractDetails(IssueCreationModel alertIssueCreationModel) throws AlertException {
         MessageReplacementValues replacementValues = alertIssueCreationModel.getSource()
-            .map(this::createCustomFieldReplacementValues)
-            .orElse(new MessageReplacementValues.Builder(alertIssueCreationModel.getProvider().getLabel(), MessageReplacementValues.DEFAULT_NOTIFICATION_REPLACEMENT_VALUE).build());
+                                                         .map(this::createCustomFieldReplacementValues)
+                                                         .orElse(new MessageReplacementValues.Builder(alertIssueCreationModel.getProvider().getLabel(), MessageReplacementValues.DEFAULT_NOTIFICATION_REPLACEMENT_VALUE).build());
         T creationRequest = createIssueCreationRequest(alertIssueCreationModel, replacementValues);
         try {
             IssueCreationResponseModel issueCreationResponseModel = createIssue(creationRequest);
@@ -82,8 +82,8 @@ public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<Strin
             String issueUILink = JiraCallbackUtils.createUILink(createdIssue);
 
             IssueCategory issueCategory = alertIssueCreationModel.getSource()
-                .map(issueCategoryRetriever::retrieveIssueCategoryFromProjectIssueModel)
-                .orElse(IssueCategory.BOM);
+                                              .map(issueCategoryRetriever::retrieveIssueCategoryFromProjectIssueModel)
+                                              .orElse(IssueCategory.BOM);
 
             return new ExistingIssueDetails<>(createdIssue.getId(), createdIssue.getKey(), createdIssueFields.getSummary(), issueUILink, IssueStatus.RESOLVABLE, issueCategory);
         } catch (IntegrationRestException restException) {
@@ -122,10 +122,10 @@ public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<Strin
             IssuePolicyDetails policyDetails = issuePolicyDetails.get();
             severity = Optional.ofNullable(policyDetails.getSeverity().getPolicyLabel());
             policyCategory = bomComponent.getRelevantPolicies()
-                .stream()
-                .filter(policy -> policyDetails.getName().equals(policy.getPolicyName()))
-                .findAny()
-                .flatMap(ComponentPolicy::getCategory);
+                                 .stream()
+                                 .filter(policy -> policyDetails.getName().equals(policy.getPolicyName()))
+                                 .findAny()
+                                 .flatMap(ComponentPolicy::getCategory);
         }
         if (vulnerabilityDetails.isPresent()) {
             severity = vulnerabilityDetails.get().getHighestSeverityAddedOrUpdated();
@@ -138,8 +138,8 @@ public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<Strin
                    .componentLicense(bomComponent.getLicense().getValue())
                    .severity(severity.orElse(MessageReplacementValues.DEFAULT_NOTIFICATION_REPLACEMENT_VALUE))
                    .policyCategory(policyCategory.orElse(MessageReplacementValues.DEFAULT_NOTIFICATION_REPLACEMENT_VALUE))
-                   .shortTermUpgradeGuidance(upgradeGuidance.getShortTermUpgradeGuidance().map(LinkableItem::getLabel).orElse(MessageReplacementValues.DEFAULT_NOTIFICATION_REPLACEMENT_VALUE))
-                   .longTermUpgradeGuidance(upgradeGuidance.getLongTermUpgradeGuidance().map(LinkableItem::getLabel).orElse(MessageReplacementValues.DEFAULT_NOTIFICATION_REPLACEMENT_VALUE))
+                   .shortTermUpgradeGuidance(upgradeGuidance.getShortTermUpgradeGuidance().map(LinkableItem::getValue).orElse(MessageReplacementValues.DEFAULT_NOTIFICATION_REPLACEMENT_VALUE))
+                   .longTermUpgradeGuidance(upgradeGuidance.getLongTermUpgradeGuidance().map(LinkableItem::getValue).orElse(MessageReplacementValues.DEFAULT_NOTIFICATION_REPLACEMENT_VALUE))
                    .build();
     }
 
@@ -148,7 +148,7 @@ public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<Strin
         LinkableItem project = alertIssueSource.getProject();
 
         LinkableItem projectVersion = alertIssueSource.getProjectVersion()
-            .orElseThrow(() -> new AlertRuntimeException("Missing project version"));
+                                          .orElseThrow(() -> new AlertRuntimeException("Missing project version"));
 
         IssueBomComponentDetails bomComponent = alertIssueSource.getBomComponentDetails();
         LinkableItem component = bomComponent.getComponent();

--- a/api-channel-jira/src/test/java/com/synopsys/integration/alert/api/channel/jira/distribution/custom/MessageValueReplacementResolverTest.java
+++ b/api-channel-jira/src/test/java/com/synopsys/integration/alert/api/channel/jira/distribution/custom/MessageValueReplacementResolverTest.java
@@ -101,6 +101,18 @@ public class MessageValueReplacementResolverTest {
         testReplacements(messageReplacementValues, originalFieldValue, expectedFieldValue);
     }
 
+    @Test
+    public void replacementUpgradeGuidanceTest() {
+        String originalFieldValue = "Short Term Guidance: {{shortTermUpgradeGuidance}} | Long Term Guidance {{longTermUpgradeGuidance}}";
+        String expectedFieldValue = "Short Term Guidance: v1.0 | Long Term Guidance v2.0";
+        MessageReplacementValues messageReplacementValues = new MessageReplacementValues.Builder("ProviderNameREPLACED", "ProjectNameREPLACED")
+                                                                .shortTermUpgradeGuidance("v1.0")
+                                                                .longTermUpgradeGuidance("v2.0")
+                                                                .build();
+
+        testReplacements(messageReplacementValues, originalFieldValue, expectedFieldValue);
+    }
+
     private void testReplacements(MessageReplacementValues messageReplacementValues, String originalValue, String expectedValue) {
         MessageValueReplacementResolver messageValueReplacementResolver = new MessageValueReplacementResolver(messageReplacementValues);
         String replacedFieldValue = messageValueReplacementResolver.createReplacedFieldValue(originalValue);

--- a/api-channel/src/main/java/com/synopsys/integration/alert/api/channel/convert/BomComponentDetailConverter.java
+++ b/api-channel/src/main/java/com/synopsys/integration/alert/api/channel/convert/BomComponentDetailConverter.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.processor.api.extract.model.project.AbstractBomComponentDetails;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 
 public class BomComponentDetailConverter {
     private final ChannelMessageFormatter formatter;
@@ -46,10 +47,10 @@ public class BomComponentDetailConverter {
     }
 
     public List<String> gatherAttributeStrings(AbstractBomComponentDetails bomComponent) {
-        return gatherAttributeStrings(bomComponent.getLicense(), bomComponent.getUsage(), bomComponent.getAdditionalAttributes());
+        return gatherAttributeStrings(bomComponent.getLicense(), bomComponent.getUsage(), bomComponent.getComponentUpgradeGuidance(), bomComponent.getAdditionalAttributes());
     }
 
-    private List<String> gatherAttributeStrings(LinkableItem licenseItem, String usageText, List<LinkableItem> additionalAttributes) {
+    private List<String> gatherAttributeStrings(LinkableItem licenseItem, String usageText, ComponentUpgradeGuidance componentUpgradeGuidance, List<LinkableItem> additionalAttributes) {
         List<String> componentAttributeStrings = new ArrayList<>(additionalAttributes.size() + 2);
 
         String licenseString = linkableItemConverter.convertToString(licenseItem, false);
@@ -59,11 +60,19 @@ public class BomComponentDetailConverter {
         String usageString = linkableItemConverter.convertToString(usageItem, false);
         componentAttributeStrings.add(usageString);
 
+        componentUpgradeGuidance.getShortTermUpgradeGuidance()
+            .stream()
+            .map(attr -> linkableItemConverter.convertToString(attr, false))
+            .forEach(componentAttributeStrings::add);
+        componentUpgradeGuidance.getLongTermUpgradeGuidance()
+            .stream()
+            .map(attr -> linkableItemConverter.convertToString(attr, false))
+            .forEach(componentAttributeStrings::add);
+
         additionalAttributes
             .stream()
             .map(attr -> linkableItemConverter.convertToString(attr, false))
             .forEach(componentAttributeStrings::add);
         return componentAttributeStrings;
     }
-
 }

--- a/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/convert/BomComponentDetailConverterTest.java
+++ b/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/convert/BomComponentDetailConverterTest.java
@@ -11,6 +11,7 @@ import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.processor.api.extract.model.project.AbstractBomComponentDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcernSeverity;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentPolicy;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentVulnerabilities;
 
 public class BomComponentDetailConverterTest {
@@ -63,6 +64,10 @@ public class BomComponentDetailConverterTest {
         ComponentPolicy componentPolicy1 = new ComponentPolicy("A Black Duck Policy", ComponentConcernSeverity.MAJOR_HIGH, true, false, null, "Uncategorized");
         ComponentPolicy componentPolicy2 = new ComponentPolicy("A Different Black Duck Policy", ComponentConcernSeverity.UNSPECIFIED_UNKNOWN, false, true, null, "Uncategorized");
 
+        LinkableItem shortTermUpgradeGuidance = new LinkableItem("Upgrade Guidance - Short Term", "1.0");
+        LinkableItem longTermUpgradeGuidance = new LinkableItem("Upgrade Guidance - Long Term", "2.0");
+        ComponentUpgradeGuidance componentUpgradeGuidance = new ComponentUpgradeGuidance(shortTermUpgradeGuidance, longTermUpgradeGuidance);
+
         LinkableItem attribute1 = new LinkableItem("Attribute", "Number 1");
         LinkableItem attribute2 = new LinkableItem("Attribute", "Number 2");
 
@@ -73,6 +78,7 @@ public class BomComponentDetailConverterTest {
             List.of(componentPolicy1, componentPolicy2),
             new LinkableItem("License", "A Software License"),
             "Example Usage",
+            componentUpgradeGuidance,
             List.of(attribute1, attribute2),
             "https://a-blackduck-url"
         ) {};

--- a/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/convert/ProjectMessageConverterTest.java
+++ b/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/convert/ProjectMessageConverterTest.java
@@ -14,6 +14,7 @@ import com.synopsys.integration.alert.processor.api.extract.model.project.BomCom
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcern;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcernSeverity;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentPolicy;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentVulnerabilities;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ProjectMessage;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ProjectOperation;
@@ -81,6 +82,10 @@ public class ProjectMessageConverterTest {
         ComponentConcern vulnerabilityConcern2 = createVulnerabilityConcern(ItemOperation.UPDATE, "CVE-135", ComponentConcernSeverity.TRIVIAL_LOW);
         ComponentConcern vulnerabilityConcern3 = createVulnerabilityConcern(ItemOperation.DELETE, "CVE-246", ComponentConcernSeverity.MINOR_MEDIUM);
 
+        LinkableItem shortTermUpgradeGuidance = new LinkableItem("Upgrade Guidance - Short Term", "1.0");
+        LinkableItem longTermUpgradeGuidance = new LinkableItem("Upgrade Guidance - Long Term", "2.0");
+        ComponentUpgradeGuidance componentUpgradeGuidance = new ComponentUpgradeGuidance(shortTermUpgradeGuidance, longTermUpgradeGuidance);
+
         LinkableItem attribute1 = new LinkableItem("Attribute", "The first attribute");
         LinkableItem attribute2 = new LinkableItem("Attribute Prime", "The second attribute");
 
@@ -92,6 +97,7 @@ public class ProjectMessageConverterTest {
             List.of(policyConcern1, policyConcern2, vulnerabilityConcern1, vulnerabilityConcern2, vulnerabilityConcern3),
             new LinkableItem("License", "The software license name", "https://license-url"),
             "The usage of the component",
+            componentUpgradeGuidance,
             List.of(attribute1, attribute2),
             "https://blackduck-issues-url"
         );

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/extract/model/project/AbstractBomComponentDetails.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/extract/model/project/AbstractBomComponentDetails.java
@@ -24,6 +24,7 @@ public abstract class AbstractBomComponentDetails extends AlertSerializableModel
 
     private final LinkableItem license;
     private final String usage;
+    private final ComponentUpgradeGuidance componentUpgradeGuidance;
     private final List<LinkableItem> additionalAttributes;
 
     private final String blackDuckIssuesUrl;
@@ -35,6 +36,7 @@ public abstract class AbstractBomComponentDetails extends AlertSerializableModel
         List<ComponentPolicy> componentPolicies,
         LinkableItem license,
         String usage,
+        ComponentUpgradeGuidance componentUpgradeGuidance,
         List<LinkableItem> additionalAttributes,
         String blackDuckIssuesUrl
     ) {
@@ -44,6 +46,7 @@ public abstract class AbstractBomComponentDetails extends AlertSerializableModel
         this.componentPolicies = componentPolicies;
         this.license = license;
         this.usage = usage;
+        this.componentUpgradeGuidance = componentUpgradeGuidance;
         this.additionalAttributes = additionalAttributes;
         this.blackDuckIssuesUrl = blackDuckIssuesUrl;
     }
@@ -70,6 +73,10 @@ public abstract class AbstractBomComponentDetails extends AlertSerializableModel
 
     public String getUsage() {
         return usage;
+    }
+
+    public ComponentUpgradeGuidance getComponentUpgradeGuidance() {
+        return componentUpgradeGuidance;
     }
 
     public List<LinkableItem> getAdditionalAttributes() {

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/extract/model/project/BomComponentDetails.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/extract/model/project/BomComponentDetails.java
@@ -26,10 +26,11 @@ public class BomComponentDetails extends AbstractBomComponentDetails implements 
         List<ComponentConcern> componentConcerns,
         LinkableItem license,
         String usage,
+        ComponentUpgradeGuidance componentUpgradeGuidance,
         List<LinkableItem> additionalAttributes,
         @Nullable String blackDuckIssuesUrl
     ) {
-        super(component, componentVersion, componentVulnerabilities, componentPolicies, license, usage, additionalAttributes, blackDuckIssuesUrl);
+        super(component, componentVersion, componentVulnerabilities, componentPolicies, license, usage, componentUpgradeGuidance, additionalAttributes, blackDuckIssuesUrl);
         this.componentConcerns = componentConcerns;
     }
 
@@ -72,6 +73,7 @@ public class BomComponentDetails extends AbstractBomComponentDetails implements 
             combinedComponentConcerns,
             getLicense(),
             getUsage(),
+            getComponentUpgradeGuidance(),
             getAdditionalAttributes(),
             getBlackDuckIssuesUrl()
         );

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/extract/model/project/ComponentUpgradeGuidance.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/extract/model/project/ComponentUpgradeGuidance.java
@@ -1,0 +1,37 @@
+/*
+ * api-processor
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.alert.processor.api.extract.model.project;
+
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
+
+import com.synopsys.integration.alert.common.message.model.LinkableItem;
+
+public class ComponentUpgradeGuidance {
+    private final LinkableItem shortTermUpgradeGuidance;
+    private final LinkableItem longTermUpgradeGuidance;
+
+    public static ComponentUpgradeGuidance none() {
+        return new ComponentUpgradeGuidance(null, null);
+    }
+
+    public ComponentUpgradeGuidance(@Nullable LinkableItem shortTermUpgradeGuidance, @Nullable LinkableItem longTermUpgradeGuidance) {
+        this.shortTermUpgradeGuidance = shortTermUpgradeGuidance;
+        this.longTermUpgradeGuidance = longTermUpgradeGuidance;
+    }
+
+    public Optional<LinkableItem> getShortTermUpgradeGuidance() {
+        return Optional.ofNullable(shortTermUpgradeGuidance);
+    }
+
+    public Optional<LinkableItem> getLongTermUpgradeGuidance() {
+        return Optional.ofNullable(longTermUpgradeGuidance);
+    }
+}
+

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/distribution/search/AzureBoardsComponentIssueFinderTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/distribution/search/AzureBoardsComponentIssueFinderTest.java
@@ -24,6 +24,7 @@ import com.synopsys.integration.alert.processor.api.extract.model.ProviderDetail
 import com.synopsys.integration.alert.processor.api.extract.model.project.AbstractBomComponentDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcernSeverity;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentPolicy;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentVulnerabilities;
 import com.synopsys.integration.azure.boards.common.service.workitem.response.WorkItemResponseFields;
 import com.synopsys.integration.azure.boards.common.service.workitem.response.WorkItemResponseModel;
@@ -82,6 +83,7 @@ public class AzureBoardsComponentIssueFinderTest {
             List.of(COMPONENT_POLICY),
             new LinkableItem("License", "A software license", "https://license-url"),
             "Example Usage",
+            ComponentUpgradeGuidance.none(),
             List.of(
                 new LinkableItem("Attribute", "Example attribute")
             ),

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/distribution/ProjectMessageToMessageContentGroupConversionUtils.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/distribution/ProjectMessageToMessageContentGroupConversionUtils.java
@@ -101,8 +101,6 @@ public final class ProjectMessageToMessageContentGroupConversionUtils {
             componentAttributes.addAll(bomComponent.getAdditionalAttributes());
             componentItemBuilder.applyAllComponentAttributes(componentAttributes);
 
-            //TODO: what is componentAttributes even used for?
-
             try {
                 componentItems.add(componentItemBuilder.build());
             } catch (AlertException e) {

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/distribution/ProjectMessageToMessageContentGroupConversionUtils.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/distribution/ProjectMessageToMessageContentGroupConversionUtils.java
@@ -13,15 +13,16 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.channel.email.attachment.compatibility.ComponentItem;
 import com.synopsys.integration.alert.channel.email.attachment.compatibility.MessageContentGroup;
 import com.synopsys.integration.alert.channel.email.attachment.compatibility.ProviderMessageContent;
 import com.synopsys.integration.alert.common.enumeration.ItemOperation;
-import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.processor.api.extract.model.project.BomComponentDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcern;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcernType;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ProjectMessage;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ProjectOperation;
 
@@ -93,7 +94,13 @@ public final class ProjectMessageToMessageContentGroupConversionUtils {
             LinkableItem usageItem = new LinkableItem("Usage", bomComponent.getUsage());
             componentAttributes.add(usageItem);
 
+            ComponentUpgradeGuidance upgradeGuidance = bomComponent.getComponentUpgradeGuidance();
+            upgradeGuidance.getLongTermUpgradeGuidance().ifPresent(componentAttributes::add);
+            upgradeGuidance.getShortTermUpgradeGuidance().ifPresent(componentAttributes::add);
+
             componentAttributes.addAll(bomComponent.getAdditionalAttributes());
+
+            //TODO: what is componentAttributes even used for?
 
             try {
                 componentItems.add(componentItemBuilder.build());

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/AbstractRuleViolationNotificationMessageExtractor.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/AbstractRuleViolationNotificationMessageExtractor.java
@@ -16,6 +16,7 @@ import com.synopsys.integration.alert.common.enumeration.ItemOperation;
 import com.synopsys.integration.alert.descriptor.api.BlackDuckProviderKey;
 import com.synopsys.integration.alert.processor.api.extract.model.project.BomComponentDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcern;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.provider.blackduck.processor.NotificationExtractorBlackDuckServicesFactoryCache;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreator;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreatorFactory;
@@ -72,7 +73,7 @@ public abstract class AbstractRuleViolationNotificationMessageExtractor<T extend
         ComponentConcern policyConcern = policyComponentConcernCreator.fromPolicyInfo(notificationContent.getPolicyInfo(), itemOperation);
         try {
             ProjectVersionComponentVersionView bomComponent = blackDuckApiClient.getResponse(new HttpUrl(componentVersionStatus.getBomComponent()), ProjectVersionComponentVersionView.class);
-            return bomComponentDetailsCreator.createBomComponentDetails(bomComponent, policyConcern, List.of());
+            return bomComponentDetailsCreator.createBomComponentDetails(bomComponent, policyConcern, ComponentUpgradeGuidance.none(), List.of());
         } catch (IntegrationRestException e) {
             bomComponent404Handler.logIf404OrThrow(e, componentVersionStatus.getComponentName(), componentVersionStatus.getComponentVersionName());
             return bomComponentDetailsCreator.createMissingBomComponentDetails(
@@ -81,6 +82,7 @@ public abstract class AbstractRuleViolationNotificationMessageExtractor<T extend
                 componentVersionStatus.getComponentVersionName(),
                 createComponentVersionUrl(componentVersionStatus),
                 List.of(policyConcern),
+                ComponentUpgradeGuidance.none(),
                 List.of()
             );
         }

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/BomEditNotificationMessageExtractor.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/BomEditNotificationMessageExtractor.java
@@ -16,6 +16,7 @@ import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.descriptor.api.BlackDuckProviderKey;
 import com.synopsys.integration.alert.processor.api.extract.model.ProviderDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.BomComponentDetails;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ProjectMessage;
 import com.synopsys.integration.alert.provider.blackduck.processor.NotificationExtractorBlackDuckServicesFactoryCache;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreator;
@@ -60,7 +61,7 @@ public class BomEditNotificationMessageExtractor extends AbstractBlackDuckCompon
         BomComponentDetails bomComponentDetails;
         try {
             ProjectVersionComponentVersionView bomComponent = blackDuckApiClient.getResponse(new HttpUrl(notificationContent.getBomComponent()), ProjectVersionComponentVersionView.class);
-            bomComponentDetails = bomComponentDetailsCreator.createBomComponentDetails(bomComponent, List.of(), List.of());
+            bomComponentDetails = bomComponentDetailsCreator.createBomComponentDetails(bomComponent, List.of(), ComponentUpgradeGuidance.none(), List.of());
         } catch (IntegrationRestException e) {
             bomComponent404Handler.logIf404OrThrow(e, notificationContent.getComponentName(), notificationContent.getComponentVersionName());
             bomComponentDetails = bomComponentDetailsCreator.createMissingBomComponentDetails(
@@ -69,6 +70,7 @@ public class BomEditNotificationMessageExtractor extends AbstractBlackDuckCompon
                 notificationContent.getComponentVersionName(),
                 notificationContent.getBomComponent(),
                 List.of(),
+                ComponentUpgradeGuidance.none(),
                 List.of()
             );
         }

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/PolicyOverrideNotificationMessageExtractor.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/PolicyOverrideNotificationMessageExtractor.java
@@ -17,6 +17,7 @@ import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.descriptor.api.BlackDuckProviderKey;
 import com.synopsys.integration.alert.processor.api.extract.model.project.BomComponentDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcern;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.provider.blackduck.processor.NotificationExtractorBlackDuckServicesFactoryCache;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreator;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreatorFactory;
@@ -64,7 +65,7 @@ public class PolicyOverrideNotificationMessageExtractor extends AbstractBlackDuc
         BomComponentDetails bomComponentDetails;
         try {
             ProjectVersionComponentVersionView bomComponent = blackDuckApiClient.getResponse(new HttpUrl(notificationContent.getBomComponent()), ProjectVersionComponentVersionView.class);
-            bomComponentDetails = bomComponentDetailsCreator.createBomComponentDetails(bomComponent, policyConcern, List.of(overrider));
+            bomComponentDetails = bomComponentDetailsCreator.createBomComponentDetails(bomComponent, policyConcern, ComponentUpgradeGuidance.none(), List.of(overrider));
         } catch (IntegrationRestException e) {
             bomComponent404Handler.logIf404OrThrow(e, notificationContent.getComponentName(), notificationContent.getComponentVersionName());
             bomComponentDetails = bomComponentDetailsCreator.createMissingBomComponentDetails(
@@ -73,6 +74,7 @@ public class PolicyOverrideNotificationMessageExtractor extends AbstractBlackDuc
                 notificationContent.getComponentVersionName(),
                 notificationContent.getBomComponent(),
                 List.of(policyConcern),
+                ComponentUpgradeGuidance.none(),
                 List.of(overrider)
             );
         }

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/VulnerabilityNotificationMessageExtractor.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/VulnerabilityNotificationMessageExtractor.java
@@ -25,6 +25,7 @@ import com.synopsys.integration.alert.descriptor.api.BlackDuckProviderKey;
 import com.synopsys.integration.alert.processor.api.extract.model.project.BomComponentDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcern;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcernSeverity;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.provider.blackduck.processor.NotificationExtractorBlackDuckServicesFactoryCache;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreator;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreatorFactory;
@@ -83,17 +84,24 @@ public class VulnerabilityNotificationMessageExtractor extends AbstractBlackDuck
         BomComponentDetails bomComponentDetails;
         try {
             ProjectVersionComponentVersionView bomComponent = blackDuckApiClient.getResponse(new HttpUrl(affectedProjectVersion.getBomComponent()), ProjectVersionComponentVersionView.class);
-            additionalAttributes = createAdditionalAttributes(blackDuckApiClient, bomComponent);
-            bomComponentDetails = bomComponentDetailsCreator.createBomComponentDetails(bomComponent, componentConcerns, additionalAttributes);
+            //additionalAttributes = createAdditionalAttributes(blackDuckApiClient, bomComponent);
+            //TODO: If additionalAttributes aren't used anywhere remove it from this class and return List.of() in its place.
+            additionalAttributes = List.of();
+            ComponentUpgradeGuidance componentUpgradeGuidance = createComponentUpgradeGuidance(blackDuckApiClient, bomComponent);
+            bomComponentDetails = bomComponentDetailsCreator.createBomComponentDetails(bomComponent, componentConcerns, componentUpgradeGuidance, additionalAttributes);
         } catch (IntegrationRestException e) {
             bomComponent404Handler.logIf404OrThrow(e, notificationContent.getComponentName(), notificationContent.getVersionName());
-            additionalAttributes = createAdditionalAttributes(blackDuckApiClient, notificationContent);
+            //additionalAttributes = createAdditionalAttributes(blackDuckApiClient, notificationContent);
+            additionalAttributes = List.of();
+            //TODO: If additionalAttributes aren't used anywhere remove it from this class and return List.of() in its place.
+            ComponentUpgradeGuidance componentUpgradeGuidance = createComponentUpgradeGuidance(blackDuckApiClient, notificationContent);
             bomComponentDetails = bomComponentDetailsCreator.createMissingBomComponentDetails(
                 notificationContent.getComponentName(),
                 null,
                 notificationContent.getVersionName(),
                 notificationContent.getComponentVersion(),
                 componentConcerns,
+                componentUpgradeGuidance,
                 additionalAttributes
             );
         }
@@ -132,7 +140,7 @@ public class VulnerabilityNotificationMessageExtractor extends AbstractBlackDuck
         }
         return ComponentConcern.vulnerability(itemOperation, vulnerability.getVulnerabilityId(), componentConcernSeverity, vulnerability.getVulnerability());
     }
-
+    /*
     private List<LinkableItem> createAdditionalAttributes(BlackDuckApiClient blackDuckApiClient, ProjectVersionComponentVersionView bomComponent) {
         BlackDuckMessageComponentVersionUpgradeGuidanceService upgradeGuidanceService = new BlackDuckMessageComponentVersionUpgradeGuidanceService(blackDuckApiClient);
         return safelyRetrieveItems(() -> upgradeGuidanceService.requestUpgradeGuidanceItems(bomComponent), UPGRADE_GUIDANCE_RESPONSE_DESCRIPTION);
@@ -145,6 +153,22 @@ public class VulnerabilityNotificationMessageExtractor extends AbstractBlackDuck
             return safelyRetrieveItems(() -> upgradeGuidanceService.requestUpgradeGuidanceItems(componentVersionView.get()), UPGRADE_GUIDANCE_RESPONSE_DESCRIPTION);
         }
         return List.of();
+    } */
+
+    //TODO: Take the List<LinkableItem> from the methods above and convert them into a ComponentUpgradeGuidance
+    private ComponentUpgradeGuidance createComponentUpgradeGuidance(BlackDuckApiClient blackDuckApiClient, ProjectVersionComponentVersionView bomComponent) {
+        BlackDuckMessageComponentVersionUpgradeGuidanceService upgradeGuidanceService = new BlackDuckMessageComponentVersionUpgradeGuidanceService(blackDuckApiClient);
+        return safelyRetrieveItems(() -> upgradeGuidanceService.requestUpgradeGuidanceItems(bomComponent), UPGRADE_GUIDANCE_RESPONSE_DESCRIPTION);
+    }
+
+    //TODO: Take the List<LinkableItem> from the methods above and convert them into a ComponentUpgradeGuidance
+    private ComponentUpgradeGuidance createComponentUpgradeGuidance(BlackDuckApiClient blackDuckApiClient, VulnerabilityUniqueProjectNotificationContent notificationContent) {
+        Optional<ComponentVersionView> componentVersionView = retrieveComponentVersionView(blackDuckApiClient, notificationContent.getComponentVersion());
+        if (componentVersionView.isPresent()) {
+            BlackDuckMessageComponentVersionUpgradeGuidanceService upgradeGuidanceService = new BlackDuckMessageComponentVersionUpgradeGuidanceService(blackDuckApiClient);
+            return safelyRetrieveItems(() -> upgradeGuidanceService.requestUpgradeGuidanceItems(componentVersionView.get()), UPGRADE_GUIDANCE_RESPONSE_DESCRIPTION);
+        }
+        return ComponentUpgradeGuidance.none();
     }
 
     private Optional<ComponentVersionView> retrieveComponentVersionView(BlackDuckApiClient blackDuckApiClient, String componentVersionUrl) {
@@ -157,12 +181,23 @@ public class VulnerabilityNotificationMessageExtractor extends AbstractBlackDuck
         }
     }
 
+    /*
     private List<LinkableItem> safelyRetrieveItems(ThrowingSupplier<List<LinkableItem>, IntegrationException> request, String responseDescription) {
         try {
             return request.get();
         } catch (IntegrationException e) {
             logger.debug("Could not retrieve {}", responseDescription, e);
             return List.of();
+        }
+    }*/
+
+    //TODO:
+    private ComponentUpgradeGuidance safelyRetrieveItems(ThrowingSupplier<ComponentUpgradeGuidance, IntegrationException> request, String responseDescription) {
+        try {
+            return request.get();
+        } catch (IntegrationException e) {
+            logger.debug("Could not retrieve {}", responseDescription, e);
+            return ComponentUpgradeGuidance.none();
         }
     }
 

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/VulnerabilityNotificationMessageExtractor.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/VulnerabilityNotificationMessageExtractor.java
@@ -20,7 +20,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.common.enumeration.ItemOperation;
-import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.descriptor.api.BlackDuckProviderKey;
 import com.synopsys.integration.alert.processor.api.extract.model.project.BomComponentDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcern;
@@ -79,21 +78,14 @@ public class VulnerabilityNotificationMessageExtractor extends AbstractBlackDuck
 
         AffectedProjectVersion affectedProjectVersion = notificationContent.getAffectedProjectVersion();
         List<ComponentConcern> componentConcerns = createComponentConcerns(notificationContent);
-        List<LinkableItem> additionalAttributes;
 
         BomComponentDetails bomComponentDetails;
         try {
             ProjectVersionComponentVersionView bomComponent = blackDuckApiClient.getResponse(new HttpUrl(affectedProjectVersion.getBomComponent()), ProjectVersionComponentVersionView.class);
-            //additionalAttributes = createAdditionalAttributes(blackDuckApiClient, bomComponent);
-            //TODO: If additionalAttributes aren't used anywhere remove it from this class and return List.of() in its place.
-            additionalAttributes = List.of();
             ComponentUpgradeGuidance componentUpgradeGuidance = createComponentUpgradeGuidance(blackDuckApiClient, bomComponent);
-            bomComponentDetails = bomComponentDetailsCreator.createBomComponentDetails(bomComponent, componentConcerns, componentUpgradeGuidance, additionalAttributes);
+            bomComponentDetails = bomComponentDetailsCreator.createBomComponentDetails(bomComponent, componentConcerns, componentUpgradeGuidance, List.of());
         } catch (IntegrationRestException e) {
             bomComponent404Handler.logIf404OrThrow(e, notificationContent.getComponentName(), notificationContent.getVersionName());
-            //additionalAttributes = createAdditionalAttributes(blackDuckApiClient, notificationContent);
-            additionalAttributes = List.of();
-            //TODO: If additionalAttributes aren't used anywhere remove it from this class and return List.of() in its place.
             ComponentUpgradeGuidance componentUpgradeGuidance = createComponentUpgradeGuidance(blackDuckApiClient, notificationContent);
             bomComponentDetails = bomComponentDetailsCreator.createMissingBomComponentDetails(
                 notificationContent.getComponentName(),
@@ -102,7 +94,7 @@ public class VulnerabilityNotificationMessageExtractor extends AbstractBlackDuck
                 notificationContent.getComponentVersion(),
                 componentConcerns,
                 componentUpgradeGuidance,
-                additionalAttributes
+                List.of()
             );
         }
         return List.of(bomComponentDetails);
@@ -140,28 +132,12 @@ public class VulnerabilityNotificationMessageExtractor extends AbstractBlackDuck
         }
         return ComponentConcern.vulnerability(itemOperation, vulnerability.getVulnerabilityId(), componentConcernSeverity, vulnerability.getVulnerability());
     }
-    /*
-    private List<LinkableItem> createAdditionalAttributes(BlackDuckApiClient blackDuckApiClient, ProjectVersionComponentVersionView bomComponent) {
-        BlackDuckMessageComponentVersionUpgradeGuidanceService upgradeGuidanceService = new BlackDuckMessageComponentVersionUpgradeGuidanceService(blackDuckApiClient);
-        return safelyRetrieveItems(() -> upgradeGuidanceService.requestUpgradeGuidanceItems(bomComponent), UPGRADE_GUIDANCE_RESPONSE_DESCRIPTION);
-    }
 
-    private List<LinkableItem> createAdditionalAttributes(BlackDuckApiClient blackDuckApiClient, VulnerabilityUniqueProjectNotificationContent notificationContent) {
-        Optional<ComponentVersionView> componentVersionView = retrieveComponentVersionView(blackDuckApiClient, notificationContent.getComponentVersion());
-        if (componentVersionView.isPresent()) {
-            BlackDuckMessageComponentVersionUpgradeGuidanceService upgradeGuidanceService = new BlackDuckMessageComponentVersionUpgradeGuidanceService(blackDuckApiClient);
-            return safelyRetrieveItems(() -> upgradeGuidanceService.requestUpgradeGuidanceItems(componentVersionView.get()), UPGRADE_GUIDANCE_RESPONSE_DESCRIPTION);
-        }
-        return List.of();
-    } */
-
-    //TODO: Take the List<LinkableItem> from the methods above and convert them into a ComponentUpgradeGuidance
     private ComponentUpgradeGuidance createComponentUpgradeGuidance(BlackDuckApiClient blackDuckApiClient, ProjectVersionComponentVersionView bomComponent) {
         BlackDuckMessageComponentVersionUpgradeGuidanceService upgradeGuidanceService = new BlackDuckMessageComponentVersionUpgradeGuidanceService(blackDuckApiClient);
         return safelyRetrieveItems(() -> upgradeGuidanceService.requestUpgradeGuidanceItems(bomComponent), UPGRADE_GUIDANCE_RESPONSE_DESCRIPTION);
     }
 
-    //TODO: Take the List<LinkableItem> from the methods above and convert them into a ComponentUpgradeGuidance
     private ComponentUpgradeGuidance createComponentUpgradeGuidance(BlackDuckApiClient blackDuckApiClient, VulnerabilityUniqueProjectNotificationContent notificationContent) {
         Optional<ComponentVersionView> componentVersionView = retrieveComponentVersionView(blackDuckApiClient, notificationContent.getComponentVersion());
         if (componentVersionView.isPresent()) {
@@ -181,17 +157,6 @@ public class VulnerabilityNotificationMessageExtractor extends AbstractBlackDuck
         }
     }
 
-    /*
-    private List<LinkableItem> safelyRetrieveItems(ThrowingSupplier<List<LinkableItem>, IntegrationException> request, String responseDescription) {
-        try {
-            return request.get();
-        } catch (IntegrationException e) {
-            logger.debug("Could not retrieve {}", responseDescription, e);
-            return List.of();
-        }
-    }*/
-
-    //TODO:
     private ComponentUpgradeGuidance safelyRetrieveItems(ThrowingSupplier<ComponentUpgradeGuidance, IntegrationException> request, String responseDescription) {
         try {
             return request.get();

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/BlackDuckMessageBomComponentDetailsCreator.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/BlackDuckMessageBomComponentDetailsCreator.java
@@ -18,6 +18,7 @@ import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.processor.api.extract.model.project.BomComponentDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcern;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentPolicy;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentVulnerabilities;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.BlackDuckMessageLabels;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.policy.BlackDuckComponentPolicyDetailsCreator;
@@ -54,11 +55,13 @@ public class BlackDuckMessageBomComponentDetailsCreator {
         this.policyDetailsCreator = policyDetailsCreator;
     }
 
-    public BomComponentDetails createBomComponentDetails(ProjectVersionComponentVersionView bomComponent, ComponentConcern componentConcern, List<LinkableItem> additionalAttributes) throws IntegrationException {
-        return createBomComponentDetails(bomComponent, List.of(componentConcern), additionalAttributes);
+    public BomComponentDetails createBomComponentDetails(ProjectVersionComponentVersionView bomComponent, ComponentConcern componentConcern, ComponentUpgradeGuidance componentUpgradeGuidance, List<LinkableItem> additionalAttributes)
+        throws IntegrationException {
+        return createBomComponentDetails(bomComponent, List.of(componentConcern), componentUpgradeGuidance, additionalAttributes);
     }
 
-    public BomComponentDetails createBomComponentDetails(ProjectVersionComponentVersionView bomComponent, List<ComponentConcern> componentConcerns, List<LinkableItem> additionalAttributes) throws IntegrationException {
+    public BomComponentDetails createBomComponentDetails(ProjectVersionComponentVersionView bomComponent, List<ComponentConcern> componentConcerns, ComponentUpgradeGuidance componentUpgradeGuidance, List<LinkableItem> additionalAttributes)
+        throws IntegrationException {
         LinkableItem component;
         LinkableItem componentVersion = null;
 
@@ -87,6 +90,7 @@ public class BlackDuckMessageBomComponentDetailsCreator {
             componentConcerns,
             licenseInfo,
             usageInfo,
+            componentUpgradeGuidance,
             additionalAttributes,
             issuesUrl
         );
@@ -98,6 +102,7 @@ public class BlackDuckMessageBomComponentDetailsCreator {
         @Nullable String componentVersionName,
         @Nullable String componentVersionUrl,
         List<ComponentConcern> componentConcerns,
+        ComponentUpgradeGuidance componentUpgradeGuidance,
         List<LinkableItem> additionalAttributes
     ) {
         LinkableItem component;
@@ -121,6 +126,7 @@ public class BlackDuckMessageBomComponentDetailsCreator {
             componentConcerns,
             licenseInfo,
             usageInfo,
+            componentUpgradeGuidance,
             additionalAttributes,
             null
         );

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/BlackDuckMessageComponentVersionUpgradeGuidanceService.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/BlackDuckMessageComponentVersionUpgradeGuidanceService.java
@@ -35,24 +35,6 @@ public class BlackDuckMessageComponentVersionUpgradeGuidanceService {
         this.blackDuckApiClient = blackDuckApiClient;
     }
 
-    /*
-    public List<LinkableItem> requestUpgradeGuidanceItems(ProjectVersionComponentVersionView bomComponent) throws IntegrationException {
-        // TODO determine what to do with multiple origins
-        Optional<UrlSingleResponse<ComponentVersionUpgradeGuidanceView>> upgradeGuidanceUrl = bomComponent.getOrigins()
-                                                                                                  .stream()
-                                                                                                  .findFirst()
-                                                                                                  .flatMap(origin -> Optional.ofNullable(origin.getMeta()))
-                                                                                                  .flatMap(this::extractFirstUpgradeGuidanceLinkSafely)
-                                                                                                  .map(url -> new UrlSingleResponse<>(url, ComponentVersionUpgradeGuidanceView.class))
-                                                                                                  .or(() -> extractComponentVersionUpgradeGuidanceUrl(bomComponent));
-        if (upgradeGuidanceUrl.isPresent()) {
-            ComponentVersionUpgradeGuidanceView upgradeGuidanceView = blackDuckApiClient.getResponse(upgradeGuidanceUrl.get());
-            return createUpgradeGuidanceItems(upgradeGuidanceView);
-        }
-        return List.of();
-    }*/
-
-    //TODO: Modify the above to use a ComponentUpgradeGuidance
     public ComponentUpgradeGuidance requestUpgradeGuidanceItems(ProjectVersionComponentVersionView bomComponent) throws IntegrationException {
         // TODO determine what to do with multiple origins
         Optional<UrlSingleResponse<ComponentVersionUpgradeGuidanceView>> upgradeGuidanceUrl = bomComponent.getOrigins()
@@ -68,17 +50,7 @@ public class BlackDuckMessageComponentVersionUpgradeGuidanceService {
         }
         return ComponentUpgradeGuidance.none();
     }
-    /*
-    public List<LinkableItem> requestUpgradeGuidanceItems(ComponentVersionView componentVersionView) throws IntegrationException {
-        Optional<UrlSingleResponse<ComponentVersionUpgradeGuidanceView>> upgradeGuidanceUrl = componentVersionView.metaUpgradeGuidanceLinkSafely();
-        if (upgradeGuidanceUrl.isPresent()) {
-            ComponentVersionUpgradeGuidanceView upgradeGuidanceView = blackDuckApiClient.getResponse(upgradeGuidanceUrl.get());
-            return createUpgradeGuidanceItems(upgradeGuidanceView);
-        }
-        return List.of();
-    }*/
 
-    //TODO: Modify the above to use a ComponentUpgradeGuidancce
     public ComponentUpgradeGuidance requestUpgradeGuidanceItems(ComponentVersionView componentVersionView) throws IntegrationException {
         Optional<UrlSingleResponse<ComponentVersionUpgradeGuidanceView>> upgradeGuidanceUrl = componentVersionView.metaUpgradeGuidanceLinkSafely();
         if (upgradeGuidanceUrl.isPresent()) {
@@ -100,24 +72,7 @@ public class BlackDuckMessageComponentVersionUpgradeGuidanceService {
         LinkSingleResponse<ComponentVersionUpgradeGuidanceView> upgradeGuidanceViewLinkName = new LinkSingleResponse<>(LINK_UPGRADE_GUIDANCE, ComponentVersionUpgradeGuidanceView.class);
         return bomComponent.metaSingleResponseSafely(upgradeGuidanceViewLinkName);
     }
-    /*
-    private List<LinkableItem> createUpgradeGuidanceItems(ComponentVersionUpgradeGuidanceView upgradeGuidanceView) {
-        List<LinkableItem> guidanceItems = new ArrayList<>(2);
 
-        Optional.ofNullable(upgradeGuidanceView.getShortTerm())
-            .map(CommonUpgradeGuidanceModel::fromShortTermGuidance)
-            .map(guidanceModel -> createUpgradeGuidanceItem(BlackDuckMessageLabels.LABEL_GUIDANCE_SHORT_TERM, guidanceModel))
-            .ifPresent(guidanceItems::add);
-
-        Optional.ofNullable(upgradeGuidanceView.getLongTerm())
-            .map(CommonUpgradeGuidanceModel::fromLongTermGuidance)
-            .map(guidanceModel -> createUpgradeGuidanceItem(BlackDuckMessageLabels.LABEL_GUIDANCE_LONG_TERM, guidanceModel))
-            .ifPresent(guidanceItems::add);
-
-        return guidanceItems;
-    }*/
-
-    //TODO: Change the above method to  return the object rather than a list
     private ComponentUpgradeGuidance createUpgradeGuidanceItems(ComponentVersionUpgradeGuidanceView upgradeGuidanceView) {
         LinkableItem shortTermGuidance = Optional.ofNullable(upgradeGuidanceView.getShortTerm())
                                              .map(CommonUpgradeGuidanceModel::fromShortTermGuidance)

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/BlackDuckMessageComponentVersionUpgradeGuidanceServiceTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/BlackDuckMessageComponentVersionUpgradeGuidanceServiceTest.java
@@ -1,15 +1,15 @@
 package com.synopsys.integration.alert.provider.blackduck.processor.message.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import com.synopsys.integration.alert.common.message.model.LinkableItem;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.blackduck.api.core.response.LinkSingleResponse;
 import com.synopsys.integration.blackduck.api.core.response.UrlSingleResponse;
 import com.synopsys.integration.blackduck.api.generated.component.ComponentVersionUpgradeGuidanceLongTermView;
@@ -35,8 +35,9 @@ public class BlackDuckMessageComponentVersionUpgradeGuidanceServiceTest {
         ProjectVersionComponentVersionView bomComponent = createBomComponent(upgradeGuidanceLink, expectedUrl);
 
         BlackDuckMessageComponentVersionUpgradeGuidanceService upgradeGuidanceService = new BlackDuckMessageComponentVersionUpgradeGuidanceService(blackDuckApiClient);
-        List<LinkableItem> upgradeGuidanceItems = upgradeGuidanceService.requestUpgradeGuidanceItems(bomComponent);
-        assertEquals(2, upgradeGuidanceItems.size());
+        ComponentUpgradeGuidance componentUpgradeGuidance = upgradeGuidanceService.requestUpgradeGuidanceItems(bomComponent);
+        assertTrue(componentUpgradeGuidance.getLongTermUpgradeGuidance().isPresent());
+        assertTrue(componentUpgradeGuidance.getShortTermUpgradeGuidance().isPresent());
     }
 
     @Test
@@ -49,8 +50,9 @@ public class BlackDuckMessageComponentVersionUpgradeGuidanceServiceTest {
         ComponentVersionView componentVersion = createComponentVersion(expectedUrl);
 
         BlackDuckMessageComponentVersionUpgradeGuidanceService upgradeGuidanceService = new BlackDuckMessageComponentVersionUpgradeGuidanceService(blackDuckApiClient);
-        List<LinkableItem> upgradeGuidanceItems = upgradeGuidanceService.requestUpgradeGuidanceItems(componentVersion);
-        assertEquals(1, upgradeGuidanceItems.size());
+        ComponentUpgradeGuidance componentUpgradeGuidance = upgradeGuidanceService.requestUpgradeGuidanceItems(componentVersion);
+        assertTrue(componentUpgradeGuidance.getLongTermUpgradeGuidance().isPresent());
+        assertFalse(componentUpgradeGuidance.getShortTermUpgradeGuidance().isPresent());
     }
 
     private ProjectVersionComponentVersionView createBomComponent(LinkSingleResponse<ComponentVersionUpgradeGuidanceView> upgradeGuidanceLink, UrlSingleResponse<ComponentVersionUpgradeGuidanceView> expectedUrl) {

--- a/ui/src/main/js/common/input/FieldMappingField.js
+++ b/ui/src/main/js/common/input/FieldMappingField.js
@@ -57,7 +57,7 @@ const FieldMappingField = ({
 
     const createNewRow = () => {
         const { fieldName, fieldValue } = fieldMappingRow;
-        const valueOptions = ['{{providerName}}', '{{projectName}}', '{{projectVersion}}', '{{componentName}}', '{{componentVersion}}', '{{componentUsage}}', '{{componentLicense}}', '{{severity}}', '{{policyCategory}}'];
+        const valueOptions = ['{{providerName}}', '{{projectName}}', '{{projectVersion}}', '{{componentName}}', '{{componentVersion}}', '{{componentUsage}}', '{{componentLicense}}', '{{severity}}', '{{policyCategory}}', '{{shortTermUpgradeGuidance}}', '{{longTermUpgradeGuidance}}'];
 
         return (
             <div>

--- a/ui/src/main/js/page/channel/jira/cloud/JiraCloudDistributionConfiguration.js
+++ b/ui/src/main/js/page/channel/jira/cloud/JiraCloudDistributionConfiguration.js
@@ -88,7 +88,7 @@ const JiraCloudDistributionConfiguration = ({
             <TextInput
                 id={JIRA_CLOUD_DISTRIBUTION_FIELD_KEYS.issueSummary}
                 label="Issue Summary"
-                description="The summary to use for each issue created. Can use the following variables to populate data from the message content {{providerName}}, {{projectName}}, {{projectVersion}}, {{componentName}}, {{componentVersion}}, {{componentUsage}}, {{componentLicense}}, {{severity}}, {{policyCategory}}"
+                description="The summary to use for each issue created. Can use the following variables to populate data from the message content {{providerName}}, {{projectName}}, {{projectVersion}}, {{componentName}}, {{componentVersion}}, {{componentUsage}}, {{componentLicense}}, {{severity}}, {{policyCategory}}, {{shortTermUpgradeGuidance}}, {{longTermUpgradeGuidance}}"
                 name={JIRA_CLOUD_DISTRIBUTION_FIELD_KEYS.issueSummary}
                 readOnly={readonly}
                 onChange={FieldModelUtilities.handleChange(data, setData)}

--- a/ui/src/main/js/page/channel/jira/server/JiraServerDistributionConfiguration.js
+++ b/ui/src/main/js/page/channel/jira/server/JiraServerDistributionConfiguration.js
@@ -88,7 +88,7 @@ const JiraServerDistributionConfiguration = ({
             <TextInput
                 id={JIRA_SERVER_DISTRIBUTION_FIELD_KEYS.issueSummary}
                 label="Issue Summary"
-                description="The summary to use for each issue created. Can use the following variables to populate data from the message content {{providerName}}, {{projectName}}, {{projectVersion}}, {{componentName}}, {{componentVersion}}, {{componentUsage}}, {{componentLicense}}, {{severity}}, {{policyCategory}}"
+                description="The summary to use for each issue created. Can use the following variables to populate data from the message content {{providerName}}, {{projectName}}, {{projectVersion}}, {{componentName}}, {{componentVersion}}, {{componentUsage}}, {{componentLicense}}, {{severity}}, {{policyCategory}}, {{shortTermUpgradeGuidance}}, {{longTermUpgradeGuidance}}"
                 name={JIRA_SERVER_DISTRIBUTION_FIELD_KEYS.issueSummary}
                 readOnly={readonly}
                 onChange={FieldModelUtilities.handleChange(data, setData)}


### PR DESCRIPTION
Removed upgrade guidance from additional attributes and created a new object ComponentUpgradeGuidance to hold the values. This ticket was to track refactoring the places it was previously used and updating the tests.

Lastly, we implemented the changes in the  MessageValueReplacementResolver, MessageReplacementValues and its builder, and in JiraIssueCreator.

UI updates to refer to the docs will be made in a separate PR.