### PR TITLE
provider blackduck test improvements

### DIFF
--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/BomEditNotificationDetailExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/BomEditNotificationDetailExtractorTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.common.rest.model.AlertNotificationModel;
 import com.synopsys.integration.alert.processor.api.detail.DetailedNotificationContent;
 import com.synopsys.integration.alert.provider.blackduck.processor.NotificationExtractorBlackDuckServicesFactoryCache;
@@ -55,6 +56,25 @@ public class BomEditNotificationDetailExtractorTest {
         assertEquals(0, detailedNotificationContent.getVulnerabilitySeverities().size());
     }
 
+    @Test
+    public void extractDetailedContentErrorTest() throws IOException, IntegrationException {
+        Long blackDuckConfigId = 0L;
+
+        String notificationString = TestResourceUtils.readFileToString(BOM_EDIT_JSON_PATH);
+        BomEditNotificationView notificationView = gson.fromJson(notificationString, BomEditNotificationView.class);
+
+        NotificationExtractorBlackDuckServicesFactoryCache cache = Mockito.mock(NotificationExtractorBlackDuckServicesFactoryCache.class);
+        Mockito.doThrow(new AlertConfigurationException("Expected Exception thrown creating BlackDuckServicesFactory")).when(cache).retrieveBlackDuckServicesFactory(Mockito.anyLong());
+
+        BomEditNotificationDetailExtractor extractor = new BomEditNotificationDetailExtractor(cache);
+
+        AlertNotificationModel notification = new AlertNotificationModel(0L, blackDuckConfigId, "BlackDuck", "Config 1", null, null, null, null, false);
+
+        List<DetailedNotificationContent> detailedNotificationContents = extractor.extractDetailedContent(notification, notificationView);
+
+        assertEquals(0, detailedNotificationContents.size());
+    }
+
     private NotificationExtractorBlackDuckServicesFactoryCache createCache(Long blackDuckConfigId, String projectName, String projectVersionName) throws IntegrationException {
         ProjectView projectView = Mockito.mock(ProjectView.class);
         Mockito.when(projectView.getName()).thenReturn(projectName);
@@ -74,5 +94,4 @@ public class BomEditNotificationDetailExtractorTest {
 
         return cache;
     }
-
 }

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/VulnerabilityNotificationDetailExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/VulnerabilityNotificationDetailExtractorTest.java
@@ -27,6 +27,7 @@ import com.synopsys.integration.blackduck.api.manual.view.VulnerabilityNotificat
 public class VulnerabilityNotificationDetailExtractorTest {
     public static final String VULNERABILITY_COMPLEX_JSON_PATH = "json/vulnerabilityNotificationComplex.json";
     public static final String VULNERABILITY_SIMPLE_JSON_PATH = "json/vulnerabilityNotificationSimple01.json";
+    public static final String VULNERABILITY_SIMPLE_ALL_SEVERITY_JSON_PATH = "json/vulnerabilityNotificationSimple02.json";
 
     private final Gson gson = new Gson();
 
@@ -81,6 +82,21 @@ public class VulnerabilityNotificationDetailExtractorTest {
 
         assertEquals(VulnerabilitySeverityType.MEDIUM.name(), deletedVuln.getSeverity());
         assertEquals("CVE-2018-0003", deletedVuln.getVulnerabilityId());
+    }
+
+    @Test
+    public void allSeverityTypesApplyTest() throws IOException {
+        VulnerabilityNotificationView vulnerabilityNotificationView = getVulnerabilityNotificationView(VULNERABILITY_SIMPLE_ALL_SEVERITY_JSON_PATH);
+
+        VulnerabilityNotificationDetailExtractor vulnerabilityNotificationDetailExtractor = new VulnerabilityNotificationDetailExtractor();
+
+        AlertNotificationModel alertNotificationModel = createAlertNotificationModel();
+
+        List<DetailedNotificationContent> filterableNotificationWrappers = vulnerabilityNotificationDetailExtractor.extractDetailedContent(alertNotificationModel, vulnerabilityNotificationView);
+
+        assertEquals(1, filterableNotificationWrappers.size());
+        DetailedNotificationContent detailedNotificationContent = filterableNotificationWrappers.get(0);
+        assertEquals(4, detailedNotificationContent.getVulnerabilitySeverities().size());
     }
 
     private VulnerabilityNotificationView getVulnerabilityNotificationView(String path) throws IOException {

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/BomEditNotificationMessageExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/BomEditNotificationMessageExtractorTest.java
@@ -1,10 +1,12 @@
 package com.synopsys.integration.alert.provider.blackduck.processor.message;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
@@ -18,10 +20,17 @@ import com.synopsys.integration.alert.processor.api.extract.model.project.Compon
 import com.synopsys.integration.alert.processor.api.extract.model.project.MessageReason;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ProjectMessage;
 import com.synopsys.integration.alert.provider.blackduck.processor.NotificationExtractorBlackDuckServicesFactoryCache;
-import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreator;
+import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckComponentVulnerabilityDetailsCreator;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreatorFactory;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BomComponent404Handler;
+import com.synopsys.integration.alert.provider.blackduck.processor.message.service.policy.BlackDuckComponentPolicyDetailsCreatorFactory;
+import com.synopsys.integration.alert.provider.blackduck.processor.message.service.policy.BlackDuckPolicySeverityConverter;
 import com.synopsys.integration.alert.provider.blackduck.processor.model.BomEditWithProjectNameNotificationContent;
+import com.synopsys.integration.blackduck.api.core.ResourceLink;
+import com.synopsys.integration.blackduck.api.core.ResourceMetadata;
+import com.synopsys.integration.blackduck.api.generated.component.ProjectVersionComponentVersionLicensesView;
+import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionComponentPolicyStatusType;
+import com.synopsys.integration.blackduck.api.generated.enumeration.UsageType;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionComponentVersionView;
 import com.synopsys.integration.blackduck.api.manual.component.BomEditNotificationContent;
 import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
@@ -38,23 +47,34 @@ public class BomEditNotificationMessageExtractorTest {
 
     private static final LinkableItem COMPONENT = new LinkableItem("Component", "A BOM component");
     private static final LinkableItem COMPONENT_VERSION = new LinkableItem("Component Version", "0.8.7");
+    private static final String COMPONENT_VERSION_URL = "http://componentVersionUrl";
     private static final ComponentVulnerabilities COMPONENT_VULNERABILITIES = ComponentVulnerabilities.none();
     private static final LinkableItem LICENSE = new LinkableItem("License", "A software license", "https://license-url");
+    private static final String LICENSE_DISPLAY = "licenseDisplay";
     private static final String USAGE = "Some generic usage";
     private static final String ISSUES_URL = "https://issues-url";
 
-    private final BomComponentDetails bomComponentDetails = createBomComponentDetails();
-
     private final BlackDuckProviderKey providerKey = new BlackDuckProviderKey();
     private final NotificationExtractorBlackDuckServicesFactoryCache servicesFactoryCache = Mockito.mock(NotificationExtractorBlackDuckServicesFactoryCache.class);
-    private final BlackDuckMessageBomComponentDetailsCreatorFactory detailsCreatorFactory = Mockito.mock(BlackDuckMessageBomComponentDetailsCreatorFactory.class);
     private final BomComponent404Handler bomComponent404Handler = new BomComponent404Handler();
+
+    private final BomEditWithProjectNameNotificationContent notificationContent = createBomEditWithProjectNameNotificationContent();
+    private BomEditNotificationMessageExtractor extractor;
+
+    @BeforeEach
+    public void init() {
+        BlackDuckPolicySeverityConverter blackDuckPolicySeverityConverter = new BlackDuckPolicySeverityConverter();
+        BlackDuckComponentVulnerabilityDetailsCreator vulnerabilityDetailsCreator = new BlackDuckComponentVulnerabilityDetailsCreator();
+        BlackDuckComponentPolicyDetailsCreatorFactory blackDuckComponentPolicyDetailsCreatorFactory = new BlackDuckComponentPolicyDetailsCreatorFactory(blackDuckPolicySeverityConverter);
+        BlackDuckMessageBomComponentDetailsCreatorFactory detailsCreatorFactory = new BlackDuckMessageBomComponentDetailsCreatorFactory(vulnerabilityDetailsCreator, blackDuckComponentPolicyDetailsCreatorFactory);
+
+        extractor = new BomEditNotificationMessageExtractor(providerKey, servicesFactoryCache, detailsCreatorFactory, bomComponent404Handler);
+    }
 
     @Test
     public void createProjectMessageTest() {
-        BomEditNotificationMessageExtractor bomEditNotificationMessageExtractor = new BomEditNotificationMessageExtractor(providerKey, servicesFactoryCache, detailsCreatorFactory, bomComponent404Handler);
-
-        ProjectMessage projectMessage = bomEditNotificationMessageExtractor.createProjectMessage(PROVIDER_DETAILS, PROJECT_ITEM, PROJECT_VERSION_ITEM, List.of(bomComponentDetails));
+        BomComponentDetails bomComponentDetails = new BomComponentDetails(COMPONENT, COMPONENT_VERSION, COMPONENT_VULNERABILITIES, List.of(), List.of(), LICENSE, USAGE, ComponentUpgradeGuidance.none(), List.of(), ISSUES_URL);
+        ProjectMessage projectMessage = extractor.createProjectMessage(PROVIDER_DETAILS, PROJECT_ITEM, PROJECT_VERSION_ITEM, List.of(bomComponentDetails));
 
         assertEquals(MessageReason.COMPONENT_UPDATE, projectMessage.getMessageReason());
         assertTrue(projectMessage.getBomComponents().contains(bomComponentDetails));
@@ -62,70 +82,87 @@ public class BomEditNotificationMessageExtractorTest {
 
     @Test
     public void createBomComponentDetailsTest() throws IntegrationException {
-        BomEditNotificationMessageExtractor bomEditNotificationMessageExtractor = new BomEditNotificationMessageExtractor(providerKey, servicesFactoryCache, detailsCreatorFactory, bomComponent404Handler);
-        BomEditWithProjectNameNotificationContent notificationContent = createBomEditWithProjectNameNotificationContent();
-        BlackDuckServicesFactory blackDuckServicesFactory = createBlackDuckServicesFactoryWithMocks();
-
-        BlackDuckMessageBomComponentDetailsCreator bomComponentDetailsCreator = Mockito.mock(BlackDuckMessageBomComponentDetailsCreator.class);
-        Mockito.when(detailsCreatorFactory.createBomComponentDetailsCreator(Mockito.any())).thenReturn(bomComponentDetailsCreator);
-        Mockito.when(bomComponentDetailsCreator.createBomComponentDetails(Mockito.any(), Mockito.anyList(), Mockito.any(), Mockito.anyList())).thenReturn(bomComponentDetails);
-
-        List<BomComponentDetails> bomComponentDetailsList = bomEditNotificationMessageExtractor.createBomComponentDetails(notificationContent, blackDuckServicesFactory);
-        assertTrue(bomComponentDetailsList.contains(bomComponentDetails));
-    }
-
-    @Test
-    public void createBomComponentDetailsExceptionTest() throws IntegrationException {
-        BomEditNotificationMessageExtractor bomEditNotificationMessageExtractor = new BomEditNotificationMessageExtractor(providerKey, servicesFactoryCache, detailsCreatorFactory, bomComponent404Handler);
-        BomEditWithProjectNameNotificationContent notificationContent = createBomEditWithProjectNameNotificationContent();
-        BlackDuckServicesFactory blackDuckServicesFactory = createBlackDuckServicesFactoryWithMocks();
-
-        BlackDuckMessageBomComponentDetailsCreator bomComponentDetailsCreator = Mockito.mock(BlackDuckMessageBomComponentDetailsCreator.class);
-        Mockito.when(detailsCreatorFactory.createBomComponentDetailsCreator(Mockito.any())).thenReturn(bomComponentDetailsCreator);
-
-        Mockito.doThrow(new IntegrationRestException(HttpMethod.GET, new HttpUrl("https://google.com"), HttpStatus.NOT_FOUND.value(), "httpStatusMessageTest", "httpResponseContentTest", "IntegrationRestExceptionForAlertTest"))
-            .when(bomComponentDetailsCreator).createBomComponentDetails(Mockito.any(), Mockito.anyList(), Mockito.any(), Mockito.anyList());
-
-        Mockito.when(bomComponentDetailsCreator.createMissingBomComponentDetails(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyList(), Mockito.any(), Mockito.anyList()))
-            .thenReturn(bomComponentDetails);
-
-        List<BomComponentDetails> bomComponentDetailsList = bomEditNotificationMessageExtractor.createBomComponentDetails(notificationContent, blackDuckServicesFactory);
-        assertTrue(bomComponentDetailsList.contains(bomComponentDetails));
-    }
-
-    private BlackDuckServicesFactory createBlackDuckServicesFactoryWithMocks() throws IntegrationException {
         BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
         BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
         Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
 
-        ProjectVersionComponentVersionView projectVersionComponentVersionView = new ProjectVersionComponentVersionView();
+        ProjectVersionComponentVersionView projectVersionComponentVersionView = createProjectVersionComponentVersionView();
         Mockito.when(blackDuckApiClient.getResponse(Mockito.any(), Mockito.any())).thenReturn(projectVersionComponentVersionView);
 
-        return blackDuckServicesFactory;
+        List<BomComponentDetails> bomComponentDetailsList = extractor.createBomComponentDetails(notificationContent, blackDuckServicesFactory);
+
+        assertEquals(1, bomComponentDetailsList.size());
+        BomComponentDetails testBomComponentDetails = bomComponentDetailsList.get(0);
+        assertEquals(COMPONENT, testBomComponentDetails.getComponent());
+        assertTrue(testBomComponentDetails.getComponentVersion().isPresent());
+        assertEquals(COMPONENT_VERSION.getValue(), testBomComponentDetails.getComponentVersion().get().getValue());
+        assertEquals(LICENSE_DISPLAY, testBomComponentDetails.getLicense().getValue());
+        assertEquals(UsageType.DYNAMICALLY_LINKED.prettyPrint(), testBomComponentDetails.getUsage());
+        assertEquals(0, testBomComponentDetails.getComponentConcerns().size());
+        assertEquals(0, testBomComponentDetails.getAdditionalAttributes().size());
+
+        ComponentUpgradeGuidance componentUpgradeGuidance = testBomComponentDetails.getComponentUpgradeGuidance();
+        assertFalse(componentUpgradeGuidance.getLongTermUpgradeGuidance().isPresent());
+        assertFalse(componentUpgradeGuidance.getShortTermUpgradeGuidance().isPresent());
+    }
+
+    @Test
+    public void createBomComponentDetailsMissingBomComponentTest() throws IntegrationException {
+        BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
+        BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
+        Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
+
+        Mockito.doThrow(new IntegrationRestException(HttpMethod.GET, new HttpUrl("https://google.com"), HttpStatus.NOT_FOUND.value(), "httpStatusMessageTest", "httpResponseContentTest", "IntegrationRestExceptionForAlertTest"))
+            .when(blackDuckApiClient).getResponse(Mockito.any(), Mockito.any());
+
+        List<BomComponentDetails> bomComponentDetailsList = extractor.createBomComponentDetails(notificationContent, blackDuckServicesFactory);
+
+        assertEquals(1, bomComponentDetailsList.size());
+        BomComponentDetails testBomComponentDetails = bomComponentDetailsList.get(0);
+        assertEquals(COMPONENT, testBomComponentDetails.getComponent());
+        assertTrue(testBomComponentDetails.getComponentVersion().isPresent());
+        assertEquals(COMPONENT_VERSION.getValue(), testBomComponentDetails.getComponentVersion().get().getValue());
+        assertTrue(testBomComponentDetails.getRelevantPolicies().isEmpty());
+        assertEquals(0, testBomComponentDetails.getComponentConcerns().size());
+        assertEquals(0, testBomComponentDetails.getAdditionalAttributes().size());
+
+        ComponentUpgradeGuidance componentUpgradeGuidance = testBomComponentDetails.getComponentUpgradeGuidance();
+        assertFalse(componentUpgradeGuidance.getLongTermUpgradeGuidance().isPresent());
+        assertFalse(componentUpgradeGuidance.getShortTermUpgradeGuidance().isPresent());
     }
 
     private BomEditWithProjectNameNotificationContent createBomEditWithProjectNameNotificationContent() {
         BomEditNotificationContent bomEditNotificationContent = new BomEditNotificationContent();
-        bomEditNotificationContent.setProjectVersion(PROJECT_VERSION_ITEM.getLabel());
+        bomEditNotificationContent.setProjectVersion(PROJECT_VERSION_ITEM.getValue());
         bomEditNotificationContent.setBomComponent("http://bomComponentUrl");
-        bomEditNotificationContent.setComponentName(COMPONENT.getLabel());
-        bomEditNotificationContent.setComponentVersionName(COMPONENT_VERSION.getLabel());
+        bomEditNotificationContent.setComponentName(COMPONENT.getValue());
+        bomEditNotificationContent.setComponentVersionName(COMPONENT_VERSION.getValue());
 
         return new BomEditWithProjectNameNotificationContent(bomEditNotificationContent, PROJECT_ITEM.getLabel(), PROJECT_VERSION_ITEM.getLabel());
     }
 
-    private BomComponentDetails createBomComponentDetails() {
-        return new BomComponentDetails(
-            COMPONENT,
-            COMPONENT_VERSION,
-            COMPONENT_VULNERABILITIES,
-            List.of(),
-            List.of(),
-            LICENSE,
-            USAGE,
-            ComponentUpgradeGuidance.none(),
-            List.of(),
-            ISSUES_URL
-        );
+    private ProjectVersionComponentVersionView createProjectVersionComponentVersionView() throws IntegrationException {
+        ProjectVersionComponentVersionView projectVersionComponentVersionView = new ProjectVersionComponentVersionView();
+
+        projectVersionComponentVersionView.setComponentName(COMPONENT.getValue());
+        projectVersionComponentVersionView.setComponentVersion(COMPONENT_VERSION_URL);
+        projectVersionComponentVersionView.setComponentVersionName(COMPONENT_VERSION.getValue());
+        projectVersionComponentVersionView.setPolicyStatus(ProjectVersionComponentPolicyStatusType.IN_VIOLATION);
+        projectVersionComponentVersionView.setUsages(List.of(UsageType.DYNAMICALLY_LINKED));
+
+        ProjectVersionComponentVersionLicensesView projectVersionComponentVersionLicensesView = new ProjectVersionComponentVersionLicensesView();
+        projectVersionComponentVersionLicensesView.setLicense("http://licenseLink");
+        projectVersionComponentVersionLicensesView.setLicenseDisplay(LICENSE_DISPLAY);
+        projectVersionComponentVersionView.setLicenses(List.of(projectVersionComponentVersionLicensesView));
+
+        ResourceLink resourceLink = new ResourceLink();
+        resourceLink.setHref(new HttpUrl("https://someHref"));
+        resourceLink.setRel("policy-rules");
+        ResourceMetadata meta = new ResourceMetadata();
+        meta.setHref(new HttpUrl("https://someUrl"));
+        meta.setLinks(List.of(resourceLink));
+        projectVersionComponentVersionView.setMeta(meta);
+
+        return projectVersionComponentVersionView;
     }
 }

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/BomEditNotificationMessageExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/BomEditNotificationMessageExtractorTest.java
@@ -1,0 +1,132 @@
+package com.synopsys.integration.alert.provider.blackduck.processor.message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+
+import com.synopsys.integration.alert.common.message.model.LinkableItem;
+import com.synopsys.integration.alert.descriptor.api.BlackDuckProviderKey;
+import com.synopsys.integration.alert.processor.api.extract.model.ProviderDetails;
+import com.synopsys.integration.alert.processor.api.extract.model.project.BomComponentDetails;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentVulnerabilities;
+import com.synopsys.integration.alert.processor.api.extract.model.project.MessageReason;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ProjectMessage;
+import com.synopsys.integration.alert.provider.blackduck.processor.NotificationExtractorBlackDuckServicesFactoryCache;
+import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreator;
+import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreatorFactory;
+import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BomComponent404Handler;
+import com.synopsys.integration.alert.provider.blackduck.processor.model.BomEditWithProjectNameNotificationContent;
+import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionComponentVersionView;
+import com.synopsys.integration.blackduck.api.manual.component.BomEditNotificationContent;
+import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
+import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.rest.HttpMethod;
+import com.synopsys.integration.rest.HttpUrl;
+import com.synopsys.integration.rest.exception.IntegrationRestException;
+
+public class BomEditNotificationMessageExtractorTest {
+    private static final ProviderDetails PROVIDER_DETAILS = new ProviderDetails(15L, new LinkableItem("Provider", "A provider", "https://provider-url"));
+    private static final LinkableItem PROJECT_ITEM = new LinkableItem("Project", "A project", "https://project-url");
+    private static final LinkableItem PROJECT_VERSION_ITEM = new LinkableItem("Project Version", "2.3.4-RC", "https://project-version-url");
+
+    private static final LinkableItem COMPONENT = new LinkableItem("Component", "A BOM component");
+    private static final LinkableItem COMPONENT_VERSION = new LinkableItem("Component Version", "0.8.7");
+    private static final ComponentVulnerabilities COMPONENT_VULNERABILITIES = ComponentVulnerabilities.none();
+    private static final LinkableItem LICENSE = new LinkableItem("License", "A software license", "https://license-url");
+    private static final String USAGE = "Some generic usage";
+    private static final String ISSUES_URL = "https://issues-url";
+
+    private final BomComponentDetails bomComponentDetails = createBomComponentDetails();
+
+    private final BlackDuckProviderKey providerKey = new BlackDuckProviderKey();
+    private final NotificationExtractorBlackDuckServicesFactoryCache servicesFactoryCache = Mockito.mock(NotificationExtractorBlackDuckServicesFactoryCache.class);
+    private final BlackDuckMessageBomComponentDetailsCreatorFactory detailsCreatorFactory = Mockito.mock(BlackDuckMessageBomComponentDetailsCreatorFactory.class);
+    private final BomComponent404Handler bomComponent404Handler = new BomComponent404Handler();
+
+    @Test
+    public void createProjectMessageTest() {
+        BomEditNotificationMessageExtractor bomEditNotificationMessageExtractor = new BomEditNotificationMessageExtractor(providerKey, servicesFactoryCache, detailsCreatorFactory, bomComponent404Handler);
+
+        ProjectMessage projectMessage = bomEditNotificationMessageExtractor.createProjectMessage(PROVIDER_DETAILS, PROJECT_ITEM, PROJECT_VERSION_ITEM, List.of(bomComponentDetails));
+
+        assertEquals(MessageReason.COMPONENT_UPDATE, projectMessage.getMessageReason());
+        assertTrue(projectMessage.getBomComponents().contains(bomComponentDetails));
+    }
+
+    @Test
+    public void createBomComponentDetailsTest() throws IntegrationException {
+        BomEditNotificationMessageExtractor bomEditNotificationMessageExtractor = new BomEditNotificationMessageExtractor(providerKey, servicesFactoryCache, detailsCreatorFactory, bomComponent404Handler);
+        BomEditWithProjectNameNotificationContent notificationContent = createBomEditWithProjectNameNotificationContent();
+        BlackDuckServicesFactory blackDuckServicesFactory = createBlackDuckServicesFactoryWithMocks();
+
+        BlackDuckMessageBomComponentDetailsCreator bomComponentDetailsCreator = Mockito.mock(BlackDuckMessageBomComponentDetailsCreator.class);
+        Mockito.when(detailsCreatorFactory.createBomComponentDetailsCreator(Mockito.any())).thenReturn(bomComponentDetailsCreator);
+        Mockito.when(bomComponentDetailsCreator.createBomComponentDetails(Mockito.any(), Mockito.anyList(), Mockito.any(), Mockito.anyList())).thenReturn(bomComponentDetails);
+
+        List<BomComponentDetails> bomComponentDetailsList = bomEditNotificationMessageExtractor.createBomComponentDetails(notificationContent, blackDuckServicesFactory);
+        assertTrue(bomComponentDetailsList.contains(bomComponentDetails));
+    }
+
+    @Test
+    public void createBomComponentDetailsExceptionTest() throws IntegrationException {
+        BomEditNotificationMessageExtractor bomEditNotificationMessageExtractor = new BomEditNotificationMessageExtractor(providerKey, servicesFactoryCache, detailsCreatorFactory, bomComponent404Handler);
+        BomEditWithProjectNameNotificationContent notificationContent = createBomEditWithProjectNameNotificationContent();
+        BlackDuckServicesFactory blackDuckServicesFactory = createBlackDuckServicesFactoryWithMocks();
+
+        BlackDuckMessageBomComponentDetailsCreator bomComponentDetailsCreator = Mockito.mock(BlackDuckMessageBomComponentDetailsCreator.class);
+        Mockito.when(detailsCreatorFactory.createBomComponentDetailsCreator(Mockito.any())).thenReturn(bomComponentDetailsCreator);
+
+        Mockito.doThrow(new IntegrationRestException(HttpMethod.GET, new HttpUrl("https://google.com"), HttpStatus.NOT_FOUND.value(), "httpStatusMessageTest", "httpResponseContentTest", "IntegrationRestExceptionForAlertTest"))
+            .when(bomComponentDetailsCreator).createBomComponentDetails(Mockito.any(), Mockito.anyList(), Mockito.any(), Mockito.anyList());
+
+        BomComponentDetails bomComponentDetails = createBomComponentDetails();
+        Mockito.when(bomComponentDetailsCreator.createMissingBomComponentDetails(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyList(), Mockito.any(), Mockito.anyList()))
+            .thenReturn(bomComponentDetails);
+
+        List<BomComponentDetails> bomComponentDetailsList = bomEditNotificationMessageExtractor.createBomComponentDetails(notificationContent, blackDuckServicesFactory);
+        assertTrue(bomComponentDetailsList.contains(bomComponentDetails));
+    }
+
+    private BlackDuckServicesFactory createBlackDuckServicesFactoryWithMocks() throws IntegrationException {
+        BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
+        BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
+        Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
+
+        ProjectVersionComponentVersionView projectVersionComponentVersionView = new ProjectVersionComponentVersionView();
+        Mockito.when(blackDuckApiClient.getResponse(Mockito.any(), Mockito.any())).thenReturn(projectVersionComponentVersionView);
+
+        return blackDuckServicesFactory;
+    }
+
+    private BomEditWithProjectNameNotificationContent createBomEditWithProjectNameNotificationContent() {
+        BomEditNotificationContent bomEditNotificationContent = new BomEditNotificationContent();
+        bomEditNotificationContent.setProjectVersion(PROJECT_VERSION_ITEM.getLabel());
+        bomEditNotificationContent.setBomComponent("http://bomComponentUrl");
+        bomEditNotificationContent.setComponentName(COMPONENT.getLabel());
+        bomEditNotificationContent.setComponentVersionName(COMPONENT_VERSION.getLabel());
+
+        return new BomEditWithProjectNameNotificationContent(bomEditNotificationContent, PROJECT_ITEM.getLabel(), PROJECT_VERSION_ITEM.getLabel());
+    }
+
+    private BomComponentDetails createBomComponentDetails() {
+        return new BomComponentDetails(
+            COMPONENT,
+            COMPONENT_VERSION,
+            COMPONENT_VULNERABILITIES,
+            List.of(),
+            List.of(),
+            LICENSE,
+            USAGE,
+            ComponentUpgradeGuidance.none(),
+            List.of(),
+            ISSUES_URL
+        );
+    }
+}

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/LicenseLimitNotificationMessageExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/LicenseLimitNotificationMessageExtractorTest.java
@@ -1,0 +1,56 @@
+package com.synopsys.integration.alert.provider.blackduck.processor.message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.alert.common.rest.model.AlertNotificationModel;
+import com.synopsys.integration.alert.common.util.DateUtils;
+import com.synopsys.integration.alert.descriptor.api.BlackDuckProviderKey;
+import com.synopsys.integration.alert.processor.api.extract.model.ProviderMessageHolder;
+import com.synopsys.integration.alert.processor.api.extract.model.SimpleMessage;
+import com.synopsys.integration.alert.processor.api.filter.NotificationContentWrapper;
+import com.synopsys.integration.blackduck.api.manual.component.LicenseLimitNotificationContent;
+import com.synopsys.integration.blackduck.api.manual.enumeration.LicenseLimitType;
+
+public class LicenseLimitNotificationMessageExtractorTest {
+    private final String summary = "License Limit Event";
+    private final String description = "License Limit Message";
+    private final BlackDuckProviderKey blackDuckProviderKey = new BlackDuckProviderKey();
+
+    @Test
+    public void extractTest() {
+        LicenseLimitNotificationContent notificationContentComponent = createLicenseLimitNotificationContent();
+        NotificationContentWrapper notificationContentWrapper = createNotificationContentWrapper(notificationContentComponent);
+
+        LicenseLimitNotificationMessageExtractor licenseLimitNotificationMessageExtractor = new LicenseLimitNotificationMessageExtractor(blackDuckProviderKey);
+        ProviderMessageHolder providerMessageHolder = licenseLimitNotificationMessageExtractor.extract(notificationContentWrapper, notificationContentComponent);
+
+        assertEquals(0, providerMessageHolder.getProjectMessages().size());
+        assertEquals(1, providerMessageHolder.getSimpleMessages().size());
+        SimpleMessage simpleMessage = providerMessageHolder.getSimpleMessages().get(0);
+
+        assertEquals(summary, simpleMessage.getSummary());
+        assertEquals(description, simpleMessage.getDescription());
+        assertEquals(4, simpleMessage.getDetails().size());
+    }
+
+    private NotificationContentWrapper createNotificationContentWrapper(LicenseLimitNotificationContent notificationContentComponent) {
+        AlertNotificationModel alertNotificationModel = new AlertNotificationModel(1L, 1L, "provider-test", "providerConfigName-test", "notificationType-test", "{content: \"content is here...\"}", DateUtils.createCurrentDateTimestamp(),
+            DateUtils.createCurrentDateTimestamp(), false);
+        return new NotificationContentWrapper(alertNotificationModel, notificationContentComponent, LicenseLimitNotificationContent.class);
+    }
+
+    private LicenseLimitNotificationContent createLicenseLimitNotificationContent() {
+        LicenseLimitNotificationContent licenseLimitNotificationContent = new LicenseLimitNotificationContent();
+        licenseLimitNotificationContent.setLicenseViolationType(LicenseLimitType.MANAGED_CODEBASE_BYTES_NEW);
+        licenseLimitNotificationContent.setMessage(description);
+        licenseLimitNotificationContent.setMarketingPageUrl("http://someUrl");
+        licenseLimitNotificationContent.setUsedCodeSize(100L);
+        licenseLimitNotificationContent.setHardLimit(200L);
+        licenseLimitNotificationContent.setSoftLimit(150L);
+
+        return licenseLimitNotificationContent;
+    }
+
+}

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/PolicyOverrideNotificationMessageExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/PolicyOverrideNotificationMessageExtractorTest.java
@@ -1,29 +1,31 @@
 package com.synopsys.integration.alert.provider.blackduck.processor.message;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.descriptor.api.BlackDuckProviderKey;
-import com.synopsys.integration.alert.processor.api.extract.model.ProviderDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.BomComponentDetails;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcern;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcernSeverity;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentPolicy;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentVulnerabilities;
-import com.synopsys.integration.alert.processor.api.extract.model.project.MessageReason;
-import com.synopsys.integration.alert.processor.api.extract.model.project.ProjectMessage;
 import com.synopsys.integration.alert.provider.blackduck.processor.NotificationExtractorBlackDuckServicesFactoryCache;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreator;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreatorFactory;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BomComponent404Handler;
-import com.synopsys.integration.alert.provider.blackduck.processor.model.BomEditWithProjectNameNotificationContent;
+import com.synopsys.integration.alert.provider.blackduck.processor.message.service.policy.BlackDuckPolicyComponentConcernCreator;
+import com.synopsys.integration.alert.provider.blackduck.processor.message.service.policy.BlackDuckPolicySeverityConverter;
+import com.synopsys.integration.alert.provider.blackduck.processor.model.PolicyOverrideUniquePolicyNotificationContent;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionComponentVersionView;
-import com.synopsys.integration.blackduck.api.manual.component.BomEditNotificationContent;
+import com.synopsys.integration.blackduck.api.manual.component.PolicyInfo;
 import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
 import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
 import com.synopsys.integration.exception.IntegrationException;
@@ -31,14 +33,11 @@ import com.synopsys.integration.rest.HttpMethod;
 import com.synopsys.integration.rest.HttpUrl;
 import com.synopsys.integration.rest.exception.IntegrationRestException;
 
-public class BomEditNotificationMessageExtractorTest {
-    private static final ProviderDetails PROVIDER_DETAILS = new ProviderDetails(15L, new LinkableItem("Provider", "A provider", "https://provider-url"));
-    private static final LinkableItem PROJECT_ITEM = new LinkableItem("Project", "A project", "https://project-url");
-    private static final LinkableItem PROJECT_VERSION_ITEM = new LinkableItem("Project Version", "2.3.4-RC", "https://project-version-url");
-
+public class PolicyOverrideNotificationMessageExtractorTest {
     private static final LinkableItem COMPONENT = new LinkableItem("Component", "A BOM component");
     private static final LinkableItem COMPONENT_VERSION = new LinkableItem("Component Version", "0.8.7");
     private static final ComponentVulnerabilities COMPONENT_VULNERABILITIES = ComponentVulnerabilities.none();
+    private static final ComponentPolicy COMPONENT_POLICY = new ComponentPolicy("policyName", ComponentConcernSeverity.BLOCKER, true, false, "A Policy Description", "category");
     private static final LinkableItem LICENSE = new LinkableItem("License", "A software license", "https://license-url");
     private static final String USAGE = "Some generic usage";
     private static final String ISSUES_URL = "https://issues-url";
@@ -50,47 +49,78 @@ public class BomEditNotificationMessageExtractorTest {
     private final BlackDuckMessageBomComponentDetailsCreatorFactory detailsCreatorFactory = Mockito.mock(BlackDuckMessageBomComponentDetailsCreatorFactory.class);
     private final BomComponent404Handler bomComponent404Handler = new BomComponent404Handler();
 
-    @Test
-    public void createProjectMessageTest() {
-        BomEditNotificationMessageExtractor bomEditNotificationMessageExtractor = new BomEditNotificationMessageExtractor(providerKey, servicesFactoryCache, detailsCreatorFactory, bomComponent404Handler);
+    private final BlackDuckPolicySeverityConverter blackDuckPolicySeverityConverter = new BlackDuckPolicySeverityConverter();
+    private final BlackDuckPolicyComponentConcernCreator blackDuckPolicyComponentConcernCreator = new BlackDuckPolicyComponentConcernCreator(blackDuckPolicySeverityConverter);
 
-        ProjectMessage projectMessage = bomEditNotificationMessageExtractor.createProjectMessage(PROVIDER_DETAILS, PROJECT_ITEM, PROJECT_VERSION_ITEM, List.of(bomComponentDetails));
+    private final PolicyOverrideUniquePolicyNotificationContent policyOverrideUniquePolicyNotificationContent = createPolicyOverrideUniquePolicyNotificationContent();
+    private PolicyOverrideNotificationMessageExtractor policyOverrideNotificationMessageExtractor;
 
-        assertEquals(MessageReason.COMPONENT_UPDATE, projectMessage.getMessageReason());
-        assertTrue(projectMessage.getBomComponents().contains(bomComponentDetails));
+    @BeforeEach
+    public void init() {
+        policyOverrideNotificationMessageExtractor = new PolicyOverrideNotificationMessageExtractor(
+            providerKey,
+            servicesFactoryCache,
+            blackDuckPolicyComponentConcernCreator,
+            detailsCreatorFactory,
+            bomComponent404Handler
+        );
     }
 
     @Test
     public void createBomComponentDetailsTest() throws IntegrationException {
-        BomEditNotificationMessageExtractor bomEditNotificationMessageExtractor = new BomEditNotificationMessageExtractor(providerKey, servicesFactoryCache, detailsCreatorFactory, bomComponent404Handler);
-        BomEditWithProjectNameNotificationContent notificationContent = createBomEditWithProjectNameNotificationContent();
         BlackDuckServicesFactory blackDuckServicesFactory = createBlackDuckServicesFactoryWithMocks();
 
         BlackDuckMessageBomComponentDetailsCreator bomComponentDetailsCreator = Mockito.mock(BlackDuckMessageBomComponentDetailsCreator.class);
         Mockito.when(detailsCreatorFactory.createBomComponentDetailsCreator(Mockito.any())).thenReturn(bomComponentDetailsCreator);
-        Mockito.when(bomComponentDetailsCreator.createBomComponentDetails(Mockito.any(), Mockito.anyList(), Mockito.any(), Mockito.anyList())).thenReturn(bomComponentDetails);
+        Mockito.when(bomComponentDetailsCreator.createBomComponentDetails(Mockito.any(), (ComponentConcern) Mockito.any(), Mockito.eq(ComponentUpgradeGuidance.none()), Mockito.anyList())).thenReturn(bomComponentDetails);
 
-        List<BomComponentDetails> bomComponentDetailsList = bomEditNotificationMessageExtractor.createBomComponentDetails(notificationContent, blackDuckServicesFactory);
+        List<BomComponentDetails> bomComponentDetailsList = policyOverrideNotificationMessageExtractor.createBomComponentDetails(policyOverrideUniquePolicyNotificationContent, blackDuckServicesFactory);
         assertTrue(bomComponentDetailsList.contains(bomComponentDetails));
     }
 
     @Test
     public void createBomComponentDetailsExceptionTest() throws IntegrationException {
-        BomEditNotificationMessageExtractor bomEditNotificationMessageExtractor = new BomEditNotificationMessageExtractor(providerKey, servicesFactoryCache, detailsCreatorFactory, bomComponent404Handler);
-        BomEditWithProjectNameNotificationContent notificationContent = createBomEditWithProjectNameNotificationContent();
         BlackDuckServicesFactory blackDuckServicesFactory = createBlackDuckServicesFactoryWithMocks();
 
         BlackDuckMessageBomComponentDetailsCreator bomComponentDetailsCreator = Mockito.mock(BlackDuckMessageBomComponentDetailsCreator.class);
         Mockito.when(detailsCreatorFactory.createBomComponentDetailsCreator(Mockito.any())).thenReturn(bomComponentDetailsCreator);
-
         Mockito.doThrow(new IntegrationRestException(HttpMethod.GET, new HttpUrl("https://google.com"), HttpStatus.NOT_FOUND.value(), "httpStatusMessageTest", "httpResponseContentTest", "IntegrationRestExceptionForAlertTest"))
-            .when(bomComponentDetailsCreator).createBomComponentDetails(Mockito.any(), Mockito.anyList(), Mockito.any(), Mockito.anyList());
+            .when(bomComponentDetailsCreator).createBomComponentDetails(Mockito.any(), (ComponentConcern) Mockito.any(), Mockito.any(), Mockito.anyList());
 
         Mockito.when(bomComponentDetailsCreator.createMissingBomComponentDetails(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyList(), Mockito.any(), Mockito.anyList()))
             .thenReturn(bomComponentDetails);
 
-        List<BomComponentDetails> bomComponentDetailsList = bomEditNotificationMessageExtractor.createBomComponentDetails(notificationContent, blackDuckServicesFactory);
+        List<BomComponentDetails> bomComponentDetailsList = policyOverrideNotificationMessageExtractor.createBomComponentDetails(policyOverrideUniquePolicyNotificationContent, blackDuckServicesFactory);
         assertTrue(bomComponentDetailsList.contains(bomComponentDetails));
+    }
+
+    private PolicyOverrideUniquePolicyNotificationContent createPolicyOverrideUniquePolicyNotificationContent() {
+        String projectName = "Project";
+        String projectVersionName = "ProjectVersionName";
+        String projectVersion = "http://projectVersionUrl";
+        String componentName = "ComponentName";
+        String componentVersionName = "ComponentVersionName";
+        String firstName = "firstName";
+        String lastName = "lastName";
+        //TODO: set the policy info
+        PolicyInfo policyInfo = new PolicyInfo();
+        String policy = "http://policyUrl";
+        String bomComponentVersionPolicyStatus = "BomComponentVersionPolicyStatus";
+        String bomComponent = "http://bomComponentUrl";
+
+        return new PolicyOverrideUniquePolicyNotificationContent(
+            projectName,
+            projectVersionName,
+            projectVersion,
+            componentName,
+            componentVersionName,
+            firstName,
+            lastName,
+            policyInfo,
+            policy,
+            bomComponentVersionPolicyStatus,
+            bomComponent
+        );
     }
 
     private BlackDuckServicesFactory createBlackDuckServicesFactoryWithMocks() throws IntegrationException {
@@ -104,22 +134,12 @@ public class BomEditNotificationMessageExtractorTest {
         return blackDuckServicesFactory;
     }
 
-    private BomEditWithProjectNameNotificationContent createBomEditWithProjectNameNotificationContent() {
-        BomEditNotificationContent bomEditNotificationContent = new BomEditNotificationContent();
-        bomEditNotificationContent.setProjectVersion(PROJECT_VERSION_ITEM.getLabel());
-        bomEditNotificationContent.setBomComponent("http://bomComponentUrl");
-        bomEditNotificationContent.setComponentName(COMPONENT.getLabel());
-        bomEditNotificationContent.setComponentVersionName(COMPONENT_VERSION.getLabel());
-
-        return new BomEditWithProjectNameNotificationContent(bomEditNotificationContent, PROJECT_ITEM.getLabel(), PROJECT_VERSION_ITEM.getLabel());
-    }
-
     private BomComponentDetails createBomComponentDetails() {
         return new BomComponentDetails(
             COMPONENT,
             COMPONENT_VERSION,
             COMPONENT_VULNERABILITIES,
-            List.of(),
+            List.of(COMPONENT_POLICY),
             List.of(),
             LICENSE,
             USAGE,
@@ -128,4 +148,5 @@ public class BomEditNotificationMessageExtractorTest {
             ISSUES_URL
         );
     }
+
 }

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/PolicyOverrideNotificationMessageExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/PolicyOverrideNotificationMessageExtractorTest.java
@@ -1,6 +1,7 @@
 package com.synopsys.integration.alert.provider.blackduck.processor.message;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -15,6 +16,7 @@ import com.synopsys.integration.alert.descriptor.api.BlackDuckProviderKey;
 import com.synopsys.integration.alert.processor.api.extract.model.project.BomComponentDetails;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcernSeverity;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentPolicy;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.provider.blackduck.processor.NotificationExtractorBlackDuckServicesFactoryCache;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckComponentVulnerabilityDetailsCreator;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreatorFactory;
@@ -62,13 +64,13 @@ public class PolicyOverrideNotificationMessageExtractorTest {
 
         BlackDuckComponentVulnerabilityDetailsCreator vulnerabilityDetailsCreator = new BlackDuckComponentVulnerabilityDetailsCreator();
         BlackDuckComponentPolicyDetailsCreatorFactory blackDuckComponentPolicyDetailsCreatorFactory = new BlackDuckComponentPolicyDetailsCreatorFactory(blackDuckPolicySeverityConverter);
-        BlackDuckMessageBomComponentDetailsCreatorFactory newDetailsCreatorFactory = new BlackDuckMessageBomComponentDetailsCreatorFactory(vulnerabilityDetailsCreator, blackDuckComponentPolicyDetailsCreatorFactory);
+        BlackDuckMessageBomComponentDetailsCreatorFactory detailsCreatorFactory = new BlackDuckMessageBomComponentDetailsCreatorFactory(vulnerabilityDetailsCreator, blackDuckComponentPolicyDetailsCreatorFactory);
 
         extractor = new PolicyOverrideNotificationMessageExtractor(
             providerKey,
             servicesFactoryCache,
             blackDuckPolicyComponentConcernCreator,
-            newDetailsCreatorFactory,
+            detailsCreatorFactory,
             bomComponent404Handler
         );
     }
@@ -106,6 +108,10 @@ public class PolicyOverrideNotificationMessageExtractorTest {
         assertEquals(LICENSE_DISPLAY, testBomComponentDetails.getLicense().getValue());
         assertEquals(UsageType.DYNAMICALLY_LINKED.prettyPrint(), testBomComponentDetails.getUsage());
         assertEquals(1, testBomComponentDetails.getAdditionalAttributes().size());
+
+        ComponentUpgradeGuidance componentUpgradeGuidance = testBomComponentDetails.getComponentUpgradeGuidance();
+        assertFalse(componentUpgradeGuidance.getLongTermUpgradeGuidance().isPresent());
+        assertFalse(componentUpgradeGuidance.getShortTermUpgradeGuidance().isPresent());
 
         assertEquals(1, testBomComponentDetails.getRelevantPolicies().size());
         ComponentPolicy testComponentPolicy = testBomComponentDetails.getRelevantPolicies().get(0);

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/PolicyOverrideNotificationMessageExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/PolicyOverrideNotificationMessageExtractorTest.java
@@ -13,14 +13,10 @@ import org.springframework.http.HttpStatus;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.descriptor.api.BlackDuckProviderKey;
 import com.synopsys.integration.alert.processor.api.extract.model.project.BomComponentDetails;
-import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcern;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentConcernSeverity;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentPolicy;
-import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
-import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentVulnerabilities;
 import com.synopsys.integration.alert.provider.blackduck.processor.NotificationExtractorBlackDuckServicesFactoryCache;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckComponentVulnerabilityDetailsCreator;
-import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreator;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreatorFactory;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BomComponent404Handler;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.policy.BlackDuckComponentPolicyDetailsCreatorFactory;
@@ -49,64 +45,36 @@ public class PolicyOverrideNotificationMessageExtractorTest {
     private static final LinkableItem COMPONENT = new LinkableItem("Component", "A BOM component");
     private static final LinkableItem COMPONENT_VERSION = new LinkableItem("Component Version", "0.8.7");
     private static final String COMPONENT_VERSION_URL = "http://componentVersionUrl";
-    private static final ComponentVulnerabilities COMPONENT_VULNERABILITIES = ComponentVulnerabilities.none();
     private static final ComponentPolicy COMPONENT_POLICY = new ComponentPolicy("policyName", ComponentConcernSeverity.BLOCKER, true, false, "A Policy Description", "category");
-    private static final LinkableItem LICENSE = new LinkableItem("License", "A software license", "https://license-url");
-    private static final String USAGE = "Some generic usage";
-    private static final String ISSUES_URL = "https://issues-url";
-
-    private final BomComponentDetails bomComponentDetails = createBomComponentDetails();
-
-    private final BlackDuckProviderKey providerKey = new BlackDuckProviderKey();
-    private final NotificationExtractorBlackDuckServicesFactoryCache servicesFactoryCache = Mockito.mock(NotificationExtractorBlackDuckServicesFactoryCache.class);
-    private final BlackDuckMessageBomComponentDetailsCreatorFactory detailsCreatorFactory = Mockito.mock(BlackDuckMessageBomComponentDetailsCreatorFactory.class);
-    private final BomComponent404Handler bomComponent404Handler = new BomComponent404Handler();
-
-    private final BlackDuckPolicySeverityConverter blackDuckPolicySeverityConverter = new BlackDuckPolicySeverityConverter();
-    private final BlackDuckPolicyComponentConcernCreator blackDuckPolicyComponentConcernCreator = new BlackDuckPolicyComponentConcernCreator(blackDuckPolicySeverityConverter);
+    private static final String LICENSE_DISPLAY = "licenseDisplay";
 
     private final PolicyOverrideUniquePolicyNotificationContent policyOverrideUniquePolicyNotificationContent = createPolicyOverrideUniquePolicyNotificationContent();
-    private PolicyOverrideNotificationMessageExtractor policyOverrideNotificationMessageExtractor;
+    private PolicyOverrideNotificationMessageExtractor extractor;
 
     @BeforeEach
     public void init() {
-        policyOverrideNotificationMessageExtractor = new PolicyOverrideNotificationMessageExtractor(
-            providerKey,
-            servicesFactoryCache,
-            blackDuckPolicyComponentConcernCreator,
-            detailsCreatorFactory,
-            bomComponent404Handler
-        );
-    }
+        BlackDuckProviderKey providerKey = new BlackDuckProviderKey();
+        NotificationExtractorBlackDuckServicesFactoryCache servicesFactoryCache = Mockito.mock(NotificationExtractorBlackDuckServicesFactoryCache.class);
+        BomComponent404Handler bomComponent404Handler = new BomComponent404Handler();
 
-    @Test
-    public void createBomComponentDetailsTest() throws IntegrationException {
-        BlackDuckServicesFactory blackDuckServicesFactory = createBlackDuckServicesFactoryWithMocks();
+        BlackDuckPolicySeverityConverter blackDuckPolicySeverityConverter = new BlackDuckPolicySeverityConverter();
+        BlackDuckPolicyComponentConcernCreator blackDuckPolicyComponentConcernCreator = new BlackDuckPolicyComponentConcernCreator(blackDuckPolicySeverityConverter);
 
-        BlackDuckMessageBomComponentDetailsCreator bomComponentDetailsCreator = Mockito.mock(BlackDuckMessageBomComponentDetailsCreator.class);
-        Mockito.when(detailsCreatorFactory.createBomComponentDetailsCreator(Mockito.any())).thenReturn(bomComponentDetailsCreator);
-        Mockito.when(bomComponentDetailsCreator.createBomComponentDetails(Mockito.any(), (ComponentConcern) Mockito.any(), Mockito.eq(ComponentUpgradeGuidance.none()), Mockito.anyList())).thenReturn(bomComponentDetails);
-
-        List<BomComponentDetails> bomComponentDetailsList = policyOverrideNotificationMessageExtractor.createBomComponentDetails(policyOverrideUniquePolicyNotificationContent, blackDuckServicesFactory);
-        assertTrue(bomComponentDetailsList.contains(bomComponentDetails));
-    }
-
-    @Test
-    public void createBomComponentDetailsREVISITEDTest() throws IntegrationException {
-        //TODO: Perhaps we can improve this test with a concrete implementation of the BlackDuckMessageBomComponentDetailsCreator
-        //  we already have a policySeverityConverter, we can use that here
         BlackDuckComponentVulnerabilityDetailsCreator vulnerabilityDetailsCreator = new BlackDuckComponentVulnerabilityDetailsCreator();
         BlackDuckComponentPolicyDetailsCreatorFactory blackDuckComponentPolicyDetailsCreatorFactory = new BlackDuckComponentPolicyDetailsCreatorFactory(blackDuckPolicySeverityConverter);
         BlackDuckMessageBomComponentDetailsCreatorFactory newDetailsCreatorFactory = new BlackDuckMessageBomComponentDetailsCreatorFactory(vulnerabilityDetailsCreator, blackDuckComponentPolicyDetailsCreatorFactory);
 
-        PolicyOverrideNotificationMessageExtractor extractor = new PolicyOverrideNotificationMessageExtractor(
+        extractor = new PolicyOverrideNotificationMessageExtractor(
             providerKey,
             servicesFactoryCache,
             blackDuckPolicyComponentConcernCreator,
             newDetailsCreatorFactory,
             bomComponent404Handler
         );
+    }
 
+    @Test
+    public void createBomComponentDetailsTest() throws IntegrationException {
         BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
         BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
         Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
@@ -130,43 +98,49 @@ public class PolicyOverrideNotificationMessageExtractorTest {
         List<BomComponentDetails> bomComponentDetailsList = extractor.createBomComponentDetails(policyOverrideUniquePolicyNotificationContent, blackDuckServicesFactory);
 
         assertEquals(1, bomComponentDetailsList.size());
-        BomComponentDetails bomComponentDetails = bomComponentDetailsList.get(0);
-        assertEquals(COMPONENT, bomComponentDetails.getComponent());
-        assertEquals(1, bomComponentDetails.getComponentConcerns().size());
-        assertTrue(bomComponentDetails.getComponentVersion().isPresent());
-        assertEquals(COMPONENT_VERSION.getValue(), bomComponentDetails.getComponentVersion().get().getValue());
-        assertEquals("licenseDisplay", bomComponentDetails.getLicense().getValue());
-        assertEquals(UsageType.DYNAMICALLY_LINKED.prettyPrint(), bomComponentDetails.getUsage());
-        assertEquals(1, bomComponentDetails.getAdditionalAttributes().size());
+        BomComponentDetails testBomComponentDetails = bomComponentDetailsList.get(0);
+        assertEquals(COMPONENT, testBomComponentDetails.getComponent());
+        assertEquals(1, testBomComponentDetails.getComponentConcerns().size());
+        assertTrue(testBomComponentDetails.getComponentVersion().isPresent());
+        assertEquals(COMPONENT_VERSION.getValue(), testBomComponentDetails.getComponentVersion().get().getValue());
+        assertEquals(LICENSE_DISPLAY, testBomComponentDetails.getLicense().getValue());
+        assertEquals(UsageType.DYNAMICALLY_LINKED.prettyPrint(), testBomComponentDetails.getUsage());
+        assertEquals(1, testBomComponentDetails.getAdditionalAttributes().size());
 
-        assertEquals(1, bomComponentDetails.getRelevantPolicies().size());
-        ComponentPolicy testComponentPolicy = bomComponentDetails.getRelevantPolicies().get(0);
+        assertEquals(1, testBomComponentDetails.getRelevantPolicies().size());
+        ComponentPolicy testComponentPolicy = testBomComponentDetails.getRelevantPolicies().get(0);
         assertTrue(testComponentPolicy.getCategory().isPresent());
         assertEquals(PolicyRuleCategoryType.UNCATEGORIZED.toString(), testComponentPolicy.getCategory().get());
     }
 
     @Test
-    public void createBomComponentDetailsExceptionTest() throws IntegrationException {
-        BlackDuckServicesFactory blackDuckServicesFactory = createBlackDuckServicesFactoryWithMocks();
+    public void createBomComponentDetailsMissingBomComponentTest() throws IntegrationException {
+        BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
+        BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
+        Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
 
-        BlackDuckMessageBomComponentDetailsCreator bomComponentDetailsCreator = Mockito.mock(BlackDuckMessageBomComponentDetailsCreator.class);
-        Mockito.when(detailsCreatorFactory.createBomComponentDetailsCreator(Mockito.any())).thenReturn(bomComponentDetailsCreator);
         Mockito.doThrow(new IntegrationRestException(HttpMethod.GET, new HttpUrl("https://google.com"), HttpStatus.NOT_FOUND.value(), "httpStatusMessageTest", "httpResponseContentTest", "IntegrationRestExceptionForAlertTest"))
-            .when(bomComponentDetailsCreator).createBomComponentDetails(Mockito.any(), (ComponentConcern) Mockito.any(), Mockito.any(), Mockito.anyList());
+            .when(blackDuckApiClient).getResponse(Mockito.any(), Mockito.any());
 
-        Mockito.when(bomComponentDetailsCreator.createMissingBomComponentDetails(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyList(), Mockito.any(), Mockito.anyList()))
-            .thenReturn(bomComponentDetails);
+        List<BomComponentDetails> bomComponentDetailsList = extractor.createBomComponentDetails(policyOverrideUniquePolicyNotificationContent, blackDuckServicesFactory);
 
-        List<BomComponentDetails> bomComponentDetailsList = policyOverrideNotificationMessageExtractor.createBomComponentDetails(policyOverrideUniquePolicyNotificationContent, blackDuckServicesFactory);
-        assertTrue(bomComponentDetailsList.contains(bomComponentDetails));
+        assertEquals(1, bomComponentDetailsList.size());
+        BomComponentDetails testBomComponentDetails = bomComponentDetailsList.get(0);
+        assertEquals(COMPONENT, testBomComponentDetails.getComponent());
+        assertEquals(1, testBomComponentDetails.getComponentConcerns().size());
+        assertTrue(testBomComponentDetails.getComponentVersion().isPresent());
+        assertEquals(COMPONENT_VERSION.getValue(), testBomComponentDetails.getComponentVersion().get().getValue());
+        assertTrue(testBomComponentDetails.getRelevantPolicies().isEmpty());
+        assertEquals(BlackDuckMessageLabels.VALUE_UNKNOWN_LICENSE, testBomComponentDetails.getLicense().getValue());
+        assertEquals(BlackDuckMessageLabels.VALUE_UNKNOWN_USAGE, testBomComponentDetails.getUsage());
     }
 
     private PolicyOverrideUniquePolicyNotificationContent createPolicyOverrideUniquePolicyNotificationContent() {
         String projectName = "Project";
         String projectVersionName = "ProjectVersionName";
         String projectVersion = "http://projectVersionUrl";
-        String componentName = "ComponentName";
-        String componentVersionName = "ComponentVersionName";
+        String componentName = COMPONENT.getValue();
+        String componentVersionName = COMPONENT_VERSION.getValue();
         String firstName = "firstName";
         String lastName = "lastName";
         String policy = "http://policyUrl";
@@ -202,7 +176,7 @@ public class PolicyOverrideNotificationMessageExtractorTest {
 
         ProjectVersionComponentVersionLicensesView projectVersionComponentVersionLicensesView = new ProjectVersionComponentVersionLicensesView();
         projectVersionComponentVersionLicensesView.setLicense("http://licenseLink");
-        projectVersionComponentVersionLicensesView.setLicenseDisplay("licenseDisplay");
+        projectVersionComponentVersionLicensesView.setLicenseDisplay(LICENSE_DISPLAY);
         projectVersionComponentVersionView.setLicenses(List.of(projectVersionComponentVersionLicensesView));
 
         ResourceLink resourceLink = new ResourceLink();
@@ -215,31 +189,4 @@ public class PolicyOverrideNotificationMessageExtractorTest {
 
         return projectVersionComponentVersionView;
     }
-
-    private BlackDuckServicesFactory createBlackDuckServicesFactoryWithMocks() throws IntegrationException {
-        BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
-        BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
-        Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
-
-        ProjectVersionComponentVersionView projectVersionComponentVersionView = new ProjectVersionComponentVersionView();
-        Mockito.when(blackDuckApiClient.getResponse(Mockito.any(), Mockito.any())).thenReturn(projectVersionComponentVersionView);
-
-        return blackDuckServicesFactory;
-    }
-
-    private BomComponentDetails createBomComponentDetails() {
-        return new BomComponentDetails(
-            COMPONENT,
-            COMPONENT_VERSION,
-            COMPONENT_VULNERABILITIES,
-            List.of(COMPONENT_POLICY),
-            List.of(),
-            LICENSE,
-            USAGE,
-            ComponentUpgradeGuidance.none(),
-            List.of(),
-            ISSUES_URL
-        );
-    }
-
 }

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/PolicyOverrideNotificationMessageExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/PolicyOverrideNotificationMessageExtractorTest.java
@@ -1,5 +1,6 @@
 package com.synopsys.integration.alert.provider.blackduck.processor.message;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -18,12 +19,23 @@ import com.synopsys.integration.alert.processor.api.extract.model.project.Compon
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentVulnerabilities;
 import com.synopsys.integration.alert.provider.blackduck.processor.NotificationExtractorBlackDuckServicesFactoryCache;
+import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckComponentVulnerabilityDetailsCreator;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreator;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreatorFactory;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BomComponent404Handler;
+import com.synopsys.integration.alert.provider.blackduck.processor.message.service.policy.BlackDuckComponentPolicyDetailsCreatorFactory;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.policy.BlackDuckPolicyComponentConcernCreator;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.policy.BlackDuckPolicySeverityConverter;
 import com.synopsys.integration.alert.provider.blackduck.processor.model.PolicyOverrideUniquePolicyNotificationContent;
+import com.synopsys.integration.blackduck.api.core.ResourceLink;
+import com.synopsys.integration.blackduck.api.core.ResourceMetadata;
+import com.synopsys.integration.blackduck.api.generated.component.ProjectVersionComponentVersionLicensesView;
+import com.synopsys.integration.blackduck.api.generated.enumeration.PolicyRuleCategoryType;
+import com.synopsys.integration.blackduck.api.generated.enumeration.PolicyRuleSeverityType;
+import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionComponentPolicyStatusType;
+import com.synopsys.integration.blackduck.api.generated.enumeration.UsageType;
+import com.synopsys.integration.blackduck.api.generated.view.ComponentPolicyRulesView;
+import com.synopsys.integration.blackduck.api.generated.view.PolicyRuleView;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionComponentVersionView;
 import com.synopsys.integration.blackduck.api.manual.component.PolicyInfo;
 import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
@@ -36,6 +48,7 @@ import com.synopsys.integration.rest.exception.IntegrationRestException;
 public class PolicyOverrideNotificationMessageExtractorTest {
     private static final LinkableItem COMPONENT = new LinkableItem("Component", "A BOM component");
     private static final LinkableItem COMPONENT_VERSION = new LinkableItem("Component Version", "0.8.7");
+    private static final String COMPONENT_VERSION_URL = "http://componentVersionUrl";
     private static final ComponentVulnerabilities COMPONENT_VULNERABILITIES = ComponentVulnerabilities.none();
     private static final ComponentPolicy COMPONENT_POLICY = new ComponentPolicy("policyName", ComponentConcernSeverity.BLOCKER, true, false, "A Policy Description", "category");
     private static final LinkableItem LICENSE = new LinkableItem("License", "A software license", "https://license-url");
@@ -79,6 +92,60 @@ public class PolicyOverrideNotificationMessageExtractorTest {
     }
 
     @Test
+    public void createBomComponentDetailsREVISITEDTest() throws IntegrationException {
+        //TODO: Perhaps we can improve this test with a concrete implementation of the BlackDuckMessageBomComponentDetailsCreator
+        //  we already have a policySeverityConverter, we can use that here
+        BlackDuckComponentVulnerabilityDetailsCreator vulnerabilityDetailsCreator = new BlackDuckComponentVulnerabilityDetailsCreator();
+        BlackDuckComponentPolicyDetailsCreatorFactory blackDuckComponentPolicyDetailsCreatorFactory = new BlackDuckComponentPolicyDetailsCreatorFactory(blackDuckPolicySeverityConverter);
+        BlackDuckMessageBomComponentDetailsCreatorFactory newDetailsCreatorFactory = new BlackDuckMessageBomComponentDetailsCreatorFactory(vulnerabilityDetailsCreator, blackDuckComponentPolicyDetailsCreatorFactory);
+
+        PolicyOverrideNotificationMessageExtractor extractor = new PolicyOverrideNotificationMessageExtractor(
+            providerKey,
+            servicesFactoryCache,
+            blackDuckPolicyComponentConcernCreator,
+            newDetailsCreatorFactory,
+            bomComponent404Handler
+        );
+
+        BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
+        BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
+        Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
+
+        ProjectVersionComponentVersionView projectVersionComponentVersionView = createProjectVersionComponentVersionView();
+        Mockito.when(blackDuckApiClient.getResponse(Mockito.any(), Mockito.any())).thenReturn(projectVersionComponentVersionView);
+
+        ComponentPolicyRulesView componentPolicyRulesView = new ComponentPolicyRulesView();
+        ResourceMetadata meta = new ResourceMetadata();
+        meta.setHref(new HttpUrl("https://someUrlPolicyRuleView"));
+        componentPolicyRulesView.setMeta(meta);
+        componentPolicyRulesView.setName(COMPONENT_POLICY.getPolicyName());
+        componentPolicyRulesView.setSeverity(PolicyRuleSeverityType.BLOCKER);
+        componentPolicyRulesView.setPolicyApprovalStatus(ProjectVersionComponentPolicyStatusType.IN_VIOLATION_OVERRIDDEN);
+        Mockito.when(blackDuckApiClient.getAllResponses(Mockito.eq(projectVersionComponentVersionView.metaPolicyRulesLink()))).thenReturn(List.of(componentPolicyRulesView));
+
+        PolicyRuleView policyRuleView = new PolicyRuleView();
+        policyRuleView.setCategory(PolicyRuleCategoryType.UNCATEGORIZED);
+        Mockito.when(blackDuckApiClient.getResponse(Mockito.eq(componentPolicyRulesView.getHref()), Mockito.any())).thenReturn(policyRuleView);
+
+        List<BomComponentDetails> bomComponentDetailsList = extractor.createBomComponentDetails(policyOverrideUniquePolicyNotificationContent, blackDuckServicesFactory);
+
+        assertEquals(1, bomComponentDetailsList.size());
+        BomComponentDetails bomComponentDetails = bomComponentDetailsList.get(0);
+        assertEquals(COMPONENT, bomComponentDetails.getComponent());
+        assertEquals(1, bomComponentDetails.getComponentConcerns().size());
+        assertTrue(bomComponentDetails.getComponentVersion().isPresent());
+        assertEquals(COMPONENT_VERSION.getValue(), bomComponentDetails.getComponentVersion().get().getValue());
+        assertEquals("licenseDisplay", bomComponentDetails.getLicense().getValue());
+        assertEquals(UsageType.DYNAMICALLY_LINKED.prettyPrint(), bomComponentDetails.getUsage());
+        assertEquals(1, bomComponentDetails.getAdditionalAttributes().size());
+
+        assertEquals(1, bomComponentDetails.getRelevantPolicies().size());
+        ComponentPolicy testComponentPolicy = bomComponentDetails.getRelevantPolicies().get(0);
+        assertTrue(testComponentPolicy.getCategory().isPresent());
+        assertEquals(PolicyRuleCategoryType.UNCATEGORIZED.toString(), testComponentPolicy.getCategory().get());
+    }
+
+    @Test
     public void createBomComponentDetailsExceptionTest() throws IntegrationException {
         BlackDuckServicesFactory blackDuckServicesFactory = createBlackDuckServicesFactoryWithMocks();
 
@@ -102,11 +169,12 @@ public class PolicyOverrideNotificationMessageExtractorTest {
         String componentVersionName = "ComponentVersionName";
         String firstName = "firstName";
         String lastName = "lastName";
-        //TODO: set the policy info
-        PolicyInfo policyInfo = new PolicyInfo();
         String policy = "http://policyUrl";
         String bomComponentVersionPolicyStatus = "BomComponentVersionPolicyStatus";
         String bomComponent = "http://bomComponentUrl";
+
+        PolicyInfo policyInfo = new PolicyInfo();
+        policyInfo.setPolicyName(COMPONENT_POLICY.getPolicyName());
 
         return new PolicyOverrideUniquePolicyNotificationContent(
             projectName,
@@ -121,6 +189,31 @@ public class PolicyOverrideNotificationMessageExtractorTest {
             bomComponentVersionPolicyStatus,
             bomComponent
         );
+    }
+
+    private ProjectVersionComponentVersionView createProjectVersionComponentVersionView() throws IntegrationException {
+        ProjectVersionComponentVersionView projectVersionComponentVersionView = new ProjectVersionComponentVersionView();
+
+        projectVersionComponentVersionView.setComponentName(COMPONENT.getValue());
+        projectVersionComponentVersionView.setComponentVersion(COMPONENT_VERSION_URL);
+        projectVersionComponentVersionView.setComponentVersionName(COMPONENT_VERSION.getValue());
+        projectVersionComponentVersionView.setPolicyStatus(ProjectVersionComponentPolicyStatusType.IN_VIOLATION);
+        projectVersionComponentVersionView.setUsages(List.of(UsageType.DYNAMICALLY_LINKED));
+
+        ProjectVersionComponentVersionLicensesView projectVersionComponentVersionLicensesView = new ProjectVersionComponentVersionLicensesView();
+        projectVersionComponentVersionLicensesView.setLicense("http://licenseLink");
+        projectVersionComponentVersionLicensesView.setLicenseDisplay("licenseDisplay");
+        projectVersionComponentVersionView.setLicenses(List.of(projectVersionComponentVersionLicensesView));
+
+        ResourceLink resourceLink = new ResourceLink();
+        resourceLink.setHref(new HttpUrl("https://someHref"));
+        resourceLink.setRel("policy-rules");
+        ResourceMetadata meta = new ResourceMetadata();
+        meta.setHref(new HttpUrl("https://someUrl"));
+        meta.setLinks(List.of(resourceLink));
+        projectVersionComponentVersionView.setMeta(meta);
+
+        return projectVersionComponentVersionView;
     }
 
     private BlackDuckServicesFactory createBlackDuckServicesFactoryWithMocks() throws IntegrationException {

--- a/provider-blackduck/src/test/resources/json/vulnerabilityNotificationSimple02.json
+++ b/provider-blackduck/src/test/resources/json/vulnerabilityNotificationSimple02.json
@@ -1,0 +1,60 @@
+{
+  "content": {
+    "componentName": "Custom Component",
+    "versionName": "1.0.0",
+    "componentVersion": "https://a-hub-server.blackduck.com/api/components/7792be90-bfd2-42d7-ae19-66e051978675/versions/5a01d0b3-a6c4-469a-b9c8-c5769cffae78",
+    "newVulnerabilityCount": 4,
+    "updatedVulnerabilityCount": 1,
+    "deletedVulnerabilityCount": 1,
+    "newVulnerabilityIds": [
+      {
+        "source": "NVD",
+        "vulnerabilityId": "CVE-2018-0001",
+        "vulnerability": "https://a-hub-server.blackduck.com/api/vulnerabilities/CVE-2018-0001",
+        "severity": "LOW"
+      },
+      {
+        "source": "NVD",
+        "vulnerabilityId": "CVE-2018-0002",
+        "vulnerability": "https://a-hub-server.blackduck.com/api/vulnerabilities/CVE-2018-0002",
+        "severity": "MEDIUM"
+      },
+      {
+        "source": "NVD",
+        "vulnerabilityId": "CVE-2018-0003",
+        "vulnerability": "https://a-hub-server.blackduck.com/api/vulnerabilities/CVE-2018-0003",
+        "severity": "HIGH"
+      },
+      {
+        "source": "NVD",
+        "vulnerabilityId": "CVE-2018-0004",
+        "vulnerability": "https://a-hub-server.blackduck.com/api/vulnerabilities/CVE-2018-0004",
+        "severity": "CRITICAL"
+      }
+    ],
+    "updatedVulnerabilityIds": [
+      {
+        "source": "NVD",
+        "vulnerabilityId": "CVE-2018-0005",
+        "vulnerability": "https://a-hub-server.blackduck.com/api/vulnerabilities/CVE-2018-0005",
+        "severity": "HIGH"
+      }
+    ],
+    "deletedVulnerabilityIds": [
+      {
+        "source": "NVD",
+        "vulnerabilityId": "CVE-2018-0006",
+        "vulnerability": "https://a-hub-server.blackduck.com/api/vulnerabilities/CVE-2018-0006",
+        "severity": "MEDIUM"
+      }
+    ],
+    "affectedProjectVersions": [
+      {
+        "projectVersion": "https://a-hub-server.blackduck.com/api/projects/fa9ca16d-1238-4795-85d4-f47853a9b06c/versions/6c39d4f1-713d-4702-b9c8-e964e6ec932c",
+        "projectName": "alert-test-project",
+        "projectVersionName": "2.0.0-SNAPSHOT",
+        "bomComponent": "https://a-hub-server.blackduck.com/api/projects/fa9ca16d-1238-4795-85d4-f47853a9b06c/versions/6c39d4f1-713d-4702-b9c8-e964e6ec932c/components/18dbecb7-a3b5-418b-9af1-44bf61ae0319/versions/3ef95202-5b60-4a62-ab07-02740212fd96"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adding coverage to provider-blackduck subproject's processor package. Most of the MessageExtractor classes appear to be similar so I wanted to pitch these tests as an example for the remainder of the tests.