### PR TITLE
provider-blackduck processor/model package tests

### DIFF
--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/NotificationExtractorBlackDuckServicesFactoryCacheTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/NotificationExtractorBlackDuckServicesFactoryCacheTest.java
@@ -1,0 +1,110 @@
+package com.synopsys.integration.alert.provider.blackduck.processor;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
+import com.synopsys.integration.alert.common.AlertProperties;
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
+import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
+import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
+import com.synopsys.integration.alert.common.rest.proxy.ProxyManager;
+import com.synopsys.integration.alert.provider.blackduck.descriptor.BlackDuckDescriptor;
+import com.synopsys.integration.alert.provider.blackduck.factory.BlackDuckPropertiesFactory;
+import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
+import com.synopsys.integration.rest.proxy.ProxyInfo;
+
+public class NotificationExtractorBlackDuckServicesFactoryCacheTest {
+    private final ConfigurationAccessor configurationAccessor = Mockito.mock(ConfigurationAccessor.class);
+    private final Gson gson = new Gson();
+    private final AlertProperties properties = new AlertProperties();
+    private final ProxyManager proxyManager = Mockito.mock(ProxyManager.class);
+    private final BlackDuckPropertiesFactory blackDuckPropertiesFactory = new BlackDuckPropertiesFactory(configurationAccessor, gson, properties, proxyManager);
+
+    private final Long blackDuckConfigId = 15L;
+
+    private NotificationExtractorBlackDuckServicesFactoryCache cache;
+
+    @BeforeEach
+    public void init() {
+        cache = new NotificationExtractorBlackDuckServicesFactoryCache(blackDuckPropertiesFactory);
+    }
+
+    @Test
+    public void retrieveBlackDuckServicesFactoryTest() throws AlertConfigurationException {
+        ConfigurationModel configurationModel = createConfigurationModel();
+        Mockito.when(configurationAccessor.getConfigurationById(Mockito.eq(blackDuckConfigId))).thenReturn(Optional.of(configurationModel));
+
+        ProxyInfo proxyInfo = ProxyInfo.NO_PROXY_INFO;
+        Mockito.when(proxyManager.createProxyInfoForHost(Mockito.any())).thenReturn(proxyInfo);
+
+        //Create a BlackDuckServiceFactory and verify the same object is cached and returned.
+        BlackDuckServicesFactory blackDuckServicesFactory = cache.retrieveBlackDuckServicesFactory(blackDuckConfigId);
+        BlackDuckServicesFactory blackDuckServicesFactoryCached = cache.retrieveBlackDuckServicesFactory(blackDuckConfigId);
+
+        assertSame(blackDuckServicesFactory, blackDuckServicesFactoryCached, "Object reference of cached BlackDuckServiceFactory does not match. Verify the first factory is getting cached correctly.");
+    }
+
+    @Test
+    public void cacheClearedTest() throws AlertConfigurationException {
+        ConfigurationModel configurationModel = createConfigurationModel();
+        Mockito.when(configurationAccessor.getConfigurationById(Mockito.eq(blackDuckConfigId))).thenReturn(Optional.of(configurationModel));
+
+        ProxyInfo proxyInfo = ProxyInfo.NO_PROXY_INFO;
+        Mockito.when(proxyManager.createProxyInfoForHost(Mockito.any())).thenReturn(proxyInfo);
+
+        BlackDuckServicesFactory blackDuckServicesFactory = cache.retrieveBlackDuckServicesFactory(blackDuckConfigId);
+        cache.clear();
+        BlackDuckServicesFactory blackDuckServicesFactoryCached = cache.retrieveBlackDuckServicesFactory(blackDuckConfigId);
+
+        assertNotSame(blackDuckServicesFactory, blackDuckServicesFactoryCached, "Object reference of cached BlackDuckServiceFactory matches. Verify that the first factory is getting cleared correctly.");
+    }
+
+    @Test
+    public void missingConfigurationTest() {
+        try {
+            cache.retrieveBlackDuckServicesFactory(blackDuckConfigId);
+            fail("Expected AlertConfigurationException to be thrown due to missing optionalProperties.");
+        } catch (AlertConfigurationException e) {
+            //Pass
+        }
+    }
+
+    @Test
+    public void invalidConfigurationTest() {
+        ConfigurationModel configurationModel = new ConfigurationModel(1L, 2L, "createdAt", "lastUpdated", ConfigContextEnum.GLOBAL, Map.of());
+        Mockito.when(configurationAccessor.getConfigurationById(Mockito.eq(blackDuckConfigId))).thenReturn(Optional.of(configurationModel));
+
+        try {
+            cache.retrieveBlackDuckServicesFactory(blackDuckConfigId);
+            fail("Expected AlertConfigurationException to be thrown due to missing configuredFields in the ConfigurationModel.");
+        } catch (AlertConfigurationException e) {
+            //Pass
+        }
+    }
+
+    private ConfigurationModel createConfigurationModel() {
+        Map<String, ConfigurationFieldModel> configuredFields = new HashMap<>();
+
+        ConfigurationFieldModel apiKey = ConfigurationFieldModel.create(BlackDuckDescriptor.KEY_BLACKDUCK_API_KEY);
+        apiKey.setFieldValue("blackDuckApiKey");
+        configuredFields.put(BlackDuckDescriptor.KEY_BLACKDUCK_API_KEY, apiKey);
+
+        ConfigurationFieldModel url = ConfigurationFieldModel.create(BlackDuckDescriptor.KEY_BLACKDUCK_URL);
+        url.setFieldValue("http://blackDuckUrl");
+        configuredFields.put(BlackDuckDescriptor.KEY_BLACKDUCK_URL, url);
+
+        return new ConfigurationModel(1L, 2L, "createdAt", "lastUpdated", ConfigContextEnum.GLOBAL, configuredFields);
+    }
+}

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/model/BomEditWithProjectNameNotificationContentTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/model/BomEditWithProjectNameNotificationContentTest.java
@@ -1,0 +1,36 @@
+package com.synopsys.integration.alert.provider.blackduck.processor.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.blackduck.api.manual.component.BomEditNotificationContent;
+
+public class BomEditWithProjectNameNotificationContentTest {
+    private static final String PROJECT_NAME = "ProjectName";
+    private static final String PROJECT_VERSION_NAME = "ProjectVersionName";
+    private static final String PROJECT_VERSION_URL = "http://projectUrl";
+
+    @Test
+    public void getContentTest() {
+        String bomComponent = "http://bomComponentLink";
+        String componentName = "Component Name";
+        String componentVersionName = "ComponentVersionName";
+
+        BomEditNotificationContent bomEditNotificationContent = new BomEditNotificationContent();
+        bomEditNotificationContent.setProjectVersion(PROJECT_VERSION_URL);
+        bomEditNotificationContent.setBomComponent(bomComponent);
+        bomEditNotificationContent.setComponentName(componentName);
+        bomEditNotificationContent.setComponentVersionName(componentVersionName);
+
+        BomEditWithProjectNameNotificationContent notificationContent = new BomEditWithProjectNameNotificationContent(bomEditNotificationContent, PROJECT_NAME, PROJECT_VERSION_NAME);
+
+        assertEquals(PROJECT_NAME, notificationContent.getProjectName());
+        assertEquals(PROJECT_VERSION_NAME, notificationContent.getProjectVersionName());
+        assertEquals(PROJECT_VERSION_URL, notificationContent.getProjectVersionUrl());
+
+        assertEquals(bomComponent, notificationContent.getBomComponent());
+        assertEquals(componentName, notificationContent.getComponentName());
+        assertEquals(componentVersionName, notificationContent.getComponentVersionName());
+    }
+}

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/model/PolicyOverrideUniquePolicyNotificationContentTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/model/PolicyOverrideUniquePolicyNotificationContentTest.java
@@ -1,0 +1,52 @@
+package com.synopsys.integration.alert.provider.blackduck.processor.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.blackduck.api.manual.component.PolicyInfo;
+
+public class PolicyOverrideUniquePolicyNotificationContentTest {
+    private static final String PROJECT_NAME = "ProjectName";
+    private static final String PROJECT_VERSION_NAME = "ProjectVersionName";
+    private static final String PROJECT_VERSION_URL = "http://projectUrl";
+
+    @Test
+    public void getContentTest() {
+        String componentName = "Component Name";
+        String componentVersionName = "Component Version Name";
+        String firstName = "firstname";
+        String lastName = "lastname";
+        PolicyInfo policyInfo = new PolicyInfo();
+        String policy = "http://policyUrl";
+        String bomComponentVersionPolicyStatus = "Some policy status";
+        String bomComponent = "http://bomComponentUrl";
+
+        PolicyOverrideUniquePolicyNotificationContent notificationContent = new PolicyOverrideUniquePolicyNotificationContent(
+            PROJECT_NAME,
+            PROJECT_VERSION_NAME,
+            PROJECT_VERSION_URL,
+            componentName,
+            componentVersionName,
+            firstName,
+            lastName,
+            policyInfo,
+            policy,
+            bomComponentVersionPolicyStatus,
+            bomComponent
+        );
+
+        assertEquals(PROJECT_NAME, notificationContent.getProjectName());
+        assertEquals(PROJECT_VERSION_NAME, notificationContent.getProjectVersionName());
+        assertEquals(PROJECT_VERSION_URL, notificationContent.getProjectVersionUrl());
+
+        assertEquals(componentName, notificationContent.getComponentName());
+        assertEquals(componentVersionName, notificationContent.getComponentVersionName());
+        assertEquals(firstName, notificationContent.getFirstName());
+        assertEquals(lastName, notificationContent.getLastName());
+        assertEquals(policyInfo, notificationContent.getPolicyInfo());
+        assertEquals(policy, notificationContent.getPolicy());
+        assertEquals(bomComponentVersionPolicyStatus, notificationContent.getBomComponentVersionPolicyStatus());
+        assertEquals(bomComponent, notificationContent.getBomComponent());
+    }
+}

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/model/RuleViolationClearedUniquePolicyNotificationContentTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/model/RuleViolationClearedUniquePolicyNotificationContentTest.java
@@ -1,0 +1,42 @@
+package com.synopsys.integration.alert.provider.blackduck.processor.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.blackduck.api.manual.component.ComponentVersionStatus;
+import com.synopsys.integration.blackduck.api.manual.component.PolicyInfo;
+
+public class RuleViolationClearedUniquePolicyNotificationContentTest {
+    private static final String PROJECT_NAME = "ProjectName";
+    private static final String PROJECT_VERSION_NAME = "ProjectVersionName";
+    private static final String PROJECT_VERSION_URL = "http://projectUrl";
+
+    @Test
+    public void getContentsTest() {
+        int componentVersionsCleared = 1;
+        ComponentVersionStatus componentVersionStatus = new ComponentVersionStatus();
+        PolicyInfo policyInfo = new PolicyInfo();
+
+        RuleViolationClearedUniquePolicyNotificationContent notificationContent = new RuleViolationClearedUniquePolicyNotificationContent(
+            PROJECT_NAME,
+            PROJECT_VERSION_NAME,
+            PROJECT_VERSION_URL,
+            componentVersionsCleared,
+            List.of(componentVersionStatus),
+            policyInfo
+        );
+
+        assertEquals(PROJECT_NAME, notificationContent.getProjectName());
+        assertEquals(PROJECT_VERSION_NAME, notificationContent.getProjectVersionName());
+        assertEquals(PROJECT_VERSION_URL, notificationContent.getProjectVersionUrl());
+
+        assertEquals(componentVersionsCleared, notificationContent.getComponentVersionsCleared());
+        assertTrue(notificationContent.getComponentVersionStatuses().contains(componentVersionStatus));
+        assertEquals(policyInfo, notificationContent.getPolicyInfo());
+    }
+
+}

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/model/RuleViolationUniquePolicyNotificationContentTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/model/RuleViolationUniquePolicyNotificationContentTest.java
@@ -1,0 +1,41 @@
+package com.synopsys.integration.alert.provider.blackduck.processor.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.blackduck.api.manual.component.ComponentVersionStatus;
+import com.synopsys.integration.blackduck.api.manual.component.PolicyInfo;
+
+public class RuleViolationUniquePolicyNotificationContentTest {
+    private static final String PROJECT_NAME = "ProjectName";
+    private static final String PROJECT_VERSION_NAME = "ProjectVersionName";
+    private static final String PROJECT_VERSION_URL = "http://projectUrl";
+
+    @Test
+    public void getContentsTest() {
+        int componentVersionsInViolation = 1;
+        ComponentVersionStatus componentVersionStatus = new ComponentVersionStatus();
+        PolicyInfo policyInfo = new PolicyInfo();
+
+        RuleViolationUniquePolicyNotificationContent notificationContent = new RuleViolationUniquePolicyNotificationContent(
+            PROJECT_NAME,
+            PROJECT_VERSION_NAME,
+            PROJECT_VERSION_URL,
+            componentVersionsInViolation,
+            List.of(componentVersionStatus),
+            policyInfo
+        );
+
+        assertEquals(PROJECT_NAME, notificationContent.getProjectName());
+        assertEquals(PROJECT_VERSION_NAME, notificationContent.getProjectVersionName());
+        assertEquals(PROJECT_VERSION_URL, notificationContent.getProjectVersionUrl());
+
+        assertEquals(componentVersionsInViolation, notificationContent.getComponentVersionsInViolation());
+        assertTrue(notificationContent.getComponentVersionStatuses().contains(componentVersionStatus));
+        assertEquals(policyInfo, notificationContent.getPolicyInfo());
+    }
+}

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/model/VulnerabilityUniqueProjectNotificationContentTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/model/VulnerabilityUniqueProjectNotificationContentTest.java
@@ -1,0 +1,91 @@
+package com.synopsys.integration.alert.provider.blackduck.processor.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.blackduck.api.manual.component.AffectedProjectVersion;
+import com.synopsys.integration.blackduck.api.manual.component.VulnerabilityNotificationContent;
+import com.synopsys.integration.blackduck.api.manual.component.VulnerabilitySourceQualifiedId;
+
+public class VulnerabilityUniqueProjectNotificationContentTest {
+    private static final String PROJECT_NAME = "ProjectName";
+    private static final String PROJECT_VERSION_NAME = "ProjectVersionName";
+    private static final String PROJECT_VERSION_URL = "http://projectUrl";
+    private static final String COMPONENT_VERSION_URL = "http://componentVersionUrl";
+    private static final String COMPONENT_NAME = "Component Name";
+    private static final String VERSION_NAME = "Version Name";
+
+    private final VulnerabilitySourceQualifiedId newVulnerabilityId = new VulnerabilitySourceQualifiedId();
+    private final VulnerabilitySourceQualifiedId updatedVulnerabilityId = new VulnerabilitySourceQualifiedId();
+    private final VulnerabilitySourceQualifiedId deletedVulnerabilityId = new VulnerabilitySourceQualifiedId();
+
+    @Test
+    public void getContentFromNotificationContentTest() {
+        String componentVersionOriginName = "Component Version Origin Name";
+        String componentVersionOriginId = "Component Version Origin Id";
+
+        AffectedProjectVersion affectedProjectVersion = new AffectedProjectVersion();
+        affectedProjectVersion.setProjectName(PROJECT_NAME);
+        affectedProjectVersion.setProjectVersionName(PROJECT_VERSION_NAME);
+        affectedProjectVersion.setProjectVersion(PROJECT_VERSION_URL);
+
+        VulnerabilityNotificationContent vulnerabilityNotificationContent = new VulnerabilityNotificationContent();
+        vulnerabilityNotificationContent.setNewVulnerabilityCount(1);
+        vulnerabilityNotificationContent.setUpdatedVulnerabilityCount(1);
+        vulnerabilityNotificationContent.setDeletedVulnerabilityCount(1);
+
+        vulnerabilityNotificationContent.setNewVulnerabilityIds(List.of(newVulnerabilityId));
+        vulnerabilityNotificationContent.setUpdatedVulnerabilityIds(List.of(updatedVulnerabilityId));
+        vulnerabilityNotificationContent.setDeletedVulnerabilityIds(List.of(deletedVulnerabilityId));
+
+        vulnerabilityNotificationContent.setComponentVersion(COMPONENT_VERSION_URL);
+        vulnerabilityNotificationContent.setComponentName(COMPONENT_NAME);
+        vulnerabilityNotificationContent.setVersionName(VERSION_NAME);
+        vulnerabilityNotificationContent.setComponentVersionOriginName(componentVersionOriginName);
+        vulnerabilityNotificationContent.setAffectedProjectVersions(List.of(affectedProjectVersion));
+        vulnerabilityNotificationContent.setComponentVersionOriginId(componentVersionOriginId);
+
+        VulnerabilityUniqueProjectNotificationContent notificationContent = new VulnerabilityUniqueProjectNotificationContent(vulnerabilityNotificationContent, affectedProjectVersion);
+
+        performAssertions(notificationContent, affectedProjectVersion);
+    }
+
+    @Test
+    public void getContentTest() {
+        AffectedProjectVersion affectedProjectVersion = new AffectedProjectVersion();
+        affectedProjectVersion.setProjectName(PROJECT_NAME);
+        affectedProjectVersion.setProjectVersionName(PROJECT_VERSION_NAME);
+        affectedProjectVersion.setProjectVersion(PROJECT_VERSION_URL);
+
+        VulnerabilityNotificationContent vulnerabilityNotificationContent = new VulnerabilityNotificationContent();
+
+        VulnerabilityUniqueProjectNotificationContent notificationContent = new VulnerabilityUniqueProjectNotificationContent(vulnerabilityNotificationContent, affectedProjectVersion);
+        notificationContent.setNewVulnerabilityIds(List.of(newVulnerabilityId));
+        notificationContent.setUpdatedVulnerabilityIds(List.of(updatedVulnerabilityId));
+        notificationContent.setDeletedVulnerabilityIds(List.of(deletedVulnerabilityId));
+        notificationContent.setComponentVersion(COMPONENT_VERSION_URL);
+        notificationContent.setComponentName(COMPONENT_NAME);
+        notificationContent.setVersionName(VERSION_NAME);
+        notificationContent.setAffectedProjectVersion(affectedProjectVersion);
+
+        performAssertions(notificationContent, affectedProjectVersion);
+    }
+
+    private void performAssertions(VulnerabilityUniqueProjectNotificationContent notificationContent, AffectedProjectVersion affectedProjectVersion) {
+        assertEquals(PROJECT_NAME, notificationContent.getProjectName());
+        assertEquals(PROJECT_VERSION_NAME, notificationContent.getProjectVersionName());
+        assertEquals(PROJECT_VERSION_URL, notificationContent.getProjectVersionUrl());
+
+        assertTrue(notificationContent.getNewVulnerabilityIds().contains(newVulnerabilityId));
+        assertTrue(notificationContent.getUpdatedVulnerabilityIds().contains(updatedVulnerabilityId));
+        assertTrue(notificationContent.getDeletedVulnerabilityIds().contains(deletedVulnerabilityId));
+        assertEquals(COMPONENT_VERSION_URL, notificationContent.getComponentVersion());
+        assertEquals(COMPONENT_NAME, notificationContent.getComponentName());
+        assertEquals(VERSION_NAME, notificationContent.getVersionName());
+        assertEquals(affectedProjectVersion, notificationContent.getAffectedProjectVersion());
+    }
+}


### PR DESCRIPTION
Adding tests for classes in processor/model package. 

Also, I added one test outside of this package for the NotificationExtractorBlackDuckServicesFactoryCache to verify the cache would return a copy of the BlackDuckServicesFactory.