### PR TITLE
Modified the Notification extraction service to fix Azure lookup

### DIFF
--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/VulnerabilityNotificationMessageExtractor.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/VulnerabilityNotificationMessageExtractor.java
@@ -76,20 +76,20 @@ public class VulnerabilityNotificationMessageExtractor extends AbstractBlackDuck
         BlackDuckMessageBomComponentDetailsCreator bomComponentDetailsCreator = detailsCreatorFactory.createBomComponentDetailsCreator(blackDuckApiClient);
 
         AffectedProjectVersion affectedProjectVersion = notificationContent.getAffectedProjectVersion();
+        String bomComponentUrl = affectedProjectVersion.getBomComponent();
         List<ComponentConcern> componentConcerns = createComponentConcerns(notificationContent);
         List<LinkableItem> additionalAttributes = createAdditionalAttributes(notificationContent, blackDuckServicesFactory);
 
         BomComponentDetails bomComponentDetails;
         try {
-            ProjectVersionComponentView bomComponent = blackDuckApiClient.getResponse(new HttpUrl(affectedProjectVersion.getBomComponent()), ProjectVersionComponentView.class);
+            ProjectVersionComponentView bomComponent = blackDuckApiClient.getResponse(new HttpUrl(bomComponentUrl), ProjectVersionComponentView.class);
             bomComponentDetails = bomComponentDetailsCreator.createBomComponentDetails(bomComponent, componentConcerns, additionalAttributes);
         } catch (IntegrationRestException e) {
             bomComponent404Handler.logIf404OrThrow(e, notificationContent.getComponentName(), notificationContent.getVersionName());
-            bomComponentDetails = bomComponentDetailsCreator.createMissingBomComponentDetails(
+            bomComponentDetails = bomComponentDetailsCreator.createMissingBomComponentDetailsForVulnerability(
                 notificationContent.getComponentName(),
-                null,
+                bomComponentUrl,
                 notificationContent.getVersionName(),
-                notificationContent.getComponentVersion(),
                 componentConcerns,
                 additionalAttributes
             );

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/BlackDuckMessageBomComponentDetailsCreator.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/BlackDuckMessageBomComponentDetailsCreator.java
@@ -62,6 +62,7 @@ public class BlackDuckMessageBomComponentDetailsCreator {
         LinkableItem component;
         LinkableItem componentVersion = null;
 
+        // FIXME using this query link only in a successful result and not in an unsuccessful result leads to inconsistent values in our custom fields which leads to inconsistent search results (bug).
         String componentQueryLink = BlackDuckMessageLinkUtils.createComponentQueryLink(bomComponent);
 
         String componentVersionUrl = bomComponent.getComponentVersion();


### PR DESCRIPTION
Azure uses a querly URL to determine which issues need to be updated. Our Extractor tool was not using consistent URLs when it couldn't find a specific bom component