### PR TITLE
Temporarily fix for the integration build

### DIFF
--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -94,7 +94,10 @@ task copyStaticWebContent(type: Copy) {
     }
     into "${project.buildDir}/resources/main/static"
 }
-tasks.build.finalizedBy(updateNpmVersion)
+
+// FIXME This is excluded right now as it makes the HomeControllerTestIT test fail
+//tasks.build.finalizedBy(updateNpmVersion)
+
 tasks.copyStaticWebContent.finalizedBy(npmBuild)
 tasks.npmBuild.mustRunAfter(updateNpmVersion)
 tasks.npmBuild.mustRunAfter(copyStaticWebContent)


### PR DESCRIPTION
Removed a task that was breaking the build by being called at a specific time.

Needs to be added back and fixed properly for future use.