### PR TITLE
Proxy controller refactor

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/UniqueConfigurationAccessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/UniqueConfigurationAccessor.java
@@ -15,13 +15,11 @@ import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurat
 public interface UniqueConfigurationAccessor<T extends AlertSerializableModel> {
     String DEFAULT_CONFIGURATION_NAME = "default-configuration";
 
-    Optional<T> getConfiguration();
-
-    Optional<T> getConfigurationByName(String configurationName);
+    Optional<T> getConfigurationByName();
 
     T createConfiguration(T configuration) throws AlertConfigurationException;
 
     T updateConfiguration(T configuration) throws AlertConfigurationException;
 
-    void deleteConfiguration(String configurationName);
+    void deleteConfiguration();
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/UniqueConfigurationAccessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/UniqueConfigurationAccessor.java
@@ -1,0 +1,26 @@
+/*
+ * alert-common
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.alert.common.persistence.accessor;
+
+import java.util.Optional;
+
+import com.synopsys.integration.alert.api.common.model.AlertSerializableModel;
+import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
+
+public interface UniqueConfigurationAccessor<T extends AlertSerializableModel> {
+    String DEFAULT_CONFIGURATION_NAME = "default-configuration";
+
+    Optional<T> getConfiguration();
+
+    T createConfiguration(T configuration) throws AlertConfigurationException;
+
+    T updateConfiguration(T configuration) throws AlertConfigurationException;
+
+    void deleteConfiguration();
+
+}

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/UniqueConfigurationAccessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/UniqueConfigurationAccessor.java
@@ -23,6 +23,5 @@ public interface UniqueConfigurationAccessor<T extends AlertSerializableModel> {
 
     T updateConfiguration(T configuration) throws AlertConfigurationException;
 
-    void deleteConfiguration();
-
+    void deleteConfiguration(String configurationName);
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/UniqueConfigurationAccessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/UniqueConfigurationAccessor.java
@@ -15,7 +15,7 @@ import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurat
 public interface UniqueConfigurationAccessor<T extends AlertSerializableModel> {
     String DEFAULT_CONFIGURATION_NAME = "default-configuration";
 
-    Optional<T> getConfigurationByName();
+    Optional<T> getConfiguration();
 
     T createConfiguration(T configuration) throws AlertConfigurationException;
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/StaticUniqueConfigResourceController.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/StaticUniqueConfigResourceController.java
@@ -1,0 +1,28 @@
+package com.synopsys.integration.alert.common.rest.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+public interface StaticUniqueConfigResourceController<T> {
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    T create(@RequestBody T resource);
+
+    @GetMapping
+    T getOne();
+
+    @PutMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    void update(@RequestBody T resource);
+
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    void delete();
+
+}

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/settings/proxy/SettingsProxyConfigurationRepository.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/settings/proxy/SettingsProxyConfigurationRepository.java
@@ -14,4 +14,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SettingsProxyConfigurationRepository extends JpaRepository<SettingsProxyConfigurationEntity, UUID> {
     Optional<SettingsProxyConfigurationEntity> findByName(String name);
+    
+    void deleteByName(String name);
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/action/SettingsProxyCrudActions.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/action/SettingsProxyCrudActions.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
-import com.synopsys.integration.alert.common.persistence.accessor.UniqueConfigurationAccessor;
 import com.synopsys.integration.alert.common.rest.api.ConfigurationCrudHelper;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
 import com.synopsys.integration.alert.component.settings.descriptor.SettingsDescriptorKey;
@@ -35,7 +34,7 @@ public class SettingsProxyCrudActions {
 
     public ActionResponse<SettingsProxyModel> getOne() {
         return configurationHelper.getOne(
-            () -> configurationAccessor.getConfigurationByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME));
+            configurationAccessor::getConfigurationByName);
     }
 
     public ActionResponse<SettingsProxyModel> create(SettingsProxyModel resource) {
@@ -48,15 +47,15 @@ public class SettingsProxyCrudActions {
     public ActionResponse<SettingsProxyModel> update(SettingsProxyModel requestResource) {
         return configurationHelper.update(
             () -> validator.validate(requestResource),
-            () -> configurationAccessor.getConfigurationByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME).isPresent(),
+            () -> configurationAccessor.getConfigurationByName().isPresent(),
             () -> configurationAccessor.updateConfiguration(requestResource)
         );
     }
 
     public ActionResponse<SettingsProxyModel> delete() {
         return configurationHelper.delete(
-            () -> configurationAccessor.getConfigurationByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME).isPresent(),
-            () -> configurationAccessor.deleteConfiguration(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME)
+            () -> configurationAccessor.getConfigurationByName().isPresent(),
+            configurationAccessor::deleteConfiguration
         );
     }
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/action/SettingsProxyCrudActions.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/action/SettingsProxyCrudActions.java
@@ -34,7 +34,7 @@ public class SettingsProxyCrudActions {
 
     public ActionResponse<SettingsProxyModel> getOne() {
         return configurationHelper.getOne(
-            configurationAccessor::getConfigurationByName);
+            configurationAccessor::getConfiguration);
     }
 
     public ActionResponse<SettingsProxyModel> create(SettingsProxyModel resource) {
@@ -47,14 +47,14 @@ public class SettingsProxyCrudActions {
     public ActionResponse<SettingsProxyModel> update(SettingsProxyModel requestResource) {
         return configurationHelper.update(
             () -> validator.validate(requestResource),
-            () -> configurationAccessor.getConfigurationByName().isPresent(),
+            () -> configurationAccessor.getConfiguration().isPresent(),
             () -> configurationAccessor.updateConfiguration(requestResource)
         );
     }
 
     public ActionResponse<SettingsProxyModel> delete() {
         return configurationHelper.delete(
-            () -> configurationAccessor.getConfigurationByName().isPresent(),
+            () -> configurationAccessor.getConfiguration().isPresent(),
             configurationAccessor::deleteConfiguration
         );
     }

--- a/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/action/SettingsProxyCrudActions.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/action/SettingsProxyCrudActions.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.persistence.accessor.UniqueConfigurationAccessor;
 import com.synopsys.integration.alert.common.rest.api.ConfigurationCrudHelper;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
 import com.synopsys.integration.alert.component.settings.descriptor.SettingsDescriptorKey;
@@ -33,7 +34,8 @@ public class SettingsProxyCrudActions {
     }
 
     public ActionResponse<SettingsProxyModel> getOne() {
-        return configurationHelper.getOne(configurationAccessor::getConfiguration);
+        return configurationHelper.getOne(
+            () -> configurationAccessor.getConfigurationByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME));
     }
 
     public ActionResponse<SettingsProxyModel> create(SettingsProxyModel resource) {
@@ -46,15 +48,15 @@ public class SettingsProxyCrudActions {
     public ActionResponse<SettingsProxyModel> update(SettingsProxyModel requestResource) {
         return configurationHelper.update(
             () -> validator.validate(requestResource),
-            () -> configurationAccessor.getConfiguration().isPresent(),
+            () -> configurationAccessor.getConfigurationByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME).isPresent(),
             () -> configurationAccessor.updateConfiguration(requestResource)
         );
     }
 
     public ActionResponse<SettingsProxyModel> delete() {
         return configurationHelper.delete(
-            () -> configurationAccessor.getConfiguration().isPresent(),
-            configurationAccessor::deleteConfiguration
+            () -> configurationAccessor.getConfigurationByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME).isPresent(),
+            () -> configurationAccessor.deleteConfiguration(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME)
         );
     }
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/action/SettingsProxyCrudActions.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/action/SettingsProxyCrudActions.java
@@ -7,15 +7,12 @@
  */
 package com.synopsys.integration.alert.component.settings.proxy.action;
 
-import java.util.UUID;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.rest.api.ConfigurationCrudHelper;
-import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
 import com.synopsys.integration.alert.component.settings.descriptor.SettingsDescriptorKey;
 import com.synopsys.integration.alert.component.settings.proxy.database.accessor.SettingsProxyConfigAccessor;
@@ -35,12 +32,8 @@ public class SettingsProxyCrudActions {
         this.validator = validator;
     }
 
-    public ActionResponse<SettingsProxyModel> getOne(UUID id) {
-        return configurationHelper.getOne(() -> configurationAccessor.getConfiguration(id));
-    }
-
-    public ActionResponse<AlertPagedModel<SettingsProxyModel>> getPaged(int page, int size) {
-        return configurationHelper.getPage(() -> configurationAccessor.getConfigurationPage(page, size));
+    public ActionResponse<SettingsProxyModel> getOne() {
+        return configurationHelper.getOne(configurationAccessor::getConfiguration);
     }
 
     public ActionResponse<SettingsProxyModel> create(SettingsProxyModel resource) {
@@ -50,18 +43,18 @@ public class SettingsProxyCrudActions {
         );
     }
 
-    public ActionResponse<SettingsProxyModel> update(UUID id, SettingsProxyModel requestResource) {
+    public ActionResponse<SettingsProxyModel> update(SettingsProxyModel requestResource) {
         return configurationHelper.update(
             () -> validator.validate(requestResource),
-            () -> configurationAccessor.getConfiguration(id).isPresent(),
-            () -> configurationAccessor.updateConfiguration(id, requestResource)
+            () -> configurationAccessor.getConfiguration().isPresent(),
+            () -> configurationAccessor.updateConfiguration(requestResource)
         );
     }
 
-    public ActionResponse<SettingsProxyModel> delete(UUID id) {
+    public ActionResponse<SettingsProxyModel> delete() {
         return configurationHelper.delete(
-            () -> configurationAccessor.getConfiguration(id).isPresent(),
-            () -> configurationAccessor.deleteConfiguration(id)
+            () -> configurationAccessor.getConfiguration().isPresent(),
+            configurationAccessor::deleteConfiguration
         );
     }
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/database/accessor/SettingsProxyConfigAccessor.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/database/accessor/SettingsProxyConfigAccessor.java
@@ -14,16 +14,12 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.common.persistence.accessor.UniqueConfigurationAccessor;
-import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 import com.synopsys.integration.alert.common.security.EncryptionUtility;
 import com.synopsys.integration.alert.common.util.DateUtils;
 import com.synopsys.integration.alert.component.settings.proxy.model.SettingsProxyModel;
@@ -34,12 +30,9 @@ import com.synopsys.integration.alert.database.settings.proxy.SettingsProxyConfi
 
 @Component
 public class SettingsProxyConfigAccessor implements UniqueConfigurationAccessor<SettingsProxyModel> {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final EncryptionUtility encryptionUtility;
     private final SettingsProxyConfigurationRepository settingsProxyConfigurationRepository;
     private final NonProxyHostsConfigurationRepository nonProxyHostsConfigurationRepository;
-
-    private final PageRequest pageRequest = PageRequest.of(AlertPagedModel.DEFAULT_PAGE_NUMBER, AlertPagedModel.DEFAULT_PAGE_SIZE);
 
     public SettingsProxyConfigAccessor(
         EncryptionUtility encryptionUtility,

--- a/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/database/accessor/SettingsProxyConfigAccessor.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/database/accessor/SettingsProxyConfigAccessor.java
@@ -49,7 +49,6 @@ public class SettingsProxyConfigAccessor implements UniqueConfigurationAccessor<
         this.nonProxyHostsConfigurationRepository = nonProxyHostsConfigurationRepository;
     }
 
-
     @Override
     @Transactional(readOnly = true)
     public Optional<SettingsProxyModel> getConfiguration() {
@@ -69,7 +68,7 @@ public class SettingsProxyConfigAccessor implements UniqueConfigurationAccessor<
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
     public SettingsProxyModel createConfiguration(SettingsProxyModel configuration) throws AlertConfigurationException {
-        Optional<SettingsProxyModel> existingConfiguration = getConfiguration();
+        Optional<SettingsProxyModel> existingConfiguration = getConfigurationByName(DEFAULT_CONFIGURATION_NAME);
         if (existingConfiguration.isPresent()) {
             throw new AlertConfigurationException("A proxy config already exists.");
         }
@@ -89,7 +88,7 @@ public class SettingsProxyConfigAccessor implements UniqueConfigurationAccessor<
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
     public SettingsProxyModel updateConfiguration(SettingsProxyModel configuration) throws AlertConfigurationException {
-        SettingsProxyConfigurationEntity configurationEntity = settingsProxyConfigurationRepository.findAll(pageRequest)
+        SettingsProxyConfigurationEntity configurationEntity = settingsProxyConfigurationRepository.findByName(configuration.getName())
                                                                    .stream()
                                                                    .findFirst()
                                                                    .orElseThrow(() -> new AlertConfigurationException("Proxy config does not exist"));
@@ -106,8 +105,8 @@ public class SettingsProxyConfigAccessor implements UniqueConfigurationAccessor<
 
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
-    public void deleteConfiguration() {
-        settingsProxyConfigurationRepository.findAll(pageRequest)
+    public void deleteConfiguration(String configurationName) {
+        settingsProxyConfigurationRepository.findByName(configurationName)
             .stream()
             .findFirst()
             .ifPresent(settingsProxyConfigurationEntity -> settingsProxyConfigurationRepository.deleteById(settingsProxyConfigurationEntity.getConfigurationId()));

--- a/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/database/accessor/SettingsProxyConfigAccessor.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/database/accessor/SettingsProxyConfigAccessor.java
@@ -46,14 +46,14 @@ public class SettingsProxyConfigAccessor implements UniqueConfigurationAccessor<
 
     @Override
     @Transactional(readOnly = true)
-    public Optional<SettingsProxyModel> getConfigurationByName() {
+    public Optional<SettingsProxyModel> getConfiguration() {
         return settingsProxyConfigurationRepository.findByName(DEFAULT_CONFIGURATION_NAME).map(this::createConfigModel);
     }
 
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
     public SettingsProxyModel createConfiguration(SettingsProxyModel configuration) throws AlertConfigurationException {
-        Optional<SettingsProxyModel> existingConfiguration = getConfigurationByName();
+        Optional<SettingsProxyModel> existingConfiguration = getConfiguration();
         if (existingConfiguration.isPresent()) {
             throw new AlertConfigurationException("A proxy config already exists.");
         }

--- a/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/web/SettingsProxyController.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/web/SettingsProxyController.java
@@ -7,18 +7,14 @@
  */
 package com.synopsys.integration.alert.component.settings.proxy.web;
 
-import java.util.UUID;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.rest.ResponseFactory;
-import com.synopsys.integration.alert.common.rest.api.ReadPageController;
-import com.synopsys.integration.alert.common.rest.api.StaticConfigResourceController;
+import com.synopsys.integration.alert.common.rest.api.StaticUniqueConfigResourceController;
 import com.synopsys.integration.alert.common.rest.api.ValidateController;
-import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 import com.synopsys.integration.alert.common.rest.model.ValidationResponseModel;
 import com.synopsys.integration.alert.component.settings.proxy.action.SettingsProxyCrudActions;
 import com.synopsys.integration.alert.component.settings.proxy.action.SettingsProxyValidationAction;
@@ -26,7 +22,7 @@ import com.synopsys.integration.alert.component.settings.proxy.model.SettingsPro
 
 @RestController
 @RequestMapping(AlertRestConstants.SETTINGS_PROXY_PATH)
-public class SettingsProxyController implements StaticConfigResourceController<SettingsProxyModel>, ValidateController<SettingsProxyModel>, ReadPageController<AlertPagedModel<SettingsProxyModel>> {
+public class SettingsProxyController implements StaticUniqueConfigResourceController<SettingsProxyModel>, ValidateController<SettingsProxyModel> {
     private final SettingsProxyCrudActions configActions;
     private final SettingsProxyValidationAction validationAction;
 
@@ -42,23 +38,18 @@ public class SettingsProxyController implements StaticConfigResourceController<S
     }
 
     @Override
-    public SettingsProxyModel getOne(UUID id) {
-        return ResponseFactory.createContentResponseFromAction(configActions.getOne(id));
+    public SettingsProxyModel getOne() {
+        return ResponseFactory.createContentResponseFromAction(configActions.getOne());
     }
 
     @Override
-    public AlertPagedModel<SettingsProxyModel> getPage(Integer pageNumber, Integer pageSize, String searchTerm) {
-        return ResponseFactory.createContentResponseFromAction(configActions.getPaged(pageNumber, pageSize));
+    public void update(SettingsProxyModel resource) {
+        ResponseFactory.createContentResponseFromAction(configActions.update(resource));
     }
 
     @Override
-    public void update(UUID id, SettingsProxyModel resource) {
-        ResponseFactory.createContentResponseFromAction(configActions.update(id, resource));
-    }
-
-    @Override
-    public void delete(UUID id) {
-        ResponseFactory.createContentResponseFromAction(configActions.delete(id));
+    public void delete() {
+        ResponseFactory.createContentResponseFromAction(configActions.delete());
     }
 
     @Override

--- a/component/src/test/java/com/synopsys/integration/alert/component/settings/proxy/actions/SettingsProxyCrudActionsTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/settings/proxy/actions/SettingsProxyCrudActionsTest.java
@@ -25,7 +25,6 @@ import com.synopsys.integration.alert.common.persistence.model.PermissionKey;
 import com.synopsys.integration.alert.common.persistence.model.PermissionMatrixModel;
 import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
-import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 import com.synopsys.integration.alert.common.security.EncryptionUtility;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
 import com.synopsys.integration.alert.common.util.DateUtils;
@@ -67,42 +66,18 @@ public class SettingsProxyCrudActionsTest {
         SettingsProxyConfigurationRepository settingsProxyConfigurationRepository = Mockito.mock(SettingsProxyConfigurationRepository.class);
         NonProxyHostsConfigurationRepository nonProxyHostsConfigurationRepository = Mockito.mock(NonProxyHostsConfigurationRepository.class);
 
-        Mockito.when(settingsProxyConfigurationRepository.findById(Mockito.eq(uuid))).thenReturn(Optional.of(createSettingsProxyConfigurationEntity(uuid)));
+        Page<SettingsProxyConfigurationEntity> proxyConfigPage = new PageImpl<>(List.of(createSettingsProxyConfigurationEntity(uuid)));
+        Mockito.when(settingsProxyConfigurationRepository.findAll(Mockito.any(PageRequest.class))).thenReturn(proxyConfigPage);
 
         SettingsProxyConfigAccessor settingsProxyConfigAccessor = new SettingsProxyConfigAccessor(encryptionUtility, settingsProxyConfigurationRepository, nonProxyHostsConfigurationRepository);
 
         SettingsProxyCrudActions configActions = new SettingsProxyCrudActions(authorizationManager, settingsProxyConfigAccessor, settingsProxyValidator, settingsDescriptorKey);
-        ActionResponse<SettingsProxyModel> actionResponse = configActions.getOne(uuid);
+        ActionResponse<SettingsProxyModel> actionResponse = configActions.getOne();
 
         assertTrue(actionResponse.isSuccessful());
         assertTrue(actionResponse.hasContent());
         assertEquals(HttpStatus.OK, actionResponse.getHttpStatus());
         assertModelObfuscated(actionResponse);
-    }
-
-    @Test
-    public void getPagedTest() {
-        UUID uuid = UUID.randomUUID();
-        SettingsProxyConfigurationRepository settingsProxyConfigurationRepository = Mockito.mock(SettingsProxyConfigurationRepository.class);
-        NonProxyHostsConfigurationRepository nonProxyHostsConfigurationRepository = Mockito.mock(NonProxyHostsConfigurationRepository.class);
-
-        Page<SettingsProxyConfigurationEntity> resultPage = new PageImpl<>(List.of(createSettingsProxyConfigurationEntity(uuid)));
-        Mockito.when(settingsProxyConfigurationRepository.findAll(Mockito.any(PageRequest.class))).thenReturn(resultPage);
-
-        SettingsProxyConfigAccessor settingsProxyConfigAccessor = new SettingsProxyConfigAccessor(encryptionUtility, settingsProxyConfigurationRepository, nonProxyHostsConfigurationRepository);
-
-        SettingsProxyCrudActions configActions = new SettingsProxyCrudActions(authorizationManager, settingsProxyConfigAccessor, settingsProxyValidator, settingsDescriptorKey);
-        ActionResponse<AlertPagedModel<SettingsProxyModel>> actionResponse = configActions.getPaged(1, 1);
-
-        assertTrue(actionResponse.isSuccessful());
-        assertTrue(actionResponse.hasContent());
-        Optional<AlertPagedModel<SettingsProxyModel>> optionalPagedModel = actionResponse.getContent();
-        assertTrue(optionalPagedModel.isPresent());
-        AlertPagedModel<SettingsProxyModel> settingsProxyModelPage = optionalPagedModel.get();
-        assertEquals(1, settingsProxyModelPage.getTotalPages());
-        List<SettingsProxyModel> settingsProxyModels = settingsProxyModelPage.getModels();
-        assertEquals(1, settingsProxyModels.size());
-        assertModelObfuscated(settingsProxyModels.get(0));
     }
 
     @Test
@@ -112,8 +87,10 @@ public class SettingsProxyCrudActionsTest {
         NonProxyHostsConfigurationRepository nonProxyHostsConfigurationRepository = Mockito.mock(NonProxyHostsConfigurationRepository.class);
 
         SettingsProxyConfigurationEntity entity = createSettingsProxyConfigurationEntity(uuid);
+        Page<SettingsProxyConfigurationEntity> proxyConfigPage = new PageImpl<>(List.of());
+        Mockito.when(settingsProxyConfigurationRepository.findAll(Mockito.any(PageRequest.class))).thenReturn(proxyConfigPage);
         Mockito.when(settingsProxyConfigurationRepository.save(Mockito.any())).thenReturn(entity);
-        Mockito.when(settingsProxyConfigurationRepository.getOne(Mockito.eq(uuid))).thenReturn(entity);
+        Mockito.when(settingsProxyConfigurationRepository.getOne(uuid)).thenReturn(entity);
 
         SettingsProxyConfigAccessor settingsProxyConfigAccessor = new SettingsProxyConfigAccessor(encryptionUtility, settingsProxyConfigurationRepository, nonProxyHostsConfigurationRepository);
 
@@ -128,21 +105,43 @@ public class SettingsProxyCrudActionsTest {
     }
 
     @Test
+    public void createTestConfigAlreadyExists() {
+        UUID uuid = UUID.randomUUID();
+        SettingsProxyConfigurationRepository settingsProxyConfigurationRepository = Mockito.mock(SettingsProxyConfigurationRepository.class);
+        NonProxyHostsConfigurationRepository nonProxyHostsConfigurationRepository = Mockito.mock(NonProxyHostsConfigurationRepository.class);
+
+        SettingsProxyConfigurationEntity entity = createSettingsProxyConfigurationEntity(uuid);
+        Page<SettingsProxyConfigurationEntity> proxyConfigPage = new PageImpl<>(List.of(entity));
+        Mockito.when(settingsProxyConfigurationRepository.findAll(Mockito.any(PageRequest.class))).thenReturn(proxyConfigPage);
+
+        SettingsProxyConfigAccessor settingsProxyConfigAccessor = new SettingsProxyConfigAccessor(encryptionUtility, settingsProxyConfigurationRepository, nonProxyHostsConfigurationRepository);
+
+        SettingsProxyCrudActions configActions = new SettingsProxyCrudActions(authorizationManager, settingsProxyConfigAccessor, settingsProxyValidator, settingsDescriptorKey);
+        ActionResponse<SettingsProxyModel> actionResponse = configActions.create(createSettingsProxyModel());
+
+        assertTrue(actionResponse.isError());
+        assertFalse(actionResponse.hasContent());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, actionResponse.getHttpStatus());
+    }
+
+    @Test
     public void updateTest() {
         UUID uuid = UUID.randomUUID();
         SettingsProxyConfigurationRepository settingsProxyConfigurationRepository = Mockito.mock(SettingsProxyConfigurationRepository.class);
         NonProxyHostsConfigurationRepository nonProxyHostsConfigurationRepository = Mockito.mock(NonProxyHostsConfigurationRepository.class);
 
         SettingsProxyConfigurationEntity entity = createSettingsProxyConfigurationEntity(uuid);
-        Mockito.when(settingsProxyConfigurationRepository.findById(Mockito.eq(uuid))).thenReturn(Optional.of(entity));
+
+        Page<SettingsProxyConfigurationEntity> proxyConfigPage = new PageImpl<>(List.of(entity));
+        Mockito.when(settingsProxyConfigurationRepository.findAll(Mockito.any(PageRequest.class))).thenReturn(proxyConfigPage);
         Mockito.when(settingsProxyConfigurationRepository.save(Mockito.any())).thenReturn(entity);
-        Mockito.when(settingsProxyConfigurationRepository.getOne(Mockito.eq(uuid))).thenReturn(entity);
+        Mockito.when(settingsProxyConfigurationRepository.getOne(uuid)).thenReturn(entity);
 
         SettingsProxyConfigAccessor settingsProxyConfigAccessor = new SettingsProxyConfigAccessor(encryptionUtility, settingsProxyConfigurationRepository, nonProxyHostsConfigurationRepository);
 
         SettingsProxyCrudActions configActions = new SettingsProxyCrudActions(authorizationManager, settingsProxyConfigAccessor, settingsProxyValidator, settingsDescriptorKey);
         SettingsProxyModel settingsProxyModel = createSettingsProxyModel();
-        ActionResponse<SettingsProxyModel> actionResponse = configActions.update(uuid, settingsProxyModel);
+        ActionResponse<SettingsProxyModel> actionResponse = configActions.update(settingsProxyModel);
 
         Mockito.verify(nonProxyHostsConfigurationRepository).saveAll(Mockito.any());
         assertTrue(actionResponse.isSuccessful());
@@ -158,12 +157,13 @@ public class SettingsProxyCrudActionsTest {
         NonProxyHostsConfigurationRepository nonProxyHostsConfigurationRepository = Mockito.mock(NonProxyHostsConfigurationRepository.class);
 
         SettingsProxyConfigurationEntity entity = createSettingsProxyConfigurationEntity(uuid);
-        Mockito.when(settingsProxyConfigurationRepository.findById(Mockito.eq(uuid))).thenReturn(Optional.of(entity));
+        Page<SettingsProxyConfigurationEntity> proxyConfigPage = new PageImpl<>(List.of(entity));
+        Mockito.when(settingsProxyConfigurationRepository.findAll(Mockito.any(PageRequest.class))).thenReturn(proxyConfigPage);
 
         SettingsProxyConfigAccessor settingsProxyConfigAccessor = new SettingsProxyConfigAccessor(encryptionUtility, settingsProxyConfigurationRepository, nonProxyHostsConfigurationRepository);
 
         SettingsProxyCrudActions configActions = new SettingsProxyCrudActions(authorizationManager, settingsProxyConfigAccessor, settingsProxyValidator, settingsDescriptorKey);
-        ActionResponse<SettingsProxyModel> actionResponse = configActions.delete(uuid);
+        ActionResponse<SettingsProxyModel> actionResponse = configActions.delete();
 
         Mockito.verify(settingsProxyConfigurationRepository).deleteById(uuid);
         assertTrue(actionResponse.isSuccessful());

--- a/component/src/test/java/com/synopsys/integration/alert/component/settings/proxy/actions/SettingsProxyCrudActionsTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/settings/proxy/actions/SettingsProxyCrudActionsTest.java
@@ -11,9 +11,6 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 
 import com.google.gson.Gson;
@@ -21,6 +18,7 @@ import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
+import com.synopsys.integration.alert.common.persistence.accessor.UniqueConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.model.PermissionKey;
 import com.synopsys.integration.alert.common.persistence.model.PermissionMatrixModel;
 import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
@@ -66,8 +64,7 @@ public class SettingsProxyCrudActionsTest {
         SettingsProxyConfigurationRepository settingsProxyConfigurationRepository = Mockito.mock(SettingsProxyConfigurationRepository.class);
         NonProxyHostsConfigurationRepository nonProxyHostsConfigurationRepository = Mockito.mock(NonProxyHostsConfigurationRepository.class);
 
-        Page<SettingsProxyConfigurationEntity> proxyConfigPage = new PageImpl<>(List.of(createSettingsProxyConfigurationEntity(uuid)));
-        Mockito.when(settingsProxyConfigurationRepository.findAll(Mockito.any(PageRequest.class))).thenReturn(proxyConfigPage);
+        Mockito.when(settingsProxyConfigurationRepository.findByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(createSettingsProxyConfigurationEntity(uuid)));
 
         SettingsProxyConfigAccessor settingsProxyConfigAccessor = new SettingsProxyConfigAccessor(encryptionUtility, settingsProxyConfigurationRepository, nonProxyHostsConfigurationRepository);
 
@@ -87,8 +84,8 @@ public class SettingsProxyCrudActionsTest {
         NonProxyHostsConfigurationRepository nonProxyHostsConfigurationRepository = Mockito.mock(NonProxyHostsConfigurationRepository.class);
 
         SettingsProxyConfigurationEntity entity = createSettingsProxyConfigurationEntity(uuid);
-        Page<SettingsProxyConfigurationEntity> proxyConfigPage = new PageImpl<>(List.of());
-        Mockito.when(settingsProxyConfigurationRepository.findAll(Mockito.any(PageRequest.class))).thenReturn(proxyConfigPage);
+        Mockito.when(settingsProxyConfigurationRepository.findByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.empty());
+
         Mockito.when(settingsProxyConfigurationRepository.save(Mockito.any())).thenReturn(entity);
         Mockito.when(settingsProxyConfigurationRepository.getOne(uuid)).thenReturn(entity);
 
@@ -110,9 +107,7 @@ public class SettingsProxyCrudActionsTest {
         SettingsProxyConfigurationRepository settingsProxyConfigurationRepository = Mockito.mock(SettingsProxyConfigurationRepository.class);
         NonProxyHostsConfigurationRepository nonProxyHostsConfigurationRepository = Mockito.mock(NonProxyHostsConfigurationRepository.class);
 
-        SettingsProxyConfigurationEntity entity = createSettingsProxyConfigurationEntity(uuid);
-        Page<SettingsProxyConfigurationEntity> proxyConfigPage = new PageImpl<>(List.of(entity));
-        Mockito.when(settingsProxyConfigurationRepository.findAll(Mockito.any(PageRequest.class))).thenReturn(proxyConfigPage);
+        Mockito.when(settingsProxyConfigurationRepository.findByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(createSettingsProxyConfigurationEntity(uuid)));
 
         SettingsProxyConfigAccessor settingsProxyConfigAccessor = new SettingsProxyConfigAccessor(encryptionUtility, settingsProxyConfigurationRepository, nonProxyHostsConfigurationRepository);
 
@@ -131,9 +126,7 @@ public class SettingsProxyCrudActionsTest {
         NonProxyHostsConfigurationRepository nonProxyHostsConfigurationRepository = Mockito.mock(NonProxyHostsConfigurationRepository.class);
 
         SettingsProxyConfigurationEntity entity = createSettingsProxyConfigurationEntity(uuid);
-
-        Page<SettingsProxyConfigurationEntity> proxyConfigPage = new PageImpl<>(List.of(entity));
-        Mockito.when(settingsProxyConfigurationRepository.findAll(Mockito.any(PageRequest.class))).thenReturn(proxyConfigPage);
+        Mockito.when(settingsProxyConfigurationRepository.findByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(entity));
         Mockito.when(settingsProxyConfigurationRepository.save(Mockito.any())).thenReturn(entity);
         Mockito.when(settingsProxyConfigurationRepository.getOne(uuid)).thenReturn(entity);
 
@@ -156,9 +149,7 @@ public class SettingsProxyCrudActionsTest {
         SettingsProxyConfigurationRepository settingsProxyConfigurationRepository = Mockito.mock(SettingsProxyConfigurationRepository.class);
         NonProxyHostsConfigurationRepository nonProxyHostsConfigurationRepository = Mockito.mock(NonProxyHostsConfigurationRepository.class);
 
-        SettingsProxyConfigurationEntity entity = createSettingsProxyConfigurationEntity(uuid);
-        Page<SettingsProxyConfigurationEntity> proxyConfigPage = new PageImpl<>(List.of(entity));
-        Mockito.when(settingsProxyConfigurationRepository.findAll(Mockito.any(PageRequest.class))).thenReturn(proxyConfigPage);
+        Mockito.when(settingsProxyConfigurationRepository.findByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(createSettingsProxyConfigurationEntity(uuid)));
 
         SettingsProxyConfigAccessor settingsProxyConfigAccessor = new SettingsProxyConfigAccessor(encryptionUtility, settingsProxyConfigurationRepository, nonProxyHostsConfigurationRepository);
 

--- a/component/src/test/java/com/synopsys/integration/alert/component/settings/proxy/actions/SettingsProxyCrudActionsTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/settings/proxy/actions/SettingsProxyCrudActionsTest.java
@@ -156,7 +156,7 @@ public class SettingsProxyCrudActionsTest {
         SettingsProxyCrudActions configActions = new SettingsProxyCrudActions(authorizationManager, settingsProxyConfigAccessor, settingsProxyValidator, settingsDescriptorKey);
         ActionResponse<SettingsProxyModel> actionResponse = configActions.delete();
 
-        Mockito.verify(settingsProxyConfigurationRepository).deleteById(uuid);
+        Mockito.verify(settingsProxyConfigurationRepository).deleteByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
         assertTrue(actionResponse.isSuccessful());
         assertFalse(actionResponse.hasContent());
         assertEquals(HttpStatus.NO_CONTENT, actionResponse.getHttpStatus());

--- a/src/test/java/com/synopsys/integration/alert/component/settings/proxy/web/SettingsProxyControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/settings/proxy/web/SettingsProxyControllerTestIT.java
@@ -26,7 +26,7 @@ import org.springframework.web.context.WebApplicationContext;
 import org.testcontainers.shaded.com.google.common.reflect.TypeToken;
 
 import com.google.gson.Gson;
-import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
+import com.synopsys.integration.alert.common.persistence.accessor.UniqueConfigurationAccessor;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.component.settings.proxy.model.SettingsProxyModel;
 import com.synopsys.integration.alert.database.settings.proxy.NonProxyHostsConfigurationRepository;
@@ -71,7 +71,7 @@ public class SettingsProxyControllerTestIT {
     @Test
     @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
     public void testCreate() throws Exception {
-        SettingsProxyModel settingsProxyModel = createSettingsProxyModel(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        SettingsProxyModel settingsProxyModel = createSettingsProxyModel(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
 
         String url = AlertRestConstants.SETTINGS_PROXY_PATH;
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(new URI(url))
@@ -84,10 +84,28 @@ public class SettingsProxyControllerTestIT {
 
     @Test
     @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
-    public void testGetOne() throws Exception {
-        SettingsProxyModel settingsProxyModel = createDefaultSettingsProxyModel(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME).orElseThrow(AssertionFailedError::new);
+    public void testCreateTwice() throws Exception {
+        createDefaultSettingsProxyModel(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME).orElseThrow(AssertionFailedError::new);
+        SettingsProxyModel newSettingsProxyModel = new SettingsProxyModel();
+        newSettingsProxyModel.setName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        newSettingsProxyModel.setProxyHost("newHostname");
+        newSettingsProxyModel.setProxyPort(678);
 
-        String url = AlertRestConstants.SETTINGS_PROXY_PATH + String.format("/%s", settingsProxyModel.getId());
+        String url = AlertRestConstants.SETTINGS_PROXY_PATH;
+        MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(new URI(url))
+                                                    .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTestConstants.ROLE_ALERT_ADMIN))
+                                                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+                                                    .content(gson.toJson(newSettingsProxyModel))
+                                                    .contentType(contentType);
+        mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isInternalServerError());
+    }
+
+    @Test
+    @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
+    public void testGetOne() throws Exception {
+        createDefaultSettingsProxyModel(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME).orElseThrow(AssertionFailedError::new);
+
+        String url = AlertRestConstants.SETTINGS_PROXY_PATH;
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(new URI(url))
                                                     .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTestConstants.ROLE_ALERT_ADMIN))
                                                     .with(SecurityMockMvcRequestPostProcessors.csrf());
@@ -96,29 +114,14 @@ public class SettingsProxyControllerTestIT {
 
     @Test
     @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
-    public void getPageTest() throws Exception {
-        int pageNumber = 0;
-        int pageSize = 1;
-        createDefaultSettingsProxyModel(String.format("%s_1", ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME)).orElseThrow(AssertionFailedError::new);
-        createDefaultSettingsProxyModel(String.format("%s_2", ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME)).orElseThrow(AssertionFailedError::new);
-
-        String url = AlertRestConstants.SETTINGS_PROXY_PATH + "?pageNumber=" + pageNumber + "&pageSize=" + pageSize;
-        MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(new URI(url))
-            .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTestConstants.ROLE_ALERT_ADMIN))
-            .with(SecurityMockMvcRequestPostProcessors.csrf());
-        mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk());
-    }
-
-    @Test
-    @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
     public void testUpdate() throws Exception {
-        SettingsProxyModel defaultSettingsProxyModel = createDefaultSettingsProxyModel(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME).orElseThrow(AssertionFailedError::new);
+        createDefaultSettingsProxyModel(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME).orElseThrow(AssertionFailedError::new);
         SettingsProxyModel newSettingsProxyModel = new SettingsProxyModel();
-        newSettingsProxyModel.setName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        newSettingsProxyModel.setName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
         newSettingsProxyModel.setProxyHost("newHostname");
         newSettingsProxyModel.setProxyPort(678);
 
-        String url = AlertRestConstants.SETTINGS_PROXY_PATH + String.format("/%s", defaultSettingsProxyModel.getId());
+        String url = AlertRestConstants.SETTINGS_PROXY_PATH;
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.put(new URI(url))
                                                     .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTestConstants.ROLE_ALERT_ADMIN))
                                                     .with(SecurityMockMvcRequestPostProcessors.csrf())
@@ -129,9 +132,9 @@ public class SettingsProxyControllerTestIT {
 
     @Test
     public void testDelete() throws Exception {
-        SettingsProxyModel defaultSettingsProxyModel = createDefaultSettingsProxyModel(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME).orElseThrow(AssertionFailedError::new);
+        createDefaultSettingsProxyModel(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME).orElseThrow(AssertionFailedError::new);
 
-        String url = AlertRestConstants.SETTINGS_PROXY_PATH + String.format("/%s", defaultSettingsProxyModel.getId());
+        String url = AlertRestConstants.SETTINGS_PROXY_PATH;
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.delete(new URI(url))
                                                     .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTestConstants.ROLE_ALERT_ADMIN))
                                                     .with(SecurityMockMvcRequestPostProcessors.csrf());
@@ -140,7 +143,7 @@ public class SettingsProxyControllerTestIT {
 
     @Test
     public void testValidate() throws Exception {
-        SettingsProxyModel settingsProxyModel = createSettingsProxyModel(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        SettingsProxyModel settingsProxyModel = createSettingsProxyModel(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
 
         String url = AlertRestConstants.SETTINGS_PROXY_PATH + "/validate";
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(new URI(url))

--- a/ui/src/main/js/page/settings/standalone/SettingsProxyConfiguration.js
+++ b/ui/src/main/js/page/settings/standalone/SettingsProxyConfiguration.js
@@ -22,19 +22,13 @@ const SettingsProxyConfiguration = ({
 
     const fetchData = async () => {
         const response = await ConfigurationRequestBuilder.createReadRequest(proxyRequestUrl, csrfToken);
-        const data = await response.json();
-
-        const { models } = data;
-        if (models && models.length > 0) {
-            const firstResult = models[0];
-            if (firstResult[passwordName]) {
-                setPasswordFromApiExists(true);
-                delete firstResult[passwordName];
-            } else {
-                setPasswordFromApiExists(false);
-            }
-            setSettingsProxyConfig(firstResult);
+        if (response.ok) {
+            const data = await response.json();
+            setPasswordFromApiExists(true);
+            delete data.proxyPassword;
+            setSettingsProxyConfig(data);
         } else {
+            setPasswordFromApiExists(false);
             setSettingsProxyConfig({ name: 'default-configuration' });
         }
     };

--- a/ui/src/main/js/page/settings/standalone/SettingsProxyConfiguration.js
+++ b/ui/src/main/js/page/settings/standalone/SettingsProxyConfiguration.js
@@ -54,9 +54,9 @@ const SettingsProxyConfiguration = ({
             setErrors={(formErrors) => setErrors(formErrors)}
             buttonIdPrefix={SETTINGS_INFO.key}
             getRequest={fetchData}
-            deleteRequest={() => ConfigurationRequestBuilder.createDeleteRequest(proxyRequestUrl, csrfToken, settingsProxyConfig.id)}
+            deleteRequest={() => ConfigurationRequestBuilder.createDeleteRequest(proxyRequestUrl, csrfToken)}
             createRequest={() => ConfigurationRequestBuilder.createNewConfigurationRequest(proxyRequestUrl, csrfToken, settingsProxyConfig)}
-            updateRequest={() => ConfigurationRequestBuilder.createUpdateRequest(proxyRequestUrl, csrfToken, settingsProxyConfig.id, settingsProxyConfig)}
+            updateRequest={() => ConfigurationRequestBuilder.createUpdateWithoutIdRequest(proxyRequestUrl, csrfToken, settingsProxyConfig)}
             validateRequest={() => ConfigurationRequestBuilder.createValidateRequest(proxyRequestUrl, csrfToken, settingsProxyConfig)}
             readonly={readOnly}
             displaySave={displaySave}


### PR DESCRIPTION
Update proxy configuration to use only a single configuration and remove the id field. In addition, we've created a "Unique" controller and accessor interfaces to better deal with configurations that do not have an ID.