### PR TITLE
Move default configuration name into a single constants file

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/ConfigurationAccessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/ConfigurationAccessor.java
@@ -15,8 +15,6 @@ import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurat
 import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 
 public interface ConfigurationAccessor<T extends AlertSerializableModel> {
-    String DEFAULT_CONFIGURATION_NAME = "default-configuration";
-
     long getConfigurationCount();
 
     Optional<T> getConfiguration(UUID id);

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/UniqueConfigurationAccessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/UniqueConfigurationAccessor.java
@@ -13,8 +13,6 @@ import com.synopsys.integration.alert.api.common.model.AlertSerializableModel;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 
 public interface UniqueConfigurationAccessor<T extends AlertSerializableModel> {
-    String DEFAULT_CONFIGURATION_NAME = "default-configuration";
-
     Optional<T> getConfiguration();
 
     T createConfiguration(T configuration) throws AlertConfigurationException;

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/AlertRestConstants.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/AlertRestConstants.java
@@ -19,7 +19,9 @@ public final class AlertRestConstants {
     public static final String SETTINGS_PATH = AlertRestConstants.BASE_PATH + "/settings";
     public static final String SETTINGS_ENCRYPTION_PATH = AlertRestConstants.SETTINGS_PATH + "/encryption";
     public static final String SETTINGS_PROXY_PATH = AlertRestConstants.SETTINGS_PATH + "/proxy";
+
     public static final String MASKED_VALUE = "*****";
+    public static final String DEFAULT_CONFIGURATION_NAME = "default-configuration";
 
     private AlertRestConstants() {
         // This class should not be instantiated

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/distribution/EmailChannelMessageSender.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/distribution/EmailChannelMessageSender.java
@@ -31,8 +31,8 @@ import com.synopsys.integration.alert.common.descriptor.config.field.errors.Aler
 import com.synopsys.integration.alert.common.descriptor.config.field.errors.FieldStatusSeverity;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.common.message.model.MessageResult;
-import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.model.job.details.EmailJobDetailsModel;
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ProjectMessage;
 import com.synopsys.integration.alert.service.email.EmailTarget;
 import com.synopsys.integration.alert.service.email.JavamailPropertiesFactory;
@@ -88,8 +88,8 @@ public class EmailChannelMessageSender implements ChannelMessageSender<EmailJobD
         }
 
         // Distribution
-        EmailGlobalConfigModel emailServerConfiguration = emailGlobalConfigAccessor.getConfigurationByName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME)
-            .orElseThrow(() -> new AlertConfigurationException("ERROR: Missing Email global config."));
+        EmailGlobalConfigModel emailServerConfiguration = emailGlobalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
+                                                              .orElseThrow(() -> new AlertConfigurationException("ERROR: Missing Email global config."));
 
         SmtpConfig smtpConfig = SmtpConfig.builder()
             .setJavamailProperties(javamailPropertiesFactory.createJavaMailProperties(emailServerConfiguration))

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalConfigurationActionTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalConfigurationActionTest.java
@@ -16,9 +16,9 @@ import com.synopsys.integration.alert.channel.email.database.accessor.EmailGloba
 import com.synopsys.integration.alert.channel.email.validator.EmailGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
-import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.model.PermissionKey;
 import com.synopsys.integration.alert.common.persistence.model.PermissionMatrixModel;
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
 import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
@@ -61,7 +61,7 @@ public class EmailGlobalConfigurationActionTest {
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
         EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         model.setSmtpHost("host");
         model.setSmtpFrom("from");
         model.setSmtpAuth(true);
@@ -87,7 +87,7 @@ public class EmailGlobalConfigurationActionTest {
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
         EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         model.setSmtpHost("host");
         model.setSmtpFrom("from");
         model.setSmtpAuth(true);

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/distribution/EmailChannelTestIT.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/distribution/EmailChannelTestIT.java
@@ -20,8 +20,8 @@ import com.synopsys.integration.alert.channel.email.database.accessor.EmailGloba
 import com.synopsys.integration.alert.channel.email.distribution.address.EmailAddressGatherer;
 import com.synopsys.integration.alert.channel.email.distribution.address.JobEmailAddressValidator;
 import com.synopsys.integration.alert.channel.email.distribution.address.ValidatedEmailAddresses;
-import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.model.job.details.EmailJobDetailsModel;
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.service.email.EmailMessagingService;
 import com.synopsys.integration.alert.service.email.JavamailPropertiesFactory;
 import com.synopsys.integration.alert.service.email.model.EmailGlobalConfigModel;
@@ -55,7 +55,7 @@ public class EmailChannelTestIT {
 
         EmailGlobalConfigModel emailGlobalConfig = createEmailGlobalConfig();
         EmailGlobalConfigAccessor emailConfigurationAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
-        Mockito.when(emailConfigurationAccessor.getConfigurationByName(Mockito.eq(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME))).thenReturn(Optional.of(emailGlobalConfig));
+        Mockito.when(emailConfigurationAccessor.getConfigurationByName(Mockito.eq(AlertRestConstants.DEFAULT_CONFIGURATION_NAME))).thenReturn(Optional.of(emailGlobalConfig));
 
         JobEmailAddressValidator emailAddressValidator = Mockito.mock(JobEmailAddressValidator.class);
         Mockito.when(emailAddressValidator.validate(Mockito.any(), Mockito.anyCollection())).thenReturn(new ValidatedEmailAddresses(Set.of(testEmailRecipient), Set.of()));
@@ -85,7 +85,7 @@ public class EmailChannelTestIT {
         String testEmailRecipient = testProperties.getProperty(TestPropertyKey.TEST_EMAIL_RECIPIENT);
 
         EmailGlobalConfigAccessor emailConfigurationAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
-        Mockito.when(emailConfigurationAccessor.getConfigurationByName(Mockito.eq(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME))).thenReturn(Optional.empty());
+        Mockito.when(emailConfigurationAccessor.getConfigurationByName(Mockito.eq(AlertRestConstants.DEFAULT_CONFIGURATION_NAME))).thenReturn(Optional.empty());
 
         JobEmailAddressValidator emailAddressValidator = Mockito.mock(JobEmailAddressValidator.class);
         Mockito.when(emailAddressValidator.validate(Mockito.any(), Mockito.anyCollection())).thenReturn(new ValidatedEmailAddresses(Set.of(testEmailRecipient), Set.of()));
@@ -104,7 +104,7 @@ public class EmailChannelTestIT {
 
     private EmailGlobalConfigModel createEmailGlobalConfig() {
         EmailGlobalConfigModel emailGlobalConfigModel = new EmailGlobalConfigModel();
-        emailGlobalConfigModel.setName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        emailGlobalConfigModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         emailGlobalConfigModel.setSmtpHost(testProperties.getProperty(TestPropertyKey.TEST_EMAIL_SMTP_HOST));
         emailGlobalConfigModel.setSmtpFrom(testProperties.getProperty(TestPropertyKey.TEST_EMAIL_SMTP_FROM));
         emailGlobalConfigModel.setSmtpUsername(testProperties.getProperty(TestPropertyKey.TEST_EMAIL_SMTP_USER));

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/validator/EmailGlobalConfigurationValidatorTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/validator/EmailGlobalConfigurationValidatorTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import com.synopsys.integration.alert.common.descriptor.config.field.errors.AlertFieldStatus;
 import com.synopsys.integration.alert.common.descriptor.validator.ConfigurationFieldValidator;
-import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.rest.model.ValidationResponseModel;
 import com.synopsys.integration.alert.service.email.model.EmailGlobalConfigModel;
 
@@ -27,7 +27,7 @@ public class EmailGlobalConfigurationValidatorTest {
     public void verifyValidConfig() {
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         model.setSmtpHost("host");
         model.setSmtpFrom("from");
         model.setSmtpAuth(true);
@@ -71,7 +71,7 @@ public class EmailGlobalConfigurationValidatorTest {
     public void verifyMissingAuth() {
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         model.setSmtpHost("host");
         model.setSmtpFrom("from");
         model.setSmtpAuth(true);
@@ -88,7 +88,7 @@ public class EmailGlobalConfigurationValidatorTest {
     public void verifyAuthNotProvided() {
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         model.setSmtpHost("host");
         model.setSmtpFrom("from");
         model.setSmtpUsername("user");
@@ -102,7 +102,7 @@ public class EmailGlobalConfigurationValidatorTest {
     public void verifyMissingAuthPassword() {
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         model.setSmtpHost("host");
         model.setSmtpFrom("from");
         model.setSmtpAuth(true);

--- a/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/database/accessor/SettingsProxyConfigAccessor.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/database/accessor/SettingsProxyConfigAccessor.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.common.persistence.accessor.UniqueConfigurationAccessor;
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.security.EncryptionUtility;
 import com.synopsys.integration.alert.common.util.DateUtils;
 import com.synopsys.integration.alert.component.settings.proxy.model.SettingsProxyModel;
@@ -47,7 +48,7 @@ public class SettingsProxyConfigAccessor implements UniqueConfigurationAccessor<
     @Override
     @Transactional(readOnly = true)
     public Optional<SettingsProxyModel> getConfiguration() {
-        return settingsProxyConfigurationRepository.findByName(DEFAULT_CONFIGURATION_NAME).map(this::createConfigModel);
+        return settingsProxyConfigurationRepository.findByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME).map(this::createConfigModel);
     }
 
     @Override
@@ -73,7 +74,7 @@ public class SettingsProxyConfigAccessor implements UniqueConfigurationAccessor<
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
     public SettingsProxyModel updateConfiguration(SettingsProxyModel configuration) throws AlertConfigurationException {
-        SettingsProxyConfigurationEntity configurationEntity = settingsProxyConfigurationRepository.findByName(DEFAULT_CONFIGURATION_NAME)
+        SettingsProxyConfigurationEntity configurationEntity = settingsProxyConfigurationRepository.findByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
                                                                    .orElseThrow(() -> new AlertConfigurationException("Proxy config does not exist"));
         UUID configurationId = configurationEntity.getConfigurationId();
         OffsetDateTime currentTime = DateUtils.createCurrentDateTimestamp();
@@ -89,7 +90,7 @@ public class SettingsProxyConfigAccessor implements UniqueConfigurationAccessor<
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
     public void deleteConfiguration() {
-        settingsProxyConfigurationRepository.deleteByName(DEFAULT_CONFIGURATION_NAME);
+        settingsProxyConfigurationRepository.deleteByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
     }
 
     private SettingsProxyModel createConfigModel(SettingsProxyConfigurationEntity proxyConfiguration) {

--- a/component/src/test/java/com/synopsys/integration/alert/component/settings/proxy/actions/SettingsProxyCrudActionsTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/settings/proxy/actions/SettingsProxyCrudActionsTest.java
@@ -17,8 +17,6 @@ import com.google.gson.Gson;
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
-import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
-import com.synopsys.integration.alert.common.persistence.accessor.UniqueConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.model.PermissionKey;
 import com.synopsys.integration.alert.common.persistence.model.PermissionMatrixModel;
 import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
@@ -64,7 +62,7 @@ public class SettingsProxyCrudActionsTest {
         SettingsProxyConfigurationRepository settingsProxyConfigurationRepository = Mockito.mock(SettingsProxyConfigurationRepository.class);
         NonProxyHostsConfigurationRepository nonProxyHostsConfigurationRepository = Mockito.mock(NonProxyHostsConfigurationRepository.class);
 
-        Mockito.when(settingsProxyConfigurationRepository.findByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(createSettingsProxyConfigurationEntity(uuid)));
+        Mockito.when(settingsProxyConfigurationRepository.findByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(createSettingsProxyConfigurationEntity(uuid)));
 
         SettingsProxyConfigAccessor settingsProxyConfigAccessor = new SettingsProxyConfigAccessor(encryptionUtility, settingsProxyConfigurationRepository, nonProxyHostsConfigurationRepository);
 
@@ -84,7 +82,7 @@ public class SettingsProxyCrudActionsTest {
         NonProxyHostsConfigurationRepository nonProxyHostsConfigurationRepository = Mockito.mock(NonProxyHostsConfigurationRepository.class);
 
         SettingsProxyConfigurationEntity entity = createSettingsProxyConfigurationEntity(uuid);
-        Mockito.when(settingsProxyConfigurationRepository.findByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.empty());
+        Mockito.when(settingsProxyConfigurationRepository.findByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.empty());
 
         Mockito.when(settingsProxyConfigurationRepository.save(Mockito.any())).thenReturn(entity);
         Mockito.when(settingsProxyConfigurationRepository.getOne(uuid)).thenReturn(entity);
@@ -107,7 +105,7 @@ public class SettingsProxyCrudActionsTest {
         SettingsProxyConfigurationRepository settingsProxyConfigurationRepository = Mockito.mock(SettingsProxyConfigurationRepository.class);
         NonProxyHostsConfigurationRepository nonProxyHostsConfigurationRepository = Mockito.mock(NonProxyHostsConfigurationRepository.class);
 
-        Mockito.when(settingsProxyConfigurationRepository.findByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(createSettingsProxyConfigurationEntity(uuid)));
+        Mockito.when(settingsProxyConfigurationRepository.findByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(createSettingsProxyConfigurationEntity(uuid)));
 
         SettingsProxyConfigAccessor settingsProxyConfigAccessor = new SettingsProxyConfigAccessor(encryptionUtility, settingsProxyConfigurationRepository, nonProxyHostsConfigurationRepository);
 
@@ -126,7 +124,7 @@ public class SettingsProxyCrudActionsTest {
         NonProxyHostsConfigurationRepository nonProxyHostsConfigurationRepository = Mockito.mock(NonProxyHostsConfigurationRepository.class);
 
         SettingsProxyConfigurationEntity entity = createSettingsProxyConfigurationEntity(uuid);
-        Mockito.when(settingsProxyConfigurationRepository.findByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(entity));
+        Mockito.when(settingsProxyConfigurationRepository.findByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(entity));
         Mockito.when(settingsProxyConfigurationRepository.save(Mockito.any())).thenReturn(entity);
         Mockito.when(settingsProxyConfigurationRepository.getOne(uuid)).thenReturn(entity);
 
@@ -149,14 +147,14 @@ public class SettingsProxyCrudActionsTest {
         SettingsProxyConfigurationRepository settingsProxyConfigurationRepository = Mockito.mock(SettingsProxyConfigurationRepository.class);
         NonProxyHostsConfigurationRepository nonProxyHostsConfigurationRepository = Mockito.mock(NonProxyHostsConfigurationRepository.class);
 
-        Mockito.when(settingsProxyConfigurationRepository.findByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(createSettingsProxyConfigurationEntity(uuid)));
+        Mockito.when(settingsProxyConfigurationRepository.findByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(createSettingsProxyConfigurationEntity(uuid)));
 
         SettingsProxyConfigAccessor settingsProxyConfigAccessor = new SettingsProxyConfigAccessor(encryptionUtility, settingsProxyConfigurationRepository, nonProxyHostsConfigurationRepository);
 
         SettingsProxyCrudActions configActions = new SettingsProxyCrudActions(authorizationManager, settingsProxyConfigAccessor, settingsProxyValidator, settingsDescriptorKey);
         ActionResponse<SettingsProxyModel> actionResponse = configActions.delete();
 
-        Mockito.verify(settingsProxyConfigurationRepository).deleteByName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        Mockito.verify(settingsProxyConfigurationRepository).deleteByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         assertTrue(actionResponse.isSuccessful());
         assertFalse(actionResponse.hasContent());
         assertEquals(HttpStatus.NO_CONTENT, actionResponse.getHttpStatus());
@@ -165,7 +163,7 @@ public class SettingsProxyCrudActionsTest {
     private SettingsProxyConfigurationEntity createSettingsProxyConfigurationEntity(UUID id) {
         return new SettingsProxyConfigurationEntity(
             id,
-            ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME,
+            AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             DateUtils.createCurrentDateTimestamp(),
             DateUtils.createCurrentDateTimestamp(),
             HOST,
@@ -178,7 +176,7 @@ public class SettingsProxyCrudActionsTest {
 
     private SettingsProxyModel createSettingsProxyModel() {
         SettingsProxyModel settingsProxyModel = new SettingsProxyModel();
-        settingsProxyModel.setName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        settingsProxyModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         settingsProxyModel.setProxyHost(HOST);
         settingsProxyModel.setProxyPort(PORT);
         settingsProxyModel.setProxyUsername(USERNAME);

--- a/component/src/test/java/com/synopsys/integration/alert/component/settings/proxy/validator/SettingsProxyValidatorTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/settings/proxy/validator/SettingsProxyValidatorTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.rest.model.ValidationResponseModel;
 import com.synopsys.integration.alert.component.settings.proxy.model.SettingsProxyModel;
 
@@ -23,7 +23,7 @@ public class SettingsProxyValidatorTest {
     @Test
     public void validateTest() {
         SettingsProxyModel settingsProxyModel = new SettingsProxyModel();
-        settingsProxyModel.setName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        settingsProxyModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         settingsProxyModel.setProxyHost(HOST);
         settingsProxyModel.setProxyPort(PORT);
         settingsProxyModel.setProxyUsername(USERNAME);
@@ -50,7 +50,7 @@ public class SettingsProxyValidatorTest {
     @Test
     public void validateWithoutHostAndPortTest() {
         SettingsProxyModel settingsProxyModel = new SettingsProxyModel();
-        settingsProxyModel.setName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        settingsProxyModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
 
         ValidationResponseModel validationResponseModel = settingsProxyValidator.validate(settingsProxyModel);
         assertTrue(validationResponseModel.hasErrors());
@@ -62,7 +62,7 @@ public class SettingsProxyValidatorTest {
     @Test
     public void validateHostWithoutPortTest() {
         SettingsProxyModel settingsProxyModel = new SettingsProxyModel();
-        settingsProxyModel.setName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        settingsProxyModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         settingsProxyModel.setProxyHost(HOST);
 
         ValidationResponseModel validationResponseModel = settingsProxyValidator.validate(settingsProxyModel);
@@ -74,7 +74,7 @@ public class SettingsProxyValidatorTest {
     @Test
     public void validatePortWithoutHostTest() {
         SettingsProxyModel settingsProxyModel = new SettingsProxyModel();
-        settingsProxyModel.setName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        settingsProxyModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         settingsProxyModel.setProxyPort(PORT);
 
         ValidationResponseModel validationResponseModel = settingsProxyValidator.validate(settingsProxyModel);
@@ -86,7 +86,7 @@ public class SettingsProxyValidatorTest {
     @Test
     public void validateUsernameWithoutPasswordTest() {
         SettingsProxyModel settingsProxyModel = new SettingsProxyModel();
-        settingsProxyModel.setName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        settingsProxyModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         settingsProxyModel.setProxyHost(HOST);
         settingsProxyModel.setProxyPort(PORT);
         settingsProxyModel.setProxyUsername(USERNAME);
@@ -100,7 +100,7 @@ public class SettingsProxyValidatorTest {
     @Test
     public void validatePasswordWithoutUsernameTest() {
         SettingsProxyModel settingsProxyModel = new SettingsProxyModel();
-        settingsProxyModel.setName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        settingsProxyModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         settingsProxyModel.setProxyHost(HOST);
         settingsProxyModel.setProxyPort(PORT);
         settingsProxyModel.setProxyPassword(PASSWORD);
@@ -114,7 +114,7 @@ public class SettingsProxyValidatorTest {
     @Test
     public void validateNonProxyHostsTest() {
         SettingsProxyModel settingsProxyModel = new SettingsProxyModel();
-        settingsProxyModel.setName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        settingsProxyModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         settingsProxyModel.setProxyPort(PORT);
         settingsProxyModel.setNonProxyHosts(List.of("nonProxyHost"));
 

--- a/src/main/java/com/synopsys/integration/alert/update/UpdateEmailService.java
+++ b/src/main/java/com/synopsys/integration/alert/update/UpdateEmailService.java
@@ -21,11 +21,11 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.channel.email.database.accessor.EmailGlobalConfigAccessor;
 import com.synopsys.integration.alert.common.AlertProperties;
-import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.SettingsKeyAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.UserAccessor;
 import com.synopsys.integration.alert.common.persistence.model.SettingsKeyModel;
 import com.synopsys.integration.alert.common.persistence.model.UserModel;
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.service.email.EmailMessagingService;
 import com.synopsys.integration.alert.service.email.EmailTarget;
 import com.synopsys.integration.alert.service.email.JavamailPropertiesFactory;
@@ -72,8 +72,8 @@ public class UpdateEmailService {
                                                     .filter(StringUtils::isNotBlank);
         if (optionalEmailAddress.isPresent()) {
             try {
-                EmailGlobalConfigModel emailServerConfiguration = emailGlobalConfigAccessor.getConfigurationByName(ConfigurationAccessor.DEFAULT_CONFIGURATION_NAME)
-                    .orElseThrow(() -> new AlertException("No global email configuration found"));
+                EmailGlobalConfigModel emailServerConfiguration = emailGlobalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
+                                                                      .orElseThrow(() -> new AlertException("No global email configuration found"));
 
                 String alertServerUrl = alertProperties.getServerURL();
                 Map<String, Object> templateFields = new HashMap<>();

--- a/src/test/java/com/synopsys/integration/alert/component/settings/proxy/web/SettingsProxyControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/settings/proxy/web/SettingsProxyControllerTestIT.java
@@ -26,7 +26,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.testcontainers.shaded.com.google.common.reflect.TypeToken;
 
 import com.google.gson.Gson;
-import com.synopsys.integration.alert.common.persistence.accessor.UniqueConfigurationAccessor;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.component.settings.proxy.model.SettingsProxyModel;
 import com.synopsys.integration.alert.database.settings.proxy.NonProxyHostsConfigurationRepository;
@@ -71,7 +70,7 @@ public class SettingsProxyControllerTestIT {
     @Test
     @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
     public void testCreate() throws Exception {
-        SettingsProxyModel settingsProxyModel = createSettingsProxyModel(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        SettingsProxyModel settingsProxyModel = createSettingsProxyModel(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
 
         String url = AlertRestConstants.SETTINGS_PROXY_PATH;
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(new URI(url))
@@ -85,9 +84,9 @@ public class SettingsProxyControllerTestIT {
     @Test
     @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
     public void testCreateTwice() throws Exception {
-        createDefaultSettingsProxyModel(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME).orElseThrow(AssertionFailedError::new);
+        createDefaultSettingsProxyModel(AlertRestConstants.DEFAULT_CONFIGURATION_NAME).orElseThrow(AssertionFailedError::new);
         SettingsProxyModel newSettingsProxyModel = new SettingsProxyModel();
-        newSettingsProxyModel.setName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        newSettingsProxyModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         newSettingsProxyModel.setProxyHost("newHostname");
         newSettingsProxyModel.setProxyPort(678);
 
@@ -103,7 +102,7 @@ public class SettingsProxyControllerTestIT {
     @Test
     @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
     public void testGetOne() throws Exception {
-        createDefaultSettingsProxyModel(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME).orElseThrow(AssertionFailedError::new);
+        createDefaultSettingsProxyModel(AlertRestConstants.DEFAULT_CONFIGURATION_NAME).orElseThrow(AssertionFailedError::new);
 
         String url = AlertRestConstants.SETTINGS_PROXY_PATH;
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(new URI(url))
@@ -115,9 +114,9 @@ public class SettingsProxyControllerTestIT {
     @Test
     @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
     public void testUpdate() throws Exception {
-        createDefaultSettingsProxyModel(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME).orElseThrow(AssertionFailedError::new);
+        createDefaultSettingsProxyModel(AlertRestConstants.DEFAULT_CONFIGURATION_NAME).orElseThrow(AssertionFailedError::new);
         SettingsProxyModel newSettingsProxyModel = new SettingsProxyModel();
-        newSettingsProxyModel.setName(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        newSettingsProxyModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         newSettingsProxyModel.setProxyHost("newHostname");
         newSettingsProxyModel.setProxyPort(678);
 
@@ -132,7 +131,7 @@ public class SettingsProxyControllerTestIT {
 
     @Test
     public void testDelete() throws Exception {
-        createDefaultSettingsProxyModel(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME).orElseThrow(AssertionFailedError::new);
+        createDefaultSettingsProxyModel(AlertRestConstants.DEFAULT_CONFIGURATION_NAME).orElseThrow(AssertionFailedError::new);
 
         String url = AlertRestConstants.SETTINGS_PROXY_PATH;
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.delete(new URI(url))
@@ -143,7 +142,7 @@ public class SettingsProxyControllerTestIT {
 
     @Test
     public void testValidate() throws Exception {
-        SettingsProxyModel settingsProxyModel = createSettingsProxyModel(UniqueConfigurationAccessor.DEFAULT_CONFIGURATION_NAME);
+        SettingsProxyModel settingsProxyModel = createSettingsProxyModel(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
 
         String url = AlertRestConstants.SETTINGS_PROXY_PATH + "/validate";
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(new URI(url))


### PR DESCRIPTION
Rather than have to call the accessor interfaces for the default configuration name, we've moved it into a single location in AlertRestConstants.