### PR TITLE
Improve Test Configuration to use a new status object

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/message/model/ConfigurationTestResult.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/message/model/ConfigurationTestResult.java
@@ -1,0 +1,27 @@
+package com.synopsys.integration.alert.common.message.model;
+
+public class ConfigurationTestResult {
+    private final boolean isSuccess;
+    private final String statusMessage;
+
+    public static ConfigurationTestResult success(String statusMessage) {
+        return new ConfigurationTestResult(true, statusMessage);
+    }
+
+    public static ConfigurationTestResult failure(String statusMessage) {
+        return new ConfigurationTestResult(false, statusMessage);
+    }
+
+    private ConfigurationTestResult(boolean isSuccess, String statusMessage) {
+        this.isSuccess = isSuccess;
+        this.statusMessage = statusMessage;
+    }
+
+    public boolean isSuccess() {
+        return isSuccess;
+    }
+
+    public String getStatusMessage() {
+        return statusMessage;
+    }
+}

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/ConfigurationTestHelper.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/ConfigurationTestHelper.java
@@ -11,15 +11,13 @@ import java.util.function.Supplier;
 
 import org.springframework.http.HttpStatus;
 
-import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.action.ValidationActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
-import com.synopsys.integration.alert.common.message.model.MessageResult;
+import com.synopsys.integration.alert.common.message.model.ConfigurationTestResult;
 import com.synopsys.integration.alert.common.rest.model.ValidationResponseModel;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
-import com.synopsys.integration.function.ThrowingSupplier;
 
 public class ConfigurationTestHelper {
 
@@ -33,7 +31,7 @@ public class ConfigurationTestHelper {
         this.descriptorKey = descriptorKey;
     }
 
-    public ValidationActionResponse test(Supplier<ValidationActionResponse> validationSupplier, ThrowingSupplier<MessageResult, AlertException> testResultSupplier) {
+    public ValidationActionResponse test(Supplier<ValidationActionResponse> validationSupplier, Supplier<ConfigurationTestResult> testResultSupplier) {
         if (!authorizationManager.hasExecutePermission(context, descriptorKey)) {
             ValidationResponseModel responseModel = ValidationResponseModel.generalError(ActionResponse.FORBIDDEN_MESSAGE);
             return new ValidationActionResponse(HttpStatus.FORBIDDEN, responseModel);
@@ -44,11 +42,11 @@ public class ConfigurationTestHelper {
             return validationResponse;
         }
 
-        try {
-            MessageResult messageResult = testResultSupplier.get();
-            return new ValidationActionResponse(HttpStatus.OK, ValidationResponseModel.success(messageResult.getStatusMessage()));
-        } catch (AlertException e) {
-            return new ValidationActionResponse(HttpStatus.OK, ValidationResponseModel.generalError(e.getMessage()));
+        ConfigurationTestResult testResult = testResultSupplier.get();
+        if (testResult.isSuccess()) {
+            return new ValidationActionResponse(HttpStatus.OK, ValidationResponseModel.success(testResult.getStatusMessage()));
+        } else {
+            return new ValidationActionResponse(HttpStatus.OK, ValidationResponseModel.generalError(testResult.getStatusMessage()));
         }
     }
 }

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/rest/api/TestHelperConfigurationTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/rest/api/TestHelperConfigurationTest.java
@@ -4,17 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.common.action.ValidationActionResponse;
-import com.synopsys.integration.alert.common.descriptor.config.field.errors.AlertFieldStatus;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
-import com.synopsys.integration.alert.common.message.model.MessageResult;
+import com.synopsys.integration.alert.common.message.model.ConfigurationTestResult;
 import com.synopsys.integration.alert.common.persistence.model.PermissionKey;
 import com.synopsys.integration.alert.common.persistence.model.PermissionMatrixModel;
 import com.synopsys.integration.alert.common.rest.model.ValidationResponseModel;
@@ -22,7 +19,6 @@ import com.synopsys.integration.alert.common.security.authorization.Authorizatio
 import com.synopsys.integration.alert.descriptor.api.model.ChannelKey;
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
 import com.synopsys.integration.alert.test.common.AuthenticationTestUtils;
-import com.synopsys.integration.function.ThrowingSupplier;
 
 public class TestHelperConfigurationTest {
     @Test
@@ -33,7 +29,7 @@ public class TestHelperConfigurationTest {
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.NO_PERMISSIONS);
         AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
         ConfigurationTestHelper testHelper = new ConfigurationTestHelper(authorizationManager, ConfigContextEnum.GLOBAL, descriptorKey);
-        ValidationActionResponse response = testHelper.test(() -> new ValidationActionResponse(HttpStatus.OK, ValidationResponseModel.success()), MessageResult::success);
+        ValidationActionResponse response = testHelper.test(() -> new ValidationActionResponse(HttpStatus.OK, ValidationResponseModel.success()), () -> ConfigurationTestResult.success("Success"));
         assertEquals(HttpStatus.FORBIDDEN, response.getHttpStatus());
     }
 
@@ -45,7 +41,7 @@ public class TestHelperConfigurationTest {
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
         AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
         ConfigurationTestHelper testHelper = new ConfigurationTestHelper(authorizationManager, ConfigContextEnum.GLOBAL, descriptorKey);
-        ValidationActionResponse response = testHelper.test(() -> new ValidationActionResponse(HttpStatus.OK, ValidationResponseModel.success()), MessageResult::success);
+        ValidationActionResponse response = testHelper.test(() -> new ValidationActionResponse(HttpStatus.OK, ValidationResponseModel.success()), () -> ConfigurationTestResult.success("Success"));
         assertEquals(HttpStatus.OK, response.getHttpStatus());
 
     }
@@ -58,7 +54,7 @@ public class TestHelperConfigurationTest {
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
         AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
         ConfigurationTestHelper testHelper = new ConfigurationTestHelper(authorizationManager, ConfigContextEnum.GLOBAL, descriptorKey);
-        ValidationActionResponse response = testHelper.test(() -> new ValidationActionResponse(HttpStatus.BAD_REQUEST, ValidationResponseModel.generalError("generalError")), MessageResult::success);
+        ValidationActionResponse response = testHelper.test(() -> new ValidationActionResponse(HttpStatus.BAD_REQUEST, ValidationResponseModel.generalError("generalError")), () -> ConfigurationTestResult.success("Success"));
         ValidationResponseModel validationResponseModel = response.getContent().orElseThrow(() -> new IllegalStateException("Validation content missing"));
         assertEquals(HttpStatus.BAD_REQUEST, response.getHttpStatus());
         assertTrue(validationResponseModel.hasErrors());
@@ -72,7 +68,7 @@ public class TestHelperConfigurationTest {
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
         AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
         ConfigurationTestHelper testHelper = new ConfigurationTestHelper(authorizationManager, ConfigContextEnum.GLOBAL, descriptorKey);
-        ValidationActionResponse response = testHelper.test(() -> new ValidationActionResponse(HttpStatus.OK, ValidationResponseModel.success()), MessageResult::success);
+        ValidationActionResponse response = testHelper.test(() -> new ValidationActionResponse(HttpStatus.OK, ValidationResponseModel.success()), () -> ConfigurationTestResult.success("Success"));
         ValidationResponseModel validationResponseModel = response.getContent().orElseThrow(() -> new IllegalStateException("Validation content missing"));
         assertEquals(HttpStatus.OK, response.getHttpStatus());
         assertFalse(validationResponseModel.hasErrors());
@@ -85,26 +81,8 @@ public class TestHelperConfigurationTest {
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
         AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
-        MessageResult errorMessage = new MessageResult("generalError", List.of(AlertFieldStatus.error("field-name", "this field has an error")));
         ConfigurationTestHelper testHelper = new ConfigurationTestHelper(authorizationManager, ConfigContextEnum.GLOBAL, descriptorKey);
-        ValidationActionResponse response = testHelper.test(() -> new ValidationActionResponse(HttpStatus.OK, ValidationResponseModel.success()), () -> errorMessage);
-        ValidationResponseModel validationResponseModel = response.getContent().orElseThrow(() -> new IllegalStateException("Validation content missing"));
-        assertEquals(HttpStatus.OK, response.getHttpStatus());
-        assertFalse(validationResponseModel.hasErrors());
-    }
-
-    @Test
-    public void testMessageThrowsException() {
-        AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
-        DescriptorKey descriptorKey = new ChannelKey("channel_key", "channel-display-name");
-        PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
-        Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
-        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
-        ThrowingSupplier<MessageResult, AlertException> messageSupplier = () -> {
-            throw new AlertException("error getting test message");
-        };
-        ConfigurationTestHelper testHelper = new ConfigurationTestHelper(authorizationManager, ConfigContextEnum.GLOBAL, descriptorKey);
-        ValidationActionResponse response = testHelper.test(() -> new ValidationActionResponse(HttpStatus.OK, ValidationResponseModel.success()), messageSupplier);
+        ValidationActionResponse response = testHelper.test(() -> new ValidationActionResponse(HttpStatus.OK, ValidationResponseModel.success()), () -> ConfigurationTestResult.failure("Failure"));
         ValidationResponseModel validationResponseModel = response.getContent().orElseThrow(() -> new IllegalStateException("Validation content missing"));
         assertEquals(HttpStatus.OK, response.getHttpStatus());
         assertTrue(validationResponseModel.hasErrors());

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalTestActionTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalTestActionTest.java
@@ -3,7 +3,6 @@ package com.synopsys.integration.alert.channel.email.action;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -26,6 +25,7 @@ import com.synopsys.integration.alert.channel.email.distribution.address.Validat
 import com.synopsys.integration.alert.channel.email.validator.EmailGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.message.model.ConfigurationTestResult;
 import com.synopsys.integration.alert.common.message.model.MessageResult;
 import com.synopsys.integration.alert.common.persistence.model.PermissionKey;
 import com.synopsys.integration.alert.common.persistence.model.PermissionMatrixModel;
@@ -55,13 +55,8 @@ public class EmailGlobalTestActionTest {
         JavamailPropertiesFactory javamailPropertiesFactory = new JavamailPropertiesFactory();
         EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(authorizationManager, validator, emailChannelMessagingService, javamailPropertiesFactory);
 
-        try {
-            MessageResult messageResult = emailGlobalTestAction.testConfigModelContent("noreply@synopsys.com", new EmailGlobalConfigModel());
-            assertFalse(messageResult.hasErrors(), "Expected the message result to not have errors");
-            assertFalse(messageResult.hasWarnings(), "Expected the message result to not have warnings");
-        } catch (AlertException e) {
-            fail("An exception was thrown where none was expected", e);
-        }
+        ConfigurationTestResult testResult = emailGlobalTestAction.testConfigModelContent("noreply@synopsys.com", new EmailGlobalConfigModel());
+        assertTrue(testResult.isSuccess(), "Expected the message result to not have errors");
     }
 
     @Test
@@ -88,12 +83,8 @@ public class EmailGlobalTestActionTest {
 
         EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(authorizationManager, validator, emailChannelMessagingService, javamailPropertiesFactory);
 
-        try {
-            emailGlobalTestAction.testConfigModelContent("", new EmailGlobalConfigModel());
-            fail("Expected an exception to be thrown");
-        } catch (AlertException e) {
-            // Pass
-        }
+        ConfigurationTestResult testResult = emailGlobalTestAction.testConfigModelContent("", new EmailGlobalConfigModel());
+        assertFalse(testResult.isSuccess());
     }
 
     @Test
@@ -102,12 +93,8 @@ public class EmailGlobalTestActionTest {
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(authorizationManager, validator, null, null);
 
-        try {
-            emailGlobalTestAction.testConfigModelContent("not a valid email address", new EmailGlobalConfigModel());
-            fail("Expected an exception to be thrown");
-        } catch (AlertException e) {
-            // Pass
-        }
+        ConfigurationTestResult testResult = emailGlobalTestAction.testConfigModelContent("not a valid email address", new EmailGlobalConfigModel());
+        assertFalse(testResult.isSuccess());
     }
 
     @Test
@@ -127,13 +114,8 @@ public class EmailGlobalTestActionTest {
 
         EmailGlobalConfigModel globalConfigModel = createValidEmailGlobalConfigModel(testProperties);
 
-        try {
-            MessageResult messageResult = emailGlobalTestAction.testConfigModelContent(emailAddress, globalConfigModel);
-            assertFalse(messageResult.hasErrors(), "Expected the message result to not have errors");
-            assertFalse(messageResult.hasWarnings(), "Expected the message result to not have warnings");
-        } catch (AlertException e) {
-            fail("An exception was thrown where none was expected", e);
-        }
+        ConfigurationTestResult testResult = emailGlobalTestAction.testConfigModelContent(emailAddress, globalConfigModel);
+        assertTrue(testResult.isSuccess(), "Expected the message result to not have errors");
     }
 
     @Test


### PR DESCRIPTION
We will now use ConfigurationTestResult to determine success or failure for the ConfigurationTestHelper. MessageResult is still required and will be converted to the new object in the implementing classes such as EmailGlobalTestAction.