### PR TITLE
Bm filter by version

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/FilteredDistributionJobResponseModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/FilteredDistributionJobResponseModel.java
@@ -24,6 +24,7 @@ public class FilteredDistributionJobResponseModel extends AlertSerializableModel
     private final List<String> vulnerabilitySeverityNames;
     private final boolean filterByProject;
     private final String projectNamePattern;
+    private final String projectVersionNamePattern;
 
     public FilteredDistributionJobResponseModel(
         UUID id,
@@ -35,7 +36,8 @@ public class FilteredDistributionJobResponseModel extends AlertSerializableModel
         List<String> policyNames,
         List<String> vulnerabilitySeverityNames,
         boolean filterByProject,
-        String projectNamePattern
+        String projectNamePattern,
+        String projectVersionNamePattern
     ) {
         this.processingType = processingType;
         this.id = id;
@@ -47,6 +49,7 @@ public class FilteredDistributionJobResponseModel extends AlertSerializableModel
         this.vulnerabilitySeverityNames = vulnerabilitySeverityNames;
         this.filterByProject = filterByProject;
         this.projectNamePattern = projectNamePattern;
+        this.projectVersionNamePattern = projectVersionNamePattern;
     }
 
     public UUID getId() {
@@ -89,4 +92,7 @@ public class FilteredDistributionJobResponseModel extends AlertSerializableModel
         return projectNamePattern;
     }
 
+    public String getProjectVersionNamePattern() {
+        return projectVersionNamePattern;
+    }
 }

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProcessingJobAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProcessingJobAccessor.java
@@ -86,6 +86,7 @@ public class DefaultProcessingJobAccessor implements ProcessingJobAccessor {
 
         boolean filterByProject = blackDuckJobDetails.getFilterByProject();
         String projectNamePattern = blackDuckJobDetails.getProjectNamePattern();
+        String projectVersionNamePattern = blackDuckJobDetails.getProjectVersionNamePattern();
 
         return new FilteredDistributionJobResponseModel(
             jobId,
@@ -97,7 +98,8 @@ public class DefaultProcessingJobAccessor implements ProcessingJobAccessor {
             policyNames,
             vulnerabilitySeverityNames,
             filterByProject,
-            projectNamePattern
+            projectNamePattern,
+            projectVersionNamePattern
         );
     }
 

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/job/DistributionJobRepository.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/job/DistributionJobRepository.java
@@ -51,7 +51,7 @@ public interface DistributionJobRepository extends JpaRepository<DistributionJob
                        + "    AND blackDuckDetails.globalConfigId = :blackDuckConfigId"
                        + "    AND notificationTypes.notificationType IN (:notificationTypeSet)"
                        + "    AND jobEntity.distributionFrequency IN (:frequencies)"
-                       + "    AND (blackDuckDetails.filterByProject = false OR blackDuckDetails.projectNamePattern IS NOT NULL OR projects.projectName IN (:projectNames))"
+                       + "    AND (blackDuckDetails.filterByProject = false OR blackDuckDetails.projectNamePattern IS NOT NULL OR blackDuckDetails.projectVersionNamePattern IS NOT NULL OR projects.projectName IN (:projectNames))"
                        + "    AND ("
                        + "          ("
                        + "            coalesce(:vulnerabilitySeverities, NULL) IS NULL"

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/detail/DetailedNotificationContent.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/detail/DetailedNotificationContent.java
@@ -22,6 +22,7 @@ import com.synopsys.integration.util.Stringable;
 public class DetailedNotificationContent extends Stringable {
     private final Long providerConfigId;
     private final String projectName;
+    private final String projectVersionName;
     private final String policyName;
     private final List<String> vulnerabilitySeverities;
     private final NotificationContentWrapper notificationContentWrapper;
@@ -30,37 +31,45 @@ public class DetailedNotificationContent extends Stringable {
         AlertNotificationModel notificationModel,
         NotificationContentComponent notificationContent,
         String projectName,
+        String projectVersionName,
         List<String> vulnerabilitySeverities
     ) {
-        return new DetailedNotificationContent(notificationModel, notificationContent, projectName, null, vulnerabilitySeverities);
+        return new DetailedNotificationContent(notificationModel, notificationContent, projectName, projectVersionName, null, vulnerabilitySeverities);
     }
 
     public static DetailedNotificationContent policy(
         AlertNotificationModel notificationModel,
         NotificationContentComponent notificationContent,
         String projectName,
+        String projectVersionName,
         String policyName
     ) {
-        return new DetailedNotificationContent(notificationModel, notificationContent, projectName, policyName, List.of());
+        return new DetailedNotificationContent(notificationModel, notificationContent, projectName, projectVersionName, policyName, List.of());
     }
 
-    public static DetailedNotificationContent project(AlertNotificationModel notificationModel, NotificationContentComponent notificationContent, String projectName) {
-        return new DetailedNotificationContent(notificationModel, notificationContent, projectName, null, List.of());
+    public static DetailedNotificationContent project(AlertNotificationModel notificationModel, NotificationContentComponent notificationContent, String projectName, String projectVersionName) {
+        return new DetailedNotificationContent(notificationModel, notificationContent, projectName, projectVersionName, null, List.of());
+    }
+
+    public static DetailedNotificationContent versionLess(AlertNotificationModel notificationModel, NotificationContentComponent notificationContent, String projectName) {
+        return new DetailedNotificationContent(notificationModel, notificationContent, projectName, null, null, List.of());
     }
 
     public static DetailedNotificationContent projectless(AlertNotificationModel notificationModel, NotificationContentComponent notificationContent) {
-        return new DetailedNotificationContent(notificationModel, notificationContent, null, null, List.of());
+        return new DetailedNotificationContent(notificationModel, notificationContent, null, null, null, List.of());
     }
 
     private DetailedNotificationContent(
         AlertNotificationModel alertNotificationModel,
         NotificationContentComponent notificationContent,
         @Nullable String projectName,
+        @Nullable String projectVersionName,
         @Nullable String policyName,
         List<String> vulnerabilitySeverities
     ) {
         this.providerConfigId = alertNotificationModel.getProviderConfigId();
         this.projectName = StringUtils.trimToNull(projectName);
+        this.projectVersionName = StringUtils.trimToNull(projectVersionName);
         this.policyName = StringUtils.trimToNull(policyName);
         this.vulnerabilitySeverities = vulnerabilitySeverities;
         this.notificationContentWrapper = new NotificationContentWrapper(alertNotificationModel, notificationContent, notificationContent.getClass());
@@ -72,6 +81,10 @@ public class DetailedNotificationContent extends Stringable {
 
     public Optional<String> getProjectName() {
         return Optional.ofNullable(projectName);
+    }
+
+    public Optional<String> getProjectVersionName() {
+        return Optional.ofNullable(projectVersionName);
     }
 
     public Optional<String> getPolicyName() {

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationFilterUtils.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationFilterUtils.java
@@ -65,8 +65,10 @@ public class JobNotificationFilterUtils {
 
         String projectVersionNamePattern = filteredDistributionJobResponseModel.getProjectVersionNamePattern();
         if (StringUtils.isNotBlank(projectVersionNamePattern)) {
+            // This check has to be made. ProjectDetails isn't empty and hasMatchingProjects is false meaning no projects match and that's a failed case.
+            // Project version pattern has to always be valid and if something else exists (Selected project or project name pattern), that also needs to be valid
             boolean listIsEmptyOrMatches = filteredDistributionJobResponseModel.getProjectDetails().isEmpty() || hasMatchingProjects;
-            return Pattern.matches(projectVersionNamePattern, projectVersionName) && (listIsEmptyOrMatches || matchingProjectNamePattern);
+            return (listIsEmptyOrMatches || matchingProjectNamePattern) && Pattern.matches(projectVersionNamePattern, projectVersionName);
         }
 
         return matchingProjectNamePattern || hasMatchingProjects;

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationFilterUtils.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationFilterUtils.java
@@ -65,10 +65,11 @@ public class JobNotificationFilterUtils {
 
         String projectVersionNamePattern = filteredDistributionJobResponseModel.getProjectVersionNamePattern();
         if (StringUtils.isNotBlank(projectVersionNamePattern)) {
-            // This check has to be made. ProjectDetails isn't empty and hasMatchingProjects is false meaning no projects match and that's a failed case.
             // Project version pattern has to always be valid and if something else exists (Selected project or project name pattern), that also needs to be valid
-            boolean listIsEmptyOrMatches = filteredDistributionJobResponseModel.getProjectDetails().isEmpty() || hasMatchingProjects;
-            return (listIsEmptyOrMatches || matchingProjectNamePattern) && Pattern.matches(projectVersionNamePattern, projectVersionName);
+            boolean selectedProjectsOrNamePatternMatches = hasMatchingProjects || matchingProjectNamePattern;
+            boolean noSelectedProjects = filteredDistributionJobResponseModel.getProjectDetails().isEmpty();
+            boolean projectMatchedOrNoneSelected = noSelectedProjects || selectedProjectsOrNamePatternMatches;
+            return projectMatchedOrNoneSelected && Pattern.matches(projectVersionNamePattern, projectVersionName);
         }
 
         return matchingProjectNamePattern || hasMatchingProjects;

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationFilterUtils.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationFilterUtils.java
@@ -26,7 +26,8 @@ public class JobNotificationFilterUtils {
             return false;
         }
         String projectName = detailedNotificationContent.getProjectName().orElse("");
-        if (!doesProjectApplyToJob(filteredDistributionJobResponseModel, projectName)) {
+        String projectVersionName = detailedNotificationContent.getProjectVersionName().orElse("");
+        if (!doesProjectApplyToJob(filteredDistributionJobResponseModel, projectName, projectVersionName)) {
             return false;
         }
         switch (notificationTypeEnum) {
@@ -48,7 +49,7 @@ public class JobNotificationFilterUtils {
         return filteredDistributionJobResponseModel.getNotificationTypes().contains(notificationType);
     }
 
-    public static boolean doesProjectApplyToJob(FilteredDistributionJobResponseModel filteredDistributionJobResponseModel, String projectName) {
+    public static boolean doesProjectApplyToJob(FilteredDistributionJobResponseModel filteredDistributionJobResponseModel, String projectName, String projectVersionName) {
         if (!filteredDistributionJobResponseModel.isFilterByProject()) {
             return true;
         }
@@ -58,11 +59,16 @@ public class JobNotificationFilterUtils {
             return true;
         }
 
+        String projectVersionNamePattern = filteredDistributionJobResponseModel.getProjectVersionNamePattern();
+        if (projectVersionNamePattern != null && Pattern.matches(projectVersionNamePattern, projectVersionName)) {
+            return true;
+        }
+
         return filteredDistributionJobResponseModel.getProjectDetails()
-                   .stream()
-                   .map(BlackDuckProjectDetailsModel::getName)
-                   .distinct()
-                   .anyMatch(projectName::equals);
+            .stream()
+            .map(BlackDuckProjectDetailsModel::getName)
+            .distinct()
+            .anyMatch(projectName::equals);
     }
 
     public static boolean doVulnerabilitySeveritiesApplyToJob(FilteredDistributionJobResponseModel filteredDistributionJobResponseModel, List<String> notificationSeverities) {

--- a/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/NotificationProcessorTest.java
+++ b/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/NotificationProcessorTest.java
@@ -172,7 +172,8 @@ public class NotificationProcessorTest {
             List.of(),
             List.of(),
             filterByProject,
-            projectNamePattern
+            projectNamePattern,
+            null
         );
     }
 

--- a/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/detail/DetailedNotificationContentTest.java
+++ b/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/detail/DetailedNotificationContentTest.java
@@ -21,9 +21,10 @@ public class DetailedNotificationContentTest {
     @Test
     public void vulnerabilityTest() {
         String projectName = "vuln project";
+        String projectVersionName = "version";
         List<String> severities = List.of("S1", "S2");
         VulnerabilityNotificationContent vulnerabilityNotificationContent = new VulnerabilityNotificationContent();
-        DetailedNotificationContent detailedContent = DetailedNotificationContent.vulnerability(ALERT_NOTIFICATION_MODEL, vulnerabilityNotificationContent, projectName, severities);
+        DetailedNotificationContent detailedContent = DetailedNotificationContent.vulnerability(ALERT_NOTIFICATION_MODEL, vulnerabilityNotificationContent, projectName, projectVersionName, severities);
         assertContent(detailedContent, ALERT_NOTIFICATION_MODEL.getProviderConfigId(), vulnerabilityNotificationContent.getClass(), severities);
         assertEquals(projectName, detailedContent.getProjectName().orElse(null));
         assertTrue(detailedContent.getPolicyName().isEmpty(), EXPECTED_NO_POLICY);
@@ -32,9 +33,10 @@ public class DetailedNotificationContentTest {
     @Test
     public void policyTest() {
         String projectName = "policy project";
+        String projectVersionName = "version";
         String policyName = "policy name 01";
         RuleViolationNotificationContent ruleViolationNotificationContent = new RuleViolationNotificationContent();
-        DetailedNotificationContent detailedContent = DetailedNotificationContent.policy(ALERT_NOTIFICATION_MODEL, ruleViolationNotificationContent, projectName, policyName);
+        DetailedNotificationContent detailedContent = DetailedNotificationContent.policy(ALERT_NOTIFICATION_MODEL, ruleViolationNotificationContent, projectName, projectVersionName, policyName);
         assertContent(detailedContent, ALERT_NOTIFICATION_MODEL.getProviderConfigId(), ruleViolationNotificationContent.getClass(), List.of());
         assertEquals(projectName, detailedContent.getProjectName().orElse(null));
         assertEquals(policyName, detailedContent.getPolicyName().orElse(null));
@@ -43,8 +45,9 @@ public class DetailedNotificationContentTest {
     @Test
     public void projectTest() {
         String projectName = "project with version";
+        String projectVersionName = "version";
         ProjectVersionNotificationContent projectVersionNotificationContent = new ProjectVersionNotificationContent();
-        DetailedNotificationContent detailedContent = DetailedNotificationContent.project(ALERT_NOTIFICATION_MODEL, projectVersionNotificationContent, projectName);
+        DetailedNotificationContent detailedContent = DetailedNotificationContent.project(ALERT_NOTIFICATION_MODEL, projectVersionNotificationContent, projectName, projectVersionName);
         assertContent(detailedContent, ALERT_NOTIFICATION_MODEL.getProviderConfigId(), projectVersionNotificationContent.getClass(), List.of());
         assertEquals(projectName, detailedContent.getProjectName().orElse(null));
         assertTrue(detailedContent.getPolicyName().isEmpty(), EXPECTED_NO_POLICY);

--- a/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/detail/DetailedNotificationContentTest.java
+++ b/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/detail/DetailedNotificationContentTest.java
@@ -1,6 +1,7 @@
 package com.synopsys.integration.alert.processor.api.detail;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -51,6 +52,7 @@ public class DetailedNotificationContentTest {
         assertContent(detailedContent, ALERT_NOTIFICATION_MODEL.getProviderConfigId(), projectVersionNotificationContent.getClass(), List.of());
         assertEquals(projectName, detailedContent.getProjectName().orElse(null));
         assertTrue(detailedContent.getPolicyName().isEmpty(), EXPECTED_NO_POLICY);
+        assertEquals(projectVersionName, detailedContent.getProjectVersionName().orElse(null));
     }
 
     @Test
@@ -60,6 +62,18 @@ public class DetailedNotificationContentTest {
         assertContent(detailedContent, ALERT_NOTIFICATION_MODEL.getProviderConfigId(), licenseLimitNotificationContent.getClass(), List.of());
         assertTrue(detailedContent.getProjectName().isEmpty(), "Expected no project name");
         assertTrue(detailedContent.getPolicyName().isEmpty(), EXPECTED_NO_POLICY);
+    }
+
+    @Test
+    public void versionlessTest() {
+        String projectName = "project with version";
+        String projectVersionName = "version";
+        ProjectVersionNotificationContent projectVersionNotificationContent = new ProjectVersionNotificationContent();
+        DetailedNotificationContent detailedContent = DetailedNotificationContent.versionLess(ALERT_NOTIFICATION_MODEL, projectVersionNotificationContent, projectName);
+        assertContent(detailedContent, ALERT_NOTIFICATION_MODEL.getProviderConfigId(), projectVersionNotificationContent.getClass(), List.of());
+        assertEquals(projectName, detailedContent.getProjectName().orElse(null));
+        assertTrue(detailedContent.getPolicyName().isEmpty(), EXPECTED_NO_POLICY);
+        assertNull(detailedContent.getProjectVersionName().orElse(null));
     }
 
     private static void assertContent(DetailedNotificationContent content, Long providerConfigId, Class<? extends NotificationContentComponent> notificationClass, List<String> vulnerabilitySeverities) {

--- a/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationFilterUtilsTest.java
+++ b/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationFilterUtilsTest.java
@@ -29,7 +29,7 @@ public class JobNotificationFilterUtilsTest {
         NotificationContentComponent notificationContent = Mockito.mock(NotificationContentComponent.class);
         AlertNotificationModel notificationModel = createAlertNotificationModel(NotificationType.VULNERABILITY);
         DetailedNotificationContent detailedNotificationContent = DetailedNotificationContent.vulnerability(notificationModel, notificationContent, PROJECT_NAME, PROJECT_VERSION_NAME, List.of("vuln"));
-        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.POLICY_OVERRIDE.name()), List.of(), List.of(), List.of(), false, "");
+        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.POLICY_OVERRIDE.name()), List.of(), List.of(), List.of(), false, "", "");
 
         assertFalse(JobNotificationFilterUtils.doesNotificationApplyToJob(jobResponseModel, detailedNotificationContent));
     }
@@ -39,7 +39,7 @@ public class JobNotificationFilterUtilsTest {
         NotificationContentComponent notificationContent = Mockito.mock(NotificationContentComponent.class);
         AlertNotificationModel notificationModel = createAlertNotificationModel(NotificationType.VULNERABILITY);
         DetailedNotificationContent detailedNotificationContent = DetailedNotificationContent.project(notificationModel, notificationContent, PROJECT_NAME, PROJECT_VERSION_NAME);
-        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of("projectDoesNotExist"), List.of(), List.of(), true, "");
+        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of("projectDoesNotExist"), List.of(), List.of(), true, "", "");
 
         assertFalse(JobNotificationFilterUtils.doesNotificationApplyToJob(jobResponseModel, detailedNotificationContent));
     }
@@ -49,11 +49,11 @@ public class JobNotificationFilterUtilsTest {
         NotificationContentComponent notificationContent = Mockito.mock(NotificationContentComponent.class);
         AlertNotificationModel notificationModel = createAlertNotificationModel(NotificationType.VULNERABILITY);
         DetailedNotificationContent detailedNotificationContent = DetailedNotificationContent.vulnerability(notificationModel, notificationContent, PROJECT_NAME, PROJECT_VERSION_NAME, List.of("vuln"));
-        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(), List.of(), List.of(), false, "");
+        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(), List.of(), List.of(), false, "", "");
 
         assertTrue(JobNotificationFilterUtils.doesNotificationApplyToJob(jobResponseModel, detailedNotificationContent));
 
-        FilteredDistributionJobResponseModel jobResponseModelWithFailure = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(), List.of(), List.of("vulnDoesNotExist"), false, "");
+        FilteredDistributionJobResponseModel jobResponseModelWithFailure = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(), List.of(), List.of("vulnDoesNotExist"), false, "", "");
         assertFalse(JobNotificationFilterUtils.doesNotificationApplyToJob(jobResponseModelWithFailure, detailedNotificationContent));
     }
 
@@ -66,7 +66,7 @@ public class JobNotificationFilterUtilsTest {
         NotificationContentComponent notificationContent = Mockito.mock(NotificationContentComponent.class);
         AlertNotificationModel notificationModel = createAlertNotificationModel(NotificationType.POLICY_OVERRIDE);
         DetailedNotificationContent detailedNotificationContent = DetailedNotificationContent.policy(notificationModel, notificationContent, PROJECT_NAME, PROJECT_VERSION_NAME, POLICY_NAME);
-        FilteredDistributionJobResponseModel jobResponseModelWithFailure = createFilteredDistributionJobResponseModel(List.of(NotificationType.POLICY_OVERRIDE.name()), List.of(), List.of("policyDoesNotExist"), List.of(), false, "");
+        FilteredDistributionJobResponseModel jobResponseModelWithFailure = createFilteredDistributionJobResponseModel(List.of(NotificationType.POLICY_OVERRIDE.name()), List.of(), List.of("policyDoesNotExist"), List.of(), false, "", "");
         assertFalse(JobNotificationFilterUtils.doesNotificationApplyToJob(jobResponseModelWithFailure, detailedNotificationContent));
     }
 
@@ -75,7 +75,7 @@ public class JobNotificationFilterUtilsTest {
         NotificationContentComponent notificationContent = Mockito.mock(NotificationContentComponent.class);
         AlertNotificationModel notificationModel = createAlertNotificationModel(NotificationType.LICENSE_LIMIT);
         DetailedNotificationContent detailedNotificationContent = DetailedNotificationContent.projectless(notificationModel, notificationContent);
-        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.LICENSE_LIMIT.name()), List.of(), List.of(), List.of(), false, "");
+        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.LICENSE_LIMIT.name()), List.of(), List.of(), List.of(), false, "", "");
 
         assertTrue(JobNotificationFilterUtils.doesNotificationApplyToJob(jobResponseModel, detailedNotificationContent));
     }
@@ -84,7 +84,7 @@ public class JobNotificationFilterUtilsTest {
     public void doesNotificationTypeMatchTest() {
         List<String> notificationTypes = List.of(NotificationType.VULNERABILITY.name(), NotificationType.POLICY_OVERRIDE.name());
 
-        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(notificationTypes, List.of(), List.of(), List.of(), false, "");
+        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(notificationTypes, List.of(), List.of(), List.of(), false, "", "");
 
         assertTrue(JobNotificationFilterUtils.doesNotificationTypeMatch(jobResponseModel, NotificationType.VULNERABILITY.name()));
         assertTrue(JobNotificationFilterUtils.doesNotificationTypeMatch(jobResponseModel, NotificationType.POLICY_OVERRIDE.name()));
@@ -93,42 +93,59 @@ public class JobNotificationFilterUtilsTest {
 
     @Test
     public void doesProjectApplyToJobTest() {
-        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(PROJECT_NAME), List.of(), List.of(), false, "");
+        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(PROJECT_NAME), List.of(), List.of(), false, "", "");
         assertTrue(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModel, PROJECT_NAME, PROJECT_VERSION_NAME));
 
-        FilteredDistributionJobResponseModel jobResponseModelFilterByProject = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(PROJECT_NAME), List.of(), List.of(), true, "");
+        FilteredDistributionJobResponseModel jobResponseModelFilterByProject = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(PROJECT_NAME), List.of(), List.of(), true, "", "");
         assertTrue(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModelFilterByProject, PROJECT_NAME, PROJECT_VERSION_NAME));
         assertFalse(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModelFilterByProject, "projectDoesNotExist", PROJECT_VERSION_NAME));
     }
 
     @Test
     public void doesProjectApplyToJobPatternMatchingTest() {
-        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(PROJECT_NAME), List.of(), List.of(), true, ".*");
+        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(PROJECT_NAME), List.of(), List.of(), true, ".*", "");
         assertTrue(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModel, PROJECT_NAME, PROJECT_VERSION_NAME));
 
-        FilteredDistributionJobResponseModel jobResponseModelFilterByNamePattern = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(PROJECT_NAME), List.of(), List.of(), true, "project*");
+        FilteredDistributionJobResponseModel jobResponseModelFilterByNamePattern = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(PROJECT_NAME), List.of(), List.of(), true, "project*",
+            "");
         assertTrue(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModelFilterByNamePattern, PROJECT_NAME, PROJECT_VERSION_NAME));
         assertFalse(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModelFilterByNamePattern, "nonMatchingName", PROJECT_VERSION_NAME));
     }
 
     @Test
     public void doVulnerabilitySeveritiesApplyToJobTest() {
-        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(), List.of(), List.of("vuln1", "vuln2"), false, "");
+        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(), List.of(), List.of("vuln1", "vuln2"), false, "", "");
         assertTrue(JobNotificationFilterUtils.doVulnerabilitySeveritiesApplyToJob(jobResponseModel, List.of("vuln1", "vuln2")));
         assertFalse(JobNotificationFilterUtils.doVulnerabilitySeveritiesApplyToJob(jobResponseModel, List.of("vulnDoesNotExist")));
 
-        FilteredDistributionJobResponseModel jobResponseModelNoVulnNames = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(), List.of(), List.of(), false, "");
+        FilteredDistributionJobResponseModel jobResponseModelNoVulnNames = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(), List.of(), List.of(), false, "", "");
         assertTrue(JobNotificationFilterUtils.doVulnerabilitySeveritiesApplyToJob(jobResponseModelNoVulnNames, List.of("vuln1")));
     }
 
     @Test
     public void doesPolicyApplyToJobTest() {
-        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.POLICY_OVERRIDE.name()), List.of(), List.of(POLICY_NAME), List.of(), false, "");
+        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.POLICY_OVERRIDE.name()), List.of(), List.of(POLICY_NAME), List.of(), false, "", "");
         assertTrue(JobNotificationFilterUtils.doesPolicyApplyToJob(jobResponseModel, POLICY_NAME));
         assertFalse(JobNotificationFilterUtils.doesPolicyApplyToJob(jobResponseModel, "policyDoesNotExist"));
 
-        FilteredDistributionJobResponseModel jobResponseModelNoPolicyNames = createFilteredDistributionJobResponseModel(List.of(NotificationType.POLICY_OVERRIDE.name()), List.of(), List.of(), List.of(), false, "");
+        FilteredDistributionJobResponseModel jobResponseModelNoPolicyNames = createFilteredDistributionJobResponseModel(List.of(NotificationType.POLICY_OVERRIDE.name()), List.of(), List.of(), List.of(), false, "", "");
         assertTrue(JobNotificationFilterUtils.doesPolicyApplyToJob(jobResponseModelNoPolicyNames, POLICY_NAME));
+    }
+
+    @Test
+    public void doesProjectVersionNameMatchTest() {
+        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(), List.of(), List.of(), List.of(), true, "", "1.0.*");
+        boolean doesProjectApplyToJob = JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModel, "projectName", "1.0.0");
+
+        assertTrue(doesProjectApplyToJob);
+    }
+
+    @Test
+    public void doesProjectVersionNameNotMatchTest() {
+        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(), List.of(), List.of(), List.of(), true, "", "1.0.*");
+        boolean doesProjectApplyToJob = JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModel, "projectName", "fakeNews");
+
+        assertFalse(doesProjectApplyToJob);
     }
 
     private FilteredDistributionJobResponseModel createFilteredDistributionJobResponseModel(
@@ -137,7 +154,8 @@ public class JobNotificationFilterUtilsTest {
         List<String> policyNames,
         List<String> vulnerabilitySeverityNames,
         boolean filerByProject,
-        String projectNamePattern
+        String projectNamePattern,
+        String projectNameVersionPattern
     ) {
         List<BlackDuckProjectDetailsModel> blackDuckProjectDetailsModel = projectNames.stream()
             .map(projectName -> new BlackDuckProjectDetailsModel(projectName, "href"))
@@ -153,7 +171,7 @@ public class JobNotificationFilterUtilsTest {
             vulnerabilitySeverityNames,
             filerByProject,
             projectNamePattern,
-            null);
+            projectNameVersionPattern);
     }
 
     private AlertNotificationModel createAlertNotificationModel(NotificationType notificationType) {
@@ -174,7 +192,7 @@ public class JobNotificationFilterUtilsTest {
         NotificationContentComponent notificationContent = Mockito.mock(NotificationContentComponent.class);
         AlertNotificationModel notificationModel = createAlertNotificationModel(notificationType);
         DetailedNotificationContent detailedNotificationContent = DetailedNotificationContent.policy(notificationModel, notificationContent, PROJECT_NAME, POLICY_NAME, PROJECT_VERSION_NAME);
-        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(notificationType.name()), List.of(), List.of(), List.of(), false, "");
+        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(notificationType.name()), List.of(), List.of(), List.of(), false, "", "");
 
         assertTrue(JobNotificationFilterUtils.doesNotificationApplyToJob(jobResponseModel, detailedNotificationContent));
     }

--- a/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationFilterUtilsTest.java
+++ b/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationFilterUtilsTest.java
@@ -21,13 +21,14 @@ import com.synopsys.integration.blackduck.api.manual.enumeration.NotificationTyp
 
 public class JobNotificationFilterUtilsTest {
     private static final String PROJECT_NAME = "projectName";
+    private static final String PROJECT_VERSION_NAME = "projectVersionName";
     private static final String POLICY_NAME = "policyName";
 
     @Test
     public void doesNotificationApplyToJobNotificationTypeFailureTest() {
         NotificationContentComponent notificationContent = Mockito.mock(NotificationContentComponent.class);
         AlertNotificationModel notificationModel = createAlertNotificationModel(NotificationType.VULNERABILITY);
-        DetailedNotificationContent detailedNotificationContent = DetailedNotificationContent.vulnerability(notificationModel, notificationContent, PROJECT_NAME, List.of("vuln"));
+        DetailedNotificationContent detailedNotificationContent = DetailedNotificationContent.vulnerability(notificationModel, notificationContent, PROJECT_NAME, PROJECT_VERSION_NAME, List.of("vuln"));
         FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.POLICY_OVERRIDE.name()), List.of(), List.of(), List.of(), false, "");
 
         assertFalse(JobNotificationFilterUtils.doesNotificationApplyToJob(jobResponseModel, detailedNotificationContent));
@@ -37,7 +38,7 @@ public class JobNotificationFilterUtilsTest {
     public void doesNotificationApplyToJobProjectFailureTest() {
         NotificationContentComponent notificationContent = Mockito.mock(NotificationContentComponent.class);
         AlertNotificationModel notificationModel = createAlertNotificationModel(NotificationType.VULNERABILITY);
-        DetailedNotificationContent detailedNotificationContent = DetailedNotificationContent.project(notificationModel, notificationContent, PROJECT_NAME);
+        DetailedNotificationContent detailedNotificationContent = DetailedNotificationContent.project(notificationModel, notificationContent, PROJECT_NAME, PROJECT_VERSION_NAME);
         FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of("projectDoesNotExist"), List.of(), List.of(), true, "");
 
         assertFalse(JobNotificationFilterUtils.doesNotificationApplyToJob(jobResponseModel, detailedNotificationContent));
@@ -47,7 +48,7 @@ public class JobNotificationFilterUtilsTest {
     public void doesNotificationApplyToJobVulnerabilityTest() {
         NotificationContentComponent notificationContent = Mockito.mock(NotificationContentComponent.class);
         AlertNotificationModel notificationModel = createAlertNotificationModel(NotificationType.VULNERABILITY);
-        DetailedNotificationContent detailedNotificationContent = DetailedNotificationContent.vulnerability(notificationModel, notificationContent, PROJECT_NAME, List.of("vuln"));
+        DetailedNotificationContent detailedNotificationContent = DetailedNotificationContent.vulnerability(notificationModel, notificationContent, PROJECT_NAME, PROJECT_VERSION_NAME, List.of("vuln"));
         FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(), List.of(), List.of(), false, "");
 
         assertTrue(JobNotificationFilterUtils.doesNotificationApplyToJob(jobResponseModel, detailedNotificationContent));
@@ -64,7 +65,7 @@ public class JobNotificationFilterUtilsTest {
 
         NotificationContentComponent notificationContent = Mockito.mock(NotificationContentComponent.class);
         AlertNotificationModel notificationModel = createAlertNotificationModel(NotificationType.POLICY_OVERRIDE);
-        DetailedNotificationContent detailedNotificationContent = DetailedNotificationContent.policy(notificationModel, notificationContent, PROJECT_NAME, POLICY_NAME);
+        DetailedNotificationContent detailedNotificationContent = DetailedNotificationContent.policy(notificationModel, notificationContent, PROJECT_NAME, PROJECT_VERSION_NAME, POLICY_NAME);
         FilteredDistributionJobResponseModel jobResponseModelWithFailure = createFilteredDistributionJobResponseModel(List.of(NotificationType.POLICY_OVERRIDE.name()), List.of(), List.of("policyDoesNotExist"), List.of(), false, "");
         assertFalse(JobNotificationFilterUtils.doesNotificationApplyToJob(jobResponseModelWithFailure, detailedNotificationContent));
     }
@@ -93,21 +94,21 @@ public class JobNotificationFilterUtilsTest {
     @Test
     public void doesProjectApplyToJobTest() {
         FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(PROJECT_NAME), List.of(), List.of(), false, "");
-        assertTrue(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModel, PROJECT_NAME));
+        assertTrue(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModel, PROJECT_NAME, PROJECT_VERSION_NAME));
 
         FilteredDistributionJobResponseModel jobResponseModelFilterByProject = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(PROJECT_NAME), List.of(), List.of(), true, "");
-        assertTrue(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModelFilterByProject, PROJECT_NAME));
-        assertFalse(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModelFilterByProject, "projectDoesNotExist"));
+        assertTrue(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModelFilterByProject, PROJECT_NAME, PROJECT_VERSION_NAME));
+        assertFalse(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModelFilterByProject, "projectDoesNotExist", PROJECT_VERSION_NAME));
     }
 
     @Test
     public void doesProjectApplyToJobPatternMatchingTest() {
         FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(PROJECT_NAME), List.of(), List.of(), true, ".*");
-        assertTrue(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModel, PROJECT_NAME));
+        assertTrue(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModel, PROJECT_NAME, PROJECT_VERSION_NAME));
 
         FilteredDistributionJobResponseModel jobResponseModelFilterByNamePattern = createFilteredDistributionJobResponseModel(List.of(NotificationType.VULNERABILITY.name()), List.of(PROJECT_NAME), List.of(), List.of(), true, "project*");
-        assertTrue(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModelFilterByNamePattern, PROJECT_NAME));
-        assertFalse(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModelFilterByNamePattern, "nonMatchingName"));
+        assertTrue(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModelFilterByNamePattern, PROJECT_NAME, PROJECT_VERSION_NAME));
+        assertFalse(JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModelFilterByNamePattern, "nonMatchingName", PROJECT_VERSION_NAME));
     }
 
     @Test
@@ -151,7 +152,8 @@ public class JobNotificationFilterUtilsTest {
             policyNames,
             vulnerabilitySeverityNames,
             filerByProject,
-            projectNamePattern);
+            projectNamePattern,
+            null);
     }
 
     private AlertNotificationModel createAlertNotificationModel(NotificationType notificationType) {
@@ -171,7 +173,7 @@ public class JobNotificationFilterUtilsTest {
     private void testPolicyNotifications(NotificationType notificationType) {
         NotificationContentComponent notificationContent = Mockito.mock(NotificationContentComponent.class);
         AlertNotificationModel notificationModel = createAlertNotificationModel(notificationType);
-        DetailedNotificationContent detailedNotificationContent = DetailedNotificationContent.policy(notificationModel, notificationContent, PROJECT_NAME, POLICY_NAME);
+        DetailedNotificationContent detailedNotificationContent = DetailedNotificationContent.policy(notificationModel, notificationContent, PROJECT_NAME, POLICY_NAME, PROJECT_VERSION_NAME);
         FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(notificationType.name()), List.of(), List.of(), List.of(), false, "");
 
         assertTrue(JobNotificationFilterUtils.doesNotificationApplyToJob(jobResponseModel, detailedNotificationContent));

--- a/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationFilterUtilsTest.java
+++ b/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationFilterUtilsTest.java
@@ -148,6 +148,51 @@ public class JobNotificationFilterUtilsTest {
         assertFalse(doesProjectApplyToJob);
     }
 
+    @Test
+    public void doesProjectVersionNameMatchWithWrongProjectTest() {
+        List<String> notValidProjects = List.of("fake project", "project 2", "flippant");
+        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(), notValidProjects, List.of(), List.of(), true, "", "1.0.*");
+        boolean doesProjectApplyToJob = JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModel, "projectName", "1.0.0");
+
+        assertFalse(doesProjectApplyToJob);
+    }
+
+    @Test
+    public void doesProjectVersionNameMatchWithProjectTest() {
+        String validProject = "projectName";
+        List<String> projects = List.of("fake project", "project 2", "flippant", validProject);
+        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(), projects, List.of(), List.of(), true, "", "1.0.*");
+        boolean doesProjectApplyToJob = JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModel, "projectName", "1.0.0");
+
+        assertTrue(doesProjectApplyToJob);
+    }
+
+    @Test
+    public void doesProjectVersionNameMatchWithNoProjectTest() {
+        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(), List.of(), List.of(), List.of(), true, "", "1.0.*");
+        boolean doesProjectApplyToJob = JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModel, "projectName", "1.0.0");
+
+        assertTrue(doesProjectApplyToJob);
+    }
+
+    @Test
+    public void doesProjectVersionNameMatchWithProjectPatternMatchTest() {
+        List<String> projects = List.of("fake project", "project 2", "flippant");
+        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(), projects, List.of(), List.of(), true, "projectN.*", "1.0.*");
+        boolean doesProjectApplyToJob = JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModel, "projectName", "1.0.0");
+
+        assertTrue(doesProjectApplyToJob);
+    }
+
+    @Test
+    public void doesProjectVersionNameMatchWithInvalidProjectPatternMatchTest() {
+        List<String> projects = List.of("fake project", "project 2", "flippant");
+        FilteredDistributionJobResponseModel jobResponseModel = createFilteredDistributionJobResponseModel(List.of(), projects, List.of(), List.of(), true, "projectN.*", "1.0.*");
+        boolean doesProjectApplyToJob = JobNotificationFilterUtils.doesProjectApplyToJob(jobResponseModel, "wrong", "1.0.0");
+
+        assertFalse(doesProjectApplyToJob);
+    }
+
     private FilteredDistributionJobResponseModel createFilteredDistributionJobResponseModel(
         List<String> notificationTypes,
         List<String> projectNames,

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/BomEditNotificationDetailExtractor.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/BomEditNotificationDetailExtractor.java
@@ -53,7 +53,7 @@ public class BomEditNotificationDetailExtractor extends NotificationDetailExtrac
 
             String projectName = project.getName();
             BomEditWithProjectNameNotificationContent updatedNotificationContent = new BomEditWithProjectNameNotificationContent(notificationContent, projectName, projectVersion.getVersionName());
-            DetailedNotificationContent detailedContent = DetailedNotificationContent.project(alertNotificationModel, updatedNotificationContent, projectName);
+            DetailedNotificationContent detailedContent = DetailedNotificationContent.project(alertNotificationModel, updatedNotificationContent, projectName, projectVersion.getVersionName());
             return List.of(detailedContent);
         }
         return List.of();

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/ComponentUnknownVersionNotificationDetailExtractor.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/ComponentUnknownVersionNotificationDetailExtractor.java
@@ -31,7 +31,7 @@ public class ComponentUnknownVersionNotificationDetailExtractor extends Notifica
     public List<DetailedNotificationContent> extractDetailedContent(AlertNotificationModel alertNotificationModel, ComponentUnknownVersionNotificationView notificationView) {
         ComponentUnknownVersionNotificationContent notificationContent = notificationView.getContent();
         ComponentUnknownVersionWithStatusNotificationContent componentUnknownVersionNotificationContent = extractContents(notificationContent);
-        return List.of(DetailedNotificationContent.project(alertNotificationModel, componentUnknownVersionNotificationContent, notificationContent.getProjectName()));
+        return List.of(DetailedNotificationContent.project(alertNotificationModel, componentUnknownVersionNotificationContent, notificationContent.getProjectName(), notificationContent.getProjectVersionName()));
     }
 
     private ComponentUnknownVersionWithStatusNotificationContent extractContents(ComponentUnknownVersionNotificationContent notificationContent) {

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/PolicyOverrideNotificationDetailExtractor.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/PolicyOverrideNotificationDetailExtractor.java
@@ -32,10 +32,10 @@ public class PolicyOverrideNotificationDetailExtractor extends NotificationDetai
     public List<DetailedNotificationContent> extractDetailedContent(AlertNotificationModel alertNotificationModel, PolicyOverrideNotificationView notificationView) {
         PolicyOverrideNotificationContent notificationContent = notificationView.getContent();
         return notificationContent.getPolicyInfos()
-                   .stream()
-                   .map(policyInfo -> createFlattenedContent(notificationContent, policyInfo))
-                   .map(content -> DetailedNotificationContent.policy(alertNotificationModel, content, notificationContent.getProjectName(), content.getPolicyInfo().getPolicyName()))
-                   .collect(Collectors.toList());
+            .stream()
+            .map(policyInfo -> createFlattenedContent(notificationContent, policyInfo))
+            .map(content -> DetailedNotificationContent.policy(alertNotificationModel, content, notificationContent.getProjectName(), notificationContent.getProjectVersionName(), content.getPolicyInfo().getPolicyName()))
+            .collect(Collectors.toList());
     }
 
     private PolicyOverrideUniquePolicyNotificationContent createFlattenedContent(PolicyOverrideNotificationContent notificationContent, PolicyInfo policyInfo) {

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/ProjectNotificationDetailExtractor.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/ProjectNotificationDetailExtractor.java
@@ -28,7 +28,7 @@ public class ProjectNotificationDetailExtractor extends NotificationDetailExtrac
     @Override
     public List<DetailedNotificationContent> extractDetailedContent(AlertNotificationModel alertNotificationModel, ProjectNotificationView notificationView) {
         ProjectNotificationContent notificationContent = notificationView.getContent();
-        return List.of(DetailedNotificationContent.project(alertNotificationModel, notificationContent, notificationContent.getProjectName()));
+        return List.of(DetailedNotificationContent.versionLess(alertNotificationModel, notificationContent, notificationContent.getProjectName()));
     }
 
 }

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/ProjectVersionNotificationDetailExtractor.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/ProjectVersionNotificationDetailExtractor.java
@@ -28,7 +28,7 @@ public class ProjectVersionNotificationDetailExtractor extends NotificationDetai
     @Override
     public List<DetailedNotificationContent> extractDetailedContent(AlertNotificationModel alertNotificationModel, ProjectVersionNotificationView notificationView) {
         ProjectVersionNotificationContent notificationContent = notificationView.getContent();
-        return List.of(DetailedNotificationContent.project(alertNotificationModel, notificationContent, notificationContent.getProjectName()));
+        return List.of(DetailedNotificationContent.project(alertNotificationModel, notificationContent, notificationContent.getProjectName(), notificationContent.getProjectVersionName()));
     }
 
 }

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/RuleViolationClearedNotificationDetailExtractor.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/RuleViolationClearedNotificationDetailExtractor.java
@@ -32,10 +32,10 @@ public class RuleViolationClearedNotificationDetailExtractor extends Notificatio
     public List<DetailedNotificationContent> extractDetailedContent(AlertNotificationModel alertNotificationModel, RuleViolationClearedNotificationView notificationView) {
         RuleViolationClearedNotificationContent notificationContent = notificationView.getContent();
         return notificationContent.getPolicyInfos()
-                   .stream()
-                   .map(policyInfo -> createFlattenedContent(notificationContent, policyInfo))
-                   .map(content -> DetailedNotificationContent.policy(alertNotificationModel, content, notificationContent.getProjectName(), content.getPolicyInfo().getPolicyName()))
-                   .collect(Collectors.toList());
+            .stream()
+            .map(policyInfo -> createFlattenedContent(notificationContent, policyInfo))
+            .map(content -> DetailedNotificationContent.policy(alertNotificationModel, content, notificationContent.getProjectName(), notificationContent.getProjectVersionName(), content.getPolicyInfo().getPolicyName()))
+            .collect(Collectors.toList());
     }
 
     private RuleViolationClearedUniquePolicyNotificationContent createFlattenedContent(RuleViolationClearedNotificationContent notificationContent, PolicyInfo policyInfo) {

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/RuleViolationNotificationDetailExtractor.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/RuleViolationNotificationDetailExtractor.java
@@ -32,10 +32,10 @@ public class RuleViolationNotificationDetailExtractor extends NotificationDetail
     public List<DetailedNotificationContent> extractDetailedContent(AlertNotificationModel alertNotificationModel, RuleViolationNotificationView notificationView) {
         RuleViolationNotificationContent notificationContent = notificationView.getContent();
         return notificationContent.getPolicyInfos()
-                   .stream()
-                   .map(policyInfo -> createFlattenedContent(notificationContent, policyInfo))
-                   .map(content -> DetailedNotificationContent.policy(alertNotificationModel, content, notificationContent.getProjectName(), content.getPolicyInfo().getPolicyName()))
-                   .collect(Collectors.toList());
+            .stream()
+            .map(policyInfo -> createFlattenedContent(notificationContent, policyInfo))
+            .map(content -> DetailedNotificationContent.policy(alertNotificationModel, content, notificationContent.getProjectName(), notificationContent.getProjectVersionName(), content.getPolicyInfo().getPolicyName()))
+            .collect(Collectors.toList());
     }
 
     private RuleViolationUniquePolicyNotificationContent createFlattenedContent(RuleViolationNotificationContent notificationContent, PolicyInfo policyInfo) {

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/VulnerabilityNotificationDetailExtractor.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/VulnerabilityNotificationDetailExtractor.java
@@ -40,16 +40,17 @@ public class VulnerabilityNotificationDetailExtractor extends NotificationDetail
 
         // Separating this notification to be per project should fix a bug with alerts being sent about unrelated projects
         return notificationContent.getAffectedProjectVersions()
-                   .stream()
-                   .map(affectedProjectVersion -> new VulnerabilityUniqueProjectNotificationContent(notificationContent, affectedProjectVersion))
-                   .map(vulnerabilityUniqueProjectNotificationContent -> DetailedNotificationContent.vulnerability(
-                       // This leaves the AlertNotificationModel as the original but modifies the NotificationContent field
-                       alertNotificationModel,
-                       vulnerabilityUniqueProjectNotificationContent,
-                       vulnerabilityUniqueProjectNotificationContent.getAffectedProjectVersion().getProjectName(),
-                       applicableSeverityTypes
-                   ))
-                   .collect(Collectors.toList());
+            .stream()
+            .map(affectedProjectVersion -> new VulnerabilityUniqueProjectNotificationContent(notificationContent, affectedProjectVersion))
+            .map(vulnerabilityUniqueProjectNotificationContent -> DetailedNotificationContent.vulnerability(
+                // This leaves the AlertNotificationModel as the original but modifies the NotificationContent field
+                alertNotificationModel,
+                vulnerabilityUniqueProjectNotificationContent,
+                vulnerabilityUniqueProjectNotificationContent.getAffectedProjectVersion().getProjectName(),
+                vulnerabilityUniqueProjectNotificationContent.getAffectedProjectVersion().getProjectVersionName(),
+                applicableSeverityTypes
+            ))
+            .collect(Collectors.toList());
     }
 
     private Set<String> getApplicableSeverityTypes(VulnerabilityNotificationContent vulnerabilityNotificationContent) {

--- a/src/test/java/com/synopsys/integration/alert/database/api/ProcessingJobAccessorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/database/api/ProcessingJobAccessorTestIT.java
@@ -50,6 +50,8 @@ public class ProcessingJobAccessorTestIT {
     private static final List<UUID> CREATED_JOBS = new LinkedList<>();
     private static final String PROJECT_NAME_1 = "testProject1";
     private static final String PROJECT_NAME_2 = "testProject2";
+    private static final String PROJECT_VERSION_NAME_1 = "version";
+    private static final String PROJECT_VERSION_NAME_2 = "1.1.0";
     private Long providerConfigId;
 
     @Autowired
@@ -102,8 +104,8 @@ public class ProcessingJobAccessorTestIT {
         createJobs(createDistributionJobModels(List.of(VulnerabilitySeverityType.LOW.name()), 100));
 
         List<DetailedNotificationContent> notifications = new ArrayList<>();
-        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.LOW.name()), PROJECT_NAME_1, null));
-        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.HIGH.name()), PROJECT_NAME_2, null));
+        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.LOW.name()), PROJECT_NAME_1, PROJECT_VERSION_NAME_1));
+        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.HIGH.name()), PROJECT_NAME_2, PROJECT_VERSION_NAME_2));
 
         int currentPage = 0;
         FilteredDistributionJobRequestModel filteredDistributionJobRequestModel = new FilteredDistributionJobRequestModel(providerConfigId, List.of(FrequencyType.REAL_TIME));

--- a/src/test/java/com/synopsys/integration/alert/database/api/ProcessingJobAccessorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/database/api/ProcessingJobAccessorTestIT.java
@@ -102,8 +102,8 @@ public class ProcessingJobAccessorTestIT {
         createJobs(createDistributionJobModels(List.of(VulnerabilitySeverityType.LOW.name()), 100));
 
         List<DetailedNotificationContent> notifications = new ArrayList<>();
-        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.LOW.name()), PROJECT_NAME_1));
-        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.HIGH.name()), PROJECT_NAME_2));
+        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.LOW.name()), PROJECT_NAME_1, null));
+        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.HIGH.name()), PROJECT_NAME_2, null));
 
         int currentPage = 0;
         FilteredDistributionJobRequestModel filteredDistributionJobRequestModel = new FilteredDistributionJobRequestModel(providerConfigId, List.of(FrequencyType.REAL_TIME));
@@ -128,12 +128,13 @@ public class ProcessingJobAccessorTestIT {
         assertEquals(expectedNumOfJobs, previousJobIdSet.size());
     }
 
-    private List<DetailedNotificationContent> createVulnerabilityNotificationWrappers(List<String> vulnerabilitySeverities, String projectName) {
+    private List<DetailedNotificationContent> createVulnerabilityNotificationWrappers(List<String> vulnerabilitySeverities, String projectName, String projectVersionName) {
         AlertNotificationModel alertNotificationModel = createAlertNotificationModel(NotificationType.VULNERABILITY);
         DetailedNotificationContent test_project = DetailedNotificationContent.vulnerability(
             alertNotificationModel,
             createVulnerabilityUniqueProjectNotificationContent(projectName),
             projectName,
+            projectVersionName,
             vulnerabilitySeverities
         );
         return List.of(test_project);

--- a/src/test/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationMapperTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationMapperTestIT.java
@@ -41,6 +41,7 @@ import com.synopsys.integration.blackduck.api.manual.enumeration.NotificationTyp
 public class JobNotificationMapperTestIT {
     private static final List<UUID> CREATED_JOBS = new LinkedList<>();
     private static final String PROJECT_NAME_1 = "test_project";
+    private static final String PROJECT_VERSION_NAME_1 = "first_version";
     private static final String POLICY_FILTER_NAME = "policyName";
 
     @Autowired
@@ -200,6 +201,31 @@ public class JobNotificationMapperTestIT {
         testProjectJob();
     }
 
+    @Test
+    public void extractJobsWithMatchingProjectVersionNamePatternFilter() {
+        createJobs(List.of(
+            new DistributionJobRequestModel(
+                true,
+                "name",
+                FrequencyType.REAL_TIME,
+                ProcessingType.DIGEST,
+                ChannelKeys.SLACK.getUniversalKey(),
+                0L,
+                true,
+                null,
+                // Regex to verify we retrieve notifications without a number in the name (PROJECT_VERSION_NAME_1)
+                "^([^0-9]*)$",
+                List.of(NotificationType.VULNERABILITY.name()),
+                List.of(),
+                List.of(),
+                List.of(),
+                new SlackJobDetailsModel(null, "webhook", "channelName", "username")
+            ))
+        );
+
+        testProjectJob();
+    }
+
     private void testSingleJob(DistributionJobRequestModel jobRequestModel, int expectedMappedNotifications) {
         createJobs(List.of(jobRequestModel));
 
@@ -348,7 +374,7 @@ public class JobNotificationMapperTestIT {
             alertNotificationModel,
             createVulnerabilityUniqueProjectNotificationContent(PROJECT_NAME_1),
             PROJECT_NAME_1,
-            null,
+            PROJECT_VERSION_NAME_1,
             List.of(VulnerabilitySeverityType.LOW.name())
         );
         String projectName1 = "test_project1";
@@ -356,7 +382,7 @@ public class JobNotificationMapperTestIT {
             alertNotificationModel,
             createVulnerabilityUniqueProjectNotificationContent(projectName1),
             projectName1,
-            null,
+            "version1",
             List.of(VulnerabilitySeverityType.HIGH.name())
         );
         String projectName2 = "test_project2";
@@ -364,7 +390,7 @@ public class JobNotificationMapperTestIT {
             alertNotificationModel,
             createVulnerabilityUniqueProjectNotificationContent(projectName2),
             projectName2,
-            null,
+            "version2",
             List.of(VulnerabilitySeverityType.LOW.name(), VulnerabilitySeverityType.HIGH.name())
         );
         AlertNotificationModel alertPolicyNotificationModel = createAlertNotificationModel(NotificationType.POLICY_OVERRIDE);
@@ -372,7 +398,7 @@ public class JobNotificationMapperTestIT {
             alertPolicyNotificationModel,
             createVulnerabilityUniqueProjectNotificationContent(projectName2),
             projectName2,
-            null,
+            "1.0.0",
             POLICY_FILTER_NAME
         );
 

--- a/src/test/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationMapperTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationMapperTestIT.java
@@ -60,8 +60,8 @@ public class JobNotificationMapperTestIT {
         createJobs(createDistributionJobModels(List.of(VulnerabilitySeverityType.LOW.name()), 100));
         createJobs(createDistributionJobModels(List.of(VulnerabilitySeverityType.LOW.name(), VulnerabilitySeverityType.HIGH.name()), 15));
         List<DetailedNotificationContent> notifications = new ArrayList<>();
-        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.LOW.name()), "testProject1"));
-        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.HIGH.name()), "testProject2"));
+        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.LOW.name()), "testProject1", null));
+        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.HIGH.name()), "testProject2", null));
 
         runTest(notifications, 115);
     }
@@ -74,9 +74,9 @@ public class JobNotificationMapperTestIT {
         createJobs(createDistributionJobModels(List.of(VulnerabilitySeverityType.CRITICAL.name()), 50));
 
         List<DetailedNotificationContent> notifications = new ArrayList<>();
-        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.LOW.name()), "testProject1"));
-        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.HIGH.name()), "testProject2"));
-        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.CRITICAL.name()), "testProject3"));
+        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.LOW.name()), "testProject1", null));
+        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.HIGH.name()), "testProject2", null));
+        notifications.addAll(createVulnerabilityNotificationWrappers(List.of(VulnerabilitySeverityType.CRITICAL.name()), "testProject3", null));
 
         runTest(notifications, 265);
     }
@@ -330,12 +330,13 @@ public class JobNotificationMapperTestIT {
         return new VulnerabilityUniqueProjectNotificationContent(new VulnerabilityNotificationContent(), affectedProjectVersion);
     }
 
-    private List<DetailedNotificationContent> createVulnerabilityNotificationWrappers(List<String> vulnerabilitySeverities, String projectName) {
+    private List<DetailedNotificationContent> createVulnerabilityNotificationWrappers(List<String> vulnerabilitySeverities, String projectName, String projectVersionName) {
         AlertNotificationModel alertNotificationModel = createAlertNotificationModel(NotificationType.VULNERABILITY);
         DetailedNotificationContent test_project = DetailedNotificationContent.vulnerability(
             alertNotificationModel,
             createVulnerabilityUniqueProjectNotificationContent(projectName),
             projectName,
+            projectVersionName,
             vulnerabilitySeverities
         );
         return List.of(test_project);
@@ -347,6 +348,7 @@ public class JobNotificationMapperTestIT {
             alertNotificationModel,
             createVulnerabilityUniqueProjectNotificationContent(PROJECT_NAME_1),
             PROJECT_NAME_1,
+            null,
             List.of(VulnerabilitySeverityType.LOW.name())
         );
         String projectName1 = "test_project1";
@@ -354,6 +356,7 @@ public class JobNotificationMapperTestIT {
             alertNotificationModel,
             createVulnerabilityUniqueProjectNotificationContent(projectName1),
             projectName1,
+            null,
             List.of(VulnerabilitySeverityType.HIGH.name())
         );
         String projectName2 = "test_project2";
@@ -361,6 +364,7 @@ public class JobNotificationMapperTestIT {
             alertNotificationModel,
             createVulnerabilityUniqueProjectNotificationContent(projectName2),
             projectName2,
+            null,
             List.of(VulnerabilitySeverityType.LOW.name(), VulnerabilitySeverityType.HIGH.name())
         );
         AlertNotificationModel alertPolicyNotificationModel = createAlertNotificationModel(NotificationType.POLICY_OVERRIDE);
@@ -368,6 +372,7 @@ public class JobNotificationMapperTestIT {
             alertPolicyNotificationModel,
             createVulnerabilityUniqueProjectNotificationContent(projectName2),
             projectName2,
+            null,
             POLICY_FILTER_NAME
         );
 


### PR DESCRIPTION
Adds a configuration option to allow users to filter by project version name
Filters on version after filtering by project name
Adds a warning to the test action in the case a matching version is not found