### PR TITLE
Use default Email SMTP password when testing saved configuration

### DIFF
--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalTestAction.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalTestAction.java
@@ -12,11 +12,13 @@ import java.util.function.Supplier;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
+import com.synopsys.integration.alert.channel.email.database.accessor.EmailGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.email.distribution.EmailChannelMessageModel;
 import com.synopsys.integration.alert.channel.email.distribution.EmailChannelMessagingService;
 import com.synopsys.integration.alert.channel.email.validator.EmailGlobalConfigurationValidator;
@@ -25,6 +27,7 @@ import com.synopsys.integration.alert.common.action.ValidationActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.message.model.ConfigurationTestResult;
 import com.synopsys.integration.alert.common.message.model.MessageResult;
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.rest.api.ConfigurationTestHelper;
 import com.synopsys.integration.alert.common.rest.api.ConfigurationValidationHelper;
 import com.synopsys.integration.alert.common.rest.model.ValidationResponseModel;
@@ -44,18 +47,20 @@ public class EmailGlobalTestAction {
     private final ConfigurationValidationHelper validationHelper;
     private final ConfigurationTestHelper testHelper;
     private final EmailGlobalConfigurationValidator validator;
+    private final EmailGlobalConfigAccessor configurationAccessor;
 
     private final EmailChannelMessagingService emailChannelMessagingService;
     private final JavamailPropertiesFactory javamailPropertiesFactory;
 
     @Autowired
     public EmailGlobalTestAction(AuthorizationManager authorizationManager, EmailGlobalConfigurationValidator validator,
-        EmailChannelMessagingService emailChannelMessagingService, JavamailPropertiesFactory javamailPropertiesFactory) {
+        EmailChannelMessagingService emailChannelMessagingService, JavamailPropertiesFactory javamailPropertiesFactory, EmailGlobalConfigAccessor configurationAccessor) {
         this.testHelper = new ConfigurationTestHelper(authorizationManager, ConfigContextEnum.GLOBAL, ChannelKeys.EMAIL);
         this.validationHelper = new ConfigurationValidationHelper(authorizationManager, ConfigContextEnum.GLOBAL, ChannelKeys.EMAIL);
         this.validator = validator;
         this.emailChannelMessagingService = emailChannelMessagingService;
         this.javamailPropertiesFactory = javamailPropertiesFactory;
+        this.configurationAccessor = configurationAccessor;
     }
 
     public ActionResponse<ValidationResponseModel> testWithPermissionCheck(String testAddress, EmailGlobalConfigModel requestResource) {
@@ -85,6 +90,14 @@ public class EmailGlobalTestAction {
         emailGlobalConfigModel.getSmtpPort().ifPresent(smtpConfigBuilder::setSmtpPort);
         emailGlobalConfigModel.getSmtpAuth().ifPresent(smtpConfigBuilder::setSmtpAuth);
         emailGlobalConfigModel.getSmtpUsername().ifPresent(smtpConfigBuilder::setSmtpUsername);
+        
+        if (BooleanUtils.toBoolean(emailGlobalConfigModel.getIsSmtpPasswordSet()) && emailGlobalConfigModel.getSmtpPassword().isEmpty()) {
+            //TODO: This assumes if the password is saved but not provided we only test using the default configuration password.
+            //  If the UI supports multiple configurations in the future we should determine which configuration to get the password from.
+            configurationAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
+                .flatMap(EmailGlobalConfigModel::getSmtpPassword)
+                .ifPresent(emailGlobalConfigModel::setSmtpPassword);
+        }
         emailGlobalConfigModel.getSmtpPassword().ifPresent(smtpConfigBuilder::setSmtpPassword);
 
         SmtpConfig smtpConfig = smtpConfigBuilder.build();


### PR DESCRIPTION
Fixes issue when attempting to test a configuration after saving. Note: Right now this will use the default configuration for the global email channel which will resolve the issue in the UI. I have left a TODO comment to find a better solution once we support multiple configurations in the UI. 

Perhaps as a future solution we could determine which configuration is "in view" and use the ID to get the correct configuration from the database. 