### PR TITLE
build: Adjust alertDatabaseDockerImageVersion to be a property

### DIFF
--- a/alert-database/build.gradle
+++ b/alert-database/build.gradle
@@ -11,10 +11,9 @@ buildscript {
     }
 }
 
-def alertDatabaseDockerImageVersion = '1.0.3-SNAPSHOT'
-
 ext {
     moduleName = 'com.synopsys.integration.alert.database'
+    alertDatabaseDockerImageVersion = '1.0.3-SNAPSHOT'
 }
 
 apply plugin: com.bmuschko.gradle.docker.DockerRemoteApiPlugin


### PR DESCRIPTION
alertDatabaseDockerImageVersion is defined as a local variable, which prevents us from getting this value using `./gradlew -p alert-database properties`. This is desired in order to automate getting the value of alertDatabaseDockerImageVersion for use in PoP builds.

With this change, we are able to retrieve this value AND the image is created with the correct version.