### PR TITLE
fix: If the origins list is empty create the old vulnerabilities link.

### DIFF
--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/BlackDuckMessageBomComponentDetailsCreator.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/BlackDuckMessageBomComponentDetailsCreator.java
@@ -299,11 +299,26 @@ public class BlackDuckMessageBomComponentDetailsCreator {
 
     // Takes the list of origins from the collapsed notifications instead of the bom component itself
     private List<HttpUrl> createVulnerabilitiesLinks(HttpUrl vulnerabilitiesUrl, List<VersionBomOriginView> allOrigins) {
+        // if the origins are empty then the link that will be created for the component will not be as accurate to report remediation data.
+        if (allOrigins.isEmpty()) {
+            return createVulnerabilitiesLinkMissingOrigins(vulnerabilitiesUrl);
+        }
+
         return allOrigins.stream()
             .map(VersionBomOriginView::getOrigin)
             .map((origin) -> createVulnerabilitiesLink(vulnerabilitiesUrl, origin))
             .flatMap(Optional::stream)
             .collect(Collectors.toList());
+    }
+
+    private List<HttpUrl> createVulnerabilitiesLinkMissingOrigins(HttpUrl vulnerabilitiesUrl) {
+        List<HttpUrl> vulnerabilitiesLinks = List.of();
+        try {
+            vulnerabilitiesLinks = List.of(vulnerabilitiesUrl.appendRelativeUrl(VULNERABILITIES_LINK.getLink()));
+        } catch (IntegrationException ex) {
+            logger.error("Error appending vulnerabilities relative URL to Bom Component detail", ex);
+        }
+        return vulnerabilitiesLinks;
     }
 
     private Optional<HttpUrl> createVulnerabilitiesLink(HttpUrl vulnerabilitiesUrl, String originUrl) {

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/VulnerabilityNotificationMessageExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/VulnerabilityNotificationMessageExtractorTest.java
@@ -2,6 +2,7 @@ package com.synopsys.integration.alert.provider.blackduck.processor.message;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
@@ -31,12 +32,15 @@ import com.synopsys.integration.blackduck.api.generated.component.ComponentVersi
 import com.synopsys.integration.blackduck.api.generated.component.ComponentVersionUpgradeGuidanceShortTermView;
 import com.synopsys.integration.blackduck.api.generated.component.ComponentVersionUpgradeGuidanceShortTermVulnerabilityRiskView;
 import com.synopsys.integration.blackduck.api.generated.component.ProjectVersionComponentVersionLicensesView;
+import com.synopsys.integration.blackduck.api.generated.component.RiskProfileCountsView;
 import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionComponentPolicyStatusType;
+import com.synopsys.integration.blackduck.api.generated.enumeration.RiskPriorityType;
 import com.synopsys.integration.blackduck.api.generated.enumeration.UsageType;
 import com.synopsys.integration.blackduck.api.generated.enumeration.VulnerabilitySeverityType;
 import com.synopsys.integration.blackduck.api.generated.response.ComponentVersionUpgradeGuidanceView;
 import com.synopsys.integration.blackduck.api.generated.view.ComponentVersionView;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionComponentVersionView;
+import com.synopsys.integration.blackduck.api.generated.view.RiskProfileView;
 import com.synopsys.integration.blackduck.api.manual.component.AffectedProjectVersion;
 import com.synopsys.integration.blackduck.api.manual.component.VulnerabilityNotificationContent;
 import com.synopsys.integration.blackduck.api.manual.component.VulnerabilitySourceQualifiedId;
@@ -83,7 +87,7 @@ public class VulnerabilityNotificationMessageExtractorTest {
         BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
         Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
 
-        ProjectVersionComponentVersionView projectVersionComponentVersionView = createProjectVersionComponentVersionView();
+        ProjectVersionComponentVersionView projectVersionComponentVersionView = createProjectVersionComponentVersionView(true);
         Mockito.when(blackDuckApiClient.getResponse(Mockito.any(), Mockito.eq(ProjectVersionComponentVersionView.class))).thenReturn(projectVersionComponentVersionView);
 
         ComponentVersionUpgradeGuidanceView componentVersionUpgradeGuidanceView = createComponentVersionUpgradeGuidanceView();
@@ -103,12 +107,47 @@ public class VulnerabilityNotificationMessageExtractorTest {
         assertEquals(UsageType.DYNAMICALLY_LINKED.prettyPrint(), testBomComponentDetails.getUsage());
         assertTrue(testBomComponentDetails.getAdditionalAttributes().isEmpty());
         assertTrue(testBomComponentDetails.getRelevantPolicies().isEmpty());
+        assertNotNull(testBomComponentDetails.getComponentVulnerabilities());
 
         assertEquals(3, testBomComponentDetails.getComponentConcerns().size());
 
         ComponentUpgradeGuidance componentUpgradeGuidance = testBomComponentDetails.getComponentUpgradeGuidance();
         assertTrue(componentUpgradeGuidance.getLongTermUpgradeGuidance().isPresent());
         assertTrue(componentUpgradeGuidance.getShortTermUpgradeGuidance().isPresent());
+    }
+
+    @Test
+    public void createBomComponentDetailsMissingOriginTest() throws IntegrationException {
+        BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
+        BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
+        Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
+
+        ProjectVersionComponentVersionView projectVersionComponentVersionView = createProjectVersionComponentVersionView(false);
+        Mockito.when(blackDuckApiClient.getResponse(Mockito.any(), Mockito.eq(ProjectVersionComponentVersionView.class))).thenReturn(projectVersionComponentVersionView);
+
+        ComponentVersionUpgradeGuidanceView componentVersionUpgradeGuidanceView = createComponentVersionUpgradeGuidanceView();
+        // A UrlSingleResponse is needed to Mock the blackDuckApiClient in BlackDuckMessageComponentVersionUpgradeGuidanceService::requestUpgradeGuidanceItems
+        UrlSingleResponse<ComponentVersionUpgradeGuidanceView> urlSingleResponse = new UrlSingleResponse<>(new HttpUrl(UPGRADE_GUIDANCE_URL), ComponentVersionUpgradeGuidanceView.class);
+        Mockito.when(blackDuckApiClient.getResponse(Mockito.eq(urlSingleResponse))).thenReturn(componentVersionUpgradeGuidanceView);
+
+        VulnerabilityUniqueProjectNotificationContent notificationContent = createVulnerabilityUniqueProjectNotificationContent();
+        List<BomComponentDetails> bomComponentDetailsList = extractor.createBomComponentDetails(notificationContent, blackDuckServicesFactory);
+
+        assertEquals(1, bomComponentDetailsList.size());
+        BomComponentDetails testBomComponentDetails = bomComponentDetailsList.get(0);
+        assertEquals(COMPONENT, testBomComponentDetails.getComponent());
+        assertTrue(testBomComponentDetails.getComponentVersion().isPresent());
+        assertEquals(COMPONENT_VERSION.getValue(), testBomComponentDetails.getComponentVersion().get().getValue());
+        assertEquals(LICENSE_DISPLAY, testBomComponentDetails.getLicense().getValue());
+        assertEquals(UsageType.DYNAMICALLY_LINKED.prettyPrint(), testBomComponentDetails.getUsage());
+        assertTrue(testBomComponentDetails.getAdditionalAttributes().isEmpty());
+        assertTrue(testBomComponentDetails.getRelevantPolicies().isEmpty());
+        assertNotNull(testBomComponentDetails.getComponentVulnerabilities());
+        assertEquals(3, testBomComponentDetails.getComponentConcerns().size());
+
+        ComponentUpgradeGuidance componentUpgradeGuidance = testBomComponentDetails.getComponentUpgradeGuidance();
+        assertTrue(componentUpgradeGuidance.getLongTermUpgradeGuidance().isEmpty());
+        assertTrue(componentUpgradeGuidance.getShortTermUpgradeGuidance().isEmpty());
     }
 
     @Test
@@ -232,7 +271,7 @@ public class VulnerabilityNotificationMessageExtractorTest {
         return notificationContent;
     }
 
-    private ProjectVersionComponentVersionView createProjectVersionComponentVersionView() throws IntegrationException {
+    private ProjectVersionComponentVersionView createProjectVersionComponentVersionView(boolean withOrigin) throws IntegrationException {
         ProjectVersionComponentVersionView projectVersionComponentVersionView = new ProjectVersionComponentVersionView();
 
         projectVersionComponentVersionView.setComponentName(COMPONENT.getValue());
@@ -250,7 +289,7 @@ public class VulnerabilityNotificationMessageExtractorTest {
         resourceLink.setHref(new HttpUrl("https://policyRulesLink"));
         resourceLink.setRel("policy-rules");
         ResourceMetadata meta = new ResourceMetadata();
-        meta.setHref(new HttpUrl("https://policyRules"));
+        meta.setHref(new HttpUrl("https://bomComponentHref"));
         meta.setLinks(List.of(resourceLink));
         projectVersionComponentVersionView.setMeta(meta);
 
@@ -260,9 +299,20 @@ public class VulnerabilityNotificationMessageExtractorTest {
         ResourceMetadata metaUpgradeGuidance = new ResourceMetadata();
         metaUpgradeGuidance.setHref(new HttpUrl("https://upgradeGuidance"));
         metaUpgradeGuidance.setLinks(List.of(resourceLinkUpgradeGuidance));
-        VersionBomOriginView versionBomOriginView = new VersionBomOriginView();
-        versionBomOriginView.setMeta(metaUpgradeGuidance);
-        projectVersionComponentVersionView.setOrigins(List.of(versionBomOriginView));
+        RiskProfileView riskProfileView = new RiskProfileView();
+        RiskProfileCountsView riskProfileCountsView = new RiskProfileCountsView();
+        riskProfileCountsView.setCount(BigDecimal.ONE);
+        riskProfileCountsView.setCountType(RiskPriorityType.HIGH);
+        riskProfileView.setCounts(List.of(riskProfileCountsView));
+        projectVersionComponentVersionView.setSecurityRiskProfile(riskProfileView);
+
+        if (withOrigin) {
+            VersionBomOriginView versionBomOriginView = new VersionBomOriginView();
+            versionBomOriginView.setMeta(metaUpgradeGuidance);
+            projectVersionComponentVersionView.setOrigins(List.of(versionBomOriginView));
+        } else {
+            projectVersionComponentVersionView.setOrigins(List.of());
+        }
 
         return projectVersionComponentVersionView;
     }


### PR DESCRIPTION
Create the older vulnerabilities links from previous versions of Alert if there are no origins in the notification for the bom component.  This ensures that a ticket is created by the issue tracker for the component.