### PR TITLE
Check if validation error exist when testing the configurations

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/action/ValidationActionResponse.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/action/ValidationActionResponse.java
@@ -50,4 +50,9 @@ public class ValidationActionResponse extends ActionResponse<ValidationResponseM
         return getContent()
                    .map(ValidationResponseModel::getMessage);
     }
+
+    public boolean hasValidationErrors() {
+        return getContent().stream()
+                   .anyMatch(ValidationResponseModel::hasErrors);
+    }
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/ConfigurationTestHelper.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/ConfigurationTestHelper.java
@@ -38,7 +38,9 @@ public class ConfigurationTestHelper {
         }
 
         ValidationActionResponse validationResponse = validationSupplier.get();
-        if (validationResponse.isError()) {
+        // validationResponse.isError() will always be false due to the validationHelper always returning an HttpStatus OK. If unused by future test actions
+        //  using different validation schemes, this should be removed.
+        if (validationResponse.isError() || validationResponse.hasValidationErrors()) {
             return validationResponse;
         }
 


### PR DESCRIPTION
This is a fix where previously validation would find errors with the configuration and would instead continue testing causing 500 server errors being thrown to the user and logged stack traces when failures occurred. 