### PR TITLE
testcontainers config to start the container before the tests

### DIFF
--- a/alert-platform/build.gradle
+++ b/alert-platform/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     constraints {
         api 'com.github.springtestdbunit:spring-test-dbunit:1.3.0'
         api 'org.testcontainers:postgresql:1.12.5'
+        api 'com.playtika.testcontainers:embedded-postgresql:2.0.5'
+        api 'org.springframework.cloud:spring-cloud-starter-bootstrap:3.0.1'
         api 'org.apache.activemq:activemq-broker:5.15.10'
 
         api 'org.jsoup:jsoup:1.9.2'

--- a/build.gradle
+++ b/build.gradle
@@ -141,9 +141,11 @@ dependencies {
     // Test and Dev
     // =============
     testImplementation 'org.testcontainers:postgresql'
+    testRuntimeClasspath 'com.playtika.testcontainers:embedded-postgresql'
+    testRuntimeClasspath 'org.springframework.cloud:spring-cloud-starter-bootstrap'
     if (getGradle().getStartParameter().taskNames.contains('runServer') && !getGradle().getStartParameter().taskNames.contains("--externaldb")) {
-        runtimeClasspath 'com.playtika.testcontainers:embedded-postgresql:2.0.5'
-        runtimeClasspath 'org.springframework.cloud:spring-cloud-starter-bootstrap:3.0.1'
+        runtimeClasspath 'com.playtika.testcontainers:embedded-postgresql'
+        runtimeClasspath 'org.springframework.cloud:spring-cloud-starter-bootstrap'
         runtimeClasspath 'org.springframework.boot:spring-boot-devtools'
     }
 

--- a/src/test/java/com/synopsys/integration/alert/processing/JmsNotificationReceiverTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/processing/JmsNotificationReceiverTestIT.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
@@ -65,8 +66,9 @@ import com.synopsys.integration.blackduck.api.manual.view.ProjectNotificationVie
 @WebAppConfiguration
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("alertdb")
+@SpringBootTest
 @TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, DirtiesContextTestExecutionListener.class, TransactionalTestExecutionListener.class, DbUnitTestExecutionListener.class })
-public class JmsNotificationReceiverTestIT {
+class JmsNotificationReceiverTestIT {
     protected TestProperties properties;
     private List<AlertNotificationModel> savedModels;
     private DistributionJobModel distributionJobModel;
@@ -128,7 +130,7 @@ public class JmsNotificationReceiverTestIT {
 
     @Test
     @Disabled
-    public void testJms() throws InterruptedException {
+    void testJms() throws InterruptedException {
         // Set breakpoints throughout this test, there is nothing to assert against here. Suggestions for breakpoints:
         //      Registering listeners: EventListenerConfigurer
         //      Sending events: EventManager

--- a/src/test/java/com/synopsys/integration/alert/util/AlertIntegrationTest.java
+++ b/src/test/java/com/synopsys/integration/alert/util/AlertIntegrationTest.java
@@ -9,6 +9,7 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
@@ -36,6 +37,7 @@ import com.synopsys.integration.alert.test.common.TestTags;
 @WebAppConfiguration
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("alertdb")
+@SpringBootTest
 @TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, DirtiesContextTestExecutionListener.class, TransactionalTestExecutionListener.class, DbUnitTestExecutionListener.class })
 public @interface AlertIntegrationTest {
 }

--- a/src/test/resources/spring-test.properties
+++ b/src/test/resources/spring-test.properties
@@ -1,5 +1,6 @@
 server.ssl.enabled=false
 spring.datasource.url=jdbc:tc:postgresql:12.2:///alertdb?TC_INITSCRIPT=file:buildSrc/src/main/resources/init_test_db.sql&TC_TMPFS=/testtmpfs:rw
+spring.datasource.hikari.jdbc-url=spring.datasource.url=jdbc:tc:postgresql:12.2:///alertdb?TC_INITSCRIPT=file:buildSrc/src/main/resources/init_test_db.sql&TC_TMPFS=/testtmpfs:rw
 spring.datasource.username=sa
 spring.datasource.password=blackduck
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver


### PR DESCRIPTION
Test containers can be configured for JDBC through the URLS.  However testcontainers needs a few dependencies to be able to start the containers at the beginning of each test.
https://www.testcontainers.org/modules/databases/jdbc/

You still need the correct dependencies with spring boot to start the container before each test:
https://github.com/Playtika/testcontainers-spring-boot