### PR TITLE
Fix missing IDs for input fields in the UI

### DIFF
--- a/ui/src/main/js/common/component/input/CheckboxInput.js
+++ b/ui/src/main/js/common/component/input/CheckboxInput.js
@@ -6,6 +6,7 @@ const CheckboxInput = ({
     id, description, errorName, errorValue, isChecked, label, labelClass, name, onChange, readOnly, required, showDescriptionPlaceHolder
 }) => (
     <LabeledField
+        id={id}
         labelClass={labelClass}
         description={description}
         showDescriptionPlaceHolder={showDescriptionPlaceHolder}

--- a/ui/src/main/js/common/component/input/DynamicSelectInput.js
+++ b/ui/src/main/js/common/component/input/DynamicSelectInput.js
@@ -135,6 +135,7 @@ const DynamicSelectInput = ({
 
     return (
         <LabeledField
+            id={id}
             description={description}
             errorName={errorName}
             errorValue={errorValue}

--- a/ui/src/main/js/common/component/input/NumberInput.js
+++ b/ui/src/main/js/common/component/input/NumberInput.js
@@ -8,6 +8,7 @@ const NumberInput = ({
     const onChangeHandler = readOnly ? null : onChange;
     return (
         <LabeledField
+            id={id}
             description={description}
             errorName={errorName}
             errorValue={errorValue}

--- a/ui/src/main/js/common/component/input/PasswordInput.js
+++ b/ui/src/main/js/common/component/input/PasswordInput.js
@@ -9,6 +9,7 @@ const PasswordInput = ({
     const onChangeHandler = readOnly ? null : onChange;
     return (
         <LabeledField
+            id={id}
             labelClass={labelClass}
             description={description}
             showDescriptionPlaceHolder={showDescriptionPlaceHolder}

--- a/ui/src/main/js/common/component/input/TextInput.js
+++ b/ui/src/main/js/common/component/input/TextInput.js
@@ -10,6 +10,7 @@ const TextInput = ({
 
     return (
         <LabeledField
+            id={id}
             labelClass={labelClass}
             description={description}
             showDescriptionPlaceHolder={showDescriptionPlaceHolder}


### PR DESCRIPTION
QA has recently told us that they have been using names and other tags to key for their automation tests. Looking into the input fields it appears that some LabeledFields are no longer passing IDs  correctly and are using the default value. This PR should address this problem by adding the id's back in.