### PR TITLE
Fix update encryption  settings when default configuration was missing

### DIFF
--- a/component/src/main/java/com/synopsys/integration/alert/component/settings/encryption/action/SettingsEncryptionCrudActions.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/settings/encryption/action/SettingsEncryptionCrudActions.java
@@ -47,9 +47,12 @@ public class SettingsEncryptionCrudActions {
     }
 
     public ActionResponse<SettingsEncryptionModel> update(SettingsEncryptionModel requestResource) {
+        // Due to the unique behavior of Encryption, in the event that nothing is saved on the system through the environment nor volume data file, we must supply
+        //  a value of TRUE for the existingModelSupplier. The encryptionUtility handles writing the data correctly whether the model exists or not. Without this,
+        //  the value will not be written to the volume data file during the update.
         return configurationHelper.update(
             () -> validator.validate(requestResource),
-            () -> getSettingsEncryptionModel().isPresent(),
+            () -> Boolean.TRUE,
             () -> updateSettingsEncryptionModel(requestResource)
         );
     }
@@ -88,8 +91,8 @@ public class SettingsEncryptionCrudActions {
     private SettingsEncryptionModel createMaskedSettingsEncryptionModel() {
         // EncryptionUtility does not return a model. A SettingsEncryptionModel with values must be created in order to obfuscate in the ConfigurationCrudHelper later.
         SettingsEncryptionModel settingsEncryptionModel = new SettingsEncryptionModel();
-        settingsEncryptionModel.setIsEncryptionPasswordSet(true);
-        settingsEncryptionModel.setIsEncryptionGlobalSaltSet(true);
+        settingsEncryptionModel.setIsEncryptionPasswordSet(encryptionUtility.isPasswordSet());
+        settingsEncryptionModel.setIsEncryptionGlobalSaltSet(encryptionUtility.isGlobalSaltSet());
         settingsEncryptionModel.setReadOnly(encryptionUtility.isEncryptionFromEnvironment());
         return settingsEncryptionModel;
     }


### PR DESCRIPTION
This is to cover an edge case during new installations where the customer does not use encryption settings and has not set up an alert_encryption_data.json file. This file would normally get created during the write but due to how we have implemented the ConfigurationCrudHelper we would perform check to see if the configuration exists (which will always fail and the update never runs). 

Due to the unique nature of encryption, we will only perform updates. Checking the configuration does not matter for the update since the encryptionUtility handles all the functionally of saving these values or getting  them back from the environment. For this reason, we've made the existing configuration supplier always return  true.