### PR TITLE
Bm convert email single config

### DIFF
--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalCrudActions.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalCrudActions.java
@@ -33,7 +33,7 @@ public class EmailGlobalCrudActions {
     }
 
     public ActionResponse<EmailGlobalConfigModel> getOne() {
-        return configurationHelper.getOne(() -> configurationAccessor.getConfiguration());
+        return configurationHelper.getOne(configurationAccessor::getConfiguration);
     }
 
     public ActionResponse<EmailGlobalConfigModel> create(EmailGlobalConfigModel resource) {

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalCrudActions.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalCrudActions.java
@@ -7,8 +7,6 @@
  */
 package com.synopsys.integration.alert.channel.email.action;
 
-import java.util.UUID;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -17,7 +15,6 @@ import com.synopsys.integration.alert.channel.email.validator.EmailGlobalConfigu
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.rest.api.ConfigurationCrudHelper;
-import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
 import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
 import com.synopsys.integration.alert.service.email.model.EmailGlobalConfigModel;
@@ -35,12 +32,8 @@ public class EmailGlobalCrudActions {
         this.validator = validator;
     }
 
-    public ActionResponse<EmailGlobalConfigModel> getOne(UUID id) {
-        return configurationHelper.getOne(() -> configurationAccessor.getConfiguration(id));
-    }
-
-    public ActionResponse<AlertPagedModel<EmailGlobalConfigModel>> getPaged(int page, int size) {
-        return configurationHelper.getPage(() -> configurationAccessor.getConfigurationPage(page, size));
+    public ActionResponse<EmailGlobalConfigModel> getOne() {
+        return configurationHelper.getOne(() -> configurationAccessor.getConfiguration());
     }
 
     public ActionResponse<EmailGlobalConfigModel> create(EmailGlobalConfigModel resource) {
@@ -50,18 +43,18 @@ public class EmailGlobalCrudActions {
         );
     }
 
-    public ActionResponse<EmailGlobalConfigModel> update(UUID id, EmailGlobalConfigModel requestResource) {
+    public ActionResponse<EmailGlobalConfigModel> update(EmailGlobalConfigModel requestResource) {
         return configurationHelper.update(
             () -> validator.validate(requestResource),
-            () -> configurationAccessor.getConfiguration(id).isPresent(),
-            () -> configurationAccessor.updateConfiguration(id, requestResource)
+            () -> configurationAccessor.doesConfigExist(),
+            () -> configurationAccessor.updateConfiguration(requestResource)
         );
     }
 
-    public ActionResponse<EmailGlobalConfigModel> delete(UUID id) {
+    public ActionResponse<EmailGlobalConfigModel> delete() {
         return configurationHelper.delete(
-            () -> configurationAccessor.getConfiguration(id).isPresent(),
-            () -> configurationAccessor.deleteConfiguration(id)
+            () -> configurationAccessor.doesConfigExist(),
+            () -> configurationAccessor.deleteConfiguration()
         );
     }
 }

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalTestAction.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalTestAction.java
@@ -27,7 +27,6 @@ import com.synopsys.integration.alert.common.action.ValidationActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.message.model.ConfigurationTestResult;
 import com.synopsys.integration.alert.common.message.model.MessageResult;
-import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.rest.api.ConfigurationTestHelper;
 import com.synopsys.integration.alert.common.rest.api.ConfigurationValidationHelper;
 import com.synopsys.integration.alert.common.rest.model.ValidationResponseModel;
@@ -53,8 +52,10 @@ public class EmailGlobalTestAction {
     private final JavamailPropertiesFactory javamailPropertiesFactory;
 
     @Autowired
-    public EmailGlobalTestAction(AuthorizationManager authorizationManager, EmailGlobalConfigurationValidator validator,
-        EmailChannelMessagingService emailChannelMessagingService, JavamailPropertiesFactory javamailPropertiesFactory, EmailGlobalConfigAccessor configurationAccessor) {
+    public EmailGlobalTestAction(
+        AuthorizationManager authorizationManager, EmailGlobalConfigurationValidator validator,
+        EmailChannelMessagingService emailChannelMessagingService, JavamailPropertiesFactory javamailPropertiesFactory, EmailGlobalConfigAccessor configurationAccessor
+    ) {
         this.testHelper = new ConfigurationTestHelper(authorizationManager, ConfigContextEnum.GLOBAL, ChannelKeys.EMAIL);
         this.validationHelper = new ConfigurationValidationHelper(authorizationManager, ConfigContextEnum.GLOBAL, ChannelKeys.EMAIL);
         this.validator = validator;
@@ -90,11 +91,11 @@ public class EmailGlobalTestAction {
         emailGlobalConfigModel.getSmtpPort().ifPresent(smtpConfigBuilder::setSmtpPort);
         emailGlobalConfigModel.getSmtpAuth().ifPresent(smtpConfigBuilder::setSmtpAuth);
         emailGlobalConfigModel.getSmtpUsername().ifPresent(smtpConfigBuilder::setSmtpUsername);
-        
+
         if (BooleanUtils.toBoolean(emailGlobalConfigModel.getIsSmtpPasswordSet()) && emailGlobalConfigModel.getSmtpPassword().isEmpty()) {
             //TODO: This assumes if the password is saved but not provided we only test using the default configuration password.
             //  If the UI supports multiple configurations in the future we should determine which configuration to get the password from.
-            configurationAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
+            configurationAccessor.getConfiguration()
                 .flatMap(EmailGlobalConfigModel::getSmtpPassword)
                 .ifPresent(emailGlobalConfigModel::setSmtpPassword);
         }

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelSaveActions.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelSaveActions.java
@@ -29,8 +29,10 @@ public class EmailGlobalConfigurationModelSaveActions implements GlobalConfigura
     private final EmailGlobalConfigAccessor configurationAccessor;
 
     @Autowired
-    public EmailGlobalConfigurationModelSaveActions(EmailGlobalConfigurationModelConverter emailFieldModelConverter, EmailGlobalCrudActions configurationActions,
-        EmailGlobalConfigAccessor configurationAccessor) {
+    public EmailGlobalConfigurationModelSaveActions(
+        EmailGlobalConfigurationModelConverter emailFieldModelConverter, EmailGlobalCrudActions configurationActions,
+        EmailGlobalConfigAccessor configurationAccessor
+    ) {
         this.emailFieldModelConverter = emailFieldModelConverter;
         this.configurationActions = configurationActions;
         this.configurationAccessor = configurationAccessor;
@@ -43,14 +45,14 @@ public class EmailGlobalConfigurationModelSaveActions implements GlobalConfigura
 
     @Override
     public void updateConcreteModel(ConfigurationModel configurationModel) {
-        Optional<UUID> defaultConfigurationId = configurationAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
+        Optional<UUID> defaultConfigurationId = configurationAccessor.getConfiguration()
             .map(EmailGlobalConfigModel::getId)
             .map(UUID::fromString);
         Optional<EmailGlobalConfigModel> emailGlobalConfigModel = emailFieldModelConverter.convert(configurationModel);
         if (defaultConfigurationId.isPresent() && emailGlobalConfigModel.isPresent()) {
             EmailGlobalConfigModel model = emailGlobalConfigModel.get();
             model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
-            configurationActions.update(defaultConfigurationId.get(), model);
+            configurationActions.update(model);
         }
     }
 
@@ -66,9 +68,8 @@ public class EmailGlobalConfigurationModelSaveActions implements GlobalConfigura
 
     @Override
     public void deleteConcreteModel(ConfigurationModel configurationModel) {
-        Optional<UUID> defaultConfigurationId = configurationAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
-            .map(EmailGlobalConfigModel::getId)
-            .map(UUID::fromString);
-        defaultConfigurationId.ifPresent(configurationActions::delete);
+        if (configurationAccessor.doesConfigExist()) {
+            configurationAccessor.deleteConfiguration();
+        }
     }
 }

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/database/accessor/EmailGlobalConfigAccessor.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/database/accessor/EmailGlobalConfigAccessor.java
@@ -18,8 +18,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,14 +27,14 @@ import com.synopsys.integration.alert.channel.email.database.configuration.Email
 import com.synopsys.integration.alert.channel.email.database.configuration.EmailConfigurationRepository;
 import com.synopsys.integration.alert.channel.email.database.configuration.properties.EmailConfigurationPropertiesRepository;
 import com.synopsys.integration.alert.channel.email.database.configuration.properties.EmailConfigurationsPropertyEntity;
-import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
-import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
+import com.synopsys.integration.alert.common.persistence.accessor.UniqueConfigurationAccessor;
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.security.EncryptionUtility;
 import com.synopsys.integration.alert.common.util.DateUtils;
 import com.synopsys.integration.alert.service.email.model.EmailGlobalConfigModel;
 
 @Component
-public class EmailGlobalConfigAccessor implements ConfigurationAccessor<EmailGlobalConfigModel> {
+public class EmailGlobalConfigAccessor implements UniqueConfigurationAccessor<EmailGlobalConfigModel> {
     private final EncryptionUtility encryptionUtility;
     private final EmailConfigurationRepository emailConfigurationRepository;
     private final EmailConfigurationPropertiesRepository emailConfigurationPropertiesRepository;
@@ -52,33 +50,20 @@ public class EmailGlobalConfigAccessor implements ConfigurationAccessor<EmailGlo
         this.emailConfigurationPropertiesRepository = emailConfigurationPropertiesRepository;
     }
 
-    @Override
     @Transactional(readOnly = true)
     public long getConfigurationCount() {
         return emailConfigurationRepository.count();
     }
 
-    @Override
     @Transactional(readOnly = true)
-    public Optional<EmailGlobalConfigModel> getConfiguration(UUID id) {
-        return emailConfigurationRepository.findById(id).map(this::createConfigModel);
+    public boolean doesConfigExist() {
+        return emailConfigurationRepository.existsByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Optional<EmailGlobalConfigModel> getConfigurationByName(String configurationName) {
-        return emailConfigurationRepository.findByName(configurationName).map(this::createConfigModel);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public AlertPagedModel<EmailGlobalConfigModel> getConfigurationPage(int page, int size) {
-        Page<EmailConfigurationEntity> resultPage = emailConfigurationRepository.findAll(PageRequest.of(page, size));
-        List<EmailGlobalConfigModel> pageContent = resultPage.getContent()
-            .stream()
-            .map(this::createConfigModel)
-            .collect(Collectors.toList());
-        return new AlertPagedModel<>(resultPage.getTotalPages(), resultPage.getNumber(), resultPage.getSize(), pageContent);
+    public Optional<EmailGlobalConfigModel> getConfiguration() {
+        return emailConfigurationRepository.findByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME).map(this::createConfigModel);
     }
 
     @Override
@@ -91,22 +76,20 @@ public class EmailGlobalConfigAccessor implements ConfigurationAccessor<EmailGlo
 
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
-    public EmailGlobalConfigModel updateConfiguration(UUID configurationId, EmailGlobalConfigModel configuration) throws AlertConfigurationException {
-        EmailConfigurationEntity configurationEntity = emailConfigurationRepository.findById(configurationId)
-            .orElseThrow(() -> new AlertConfigurationException(String.format("Config with id '%s' did not exist", configurationId.toString())));
+    public EmailGlobalConfigModel updateConfiguration(EmailGlobalConfigModel configuration) throws AlertConfigurationException {
+        EmailConfigurationEntity configurationEntity = emailConfigurationRepository.findByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
+            .orElseThrow(() -> new AlertConfigurationException(String.format("Config with name '%s' did not exist", AlertRestConstants.DEFAULT_CONFIGURATION_NAME)));
         if (BooleanUtils.toBoolean(configuration.getIsSmtpPasswordSet()) && configuration.getSmtpPassword().isEmpty()) {
             String decryptedPassword = encryptionUtility.decrypt(configurationEntity.getAuthPassword());
             configuration.setSmtpPassword(decryptedPassword);
         }
-        return populateConfiguration(configurationId, configuration, configurationEntity.getCreatedAt());
+        return populateConfiguration(configurationEntity.getConfigurationId(), configuration, configurationEntity.getCreatedAt());
     }
 
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
-    public void deleteConfiguration(UUID configurationId) {
-        if (null != configurationId) {
-            emailConfigurationRepository.deleteById(configurationId);
-        }
+    public void deleteConfiguration() {
+        emailConfigurationRepository.deleteByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
     }
 
     private EmailGlobalConfigModel populateConfiguration(UUID configurationId, EmailGlobalConfigModel configuration, OffsetDateTime createdAt) {

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/database/configuration/EmailConfigurationRepository.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/database/configuration/EmailConfigurationRepository.java
@@ -16,4 +16,8 @@ public interface EmailConfigurationRepository extends JpaRepository<EmailConfigu
 
     Optional<EmailConfigurationEntity> findByName(String name);
 
+    void deleteByName(String name);
+
+    boolean existsByName(String name);
+
 }

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/distribution/EmailChannelMessageSender.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/distribution/EmailChannelMessageSender.java
@@ -32,7 +32,6 @@ import com.synopsys.integration.alert.common.descriptor.config.field.errors.Fiel
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.common.message.model.MessageResult;
 import com.synopsys.integration.alert.common.persistence.model.job.details.EmailJobDetailsModel;
-import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ProjectMessage;
 import com.synopsys.integration.alert.service.email.EmailTarget;
 import com.synopsys.integration.alert.service.email.JavamailPropertiesFactory;
@@ -88,8 +87,8 @@ public class EmailChannelMessageSender implements ChannelMessageSender<EmailJobD
         }
 
         // Distribution
-        EmailGlobalConfigModel emailServerConfiguration = emailGlobalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
-                                                              .orElseThrow(() -> new AlertConfigurationException("ERROR: Missing Email global config."));
+        EmailGlobalConfigModel emailServerConfiguration = emailGlobalConfigAccessor.getConfiguration()
+            .orElseThrow(() -> new AlertConfigurationException("ERROR: Missing Email global config."));
 
         SmtpConfig smtpConfig = SmtpConfig.builder()
             .setJavamailProperties(javamailPropertiesFactory.createJavaMailProperties(emailServerConfiguration))

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/web/EmailGlobalConfigController.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/web/EmailGlobalConfigController.java
@@ -7,8 +7,6 @@
  */
 package com.synopsys.integration.alert.channel.email.web;
 
-import java.util.UUID;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,18 +19,14 @@ import com.synopsys.integration.alert.channel.email.action.EmailGlobalTestAction
 import com.synopsys.integration.alert.channel.email.action.EmailGlobalValidationAction;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.rest.ResponseFactory;
-import com.synopsys.integration.alert.common.rest.api.ReadPageController;
-import com.synopsys.integration.alert.common.rest.api.StaticConfigResourceController;
+import com.synopsys.integration.alert.common.rest.api.StaticUniqueConfigResourceController;
 import com.synopsys.integration.alert.common.rest.api.ValidateController;
-import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 import com.synopsys.integration.alert.common.rest.model.ValidationResponseModel;
 import com.synopsys.integration.alert.service.email.model.EmailGlobalConfigModel;
 
-// FIXME: Need to mask sensitive data. Need to allow any values in Additional properties.
-
 @RestController
 @RequestMapping(AlertRestConstants.EMAIL_CONFIGURATION_PATH)
-public class EmailGlobalConfigController implements StaticConfigResourceController<EmailGlobalConfigModel>, ValidateController<EmailGlobalConfigModel>, ReadPageController<AlertPagedModel<EmailGlobalConfigModel>> {
+public class EmailGlobalConfigController implements StaticUniqueConfigResourceController<EmailGlobalConfigModel>, ValidateController<EmailGlobalConfigModel> {
     private final EmailGlobalCrudActions configActions;
     private final EmailGlobalValidationAction validationAction;
     private final EmailGlobalTestAction testAction;
@@ -45,13 +39,8 @@ public class EmailGlobalConfigController implements StaticConfigResourceControll
     }
 
     @Override
-    public EmailGlobalConfigModel getOne(UUID id) {
-        return ResponseFactory.createContentResponseFromAction(configActions.getOne(id));
-    }
-
-    @Override
-    public AlertPagedModel<EmailGlobalConfigModel> getPage(Integer pageNumber, Integer pageSize, String searchTerm) {
-        return ResponseFactory.createContentResponseFromAction(configActions.getPaged(pageNumber, pageSize));
+    public EmailGlobalConfigModel getOne() {
+        return ResponseFactory.createContentResponseFromAction(configActions.getOne());
     }
 
     @Override
@@ -60,18 +49,18 @@ public class EmailGlobalConfigController implements StaticConfigResourceControll
     }
 
     @Override
-    public void update(UUID id, EmailGlobalConfigModel resource) {
-        ResponseFactory.createContentResponseFromAction(configActions.update(id, resource));
+    public void update(EmailGlobalConfigModel resource) {
+        ResponseFactory.createContentResponseFromAction(configActions.update(resource));
+    }
+
+    @Override
+    public void delete() {
+        ResponseFactory.createContentResponseFromAction(configActions.delete());
     }
 
     @Override
     public ValidationResponseModel validate(EmailGlobalConfigModel requestBody) {
         return ResponseFactory.createContentResponseFromAction(validationAction.validate(requestBody));
-    }
-
-    @Override
-    public void delete(UUID id) {
-        ResponseFactory.createContentResponseFromAction(configActions.delete(id));
     }
 
     @PostMapping("/test")

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalConfigurationActionTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalConfigurationActionTest.java
@@ -33,7 +33,6 @@ public class EmailGlobalConfigurationActionTest {
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
         AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
-        UUID configId = UUID.randomUUID();
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
         EmailGlobalConfigModel model = new EmailGlobalConfigModel();
@@ -42,10 +41,10 @@ public class EmailGlobalConfigurationActionTest {
         model.setSmtpAuth(true);
         model.setSmtpUsername("user");
         model.setSmtpPassword("password");
-        Mockito.when(emailGlobalConfigAccessor.getConfiguration(Mockito.any(UUID.class))).thenReturn(Optional.of(model));
+        Mockito.when(emailGlobalConfigAccessor.getConfiguration()).thenReturn(Optional.of(model));
 
         EmailGlobalCrudActions configActions = new EmailGlobalCrudActions(authorizationManager, emailGlobalConfigAccessor, validator);
-        ActionResponse<EmailGlobalConfigModel> response = configActions.getOne(configId);
+        ActionResponse<EmailGlobalConfigModel> response = configActions.getOne();
         assertEquals(HttpStatus.OK, response.getHttpStatus());
         assertTrue(response.hasContent());
         assertEquals(model.obfuscate(), response.getContent().get());
@@ -83,7 +82,6 @@ public class EmailGlobalConfigurationActionTest {
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
         AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
-        UUID configId = UUID.randomUUID();
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
         EmailGlobalConfigModel model = new EmailGlobalConfigModel();
@@ -93,11 +91,12 @@ public class EmailGlobalConfigurationActionTest {
         model.setSmtpAuth(true);
         model.setSmtpUsername("user");
         model.setSmtpPassword("password");
-        Mockito.when(emailGlobalConfigAccessor.getConfiguration(Mockito.any(UUID.class))).thenReturn(Optional.of(model));
-        Mockito.when(emailGlobalConfigAccessor.updateConfiguration(Mockito.any(UUID.class), Mockito.eq(model))).thenReturn(model);
+        Mockito.when(emailGlobalConfigAccessor.getConfiguration()).thenReturn(Optional.of(model));
+        Mockito.when(emailGlobalConfigAccessor.updateConfiguration(Mockito.eq(model))).thenReturn(model);
+        Mockito.when(emailGlobalConfigAccessor.doesConfigExist()).thenReturn(true);
 
         EmailGlobalCrudActions configActions = new EmailGlobalCrudActions(authorizationManager, emailGlobalConfigAccessor, validator);
-        ActionResponse<EmailGlobalConfigModel> response = configActions.update(configId, model);
+        ActionResponse<EmailGlobalConfigModel> response = configActions.update(model);
         assertEquals(HttpStatus.OK, response.getHttpStatus());
         assertTrue(response.hasContent());
         assertEquals(model.obfuscate(), response.getContent().get());
@@ -110,7 +109,6 @@ public class EmailGlobalConfigurationActionTest {
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
         AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
-        UUID configId = UUID.randomUUID();
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
         EmailGlobalConfigModel model = new EmailGlobalConfigModel();
@@ -119,10 +117,11 @@ public class EmailGlobalConfigurationActionTest {
         model.setSmtpAuth(true);
         model.setSmtpUsername("user");
         model.setSmtpPassword("password");
-        Mockito.when(emailGlobalConfigAccessor.getConfiguration(Mockito.any(UUID.class))).thenReturn(Optional.of(model));
+        Mockito.when(emailGlobalConfigAccessor.getConfiguration()).thenReturn(Optional.of(model));
+        Mockito.when(emailGlobalConfigAccessor.doesConfigExist()).thenReturn(true);
 
         EmailGlobalCrudActions configActions = new EmailGlobalCrudActions(authorizationManager, emailGlobalConfigAccessor, validator);
-        ActionResponse<EmailGlobalConfigModel> response = configActions.delete(configId);
+        ActionResponse<EmailGlobalConfigModel> response = configActions.delete();
         assertEquals(HttpStatus.NO_CONTENT, response.getHttpStatus());
     }
 
@@ -133,12 +132,11 @@ public class EmailGlobalConfigurationActionTest {
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.NO_PERMISSIONS);
         AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
-        UUID configId = UUID.randomUUID();
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
 
         EmailGlobalCrudActions configActions = new EmailGlobalCrudActions(authorizationManager, emailGlobalConfigAccessor, validator);
-        ActionResponse<EmailGlobalConfigModel> response = configActions.getOne(configId);
+        ActionResponse<EmailGlobalConfigModel> response = configActions.getOne();
         assertEquals(HttpStatus.FORBIDDEN, response.getHttpStatus());
     }
 
@@ -181,7 +179,7 @@ public class EmailGlobalConfigurationActionTest {
         model.setSmtpPassword("password");
 
         EmailGlobalCrudActions configActions = new EmailGlobalCrudActions(authorizationManager, emailGlobalConfigAccessor, validator);
-        ActionResponse<EmailGlobalConfigModel> response = configActions.update(configId, model);
+        ActionResponse<EmailGlobalConfigModel> response = configActions.update(model);
         assertEquals(HttpStatus.FORBIDDEN, response.getHttpStatus());
     }
 
@@ -195,7 +193,7 @@ public class EmailGlobalConfigurationActionTest {
         UUID configId = UUID.randomUUID();
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
-        Mockito.when(emailGlobalConfigAccessor.getConfiguration(Mockito.any(UUID.class))).thenReturn(Optional.empty());
+        Mockito.when(emailGlobalConfigAccessor.getConfiguration()).thenReturn(Optional.empty());
 
         EmailGlobalConfigModel model = new EmailGlobalConfigModel();
         model.setSmtpHost("host");
@@ -205,7 +203,7 @@ public class EmailGlobalConfigurationActionTest {
         model.setSmtpPassword("password");
 
         EmailGlobalCrudActions configActions = new EmailGlobalCrudActions(authorizationManager, emailGlobalConfigAccessor, validator);
-        ActionResponse<EmailGlobalConfigModel> response = configActions.update(configId, model);
+        ActionResponse<EmailGlobalConfigModel> response = configActions.update(model);
         assertEquals(HttpStatus.NOT_FOUND, response.getHttpStatus());
     }
 
@@ -221,7 +219,7 @@ public class EmailGlobalConfigurationActionTest {
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
 
         EmailGlobalCrudActions configActions = new EmailGlobalCrudActions(authorizationManager, emailGlobalConfigAccessor, validator);
-        ActionResponse<EmailGlobalConfigModel> response = configActions.delete(configId);
+        ActionResponse<EmailGlobalConfigModel> response = configActions.delete();
         assertEquals(HttpStatus.FORBIDDEN, response.getHttpStatus());
     }
 
@@ -232,13 +230,12 @@ public class EmailGlobalConfigurationActionTest {
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
         AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
-        UUID configId = UUID.randomUUID();
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
-        Mockito.when(emailGlobalConfigAccessor.getConfiguration(Mockito.any(UUID.class))).thenReturn(Optional.empty());
+        Mockito.when(emailGlobalConfigAccessor.getConfiguration()).thenReturn(Optional.empty());
 
         EmailGlobalCrudActions configActions = new EmailGlobalCrudActions(authorizationManager, emailGlobalConfigAccessor, validator);
-        ActionResponse<EmailGlobalConfigModel> response = configActions.delete(configId);
+        ActionResponse<EmailGlobalConfigModel> response = configActions.delete();
         assertEquals(HttpStatus.NOT_FOUND, response.getHttpStatus());
     }
 

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalTestActionTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalTestActionTest.java
@@ -124,7 +124,7 @@ public class EmailGlobalTestActionTest {
         EmailGlobalConfigModel configModelWithPassword = new EmailGlobalConfigModel();
         configModelWithPassword.setIsSmtpPasswordSet(true);
         configModelWithPassword.setSmtpPassword("password");
-        Mockito.when(configurationAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(configModelWithPassword));
+        Mockito.when(configurationAccessor.getConfiguration()).thenReturn(Optional.of(configModelWithPassword));
 
         ConfigurationTestResult testResult = emailGlobalTestAction.testConfigModelContent("noreply@synopsys.com", emailGlobalConfigModel);
         assertTrue(testResult.isSuccess(), "Expected the message result to not have errors");
@@ -149,7 +149,7 @@ public class EmailGlobalTestActionTest {
 
         EmailGlobalConfigModel globalConfigModelWithoutPassword = createEmailGlobalConfigModelObfuscated(testProperties);
         EmailGlobalConfigModel globalConfigModelWithPassword = createValidEmailGlobalConfigModel(testProperties);
-        Mockito.when(configurationAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(globalConfigModelWithPassword));
+        Mockito.when(configurationAccessor.getConfiguration()).thenReturn(Optional.of(globalConfigModelWithPassword));
 
         ConfigurationTestResult testResult = emailGlobalTestAction.testConfigModelContent(emailAddress, globalConfigModelWithoutPassword);
         assertTrue(testResult.isSuccess(), "Expected the message result to not have errors");

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelSaveActionsTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelSaveActionsTest.java
@@ -16,6 +16,10 @@ import org.mockito.Mockito;
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.channel.email.action.EmailGlobalCrudActions;
 import com.synopsys.integration.alert.channel.email.database.accessor.EmailGlobalConfigAccessor;
+import com.synopsys.integration.alert.channel.email.database.configuration.EmailConfigurationEntity;
+import com.synopsys.integration.alert.channel.email.database.configuration.EmailConfigurationRepository;
+import com.synopsys.integration.alert.channel.email.database.configuration.properties.EmailConfigurationPropertiesRepository;
+import com.synopsys.integration.alert.channel.email.database.configuration.properties.EmailConfigurationsPropertyEntity;
 import com.synopsys.integration.alert.channel.email.validator.EmailGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
@@ -26,10 +30,6 @@ import com.synopsys.integration.alert.common.persistence.model.PermissionMatrixM
 import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
 import com.synopsys.integration.alert.common.security.EncryptionUtility;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
-import com.synopsys.integration.alert.channel.email.database.configuration.EmailConfigurationEntity;
-import com.synopsys.integration.alert.channel.email.database.configuration.EmailConfigurationRepository;
-import com.synopsys.integration.alert.channel.email.database.configuration.properties.EmailConfigurationPropertiesRepository;
-import com.synopsys.integration.alert.channel.email.database.configuration.properties.EmailConfigurationsPropertyEntity;
 import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
 import com.synopsys.integration.alert.service.email.enumeration.EmailPropertyKeys;
@@ -142,6 +142,7 @@ class EmailGlobalConfigurationModelSaveActionsTest {
 
         Mockito.when(emailConfigurationRepository.findByName(Mockito.anyString())).thenAnswer(invocation -> Optional.ofNullable(savedEntity.get()));
         Mockito.when(emailConfigurationRepository.findById(Mockito.any())).thenAnswer(invocation -> Optional.ofNullable(savedEntity.get()));
+        Mockito.when(emailConfigurationRepository.existsByName(Mockito.anyString())).thenReturn(true);
 
         Mockito.when(emailConfigurationPropertiesRepository.saveAll(Mockito.any(List.class))).thenAnswer(invocation -> {
             Iterable<EmailConfigurationsPropertyEntity> iterable = invocation.getArgument(0);
@@ -285,7 +286,8 @@ class EmailGlobalConfigurationModelSaveActionsTest {
             savedEntity.set(null);
             savedProperty.set(null);
             return null;
-        }).when(emailConfigurationRepository).deleteById(Mockito.any());
+        }).when(emailConfigurationRepository).deleteByName(Mockito.anyString());
+        Mockito.when(emailConfigurationRepository.existsByName(Mockito.anyString())).thenReturn(true);
 
         Mockito.when(emailConfigurationPropertiesRepository.saveAll(Mockito.any(List.class))).thenAnswer(invocation -> {
             Iterable<EmailConfigurationsPropertyEntity> iterable = invocation.getArgument(0);

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/distribution/EmailChannelTestIT.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/distribution/EmailChannelTestIT.java
@@ -55,7 +55,7 @@ public class EmailChannelTestIT {
 
         EmailGlobalConfigModel emailGlobalConfig = createEmailGlobalConfig();
         EmailGlobalConfigAccessor emailConfigurationAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
-        Mockito.when(emailConfigurationAccessor.getConfigurationByName(Mockito.eq(AlertRestConstants.DEFAULT_CONFIGURATION_NAME))).thenReturn(Optional.of(emailGlobalConfig));
+        Mockito.when(emailConfigurationAccessor.getConfiguration()).thenReturn(Optional.of(emailGlobalConfig));
 
         JobEmailAddressValidator emailAddressValidator = Mockito.mock(JobEmailAddressValidator.class);
         Mockito.when(emailAddressValidator.validate(Mockito.any(), Mockito.anyCollection())).thenReturn(new ValidatedEmailAddresses(Set.of(testEmailRecipient), Set.of()));
@@ -85,7 +85,7 @@ public class EmailChannelTestIT {
         String testEmailRecipient = testProperties.getProperty(TestPropertyKey.TEST_EMAIL_RECIPIENT);
 
         EmailGlobalConfigAccessor emailConfigurationAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
-        Mockito.when(emailConfigurationAccessor.getConfigurationByName(Mockito.eq(AlertRestConstants.DEFAULT_CONFIGURATION_NAME))).thenReturn(Optional.empty());
+        Mockito.when(emailConfigurationAccessor.getConfiguration()).thenReturn(Optional.empty());
 
         JobEmailAddressValidator emailAddressValidator = Mockito.mock(JobEmailAddressValidator.class);
         Mockito.when(emailAddressValidator.validate(Mockito.any(), Mockito.anyCollection())).thenReturn(new ValidatedEmailAddresses(Set.of(testEmailRecipient), Set.of()));

--- a/src/main/java/com/synopsys/integration/alert/update/UpdateEmailService.java
+++ b/src/main/java/com/synopsys/integration/alert/update/UpdateEmailService.java
@@ -25,7 +25,6 @@ import com.synopsys.integration.alert.common.persistence.accessor.SettingsKeyAcc
 import com.synopsys.integration.alert.common.persistence.accessor.UserAccessor;
 import com.synopsys.integration.alert.common.persistence.model.SettingsKeyModel;
 import com.synopsys.integration.alert.common.persistence.model.UserModel;
-import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.service.email.EmailMessagingService;
 import com.synopsys.integration.alert.service.email.EmailTarget;
 import com.synopsys.integration.alert.service.email.JavamailPropertiesFactory;
@@ -50,8 +49,10 @@ public class UpdateEmailService {
     private final JavamailPropertiesFactory javamailPropertiesFactory;
 
     @Autowired
-    public UpdateEmailService(AlertProperties alertProperties, SettingsKeyAccessor settingsKeyAccessor, UserAccessor userAccessor, EmailGlobalConfigAccessor emailGlobalConfigAccessor, EmailMessagingService emailMessagingService,
-        JavamailPropertiesFactory javamailPropertiesFactory) {
+    public UpdateEmailService(
+        AlertProperties alertProperties, SettingsKeyAccessor settingsKeyAccessor, UserAccessor userAccessor, EmailGlobalConfigAccessor emailGlobalConfigAccessor, EmailMessagingService emailMessagingService,
+        JavamailPropertiesFactory javamailPropertiesFactory
+    ) {
         this.alertProperties = alertProperties;
         this.settingsKeyAccessor = settingsKeyAccessor;
         this.userAccessor = userAccessor;
@@ -68,12 +69,12 @@ public class UpdateEmailService {
 
         String username = "sysadmin";
         Optional<String> optionalEmailAddress = userAccessor.getUser(username)
-                                                    .map(UserModel::getEmailAddress)
-                                                    .filter(StringUtils::isNotBlank);
+            .map(UserModel::getEmailAddress)
+            .filter(StringUtils::isNotBlank);
         if (optionalEmailAddress.isPresent()) {
             try {
-                EmailGlobalConfigModel emailServerConfiguration = emailGlobalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
-                                                                      .orElseThrow(() -> new AlertException("No global email configuration found"));
+                EmailGlobalConfigModel emailServerConfiguration = emailGlobalConfigAccessor.getConfiguration()
+                    .orElseThrow(() -> new AlertException("No global email configuration found"));
 
                 String alertServerUrl = alertProperties.getServerURL();
                 Map<String, Object> templateFields = new HashMap<>();
@@ -105,13 +106,14 @@ public class UpdateEmailService {
 
     private boolean wasEmailAlreadySentForVersion(String updateVersion) {
         return settingsKeyAccessor
-                   .getSettingsKeyByKey(SETTINGS_KEY_VERSION_FOR_UPDATE_EMAIL)
-                   .map(SettingsKeyModel::getValue)
-                   .filter(storedValue -> storedValue.equals(updateVersion))
-                   .isPresent();
+            .getSettingsKeyByKey(SETTINGS_KEY_VERSION_FOR_UPDATE_EMAIL)
+            .map(SettingsKeyModel::getValue)
+            .filter(storedValue -> storedValue.equals(updateVersion))
+            .isPresent();
     }
 
-    private void handleSend(Properties javamailProperties, String smtpFrom, String smtpHost, int smtpPort, boolean smtpAuth, String smtpUsername, String smtpPassword, Map<String, Object> templateFields, String emailAddress) throws AlertException {
+    private void handleSend(Properties javamailProperties, String smtpFrom, String smtpHost, int smtpPort, boolean smtpAuth, String smtpUsername, String smtpPassword, Map<String, Object> templateFields, String emailAddress)
+        throws AlertException {
         try {
             String alertLogo = alertProperties.createSynopsysLogoPath();
 

--- a/src/test/java/com/synopsys/integration/alert/channel/email/environment/EmailEnvironmentHandlerFactoryTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/email/environment/EmailEnvironmentHandlerFactoryTestIT.java
@@ -6,10 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Properties;
-import java.util.UUID;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +17,6 @@ import org.springframework.core.env.Environment;
 
 import com.synopsys.integration.alert.channel.email.database.accessor.EmailGlobalConfigAccessor;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
-import com.synopsys.integration.alert.common.rest.model.Config;
 import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
 import com.synopsys.integration.alert.environment.EnvironmentVariableHandler;
 import com.synopsys.integration.alert.environment.EnvironmentVariableHandlerFactory;
@@ -38,11 +37,11 @@ class EmailEnvironmentHandlerFactoryTestIT {
     private EmailGlobalConfigAccessor emailGlobalConfigAccessor;
 
     @AfterEach
+    @BeforeEach
     public void cleanup() {
-        emailGlobalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
-            .map(Config::getId)
-            .map(UUID::fromString)
-            .ifPresent(emailGlobalConfigAccessor::deleteConfiguration);
+        if (emailGlobalConfigAccessor.doesConfigExist()) {
+            emailGlobalConfigAccessor.deleteConfiguration();
+        }
     }
 
     @Test

--- a/src/test/java/com/synopsys/integration/alert/web/config/EmailConfigActionTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/web/config/EmailConfigActionTestIT.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,7 +27,6 @@ import com.synopsys.integration.alert.common.persistence.accessor.DescriptorAcce
 import com.synopsys.integration.alert.common.persistence.model.PermissionKey;
 import com.synopsys.integration.alert.common.persistence.model.PermissionMatrixModel;
 import com.synopsys.integration.alert.common.persistence.util.ConfigurationFieldModelConverter;
-import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.rest.FieldModelProcessor;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
@@ -77,10 +75,9 @@ public class EmailConfigActionTestIT {
 
     @BeforeEach
     void deleteDefaultConfig() {
-        emailGlobalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
-            .map(EmailGlobalConfigModel::getId)
-            .map(id -> UUID.fromString(id))
-            .ifPresent(emailGlobalConfigAccessor::deleteConfiguration);
+        if (emailGlobalConfigAccessor.doesConfigExist()) {
+            emailGlobalConfigAccessor.deleteConfiguration();
+        }
     }
 
     @Test
@@ -93,7 +90,7 @@ public class EmailConfigActionTestIT {
         FieldModel fieldModel = createEmailFieldModel();
         configActions.create(fieldModel);
 
-        Optional<EmailGlobalConfigModel> staticEmailConfig = emailGlobalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
+        Optional<EmailGlobalConfigModel> staticEmailConfig = emailGlobalConfigAccessor.getConfiguration();
         assertTrue(staticEmailConfig.isPresent());
         EmailGlobalConfigModel staticModel = staticEmailConfig.get();
         assertEquals(Boolean.TRUE, staticModel.getSmtpAuth().orElse(null));
@@ -126,7 +123,7 @@ public class EmailConfigActionTestIT {
 
         configActions.update(Long.valueOf(fieldModel.getId()), fieldModel);
 
-        Optional<EmailGlobalConfigModel> staticEmailConfig = emailGlobalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
+        Optional<EmailGlobalConfigModel> staticEmailConfig = emailGlobalConfigAccessor.getConfiguration();
         assertTrue(staticEmailConfig.isPresent());
         EmailGlobalConfigModel staticModel = staticEmailConfig.get();
         assertEquals(Boolean.TRUE, staticModel.getSmtpAuth().orElse(null));
@@ -156,7 +153,7 @@ public class EmailConfigActionTestIT {
 
         configActions.update(Long.valueOf(fieldModel.getId()), fieldModel);
 
-        Optional<EmailGlobalConfigModel> staticEmailConfig = emailGlobalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
+        Optional<EmailGlobalConfigModel> staticEmailConfig = emailGlobalConfigAccessor.getConfiguration();
         assertTrue(staticEmailConfig.isPresent());
         EmailGlobalConfigModel staticModel = staticEmailConfig.get();
         assertEquals(Boolean.TRUE, staticModel.getSmtpAuth().orElse(null));
@@ -183,7 +180,7 @@ public class EmailConfigActionTestIT {
         fieldModel = configActions.create(fieldModel).getContent().orElseThrow(() -> new AlertConfigurationException("Couldn't create configuration"));
 
         configActions.delete(Long.valueOf(fieldModel.getId()));
-        Optional<EmailGlobalConfigModel> staticEmailConfig = emailGlobalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
+        Optional<EmailGlobalConfigModel> staticEmailConfig = emailGlobalConfigAccessor.getConfiguration();
         assertTrue(staticEmailConfig.isEmpty());
 
     }

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blackduck-alert",
-    "version": "6.9.0-SIGQA12",
+    "version": "6.9.0-SIGQA13-SNAPSHOT",
     "description": "Alert UI",
     "keywords": [
         "blackduck",

--- a/ui/src/main/js/page/channel/email/EmailGlobalConfiguration.js
+++ b/ui/src/main/js/page/channel/email/EmailGlobalConfiguration.js
@@ -41,11 +41,12 @@ const EmailGlobalConfiguration = ({
 
     const fetchData = async () => {
         const response = await ConfigurationRequestBuilder.createReadRequest(emailRequestUrl, csrfToken);
-        const data = await response.json();
-
-        const { models } = data;
-        const firstResult = (models && models.length > 0) ? models[0] : { name: 'default-configuration' };
-        setEmailConfig(firstResult);
+        if (response.ok) {
+            const data = await response.json();
+            setEmailConfig(data);
+        } else {
+            setEmailConfig({ name: 'default-configuration' });
+        }
     };
 
     return (
@@ -62,8 +63,8 @@ const EmailGlobalConfiguration = ({
                 clearTestForm={() => setTestEmailAddress('')}
                 buttonIdPrefix={EMAIL_INFO.key}
                 getRequest={fetchData}
-                deleteRequest={() => ConfigurationRequestBuilder.createDeleteRequest(emailRequestUrl, csrfToken, emailConfig.id)}
-                updateRequest={() => ConfigurationRequestBuilder.createUpdateRequest(emailRequestUrl, csrfToken, emailConfig.id, emailConfig)}
+                deleteRequest={() => ConfigurationRequestBuilder.createDeleteRequest(emailRequestUrl, csrfToken)}
+                updateRequest={() => ConfigurationRequestBuilder.createUpdateWithoutIdRequest(emailRequestUrl, csrfToken, emailConfig)}
                 createRequest={() => ConfigurationRequestBuilder.createNewConfigurationRequest(emailRequestUrl, csrfToken, emailConfig)}
                 validateRequest={() => ConfigurationRequestBuilder.createValidateRequest(emailRequestUrl, csrfToken, emailConfig)}
                 testRequest={() => ConfigurationRequestBuilder.createTestRequest(emailRequestUrl, csrfToken, emailConfig, `sendTo=${testEmailAddress}`)}


### PR DESCRIPTION
Remove the support for multiple email configs in favor of a single entity that is always updated.