### PR TITLE
Change validation for proxy model to ignore checking password if username is blank

### DIFF
--- a/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/validator/SettingsProxyValidator.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/validator/SettingsProxyValidator.java
@@ -44,7 +44,7 @@ public class SettingsProxyValidator {
             validateRequiredFieldIsNotBlank(statuses, model.getProxyHost().isPresent(), PROXY_HOST_FIELD_NAME);
         }
 
-        if (model.getProxyUsername().isPresent()) {
+        if (model.getProxyUsername().filter(StringUtils::isNotBlank).isPresent()) {
             validateRequiredFieldIsNotBlank(statuses, model.getProxyHost().isPresent(), PROXY_HOST_FIELD_NAME);
             if (!BooleanUtils.toBoolean(model.getIsProxyPasswordSet())) {
                 validateRequiredFieldIsNotBlank(statuses, model.getProxyPassword().isPresent(), PROXY_PASSWORD_FIELD_NAME);

--- a/component/src/test/java/com/synopsys/integration/alert/component/settings/proxy/validator/SettingsProxyValidatorTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/settings/proxy/validator/SettingsProxyValidatorTest.java
@@ -139,6 +139,19 @@ class SettingsProxyValidatorTest {
     }
 
     @Test
+    void validateUsernameBlank() {
+        SettingsProxyModel settingsProxyModel = new SettingsProxyModel();
+        settingsProxyModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
+        settingsProxyModel.setProxyHost(HOST);
+        settingsProxyModel.setProxyPort(PORT);
+        settingsProxyModel.setProxyUsername("");
+        settingsProxyModel.setIsProxyPasswordSet(false);
+
+        ValidationResponseModel validationResponseModel = settingsProxyValidator.validate(settingsProxyModel);
+        assertFalse(validationResponseModel.hasErrors());
+    }
+
+    @Test
     void validateNonProxyHostsTest() {
         SettingsProxyModel settingsProxyModel = new SettingsProxyModel();
         settingsProxyModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);


### PR DESCRIPTION
This is to catch a case where the optional field is present, but empty. This occurs if the field was saved, but later erased and re-saved.