### PR TITLE
Fixed an issue with too many or not enough messages getting created by Alert with duplicate providers

### DIFF
--- a/alert-database-job/src/main/java/com/synopsys/integration/alert/database/api/DefaultProcessingJobAccessor.java
+++ b/alert-database-job/src/main/java/com/synopsys/integration/alert/database/api/DefaultProcessingJobAccessor.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.common.enumeration.ProcessingType;
 import com.synopsys.integration.alert.common.persistence.accessor.ProcessingJobAccessor;
@@ -40,7 +41,12 @@ public class DefaultProcessingJobAccessor implements ProcessingJobAccessor {
     }
 
     @Override
-    public AlertPagedModel<FilteredDistributionJobResponseModel> getMatchingEnabledJobsByFilteredNotifications(FilteredDistributionJobRequestModel filteredDistributionJobRequestModel, int pageNumber, int pageLimit) {
+    @Transactional(readOnly = true)
+    public AlertPagedModel<FilteredDistributionJobResponseModel> getMatchingEnabledJobsByFilteredNotifications(
+        FilteredDistributionJobRequestModel filteredDistributionJobRequestModel,
+        int pageNumber,
+        int pageLimit
+    ) {
         List<String> frequencyTypes = filteredDistributionJobRequestModel.getFrequencyTypes()
             .stream()
             .map(Enum::name)
@@ -51,7 +57,9 @@ public class DefaultProcessingJobAccessor implements ProcessingJobAccessor {
 
         // If no policies and/or vulnerabilitySeverities exist the repository query expects a null to be passed
         Set<String> policyNames = filteredDistributionJobRequestModel.getPolicyNames().isEmpty() ? null : filteredDistributionJobRequestModel.getPolicyNames();
-        Set<String> vulnerabilitySeverities = filteredDistributionJobRequestModel.getVulnerabilitySeverities().isEmpty() ? null : filteredDistributionJobRequestModel.getVulnerabilitySeverities();
+        Set<String> vulnerabilitySeverities = filteredDistributionJobRequestModel.getVulnerabilitySeverities().isEmpty() ?
+            null :
+            filteredDistributionJobRequestModel.getVulnerabilitySeverities();
 
         PageRequest pageRequest = PageRequest.of(pageNumber, pageLimit);
         Page<DistributionJobEntity> pageOfDistributionJobEntities = distributionJobRepository.findAndSortMatchingEnabledJobsByFilteredNotifications(

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/NotificationProcessor.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/NotificationProcessor.java
@@ -99,8 +99,15 @@ public final class NotificationProcessor {
 
     private void processAndDistribute(FilteredJobNotificationWrapper jobNotificationWrapper) {
         List<NotificationContentWrapper> filteredNotifications = jobNotificationWrapper.getJobNotifications();
-        ProcessedNotificationDetails processedNotificationDetails = new ProcessedNotificationDetails(jobNotificationWrapper.getJobId(), jobNotificationWrapper.getChannelName(), jobNotificationWrapper.getJobName());
-        ProcessedProviderMessageHolder processedMessageHolder = notificationContentProcessor.processNotificationContent(jobNotificationWrapper.getProcessingType(), filteredNotifications);
+        ProcessedNotificationDetails processedNotificationDetails = new ProcessedNotificationDetails(
+            jobNotificationWrapper.getJobId(),
+            jobNotificationWrapper.getChannelName(),
+            jobNotificationWrapper.getJobName()
+        );
+        ProcessedProviderMessageHolder processedMessageHolder = notificationContentProcessor.processNotificationContent(
+            jobNotificationWrapper.getProcessingType(),
+            filteredNotifications
+        );
 
         providerMessageDistributor.distribute(processedNotificationDetails, processedMessageHolder);
     }

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/NotificationProcessor.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/NotificationProcessor.java
@@ -28,7 +28,6 @@ import com.synopsys.integration.alert.processor.api.extract.model.ProcessedProvi
 import com.synopsys.integration.alert.processor.api.filter.FilteredJobNotificationWrapper;
 import com.synopsys.integration.alert.processor.api.filter.JobNotificationMapper;
 import com.synopsys.integration.alert.processor.api.filter.NotificationContentWrapper;
-import com.synopsys.integration.alert.processor.api.filter.StatefulAlertPage;
 
 @Component
 // TODO rename to WorkflowNotificationProcessor
@@ -87,14 +86,8 @@ public final class NotificationProcessor {
             .map(notificationDetailExtractionDelegator::wrapNotification)
             .flatMap(List::stream)
             .collect(Collectors.toList());
-        StatefulAlertPage<FilteredJobNotificationWrapper, RuntimeException> statefulAlertPage = jobNotificationMapper.mapJobsToNotifications(filterableNotifications, frequencies);
-        // If there are elements to process in the current page or if there are more pages, keep looping.
-        while (!statefulAlertPage.isCurrentPageEmpty() || statefulAlertPage.hasNextPage()) {
-            for (FilteredJobNotificationWrapper jobNotificationWrapper : statefulAlertPage.getCurrentModels()) {
-                processAndDistribute(jobNotificationWrapper);
-            }
-            statefulAlertPage = statefulAlertPage.retrieveNextPage();
-        }
+        jobNotificationMapper.mapJobsToNotifications(filterableNotifications, frequencies).stream()
+            .forEach(filteredJobNotificationWrapper -> processAndDistribute(filteredJobNotificationWrapper));
     }
 
     private void processAndDistribute(FilteredJobNotificationWrapper jobNotificationWrapper) {

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationMapper.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationMapper.java
@@ -7,11 +7,10 @@
  */
 package com.synopsys.integration.alert.processor.api.filter;
 
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Predicate;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,13 +22,10 @@ import com.synopsys.integration.alert.common.persistence.model.job.FilteredDistr
 import com.synopsys.integration.alert.common.persistence.model.job.FilteredDistributionJobResponseModel;
 import com.synopsys.integration.alert.common.rest.model.AlertPagedDetails;
 import com.synopsys.integration.alert.processor.api.detail.DetailedNotificationContent;
+import com.synopsys.integration.util.Stringable;
 
 @Component
 public class JobNotificationMapper {
-    private static final int PAGE_SIZE = 100;
-    private static final int INITIAL_PAGE_NUMBER = 0;
-    private static final Predicate<AlertPagedDetails> HAS_NEXT_PAGE = page -> page.getCurrentPage() < (page.getTotalPages() - 1);
-
     private final ProcessingJobAccessor processingJobAccessor;
 
     @Autowired
@@ -49,105 +45,107 @@ public class JobNotificationMapper {
      * Filter by Policy name (From notification if applicable)
      * @param detailedContents List of notifications that will be iterated over and applied to jobs that are found
      * @param frequencies      an Additional filter to specify when querying data from the DB
-     * @return a {@code StatefulAlertPage} where a page of distribution jobs is used to map to a list of notifications that were passed in.
      */
-    public StatefulAlertPage<FilteredJobNotificationWrapper, RuntimeException> mapJobsToNotifications(
+    public Set<FilteredJobNotificationWrapper> mapJobsToNotifications(
         List<DetailedNotificationContent> detailedContents,
         List<FrequencyType> frequencies
     ) {
-        FilteredJobWrapperPageRetriever filteredJobWrapperPageRetriever = new FilteredJobWrapperPageRetriever(detailedContents, frequencies);
-        AlertPagedDetails<FilteredJobNotificationWrapper> firstPage = filteredJobWrapperPageRetriever.retrievePage(INITIAL_PAGE_NUMBER, PAGE_SIZE);
-        return new StatefulAlertPage<>(firstPage, filteredJobWrapperPageRetriever, HAS_NEXT_PAGE);
+        return detailedContents
+            .stream()
+            .map(content -> convertToRequest(content, frequencies))
+            .map(jobRequestModel -> retrieveResponse(jobRequestModel, detailedContents))
+            .flatMap(Set::stream)
+            .map(this::convertToWrapper)
+            .collect(Collectors.toSet());
     }
 
-    private AlertPagedDetails<FilteredJobNotificationWrapper> mapPageOfJobsToNotification(
-        List<DetailedNotificationContent> detailedContents,
-        List<FrequencyType> frequencies,
-        int pageNumber,
-        int pageSize
+    private FilteredDistributionJobRequestModel convertToRequest(DetailedNotificationContent detailedNotificationContent, List<FrequencyType> frequencies) {
+        FilteredDistributionJobRequestModel filteredDistributionJobRequestModel = new FilteredDistributionJobRequestModel(
+            detailedNotificationContent.getProviderConfigId(),
+            frequencies
+        );
+        detailedNotificationContent.getProjectName().ifPresent(filteredDistributionJobRequestModel::addProjectName);
+        filteredDistributionJobRequestModel.addNotificationType(detailedNotificationContent.getNotificationContentWrapper().extractNotificationType());
+        filteredDistributionJobRequestModel.addVulnerabilitySeverities(detailedNotificationContent.getVulnerabilitySeverities());
+        detailedNotificationContent.getPolicyName().ifPresent(filteredDistributionJobRequestModel::addPolicyName);
+        return filteredDistributionJobRequestModel;
+    }
+
+    private Set<JobWithNotifications> retrieveResponse(
+        FilteredDistributionJobRequestModel filteredDistributionJobRequestModel,
+        List<DetailedNotificationContent> detailedNotificationContents
     ) {
-        if (detailedContents.isEmpty()) {
-            return new AlertPagedDetails<>(1, pageNumber, pageSize, List.of());
-        }
+        int pageNumber = 0;
+        int pageSize = 1000;
+        AlertPagedDetails<FilteredDistributionJobResponseModel> jobs = processingJobAccessor.getMatchingEnabledJobsByFilteredNotifications(
+            filteredDistributionJobRequestModel,
+            pageNumber,
+            pageSize
+        );
+        Set<JobWithNotifications> jobWithNotifications = new HashSet<>();
+        while (jobs.getCurrentPage() <= jobs.getTotalPages()) {
+            jobs.getModels().stream()
+                .map(JobWithNotifications::new)
+                .map(jobWithNotification -> jobWithNotification.addNotificationsIfApplicable(
+                    filteredDistributionJobRequestModel.getProviderConfigId(),
+                    detailedNotificationContents
+                ))
+                .filter(JobWithNotifications::hasRelevantNotifications)
+                .forEach(jobWithNotifications::add);
 
-        Map<FilteredDistributionJobResponseModel, List<NotificationContentWrapper>> groupedFilterableNotifications = new HashMap<>();
-
-        int totalPages = 0;
-        List<FilteredDistributionJobRequestModel> filteredDistributionJobRequestModels = createRequestModelFromNotifications(detailedContents, frequencies);
-        for (FilteredDistributionJobRequestModel filteredDistributionJobRequestModel : filteredDistributionJobRequestModels) {
-            AlertPagedDetails<FilteredDistributionJobResponseModel> jobs = processingJobAccessor.getMatchingEnabledJobsByFilteredNotifications(
+            pageNumber++;
+            jobs = processingJobAccessor.getMatchingEnabledJobsByFilteredNotifications(
                 filteredDistributionJobRequestModel,
                 pageNumber,
                 pageSize
             );
-            totalPages += jobs.getTotalPages();
-            for (DetailedNotificationContent detailedNotificationContent : detailedContents) {
-                for (FilteredDistributionJobResponseModel filteredDistributionJobResponseModel : jobs.getModels()) {
+        }
 
-                    if (JobNotificationFilterUtils.doesNotificationApplyToJob(filteredDistributionJobResponseModel, detailedNotificationContent) &&
-                        detailedNotificationContent.getProviderConfigId() == filteredDistributionJobRequestModel.getProviderConfigId()) {
-                        List<NotificationContentWrapper> applicableNotifications = groupedFilterableNotifications.computeIfAbsent(
-                            filteredDistributionJobResponseModel,
-                            ignoredKey -> new LinkedList<>()
-                        );
-                        applicableNotifications.add(detailedNotificationContent.getNotificationContentWrapper());
-                    }
+        return jobWithNotifications;
+    }
+
+    private FilteredJobNotificationWrapper convertToWrapper(JobWithNotifications jobWithNotifications) {
+        FilteredDistributionJobResponseModel filteredDistributionJobResponseModel = jobWithNotifications.getFilteredDistributionJobResponseModel();
+        return new FilteredJobNotificationWrapper(
+            filteredDistributionJobResponseModel.getId(),
+            filteredDistributionJobResponseModel.getProcessingType(),
+            filteredDistributionJobResponseModel.getChannelName(),
+            filteredDistributionJobResponseModel.getJobName(),
+            jobWithNotifications.getNotificationContentWrappers()
+        );
+    }
+
+    private class JobWithNotifications extends Stringable {
+        private FilteredDistributionJobResponseModel filteredDistributionJobResponseModel;
+        private List<NotificationContentWrapper> notificationContentWrappers = new LinkedList<>();
+
+        public JobWithNotifications(
+            FilteredDistributionJobResponseModel filteredDistributionJobResponseModel
+        ) {
+            this.filteredDistributionJobResponseModel = filteredDistributionJobResponseModel;
+        }
+
+        public FilteredDistributionJobResponseModel getFilteredDistributionJobResponseModel() {
+            return filteredDistributionJobResponseModel;
+        }
+
+        public List<NotificationContentWrapper> getNotificationContentWrappers() {
+            return notificationContentWrappers;
+        }
+
+        public JobWithNotifications addNotificationsIfApplicable(Long providerId, List<DetailedNotificationContent> detailedNotificationContents) {
+            for (DetailedNotificationContent detailedNotificationContent : detailedNotificationContents) {
+                if (JobNotificationFilterUtils.doesNotificationApplyToJob(filteredDistributionJobResponseModel, detailedNotificationContent)
+                    && detailedNotificationContent.getProviderConfigId() == providerId) {
+                    notificationContentWrappers.add(detailedNotificationContent.getNotificationContentWrapper());
                 }
             }
+            return this;
         }
 
-        List<FilteredJobNotificationWrapper> filterableJobNotifications = new LinkedList<>();
-        for (Map.Entry<FilteredDistributionJobResponseModel, List<NotificationContentWrapper>> groupedEntry : groupedFilterableNotifications.entrySet()) {
-            FilteredDistributionJobResponseModel filteredJob = groupedEntry.getKey();
-            FilteredJobNotificationWrapper wrappedJobNotifications = new FilteredJobNotificationWrapper(
-                filteredJob.getId(),
-                filteredJob.getProcessingType(),
-                filteredJob.getChannelName(),
-                filteredJob.getJobName(),
-                groupedEntry.getValue()
-            );
-            filterableJobNotifications.add(wrappedJobNotifications);
+        public boolean hasRelevantNotifications() {
+            return !notificationContentWrappers.isEmpty();
         }
-
-        return new AlertPagedDetails<>(totalPages, pageNumber, pageSize, filterableJobNotifications);
-    }
-
-    private List<FilteredDistributionJobRequestModel> createRequestModelFromNotifications(List<DetailedNotificationContent> detailedContents, List<FrequencyType> frequencies) {
-        return detailedContents
-            .stream()
-            .map(DetailedNotificationContent::getProviderConfigId)
-            .map(id -> {
-                FilteredDistributionJobRequestModel filteredDistributionJobRequestModel = new FilteredDistributionJobRequestModel(id, frequencies);
-                for (DetailedNotificationContent detailedNotificationContent : detailedContents) {
-                    detailedNotificationContent.getProjectName().ifPresent(filteredDistributionJobRequestModel::addProjectName);
-                    filteredDistributionJobRequestModel.addNotificationType(detailedNotificationContent.getNotificationContentWrapper().extractNotificationType());
-                    filteredDistributionJobRequestModel.addVulnerabilitySeverities(detailedNotificationContent.getVulnerabilitySeverities());
-                    detailedNotificationContent.getPolicyName().ifPresent(filteredDistributionJobRequestModel::addPolicyName);
-                }
-                return filteredDistributionJobRequestModel;
-            })
-            .collect(Collectors.toList());
-    }
-
-    private class FilteredJobWrapperPageRetriever implements PageRetriever<FilteredJobNotificationWrapper, RuntimeException> {
-        private final List<DetailedNotificationContent> detailedContents;
-        private final List<FrequencyType> frequencies;
-
-        public FilteredJobWrapperPageRetriever(List<DetailedNotificationContent> detailedContents, List<FrequencyType> frequencies) {
-            this.detailedContents = detailedContents;
-            this.frequencies = frequencies;
-        }
-
-        @Override
-        public AlertPagedDetails<FilteredJobNotificationWrapper> retrieveNextPage(int currentOffset, int currentLimit) throws RuntimeException {
-            return retrievePage(currentOffset + 1, currentLimit);
-        }
-
-        @Override
-        public AlertPagedDetails<FilteredJobNotificationWrapper> retrievePage(int currentOffset, int currentLimit) throws RuntimeException {
-            return mapPageOfJobsToNotification(detailedContents, frequencies, currentOffset, currentLimit);
-        }
-
     }
 
 }

--- a/src/test/java/com/synopsys/integration/alert/channel/email/environment/EmailEnvironmentHandlerFactoryTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/email/environment/EmailEnvironmentHandlerFactoryTestIT.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +39,7 @@ class EmailEnvironmentHandlerFactoryTestIT {
     private EmailGlobalConfigAccessor emailGlobalConfigAccessor;
 
     @AfterEach
+    @BeforeEach
     public void cleanup() {
         emailGlobalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
             .map(Config::getId)

--- a/src/test/java/com/synopsys/integration/alert/processing/NotificationReceivedEventHandlerTest.java
+++ b/src/test/java/com/synopsys/integration/alert/processing/NotificationReceivedEventHandlerTest.java
@@ -4,8 +4,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -16,14 +16,10 @@ import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.api.event.NotificationReceivedEvent;
 import com.synopsys.integration.alert.common.persistence.accessor.NotificationAccessor;
 import com.synopsys.integration.alert.common.rest.model.AlertNotificationModel;
-import com.synopsys.integration.alert.common.rest.model.AlertPagedDetails;
 import com.synopsys.integration.alert.common.util.DateUtils;
 import com.synopsys.integration.alert.processor.api.NotificationProcessor;
 import com.synopsys.integration.alert.processor.api.detail.NotificationDetailExtractionDelegator;
-import com.synopsys.integration.alert.processor.api.filter.FilteredJobNotificationWrapper;
 import com.synopsys.integration.alert.processor.api.filter.JobNotificationMapper;
-import com.synopsys.integration.alert.processor.api.filter.PageRetriever;
-import com.synopsys.integration.alert.processor.api.filter.StatefulAlertPage;
 import com.synopsys.integration.alert.test.common.TestResourceUtils;
 import com.synopsys.integration.blackduck.http.transform.subclass.BlackDuckResponseResolver;
 
@@ -89,15 +85,14 @@ class NotificationReceivedEventHandlerTest {
         String providerConfigName = "providerConfigName";
 
         return new AlertNotificationModel(id, providerConfigId, provider, providerConfigName, notificationType, content, DateUtils.createCurrentDateTimestamp(),
-            DateUtils.createCurrentDateTimestamp(), processed);
+            DateUtils.createCurrentDateTimestamp(), processed
+        );
     }
 
     private NotificationProcessor mockNotificationProcessor(NotificationAccessor notificationAccessor) {
         NotificationDetailExtractionDelegator detailExtractionDelegator = new NotificationDetailExtractionDelegator(blackDuckResponseResolver, List.of());
         JobNotificationMapper jobNotificationMapper = Mockito.mock(JobNotificationMapper.class);
-        Predicate<AlertPagedDetails> hasNextPage = page -> page.getCurrentPage() < (page.getTotalPages() - 1);
-        StatefulAlertPage<FilteredJobNotificationWrapper, RuntimeException> statefulAlertPage = new StatefulAlertPage(AlertPagedDetails.emptyPage(), Mockito.mock(PageRetriever.class), hasNextPage);
-        Mockito.when(jobNotificationMapper.mapJobsToNotifications(Mockito.anyList(), Mockito.anyList())).thenReturn(statefulAlertPage);
+        Mockito.when(jobNotificationMapper.mapJobsToNotifications(Mockito.anyList(), Mockito.anyList())).thenReturn(Set.of());
         return new NotificationProcessor(detailExtractionDelegator, jobNotificationMapper, null, null, List.of(), notificationAccessor);
     }
 

--- a/src/test/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationMapperTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/processor/api/filter/JobNotificationMapperTestIT.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -84,20 +83,10 @@ public class JobNotificationMapperTestIT {
 
     private void runTest(List<DetailedNotificationContent> notifications, int expectedNumOfJobs) {
         JobNotificationMapper jobNotificationMapper = new JobNotificationMapper(processingJobAccessor);
-        Set<FilteredJobNotificationWrapper> notificationWrappers = new HashSet<>();
-        Set<NotificationContentWrapper> jobNotifications = new HashSet<>();
 
-        StatefulAlertPage<FilteredJobNotificationWrapper, RuntimeException> mappedNotifications = jobNotificationMapper.mapJobsToNotifications(notifications, List.of(FrequencyType.REAL_TIME));
-        while (!mappedNotifications.isCurrentPageEmpty()) {
-            notificationWrappers.addAll(mappedNotifications.getCurrentModels());
-            for (FilteredJobNotificationWrapper jobNotificationWrapper : mappedNotifications.getCurrentModels()) {
-                jobNotifications.addAll(jobNotificationWrapper.getJobNotifications());
-            }
-            mappedNotifications = mappedNotifications.retrieveNextPage();
-        }
+        Set<FilteredJobNotificationWrapper> mappedNotifications = jobNotificationMapper.mapJobsToNotifications(notifications, List.of(FrequencyType.REAL_TIME));
 
-        assertEquals(expectedNumOfJobs, notificationWrappers.size());
-        assertEquals(notifications.size(), jobNotifications.size());
+        assertEquals(expectedNumOfJobs, mappedNotifications.size());
     }
 
     @Test
@@ -105,10 +94,13 @@ public class JobNotificationMapperTestIT {
         createJobs(createDistributionJobModels());
 
         JobNotificationMapper jobNotificationMapper = new JobNotificationMapper(processingJobAccessor);
-        StatefulAlertPage<FilteredJobNotificationWrapper, RuntimeException> mappedNotifications = jobNotificationMapper.mapJobsToNotifications(createNotificationWrappers(), List.of(FrequencyType.REAL_TIME));
+        Set<FilteredJobNotificationWrapper> mappedNotifications = jobNotificationMapper.mapJobsToNotifications(
+            createNotificationWrappers(),
+            List.of(FrequencyType.REAL_TIME)
+        );
 
-        assertEquals(3, mappedNotifications.getCurrentModels().size());
-        for (FilteredJobNotificationWrapper mappedJobNotifications : mappedNotifications.getCurrentModels()) {
+        assertEquals(3, mappedNotifications.size());
+        for (FilteredJobNotificationWrapper mappedJobNotifications : mappedNotifications) {
             List<NotificationContentWrapper> jobNotifications = mappedJobNotifications.getJobNotifications();
             assertFalse(jobNotifications.isEmpty(), "Expected the list not to be empty");
             assertTrue(jobNotifications.size() < 4, "Expected the list to contain fewer elements");
@@ -118,8 +110,11 @@ public class JobNotificationMapperTestIT {
     @Test
     public void mapNoJobsTest() {
         JobNotificationMapper jobNotificationMapper = new JobNotificationMapper(processingJobAccessor);
-        StatefulAlertPage<FilteredJobNotificationWrapper, RuntimeException> mappedNotifications = jobNotificationMapper.mapJobsToNotifications(createNotificationWrappers(), List.of(FrequencyType.REAL_TIME));
-        assertEquals(0, mappedNotifications.getCurrentModels().size(), "Expected the list to be empty");
+        Set<FilteredJobNotificationWrapper> mappedNotifications = jobNotificationMapper.mapJobsToNotifications(
+            createNotificationWrappers(),
+            List.of(FrequencyType.REAL_TIME)
+        );
+        assertEquals(0, mappedNotifications.size(), "Expected the list to be empty");
     }
 
     @Test
@@ -230,11 +225,13 @@ public class JobNotificationMapperTestIT {
         createJobs(List.of(jobRequestModel));
 
         JobNotificationMapper jobNotificationMapper = new JobNotificationMapper(processingJobAccessor);
-        StatefulAlertPage<FilteredJobNotificationWrapper, RuntimeException> pageMappedNotifications = jobNotificationMapper.mapJobsToNotifications(createNotificationWrappers(), List.of(FrequencyType.REAL_TIME));
-        List<FilteredJobNotificationWrapper> mappedNotifications = pageMappedNotifications.getCurrentModels();
+        Set<FilteredJobNotificationWrapper> pageMappedNotifications = jobNotificationMapper.mapJobsToNotifications(
+            createNotificationWrappers(),
+            List.of(FrequencyType.REAL_TIME)
+        );
 
-        assertEquals(1, mappedNotifications.size());
-        FilteredJobNotificationWrapper jobNotificationWrapper = mappedNotifications.get(0);
+        assertEquals(1, pageMappedNotifications.size());
+        FilteredJobNotificationWrapper jobNotificationWrapper = pageMappedNotifications.stream().findFirst().orElse(null);
 
         List<NotificationContentWrapper> filterableNotificationWrappers = jobNotificationWrapper.getJobNotifications();
         assertEquals(expectedMappedNotifications, filterableNotificationWrappers.size());
@@ -243,12 +240,13 @@ public class JobNotificationMapperTestIT {
     private void testProjectJob() {
         JobNotificationMapper defaultJobNotificationExtractor = new JobNotificationMapper(processingJobAccessor);
         List<DetailedNotificationContent> notificationWrappers = createNotificationWrappers();
-        StatefulAlertPage<FilteredJobNotificationWrapper, RuntimeException> pageMappedNotifications = defaultJobNotificationExtractor.mapJobsToNotifications(notificationWrappers, List.of(FrequencyType.REAL_TIME));
-        List<FilteredJobNotificationWrapper> filteredJobNotificationWrappers = pageMappedNotifications.getCurrentModels();
+        Set<FilteredJobNotificationWrapper> pageMappedNotifications = defaultJobNotificationExtractor.mapJobsToNotifications(
+            notificationWrappers,
+            List.of(FrequencyType.REAL_TIME)
+        );
+        assertEquals(1, pageMappedNotifications.size());
 
-        assertEquals(1, filteredJobNotificationWrappers.size());
-
-        List<NotificationContentWrapper> filterableNotificationWrappers = filteredJobNotificationWrappers.get(0).getJobNotifications();
+        List<NotificationContentWrapper> filterableNotificationWrappers = pageMappedNotifications.stream().findFirst().orElse(null).getJobNotifications();
         assertEquals(1, filterableNotificationWrappers.size());
 
         NotificationContentWrapper filterableNotificationWrapper = filterableNotificationWrappers.get(0);


### PR DESCRIPTION
Removed a findAny statement that randomly picked which provider to use.
Removed unnecessary notifications from the wrapper when they did not apply to the job.