### PR TITLE
Non proxy host save fix

### DIFF
--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/settings/proxy/NonProxyHostsConfigurationRepository.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/settings/proxy/NonProxyHostsConfigurationRepository.java
@@ -7,7 +7,19 @@
  */
 package com.synopsys.integration.alert.database.settings.proxy;
 
+import java.util.UUID;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NonProxyHostsConfigurationRepository extends JpaRepository<NonProxyHostConfigurationEntity, NonProxyHostConfigurationPK> {
+
+    @Query(
+        "DELETE FROM NonProxyHostConfigurationEntity entity"
+            + " WHERE entity.configurationId = :configurationId"
+    )
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    void bulkDeleteByConfigurationId(@Param("configurationId") UUID configurationId);
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/database/accessor/SettingsProxyConfigAccessor.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/settings/proxy/database/accessor/SettingsProxyConfigAccessor.java
@@ -86,6 +86,7 @@ public class SettingsProxyConfigAccessor implements UniqueConfigurationAccessor<
         OffsetDateTime currentTime = DateUtils.createCurrentDateTimestamp();
         SettingsProxyConfigurationEntity configurationToSave = toEntity(configurationId, configuration, configurationEntity.getCreatedAt(), currentTime);
         SettingsProxyConfigurationEntity savedProxyConfig = settingsProxyConfigurationRepository.save(configurationToSave);
+        nonProxyHostsConfigurationRepository.bulkDeleteByConfigurationId(savedProxyConfig.getConfigurationId());
         List<NonProxyHostConfigurationEntity> nonProxyHosts = toNonProxyHostEntityList(configurationId, configuration);
         nonProxyHostsConfigurationRepository.saveAll(nonProxyHosts);
         savedProxyConfig = settingsProxyConfigurationRepository.getOne(savedProxyConfig.getConfigurationId());


### PR DESCRIPTION
When saving a proxy configuration, if you delete the non-proxy hosts we would revert back to all of the saved configurations.  In order to fix this issue we must add a delete before we perform the save all in the accessor. This is similar to  what we were already doing in the email global config with additional properties.