### PR TITLE
Environment Handler Refactor

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/ConfigurationCrudHelper.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/ConfigurationCrudHelper.java
@@ -15,13 +15,13 @@ import org.slf4j.Logger;
 import org.springframework.http.HttpStatus;
 
 import com.synopsys.integration.alert.api.common.model.AlertSerializableModel;
+import com.synopsys.integration.alert.api.common.model.Obfuscated;
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.logging.AlertLoggerFactory;
 import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
-import com.synopsys.integration.alert.common.rest.model.Obfuscated;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
 import com.synopsys.integration.function.ThrowingSupplier;

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/model/SettingsProxyModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/model/SettingsProxyModel.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.synopsys.integration.alert.api.common.model.Obfuscated;
+
 public class SettingsProxyModel extends ConfigWithMetadata implements Obfuscated<SettingsProxyModel> {
     private String proxyHost;
     private Integer proxyPort;

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/rest/api/ConfigurationCrudHelperTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/rest/api/ConfigurationCrudHelperTest.java
@@ -9,13 +9,13 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
+import com.synopsys.integration.alert.api.common.model.Obfuscated;
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.persistence.model.PermissionKey;
 import com.synopsys.integration.alert.common.persistence.model.PermissionMatrixModel;
-import com.synopsys.integration.alert.common.rest.model.Obfuscated;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
 import com.synopsys.integration.alert.descriptor.api.model.ChannelKey;
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;

--- a/api-common-model/src/main/java/com/synopsys/integration/alert/api/common/model/Obfuscated.java
+++ b/api-common-model/src/main/java/com/synopsys/integration/alert/api/common/model/Obfuscated.java
@@ -5,7 +5,7 @@
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
-package com.synopsys.integration.alert.common.rest.model;
+package com.synopsys.integration.alert.api.common.model;
 
 public interface Obfuscated<T> {
     T obfuscate();

--- a/api-environment/src/main/java/com/synopsys/integration/alert/environment/EnvironmentVariableHandler2.java
+++ b/api-environment/src/main/java/com/synopsys/integration/alert/environment/EnvironmentVariableHandler2.java
@@ -82,16 +82,6 @@ public class EnvironmentVariableHandler2<T extends Obfuscated<T>> {
     public EnvironmentProcessingResult updateFromEnvironment() {
         boolean configurationMissing = configurationMissingCheck.getAsBoolean();
         if (configurationMissing) {
-            //return updateFunction.apply();
-        }
-
-        return EnvironmentProcessingResult.empty();
-    }
-
-    //TODO: Rename and replace with the above
-    public EnvironmentProcessingResult updateFromEnvironment2() {
-        boolean configurationMissing = configurationMissingCheck.getAsBoolean();
-        if (configurationMissing) {
             //T configurationModel = createConfiguration();
             T configurationModel = configModelSupplier.get();
             ValidationResponseModel validationResponseModel = validator.apply(configurationModel);

--- a/api-environment/src/main/java/com/synopsys/integration/alert/environment/EnvironmentVariableHandler2.java
+++ b/api-environment/src/main/java/com/synopsys/integration/alert/environment/EnvironmentVariableHandler2.java
@@ -1,0 +1,118 @@
+/*
+ * api-environment
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.alert.environment;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.synopsys.integration.alert.api.common.model.Obfuscated;
+import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
+import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatus;
+
+public class EnvironmentVariableHandler2<T extends Obfuscated<T>> {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final String name;
+    private final Set<String> environmentVariableNames;
+    private final BooleanSupplier configurationMissingCheck;
+    private final Function<T, EnvironmentProcessingResult> updateFunction;
+    private final Function<T, ValidationResponseModel> validator;
+    private final Supplier<T> configModelSupplier;
+
+    public static <T extends Obfuscated<T>> EnvironmentVariableHandler2<T> create(
+        String name,
+        Set<String> environmentVariableNames,
+        BooleanSupplier configurationMissingCheck,
+        Function<T, EnvironmentProcessingResult> updateFunction,
+        Function<T, ValidationResponseModel> validator,
+        Supplier<T> configModelSupplier
+    ) {
+        return new EnvironmentVariableHandler2<>(name, environmentVariableNames, configurationMissingCheck, updateFunction, validator, configModelSupplier);
+    }
+
+    /*
+    public EnvironmentVariableHandler(String name, Set<String> environmentVariableNames, BooleanSupplier configurationMissingCheck, Supplier<EnvironmentProcessingResult> updateFunction) {
+        this.name = name;
+        this.environmentVariableNames = environmentVariableNames;
+        this.configurationMissingCheck = configurationMissingCheck;
+        this.updateFunction = updateFunction;
+        //TODO:
+        this.validator = null;
+    }*/
+
+    //TODO: Make this private, note that it may break unit tests
+    public EnvironmentVariableHandler2(
+        String name,
+        Set<String> environmentVariableNames,
+        BooleanSupplier configurationMissingCheck,
+        Function<T, EnvironmentProcessingResult> updateFunction,
+        Function<T, ValidationResponseModel> validator,
+        Supplier<T> configModelSupplier
+    ) {
+        this.name = name;
+        this.environmentVariableNames = environmentVariableNames;
+        this.configurationMissingCheck = configurationMissingCheck;
+        this.updateFunction = updateFunction;
+        this.validator = validator;
+        this.configModelSupplier = configModelSupplier;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Set<String> getVariableNames() {
+        return environmentVariableNames;
+    }
+
+    public boolean isConfigurationMissing() {
+        return configurationMissingCheck.getAsBoolean();
+    }
+
+    public EnvironmentProcessingResult updateFromEnvironment() {
+        boolean configurationMissing = configurationMissingCheck.getAsBoolean();
+        if (configurationMissing) {
+            //return updateFunction.apply();
+        }
+
+        return EnvironmentProcessingResult.empty();
+    }
+
+    //TODO: Rename and replace with the above
+    public EnvironmentProcessingResult updateFromEnvironment2() {
+        boolean configurationMissing = configurationMissingCheck.getAsBoolean();
+        if (configurationMissing) {
+            //T configurationModel = createConfiguration();
+            T configurationModel = configModelSupplier.get();
+            ValidationResponseModel validationResponseModel = validator.apply(configurationModel);
+            if (validationResponseModel.hasErrors()) {
+                logger.error("Error inserting startup values: {}", validationResponseModel.getMessage());
+                Map<String, AlertFieldStatus> errors = validationResponseModel.getErrors();
+                for (Map.Entry<String, AlertFieldStatus> error : errors.entrySet()) {
+                    AlertFieldStatus status = error.getValue();
+                    logger.error("Field: '{}' failed with the error: {}", status.getFieldName(), status.getFieldMessage());
+                }
+                return EnvironmentProcessingResult.empty();
+            }
+            return updateFunction.apply(configurationModel);
+        }
+
+        return EnvironmentProcessingResult.empty();
+    }
+
+    //Option 2, call methods from EnvVarProc
+    //first call isConfigurationMissing -> if true, call get ConfigModel
+    //public <T extends Obfuscated<T>> ValidationResponseModel configureModel(Supplier<T> modelCreator) {
+
+    //}
+}

--- a/api-environment/src/main/java/com/synopsys/integration/alert/environment/EnvironmentVariableHandlerFactory2.java
+++ b/api-environment/src/main/java/com/synopsys/integration/alert/environment/EnvironmentVariableHandlerFactory2.java
@@ -1,0 +1,15 @@
+/*
+ * api-environment
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.alert.environment;
+
+import com.synopsys.integration.alert.api.common.model.Obfuscated;
+
+public interface EnvironmentVariableHandlerFactory2<T extends Obfuscated<T>> {
+
+    EnvironmentVariableHandler2<T> build();
+}

--- a/api-environment/src/main/java/com/synopsys/integration/alert/environment/EnvironmentVariableProcessor2.java
+++ b/api-environment/src/main/java/com/synopsys/integration/alert/environment/EnvironmentVariableProcessor2.java
@@ -43,7 +43,7 @@ public class EnvironmentVariableProcessor2 {
             logger.info("Handler name: {}", handler.getName());
             logger.info(LINE_DIVIDER);
             logVariableNames(handler.getVariableNames());
-            EnvironmentProcessingResult result = handler.updateFromEnvironment2();
+            EnvironmentProcessingResult result = handler.updateFromEnvironment();
             logConfiguration(result);
         }
     }

--- a/api-environment/src/main/java/com/synopsys/integration/alert/environment/EnvironmentVariableProcessor2.java
+++ b/api-environment/src/main/java/com/synopsys/integration/alert/environment/EnvironmentVariableProcessor2.java
@@ -1,0 +1,77 @@
+/*
+ * api-environment
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.alert.environment;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EnvironmentVariableProcessor2 {
+    private static final String LINE_DIVIDER = "---------------------------------";
+    private static final String TWO_SPACE_INDENT = "  ";
+    private static final String FOUR_SPACE_INDENT = "    ";
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final List<EnvironmentVariableHandlerFactory2<?>> factoryList;
+
+    @Autowired
+    public EnvironmentVariableProcessor2(List<EnvironmentVariableHandlerFactory2<?>> factoryList) {
+        this.factoryList = factoryList;
+    }
+
+    public void updateConfigurations() {
+        logger.info("** {} **", LINE_DIVIDER);
+        logger.info("Initializing system configurations from environment variables...");
+        logger.info("Building environment variables handlers.");
+        List<EnvironmentVariableHandler2<?>> handlerList = factoryList.stream()
+            .map(EnvironmentVariableHandlerFactory2::build)
+            .collect(Collectors.toList());
+        logger.info("Begin handling environment variables...");
+        for (EnvironmentVariableHandler2<?> handler : handlerList) {
+            logger.info(LINE_DIVIDER);
+            logger.info("Handler name: {}", handler.getName());
+            logger.info(LINE_DIVIDER);
+            logVariableNames(handler.getVariableNames());
+            EnvironmentProcessingResult result = handler.updateFromEnvironment2();
+            logConfiguration(result);
+        }
+    }
+
+    private void logVariableNames(Set<String> names) {
+        logger.info("{}### Environment Variables ### ", TWO_SPACE_INDENT);
+        List<String> sortedNames = names.stream()
+            .map(String::trim)
+            .sorted()
+            .collect(Collectors.toList());
+
+        for (String name : sortedNames) {
+            logger.info("{}{}", FOUR_SPACE_INDENT, name);
+        }
+    }
+
+    private void logConfiguration(EnvironmentProcessingResult configurationProperties) {
+        if (configurationProperties.hasValues()) {
+            List<String> sortedVariableNames = configurationProperties.getVariableNames().stream()
+                .sorted()
+                .collect(Collectors.toList());
+            logger.info(TWO_SPACE_INDENT);
+            logger.info("{}### Environment Variables Used to Configure System ### ", TWO_SPACE_INDENT);
+            for (String variableName : sortedVariableNames) {
+                Optional<String> variableValue = configurationProperties.getVariableValue(variableName);
+                variableValue.ifPresent(value -> logger.info("{}{} = {}", FOUR_SPACE_INDENT, variableName, value));
+            }
+            logger.info(TWO_SPACE_INDENT);
+        }
+    }
+}

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/environment/EmailEnvironmentVariableHandlerFactory2.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/environment/EmailEnvironmentVariableHandlerFactory2.java
@@ -1,0 +1,216 @@
+/*
+ * channel-email
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.alert.channel.email.environment;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.math.NumberUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.api.common.model.AlertConstants;
+import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
+import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
+import com.synopsys.integration.alert.channel.email.database.accessor.EmailGlobalConfigAccessor;
+import com.synopsys.integration.alert.channel.email.validator.EmailGlobalConfigurationValidator;
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
+import com.synopsys.integration.alert.environment.EnvironmentProcessingResult;
+import com.synopsys.integration.alert.environment.EnvironmentVariableHandler;
+import com.synopsys.integration.alert.environment.EnvironmentVariableHandlerFactory2;
+import com.synopsys.integration.alert.environment.EnvironmentVariableUtility;
+import com.synopsys.integration.alert.service.email.model.EmailGlobalConfigModel;
+
+@Component
+public class EmailEnvironmentVariableHandlerFactory2 implements EnvironmentVariableHandlerFactory2<EmailGlobalConfigModel> {
+    public static final String ENVIRONMENT_VARIABLE_PREFIX = "ALERT_CHANNEL_EMAIL_";
+    public static final String ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX = ENVIRONMENT_VARIABLE_PREFIX + "MAIL_";
+
+    // fields in model
+    public static final String AUTH_REQUIRED_KEY = ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_AUTH";
+    public static final String EMAIL_FROM_KEY = ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_FROM";
+    public static final String EMAIL_HOST_KEY = ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_HOST";
+    public static final String AUTH_PASSWORD_KEY = ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_PASSWORD";
+    public static final String EMAIL_PORT_KEY = ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_PORT";
+    public static final String AUTH_USER_KEY = ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_USER";
+
+    public static final Set<String> EMAIL_CONFIGURATION_KEYSET = Set.of(
+        AUTH_REQUIRED_KEY, EMAIL_FROM_KEY, EMAIL_HOST_KEY, AUTH_PASSWORD_KEY, EMAIL_PORT_KEY, AUTH_USER_KEY);
+
+    // additional property keys
+    public static final Set<String> OLD_ADDITIONAL_PROPERTY_KEYSET = Set.of(
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_ALLOW8BITMIME",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_AUTH_DIGEST-MD5_DISABLE",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_AUTH_LOGIN_DISABLE",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_AUTH_MECHANISMS",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_AUTH_NTLM_DISABLE",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_AUTH_NTLM_DOMAIN",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_AUTH_NTLM_FLAGS",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_AUTH_PLAIN_DISABLE",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_AUTH_XOAUTH2_DISABLE",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_CONNECTIONTIMEOUT",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_DSN_NOTIFY",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_DSN_RET",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_EHLO",
+
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_LOCALADDRESS",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_LOCALHOST",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_LOCALPORT",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_MAILEXTENSION",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_NOOP_STRICT",
+
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_PROXY_HOST",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_PROXY_PORT",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_QUITWAIT",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_REPORTSUCCESS",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_SASL_AUTHORIZATIONID",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_SASL_ENABLE",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_SASL_MECHANISMS",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_SASL_REALM",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_SASL_USECANONICALHOSTNAME",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_SENDPARTIAL",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_SOCKS_HOST",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_SOCKS_PORT",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_SSL_CHECKSERVERIDENTITY",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_SSL_CIPHERSUITES",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_SSL_ENABLE",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_SSL_PROTOCOLS",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_SSL_TRUST",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_STARTTLS_ENABLE",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_STARTTLS_REQUIRED",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_SUBMITTER",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_TIMEOUT",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_USERSET",
+        ENVIRONMENT_VARIABLE_JAVAMAIL_PREFIX + "SMTP_WRITETIMEOUT"
+    );
+
+    private final EmailGlobalConfigAccessor configAccessor;
+    private final EnvironmentVariableUtility environmentVariableUtility;
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final EmailGlobalConfigurationValidator validator;
+
+    @Autowired
+    public EmailEnvironmentVariableHandlerFactory2(EmailGlobalConfigAccessor configAccessor, EnvironmentVariableUtility environmentVariableUtility, EmailGlobalConfigurationValidator validator) {
+        this.configAccessor = configAccessor;
+        this.environmentVariableUtility = environmentVariableUtility;
+        this.validator = validator;
+    }
+
+    @Override
+    public EnvironmentVariableHandler<EmailGlobalConfigModel> build() {
+        return EnvironmentVariableHandler.create(
+            ChannelKeys.EMAIL.getDisplayName(),
+            Stream.concat(EMAIL_CONFIGURATION_KEYSET.stream(), OLD_ADDITIONAL_PROPERTY_KEYSET.stream()).collect(Collectors.toSet()),
+            this::isConfigurationMissing,
+            this::updateConfiguration,
+            this::validateConfiguration,
+            this::configureModel
+        );
+    }
+
+    private Boolean isConfigurationMissing() {
+        return !configAccessor.doesConfigurationExist();
+    }
+
+    private ValidationResponseModel validateConfiguration(EmailGlobalConfigModel configModel) {
+        return validator.validate(configModel);
+    }
+
+    private EnvironmentProcessingResult updateConfiguration(EmailGlobalConfigModel configModel) {
+        EmailGlobalConfigModel obfuscatedModel = configModel.obfuscate();
+
+        EnvironmentProcessingResult.Builder builder = new EnvironmentProcessingResult.Builder(EMAIL_CONFIGURATION_KEYSET)
+            .addVariableNames(OLD_ADDITIONAL_PROPERTY_KEYSET);
+
+        for (String additionalPropertyName : OLD_ADDITIONAL_PROPERTY_KEYSET) {
+            if (environmentVariableUtility.hasEnvironmentValue(additionalPropertyName)) {
+                String value = environmentVariableUtility.getEnvironmentValue(additionalPropertyName).orElse(null);
+                builder.addVariableValue(additionalPropertyName, value);
+            }
+        }
+
+        obfuscatedModel.getSmtpHost().ifPresent(value -> builder.addVariableValue(EMAIL_HOST_KEY, value));
+        obfuscatedModel.getSmtpPort().map(String::valueOf).ifPresent(value -> builder.addVariableValue(EMAIL_PORT_KEY, value));
+        obfuscatedModel.getSmtpFrom().ifPresent(value -> builder.addVariableValue(EMAIL_FROM_KEY, value));
+        obfuscatedModel.getSmtpAuth().map(String::valueOf).ifPresent(value -> builder.addVariableValue(AUTH_REQUIRED_KEY, value));
+        obfuscatedModel.getSmtpUsername().ifPresent(value -> builder.addVariableValue(AUTH_USER_KEY, value));
+
+        if (Boolean.TRUE.equals(obfuscatedModel.getIsSmtpPasswordSet())) {
+            builder.addVariableValue(AUTH_PASSWORD_KEY, AlertConstants.MASKED_VALUE);
+        }
+
+        EnvironmentProcessingResult result = builder.build();
+        if (result.hasValues()) {
+            try {
+                configAccessor.createConfiguration(configModel);
+            } catch (AlertConfigurationException ex) {
+                logger.error("Failed to create config: ", ex);
+            }
+        }
+
+        return result;
+    }
+
+    private EmailGlobalConfigModel configureModel() {
+        EmailGlobalConfigModel configModel = new EmailGlobalConfigModel();
+        configModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
+        configureEmailSettings(configModel);
+        configureAdditionalProperties(configModel);
+
+        return configModel;
+    }
+
+    private void configureEmailSettings(EmailGlobalConfigModel configuration) {
+        environmentVariableUtility.getEnvironmentValue(EMAIL_HOST_KEY)
+            .ifPresent(configuration::setSmtpHost);
+
+        environmentVariableUtility.getEnvironmentValue(EMAIL_PORT_KEY)
+            .filter(NumberUtils::isDigits)
+            .map(NumberUtils::toInt)
+            .ifPresent(configuration::setSmtpPort);
+
+        environmentVariableUtility.getEnvironmentValue(EMAIL_FROM_KEY)
+            .ifPresent(configuration::setSmtpFrom);
+
+        environmentVariableUtility.getEnvironmentValue(AUTH_REQUIRED_KEY)
+            .map(Boolean::valueOf)
+            .ifPresent(configuration::setSmtpAuth);
+
+        environmentVariableUtility.getEnvironmentValue(AUTH_USER_KEY)
+            .ifPresent(configuration::setSmtpUsername);
+
+        environmentVariableUtility.getEnvironmentValue(AUTH_PASSWORD_KEY)
+            .ifPresent(configuration::setSmtpPassword);
+
+    }
+
+    private void configureAdditionalProperties(EmailGlobalConfigModel configuration) {
+        Map<String, String> additionalProperties = new HashMap<>();
+        for (String additionalPropertyName : OLD_ADDITIONAL_PROPERTY_KEYSET) {
+            if (environmentVariableUtility.hasEnvironmentValue(additionalPropertyName)) {
+                String javamailPropertyName = EmailEnvironmentVariableHandlerFactory2.convertVariableNameToJavamailPropertyKey(additionalPropertyName);
+                String value = environmentVariableUtility.getEnvironmentValue(additionalPropertyName).orElse(null);
+                additionalProperties.put(javamailPropertyName, value);
+            }
+        }
+        configuration.setAdditionalJavaMailProperties(additionalProperties);
+    }
+
+    public static String convertVariableNameToJavamailPropertyKey(String environmentVariableName) {
+        String propertyKey = environmentVariableName.substring(ENVIRONMENT_VARIABLE_PREFIX.length());
+        propertyKey = propertyKey.replace("_", ".").toLowerCase();
+        return propertyKey;
+    }
+
+}

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/environment/EmailEnvironmentVariableHandlerFactory2.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/environment/EmailEnvironmentVariableHandlerFactory2.java
@@ -27,7 +27,7 @@ import com.synopsys.integration.alert.channel.email.validator.EmailGlobalConfigu
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
 import com.synopsys.integration.alert.environment.EnvironmentProcessingResult;
-import com.synopsys.integration.alert.environment.EnvironmentVariableHandler;
+import com.synopsys.integration.alert.environment.EnvironmentVariableHandler2;
 import com.synopsys.integration.alert.environment.EnvironmentVariableHandlerFactory2;
 import com.synopsys.integration.alert.environment.EnvironmentVariableUtility;
 import com.synopsys.integration.alert.service.email.model.EmailGlobalConfigModel;
@@ -108,8 +108,8 @@ public class EmailEnvironmentVariableHandlerFactory2 implements EnvironmentVaria
     }
 
     @Override
-    public EnvironmentVariableHandler<EmailGlobalConfigModel> build() {
-        return EnvironmentVariableHandler.create(
+    public EnvironmentVariableHandler2<EmailGlobalConfigModel> build() {
+        return EnvironmentVariableHandler2.create(
             ChannelKeys.EMAIL.getDisplayName(),
             Stream.concat(EMAIL_CONFIGURATION_KEYSET.stream(), OLD_ADDITIONAL_PROPERTY_KEYSET.stream()).collect(Collectors.toSet()),
             this::isConfigurationMissing,

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/environment/EmailEnvironmentVariableHandlerFactory2.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/environment/EmailEnvironmentVariableHandlerFactory2.java
@@ -123,6 +123,15 @@ public class EmailEnvironmentVariableHandlerFactory2 implements EnvironmentVaria
         return !configAccessor.doesConfigurationExist();
     }
 
+    private EmailGlobalConfigModel configureModel() {
+        EmailGlobalConfigModel configModel = new EmailGlobalConfigModel();
+        configModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
+        configureEmailSettings(configModel);
+        configureAdditionalProperties(configModel);
+
+        return configModel;
+    }
+
     private ValidationResponseModel validateConfiguration(EmailGlobalConfigModel configModel) {
         return validator.validate(configModel);
     }
@@ -160,15 +169,6 @@ public class EmailEnvironmentVariableHandlerFactory2 implements EnvironmentVaria
         }
 
         return result;
-    }
-
-    private EmailGlobalConfigModel configureModel() {
-        EmailGlobalConfigModel configModel = new EmailGlobalConfigModel();
-        configModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
-        configureEmailSettings(configModel);
-        configureAdditionalProperties(configModel);
-
-        return configModel;
     }
 
     private void configureEmailSettings(EmailGlobalConfigModel configuration) {

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/model/JiraServerGlobalConfigModel.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/model/JiraServerGlobalConfigModel.java
@@ -11,8 +11,8 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.synopsys.integration.alert.api.common.model.Obfuscated;
 import com.synopsys.integration.alert.common.rest.model.ConfigWithMetadata;
-import com.synopsys.integration.alert.common.rest.model.Obfuscated;
 
 public class JiraServerGlobalConfigModel extends ConfigWithMetadata implements Obfuscated<JiraServerGlobalConfigModel> {
     private String url;

--- a/component/src/main/java/com/synopsys/integration/alert/component/settings/encryption/model/SettingsEncryptionModel.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/settings/encryption/model/SettingsEncryptionModel.java
@@ -10,7 +10,7 @@ package com.synopsys.integration.alert.component.settings.encryption.model;
 import java.util.Optional;
 
 import com.synopsys.integration.alert.api.common.model.AlertSerializableModel;
-import com.synopsys.integration.alert.common.rest.model.Obfuscated;
+import com.synopsys.integration.alert.api.common.model.Obfuscated;
 
 public class SettingsEncryptionModel extends AlertSerializableModel implements Obfuscated<SettingsEncryptionModel> {
     private Boolean isEncryptionPasswordSet;

--- a/service-email/src/main/java/com/synopsys/integration/alert/service/email/model/EmailGlobalConfigModel.java
+++ b/service-email/src/main/java/com/synopsys/integration/alert/service/email/model/EmailGlobalConfigModel.java
@@ -12,8 +12,8 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.synopsys.integration.alert.api.common.model.Obfuscated;
 import com.synopsys.integration.alert.common.rest.model.ConfigWithMetadata;
-import com.synopsys.integration.alert.common.rest.model.Obfuscated;
 
 public class EmailGlobalConfigModel extends ConfigWithMetadata implements Obfuscated<EmailGlobalConfigModel> {
     private String smtpFrom;


### PR DESCRIPTION
Opening this as a draft. To get some feedback on the updated approach for handling environment variables for new channels.

The primary goal here was to add a validation step introduced in 6.9.0 but to improve it by requiring it at the handler level rather than each having its own implementation.

To accomplish this I took the following steps:

- Moved Obfuscated interface to be in alert-common-model which allows it to be accessed from api-environment.
- Created EnvironmentVariableHandler2 with functions and suppliers for creating the model, validating, and updating within the updateFromEnvironment method.
- Created EmailEnvironmentVariableHandlerFactory2 as a proof of concept for these changes, splitting it into 3 methods to:  supply an EmailGlobalConfigModel, a function to validate the model, and a function to create and return  an EnvironmentProcessingResult

All other changes here were made to support the existing handlers, and allow the testing of updated V2 handlers. If this draft looks good, I will replace the old V1 handlers and implement these changes for Proxy, Encryption, and Jira Server.