### PR TITLE
 jira server fixes

### DIFF
--- a/ui/src/main/js/page/channel/jira/server/ConcreteJiraServerGlobalConfiguration.js
+++ b/ui/src/main/js/page/channel/jira/server/ConcreteJiraServerGlobalConfiguration.js
@@ -74,6 +74,7 @@ const ConcreteJiraServerGlobalConfiguration = ({
                 displayTest={displayTest}
                 displaySave={displaySave}
                 displayDelete={false}
+                displayCancel
                 errorHandler={errorHandler}
             >
                 <TextInput


### PR DESCRIPTION
- Fix the test action to read a password from the database if saved.
- Show cancel option when creating or editing a jira server configuration
