### PR TITLE
Front end blank value test config fixes for proxy/email 

### DIFF
--- a/ui/src/main/js/common/util/configurationRequestBuilder.js
+++ b/ui/src/main/js/common/util/configurationRequestBuilder.js
@@ -115,7 +115,7 @@ export function createValidateRequest(apiUrl, csrfToken, fieldModel) {
 
 export function createTestRequest(apiUrl, csrfToken, fieldModel, queryParamKey, queryParamValue) {
     let url = `${apiUrl}/test`;
-    if (queryParamKey && queryParamValue) {
+    if (queryParamKey) {
         url = url.concat(`?${encodeURIComponent(queryParamKey)}=${encodeURIComponent(queryParamValue)}`);
     }
 


### PR DESCRIPTION
It's possible that the queryParamValue is blank in the UI and therefore we should not be checking it along with the key. The UI will encode and make a request using "" as the value which is handled by the validators in the backend.