### PR TITLE
Fixed Jira Servers broken test functionality

### DIFF
--- a/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/action/IssueTrackerTestAction.java
+++ b/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/action/IssueTrackerTestAction.java
@@ -49,7 +49,7 @@ public abstract class IssueTrackerTestAction<D extends DistributionJobDetailsMod
     @Override
     public MessageResult testConfig(DistributionJobModel testJobModel, String jobName, @Nullable String customTopic, @Nullable String customMessage) throws AlertException {
         D distributionDetails = (D) testJobModel.getDistributionJobDetails();
-        IssueTrackerMessageSender<T> messageSender = messageSenderFactory.createMessageSender(distributionDetails);
+        IssueTrackerMessageSender<T> messageSender = messageSenderFactory.createMessageSender(distributionDetails, testJobModel.getChannelGlobalConfigId());
 
         String topicString = Optional.ofNullable(customTopic).orElse("Alert Test Topic");
         String messageString = Optional.ofNullable(customMessage).orElse("Alert Test Message");

--- a/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/send/IssueTrackerMessageSenderFactory.java
+++ b/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/send/IssueTrackerMessageSenderFactory.java
@@ -8,11 +8,14 @@
 package com.synopsys.integration.alert.api.channel.issue.send;
 
 import java.io.Serializable;
+import java.util.UUID;
+
+import org.springframework.lang.Nullable;
 
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.common.persistence.model.job.details.DistributionJobDetailsModel;
 
 public interface IssueTrackerMessageSenderFactory<D extends DistributionJobDetailsModel, T extends Serializable> {
-    IssueTrackerMessageSender<T> createMessageSender(D distributionDetails) throws AlertException;
+    IssueTrackerMessageSender<T> createMessageSender(D distributionDetails, @Nullable UUID globalId) throws AlertException;
 
 }

--- a/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/action/IssueTrackerFieldModelTestActionTest.java
+++ b/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/action/IssueTrackerFieldModelTestActionTest.java
@@ -41,7 +41,7 @@ public class IssueTrackerFieldModelTestActionTest {
         IssueTrackerMessageSender<String> messageSender = Mockito.mock(IssueTrackerMessageSender.class);
         Mockito.when(messageSender.sendMessages(Mockito.any())).thenThrow(new AlertException(testExceptionMessage));
 
-        IssueTrackerMessageSenderFactory<TestJobDetails, String> messageSenderFactory = distributionDetails -> messageSender;
+        IssueTrackerMessageSenderFactory<TestJobDetails, String> messageSenderFactory = (distributionDetails, id) -> messageSender;
         TestIssueTrackerTestAction issueTrackerTestAction = new TestIssueTrackerTestAction(messageSenderFactory);
 
         MessageResult messageResult = issueTrackerTestAction.testConfig(TEST_JOB_MODEL, "jobName", null, null);
@@ -53,7 +53,7 @@ public class IssueTrackerFieldModelTestActionTest {
         IssueTrackerMessageSender<String> messageSender = Mockito.mock(IssueTrackerMessageSender.class);
         Mockito.when(messageSender.sendMessages(Mockito.any())).thenReturn(List.of());
 
-        IssueTrackerMessageSenderFactory<TestJobDetails, String> messageSenderFactory = distributionDetails -> messageSender;
+        IssueTrackerMessageSenderFactory<TestJobDetails, String> messageSenderFactory = (distributionDetails, id) -> messageSender;
         TestIssueTrackerTestAction issueTrackerTestAction = new TestIssueTrackerTestAction(messageSenderFactory);
 
         MessageResult messageResult = issueTrackerTestAction.testConfig(TEST_JOB_MODEL, "jobName", null, null);
@@ -65,7 +65,7 @@ public class IssueTrackerFieldModelTestActionTest {
         IssueTrackerMessageSender<String> messageSender = Mockito.mock(IssueTrackerMessageSender.class);
         Mockito.when(messageSender.sendMessages(Mockito.any())).thenReturn(List.of(TEST_ISSUE_RESPONSE_MODEL));
 
-        IssueTrackerMessageSenderFactory<TestJobDetails, String> messageSenderFactory = distributionDetails -> messageSender;
+        IssueTrackerMessageSenderFactory<TestJobDetails, String> messageSenderFactory = (distributionDetails, id) -> messageSender;
         TestIssueTrackerTestAction issueTrackerTestAction = new TestIssueTrackerTestAction(messageSenderFactory);
 
         MessageResult messageResult = issueTrackerTestAction.testConfig(TEST_JOB_MODEL, "jobName", null, null);
@@ -84,7 +84,7 @@ public class IssueTrackerFieldModelTestActionTest {
             return List.of();
         });
 
-        IssueTrackerMessageSenderFactory<TestJobDetails, String> messageSenderFactory = distributionDetails -> messageSender;
+        IssueTrackerMessageSenderFactory<TestJobDetails, String> messageSenderFactory = (distributionDetails, id) -> messageSender;
         TestIssueTrackerTestAction issueTrackerTestAction = new TestIssueTrackerTestAction(messageSenderFactory, true, false);
 
         MessageResult messageResult = issueTrackerTestAction.testConfig(TEST_JOB_MODEL, "jobName", null, null);
@@ -96,7 +96,7 @@ public class IssueTrackerFieldModelTestActionTest {
         IssueTrackerMessageSender<String> messageSender = Mockito.mock(IssueTrackerMessageSender.class);
         Mockito.when(messageSender.sendMessages(Mockito.any())).thenReturn(List.of(TEST_ISSUE_RESPONSE_MODEL));
 
-        IssueTrackerMessageSenderFactory<TestJobDetails, String> messageSenderFactory = distributionDetails -> messageSender;
+        IssueTrackerMessageSenderFactory<TestJobDetails, String> messageSenderFactory = (distributionDetails, id) -> messageSender;
         TestIssueTrackerTestAction issueTrackerTestAction = new TestIssueTrackerTestAction(messageSenderFactory, true, false);
 
         MessageResult messageResult = issueTrackerTestAction.testConfig(TEST_JOB_MODEL, "jobName", null, null);
@@ -120,7 +120,7 @@ public class IssueTrackerFieldModelTestActionTest {
             return List.of(TEST_ISSUE_RESPONSE_MODEL);
         });
 
-        IssueTrackerMessageSenderFactory<TestJobDetails, String> messageSenderFactory = distributionDetails -> messageSender;
+        IssueTrackerMessageSenderFactory<TestJobDetails, String> messageSenderFactory = (distributionDetails, id) -> messageSender;
         TestIssueTrackerTestAction issueTrackerTestAction = new TestIssueTrackerTestAction(messageSenderFactory, true, true);
 
         MessageResult messageResult = issueTrackerTestAction.testConfig(TEST_JOB_MODEL, "jobName", null, null);

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/AzureBoardsMessageSenderFactory.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/AzureBoardsMessageSenderFactory.java
@@ -7,6 +7,8 @@
  */
 package com.synopsys.integration.alert.channel.azure.boards.distribution;
 
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -66,7 +68,7 @@ public class AzureBoardsMessageSenderFactory implements IssueTrackerMessageSende
     }
 
     @Override
-    public IssueTrackerMessageSender<Integer> createMessageSender(AzureBoardsJobDetailsModel distributionDetails) throws AlertException {
+    public IssueTrackerMessageSender<Integer> createMessageSender(AzureBoardsJobDetailsModel distributionDetails, UUID globalId) throws AlertException {
         AzureBoardsProperties azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
         azureBoardsProperties.validateProperties();
 

--- a/channel-jira-cloud/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/JiraCloudMessageSenderFactory.java
+++ b/channel-jira-cloud/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/JiraCloudMessageSenderFactory.java
@@ -7,6 +7,8 @@
  */
 package com.synopsys.integration.alert.channel.jira.cloud.distribution;
 
+import java.util.UUID;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,7 +64,7 @@ public class JiraCloudMessageSenderFactory implements IssueTrackerMessageSenderF
     }
 
     @Override
-    public IssueTrackerMessageSender<String> createMessageSender(JiraCloudJobDetailsModel distributionDetails) throws AlertException {
+    public IssueTrackerMessageSender<String> createMessageSender(JiraCloudJobDetailsModel distributionDetails, UUID globalId) throws AlertException {
         JiraCloudProperties jiraCloudProperties = jiraCloudPropertiesFactory.createJiraProperties();
         JiraCloudServiceFactory jiraCloudServiceFactory = jiraCloudProperties.createJiraServicesCloudFactory(logger, gson);
 

--- a/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/JiraCloudSummaryFieldLengthTestIT.java
+++ b/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/JiraCloudSummaryFieldLengthTestIT.java
@@ -91,7 +91,7 @@ public class JiraCloudSummaryFieldLengthTestIT {
             new IssueTrackerCallbackInfoCreator(),
             issueCategoryRetriever);
         JiraCloudJobDetailsModel jiraCloudJobDetails = createJiraCloudJobDetails(testProperties);
-        return jiraCloudMessageSenderFactory.createMessageSender(jiraCloudJobDetails);
+        return jiraCloudMessageSenderFactory.createMessageSender(jiraCloudJobDetails, null);
     }
 
     private static JiraCloudPropertiesFactory createJiraCloudPropertiesFactory(TestProperties testProperties) throws AlertConfigurationException {

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/distribution/JiraServerMessageSenderFactory.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/distribution/JiraServerMessageSenderFactory.java
@@ -7,6 +7,8 @@
  */
 package com.synopsys.integration.alert.channel.jira.server.distribution;
 
+import java.util.UUID;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,8 +64,8 @@ public class JiraServerMessageSenderFactory implements IssueTrackerMessageSender
     }
 
     @Override
-    public IssueTrackerMessageSender<String> createMessageSender(JiraServerJobDetailsModel distributionDetails) throws AlertException {
-        JiraServerProperties jiraServerProperties = jiraServerPropertiesFactory.createJiraPropertiesWithJobId(distributionDetails.getJobId());
+    public IssueTrackerMessageSender<String> createMessageSender(JiraServerJobDetailsModel distributionDetails, UUID globalId) throws AlertException {
+        JiraServerProperties jiraServerProperties = jiraServerPropertiesFactory.createJiraProperties(globalId);
         JiraServerServiceFactory jiraServerServiceFactory = jiraServerProperties.createJiraServicesServerFactory(logger, gson);
 
         // Jira Services

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/JiraServerSummaryFieldLengthTestIT.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/JiraServerSummaryFieldLengthTestIT.java
@@ -92,7 +92,8 @@ public class JiraServerSummaryFieldLengthTestIT {
             new IssueTrackerCallbackInfoCreator(),
             issueCategoryRetriever);
         JiraServerJobDetailsModel jiraServerJobDetails = createJiraServerJobDetails(testProperties);
-        return jiraServerMessageSenderFactory.createMessageSender(jiraServerJobDetails);
+        //Can pass null due to properties mocking
+        return jiraServerMessageSenderFactory.createMessageSender(jiraServerJobDetails, null);
     }
 
     private static JiraServerPropertiesFactory createJiraServerPropertiesFactory(TestProperties testProperties) throws AlertConfigurationException {
@@ -102,7 +103,7 @@ public class JiraServerSummaryFieldLengthTestIT {
 
         JiraServerPropertiesFactory jiraServerPropertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
         JiraServerProperties jiraServerProperties = new JiraServerProperties(url, password, username, true, ProxyInfo.NO_PROXY_INFO);
-        Mockito.when(jiraServerPropertiesFactory.createJiraPropertiesWithJobId(Mockito.any(UUID.class))).thenReturn(jiraServerProperties);
+        Mockito.when(jiraServerPropertiesFactory.createJiraProperties(Mockito.any(UUID.class))).thenReturn(jiraServerProperties);
 
         return jiraServerPropertiesFactory;
     }


### PR DESCRIPTION
We incorrectly used the jobId to try and retrieve the existing job even though none previously existed as the user never hit save.