### PR TITLE
jira job migrate

### DIFF
--- a/alert-database/src/main/resources/liquibase/6.10.0/changelog.xml
+++ b/alert-database/src/main/resources/liquibase/6.10.0/changelog.xml
@@ -2,6 +2,6 @@
 <databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
     <include file="static-jira-server-configuration-tables.xml" relativeToChangelogFile="true"/>
-    <include file="migrate-jira-server-global-config.xml" relativeToChangelogFile="true"/>
     <include file="add-distribution-job-column.xml" relativeToChangelogFile="true"/>
+    <include file="migrate-jira-server-global-config.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/alert-database/src/main/resources/liquibase/6.10.0/migrate-jira-server-global-config.xml
+++ b/alert-database/src/main/resources/liquibase/6.10.0/migrate-jira-server-global-config.xml
@@ -62,4 +62,21 @@
               AND configFields.source_key = 'jira.server.disable.plugin.check';
         </sql>
     </changeSet>
+    <!-- Migrate existing jira server jobs to use the default configuration -->
+    <changeSet author="psantos" id="migrate-jira-jobs">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">
+                SELECT COUNT(*)
+                FROM alert.distribution_jobs job
+                WHERE job.channel_descriptor_name = 'channel_jira_server' LIMIT 1;
+            </sqlCheck>
+        </preConditions>
+        <sql dbms="postgresql" stripComments="true">
+            UPDATE alert.distribution_jobs job
+            SET channel_global_config_id =
+            SELECT configuration_id
+            FROM alert.configuration_jira_server config
+            WHERE config.name = 'default-configuration' WHERE job.channel_descriptor_name = 'channel_jira_server';
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/alert-database/src/main/resources/liquibase/6.10.0/migrate-jira-server-global-config.xml
+++ b/alert-database/src/main/resources/liquibase/6.10.0/migrate-jira-server-global-config.xml
@@ -73,10 +73,8 @@
         </preConditions>
         <sql dbms="postgresql" stripComments="true">
             UPDATE alert.distribution_jobs job
-            SET channel_global_config_id =
-            SELECT configuration_id
-            FROM alert.configuration_jira_server config
-            WHERE config.name = 'default-configuration' WHERE job.channel_descriptor_name = 'channel_jira_server';
+            SET channel_global_config_id = config.configuration_id FROM alert.configuration_jira_server config
+            WHERE job.channel_descriptor_name = 'channel_jira_server' AND config.name = 'default-configuration';
         </sql>
     </changeSet>
 </databaseChangeLog>

--- a/alert-database/src/main/resources/liquibase/6.10.0/migrate-jira-server-global-config.xml
+++ b/alert-database/src/main/resources/liquibase/6.10.0/migrate-jira-server-global-config.xml
@@ -23,7 +23,7 @@
     <changeSet author="psantos" id="update-initial-jira-server-config-entries">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="1">
-                SELECT COUNT(url)
+                SELECT COUNT(*)
                 FROM alert.configuration_jira_server
                 WHERE name = 'default-configuration';
             </sqlCheck>
@@ -65,8 +65,8 @@
     <!-- Migrate existing jira server jobs to use the default configuration -->
     <changeSet author="psantos" id="migrate-jira-jobs">
         <preConditions onFail="MARK_RAN">
-            <sqlCheck expectedResult="1">
-                SELECT COUNT(*)
+            <sqlCheck expectedResult="channel_jira_server">
+                SELECT job.channel_descriptor_name
                 FROM alert.distribution_jobs job
                 WHERE job.channel_descriptor_name = 'channel_jira_server' LIMIT 1;
             </sqlCheck>

--- a/alert-database/src/main/resources/liquibase/6.10.0/migrate-jira-server-global-config.xml
+++ b/alert-database/src/main/resources/liquibase/6.10.0/migrate-jira-server-global-config.xml
@@ -73,8 +73,8 @@
         </preConditions>
         <sql dbms="postgresql" stripComments="true">
             UPDATE alert.distribution_jobs job
-            SET channel_global_config_id = config.configuration_id FROM alert.configuration_jira_server config
-            WHERE job.channel_descriptor_name = 'channel_jira_server' AND config.name = 'default-configuration';
+            SET channel_global_config_id = (SELECT config.configuration_id FROM alert.configuration_jira_server config WHERE config.name = 'default-configuration')
+            WHERE job.channel_descriptor_name = 'channel_jira_server';
         </sql>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Update liquibase scripts to migrate jira jobs to use the new default configuration.