### PR TITLE
Update Email model to use required fields

### DIFF
--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalTestAction.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalTestAction.java
@@ -71,7 +71,8 @@ public class EmailGlobalTestAction {
 
     public ConfigurationTestResult testConfigModelContent(String testAddress, EmailGlobalConfigModel emailGlobalConfigModel) {
         if (StringUtils.isBlank(testAddress)) {
-            return ConfigurationTestResult.failure("Could not determine what email address to send this content to. testAddress was not provided or was blank. Please provide a valid email address to test the configuration.");
+            return ConfigurationTestResult.failure(
+                "Could not determine what email address to send this content to. testAddress was not provided or was blank. Please provide a valid email address to test the configuration.");
         }
 
         try {
@@ -86,8 +87,8 @@ public class EmailGlobalTestAction {
         SmtpConfigBuilder smtpConfigBuilder = SmtpConfig.builder();
         smtpConfigBuilder.setJavamailProperties(javamailPropertiesFactory.createJavaMailProperties(emailGlobalConfigModel));
 
-        emailGlobalConfigModel.getSmtpFrom().ifPresent(smtpConfigBuilder::setSmtpFrom);
-        emailGlobalConfigModel.getSmtpHost().ifPresent(smtpConfigBuilder::setSmtpHost);
+        smtpConfigBuilder.setSmtpFrom(emailGlobalConfigModel.getSmtpFrom());
+        smtpConfigBuilder.setSmtpHost(emailGlobalConfigModel.getSmtpHost());
         emailGlobalConfigModel.getSmtpPort().ifPresent(smtpConfigBuilder::setSmtpPort);
         emailGlobalConfigModel.getSmtpAuth().ifPresent(smtpConfigBuilder::setSmtpAuth);
         emailGlobalConfigModel.getSmtpUsername().ifPresent(smtpConfigBuilder::setSmtpUsername);

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/distribution/EmailChannelMessageSender.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/distribution/EmailChannelMessageSender.java
@@ -92,8 +92,8 @@ public class EmailChannelMessageSender implements ChannelMessageSender<EmailJobD
 
         SmtpConfig smtpConfig = SmtpConfig.builder()
             .setJavamailProperties(javamailPropertiesFactory.createJavaMailProperties(emailServerConfiguration))
-            .setSmtpFrom(emailServerConfiguration.getSmtpFrom().orElse(null))
-            .setSmtpHost(emailServerConfiguration.getSmtpHost().orElse(null))
+            .setSmtpFrom(emailServerConfiguration.getSmtpFrom())
+            .setSmtpHost(emailServerConfiguration.getSmtpHost())
             .setSmtpPort(emailServerConfiguration.getSmtpPort().orElse(-1))
             .setSmtpAuth(emailServerConfiguration.getSmtpAuth().orElse(false))
             .setSmtpUsername(emailServerConfiguration.getSmtpUsername().orElse(null))
@@ -116,7 +116,8 @@ public class EmailChannelMessageSender implements ChannelMessageSender<EmailJobD
                     throw new AlertException("Could not determine what email addresses to send this content to");
                 } else {
                     String invalidEmailAddressesString = StringUtils.join(invalidEmailAddresses, ", ");
-                    throw new AlertException(String.format("No valid email addresses to send this content to. The following email addresses were invalid: %s", invalidEmailAddressesString));
+                    throw new AlertException(String
+                        .format("No valid email addresses to send this content to. The following email addresses were invalid: %s", invalidEmailAddressesString));
                 }
             }
 

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/validator/EmailGlobalConfigurationValidator.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/validator/EmailGlobalConfigurationValidator.java
@@ -28,10 +28,10 @@ public class EmailGlobalConfigurationValidator {
         if (StringUtils.isBlank(model.getName())) {
             statuses.add(AlertFieldStatus.error("name", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
         }
-        if (model.getSmtpHost().filter(StringUtils::isNotBlank).isEmpty()) {
+        if (StringUtils.isBlank(model.getSmtpHost())) {
             statuses.add(AlertFieldStatus.error("host", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
         }
-        if (model.getSmtpFrom().filter(StringUtils::isNotBlank).isEmpty()) {
+        if (StringUtils.isBlank(model.getSmtpFrom())) {
             statuses.add(AlertFieldStatus.error("from", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
         }
 

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalConfigurationActionTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalConfigurationActionTest.java
@@ -25,19 +25,18 @@ import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
 import com.synopsys.integration.alert.service.email.model.EmailGlobalConfigModel;
 import com.synopsys.integration.alert.test.common.AuthenticationTestUtils;
 
-public class EmailGlobalConfigurationActionTest {
+class EmailGlobalConfigurationActionTest {
     @Test
-    public void testGetOne() {
+    void testGetOne() {
         AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
         DescriptorKey descriptorKey = ChannelKeys.EMAIL;
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
-        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
+        AuthorizationManager authorizationManager = authenticationTestUtils
+            .createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
-        EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setSmtpHost("host");
-        model.setSmtpFrom("from");
+        EmailGlobalConfigModel model = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host");
         model.setSmtpAuth(true);
         model.setSmtpUsername("user");
         model.setSmtpPassword("password");
@@ -51,18 +50,16 @@ public class EmailGlobalConfigurationActionTest {
     }
 
     @Test
-    public void testCreate() throws AlertConfigurationException {
+    void testCreate() throws AlertConfigurationException {
         AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
         DescriptorKey descriptorKey = ChannelKeys.EMAIL;
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
-        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
+        AuthorizationManager authorizationManager = authenticationTestUtils
+            .createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
-        EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
-        model.setSmtpHost("host");
-        model.setSmtpFrom("from");
+        EmailGlobalConfigModel model = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host");
         model.setSmtpAuth(true);
         model.setSmtpUsername("user");
         model.setSmtpPassword("password");
@@ -76,18 +73,16 @@ public class EmailGlobalConfigurationActionTest {
     }
 
     @Test
-    public void testUpdate() throws AlertConfigurationException {
+    void testUpdate() throws AlertConfigurationException {
         AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
         DescriptorKey descriptorKey = ChannelKeys.EMAIL;
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
-        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
+        AuthorizationManager authorizationManager = authenticationTestUtils
+            .createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
-        EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
-        model.setSmtpHost("host");
-        model.setSmtpFrom("from");
+        EmailGlobalConfigModel model = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host");
         model.setSmtpAuth(true);
         model.setSmtpUsername("user");
         model.setSmtpPassword("password");
@@ -103,17 +98,16 @@ public class EmailGlobalConfigurationActionTest {
     }
 
     @Test
-    public void testDelete() {
+    void testDelete() {
         AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
         DescriptorKey descriptorKey = ChannelKeys.EMAIL;
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
-        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
+        AuthorizationManager authorizationManager = authenticationTestUtils
+            .createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
-        EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setSmtpHost("host");
-        model.setSmtpFrom("from");
+        EmailGlobalConfigModel model = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host");
         model.setSmtpAuth(true);
         model.setSmtpUsername("user");
         model.setSmtpPassword("password");
@@ -126,12 +120,13 @@ public class EmailGlobalConfigurationActionTest {
     }
 
     @Test
-    public void testGetOneForbidden() {
+    void testGetOneForbidden() {
         AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
         DescriptorKey descriptorKey = ChannelKeys.EMAIL;
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.NO_PERMISSIONS);
-        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
+        AuthorizationManager authorizationManager = authenticationTestUtils
+            .createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
 
@@ -141,17 +136,16 @@ public class EmailGlobalConfigurationActionTest {
     }
 
     @Test
-    public void testCreateForbidden() {
+    void testCreateForbidden() {
         AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
         DescriptorKey descriptorKey = ChannelKeys.EMAIL;
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.NO_PERMISSIONS);
-        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
+        AuthorizationManager authorizationManager = authenticationTestUtils
+            .createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
-        EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setSmtpHost("host");
-        model.setSmtpFrom("from");
+        EmailGlobalConfigModel model = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host");
         model.setSmtpAuth(true);
         model.setSmtpUsername("user");
         model.setSmtpPassword("password");
@@ -162,18 +156,17 @@ public class EmailGlobalConfigurationActionTest {
     }
 
     @Test
-    public void testUpdateForbidden() {
+    void testUpdateForbidden() {
         AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
         DescriptorKey descriptorKey = ChannelKeys.EMAIL;
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.NO_PERMISSIONS);
-        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
+        AuthorizationManager authorizationManager = authenticationTestUtils
+            .createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
         UUID configId = UUID.randomUUID();
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
-        EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setSmtpHost("host");
-        model.setSmtpFrom("from");
+        EmailGlobalConfigModel model = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host");
         model.setSmtpAuth(true);
         model.setSmtpUsername("user");
         model.setSmtpPassword("password");
@@ -184,20 +177,19 @@ public class EmailGlobalConfigurationActionTest {
     }
 
     @Test
-    public void testUpdateNotFound() {
+    void testUpdateNotFound() {
         AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
         DescriptorKey descriptorKey = ChannelKeys.EMAIL;
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
-        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
+        AuthorizationManager authorizationManager = authenticationTestUtils
+            .createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
         UUID configId = UUID.randomUUID();
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
         Mockito.when(emailGlobalConfigAccessor.getConfiguration()).thenReturn(Optional.empty());
 
-        EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setSmtpHost("host");
-        model.setSmtpFrom("from");
+        EmailGlobalConfigModel model = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host");
         model.setSmtpAuth(true);
         model.setSmtpUsername("user");
         model.setSmtpPassword("password");
@@ -208,12 +200,13 @@ public class EmailGlobalConfigurationActionTest {
     }
 
     @Test
-    public void testDeleteForbidden() {
+    void testDeleteForbidden() {
         AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
         DescriptorKey descriptorKey = ChannelKeys.EMAIL;
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.NO_PERMISSIONS);
-        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
+        AuthorizationManager authorizationManager = authenticationTestUtils
+            .createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
         UUID configId = UUID.randomUUID();
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
@@ -224,12 +217,13 @@ public class EmailGlobalConfigurationActionTest {
     }
 
     @Test
-    public void testDeleteNotFound() {
+    void testDeleteNotFound() {
         AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
         DescriptorKey descriptorKey = ChannelKeys.EMAIL;
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
-        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
+        AuthorizationManager authorizationManager = authenticationTestUtils
+            .createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
         Mockito.when(emailGlobalConfigAccessor.getConfiguration()).thenReturn(Optional.empty());

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalTestActionTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalTestActionTest.java
@@ -49,7 +49,7 @@ import com.synopsys.integration.alert.test.common.TestProperties;
 import com.synopsys.integration.alert.test.common.TestPropertyKey;
 import com.synopsys.integration.alert.test.common.TestTags;
 
-public class EmailGlobalTestActionTest {
+class EmailGlobalTestActionTest {
     private EmailGlobalConfigAccessor configurationAccessor;
 
     @BeforeEach
@@ -58,21 +58,28 @@ public class EmailGlobalTestActionTest {
     }
 
     @Test
-    public void testConfigValidTest() throws AlertException {
+    void testConfigValidTest() throws AlertException {
         AuthorizationManager authorizationManager = createAuthorizationManager(255);
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailChannelMessagingService emailChannelMessagingService = Mockito.mock(EmailChannelMessagingService.class);
         Mockito.when(emailChannelMessagingService.sendMessage(Mockito.any(), Mockito.any())).thenReturn(new MessageResult("PASS"));
 
         JavamailPropertiesFactory javamailPropertiesFactory = new JavamailPropertiesFactory();
-        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(authorizationManager, validator, emailChannelMessagingService, javamailPropertiesFactory, configurationAccessor);
+        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(
+            authorizationManager,
+            validator,
+            emailChannelMessagingService,
+            javamailPropertiesFactory,
+            configurationAccessor
+        );
 
-        ConfigurationTestResult testResult = emailGlobalTestAction.testConfigModelContent("noreply@synopsys.com", new EmailGlobalConfigModel());
+        ConfigurationTestResult testResult = emailGlobalTestAction
+            .testConfigModelContent("noreply@synopsys.com", new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host"));
         assertTrue(testResult.isSuccess(), "Expected the message result to not have errors");
     }
 
     @Test
-    public void testConfigMissingDestinationTest() {
+    void testConfigMissingDestinationTest() {
         AuthorizationManager authorizationManager = createAuthorizationManager(255);
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailAddressGatherer emailAddressGatherer = Mockito.mock(EmailAddressGatherer.class);
@@ -93,35 +100,49 @@ public class EmailGlobalTestActionTest {
 
         JavamailPropertiesFactory javamailPropertiesFactory = new JavamailPropertiesFactory();
 
-        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(authorizationManager, validator, emailChannelMessagingService, javamailPropertiesFactory, configurationAccessor);
+        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(
+            authorizationManager,
+            validator,
+            emailChannelMessagingService,
+            javamailPropertiesFactory,
+            configurationAccessor
+        );
 
-        ConfigurationTestResult testResult = emailGlobalTestAction.testConfigModelContent("", new EmailGlobalConfigModel());
+        ConfigurationTestResult testResult = emailGlobalTestAction
+            .testConfigModelContent("", new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host"));
         assertFalse(testResult.isSuccess());
     }
 
     @Test
-    public void testConfigInvalidDestinationTest() {
+    void testConfigInvalidDestinationTest() {
         AuthorizationManager authorizationManager = createAuthorizationManager(AuthenticationTestUtils.FULL_PERMISSIONS);
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(authorizationManager, validator, null, null, null);
 
-        ConfigurationTestResult testResult = emailGlobalTestAction.testConfigModelContent("not a valid email address", new EmailGlobalConfigModel());
+        ConfigurationTestResult testResult = emailGlobalTestAction
+            .testConfigModelContent("not a valid email address", new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host"));
         assertFalse(testResult.isSuccess());
     }
 
     @Test
-    public void testSmtpPasswordMissingTest() throws AlertException {
+    void testSmtpPasswordMissingTest() throws AlertException {
         AuthorizationManager authorizationManager = createAuthorizationManager(255);
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailChannelMessagingService emailChannelMessagingService = Mockito.mock(EmailChannelMessagingService.class);
         Mockito.when(emailChannelMessagingService.sendMessage(Mockito.any(), Mockito.any())).thenReturn(new MessageResult("PASS"));
 
         JavamailPropertiesFactory javamailPropertiesFactory = new JavamailPropertiesFactory();
-        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(authorizationManager, validator, emailChannelMessagingService, javamailPropertiesFactory, configurationAccessor);
+        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(
+            authorizationManager,
+            validator,
+            emailChannelMessagingService,
+            javamailPropertiesFactory,
+            configurationAccessor
+        );
 
-        EmailGlobalConfigModel emailGlobalConfigModel = new EmailGlobalConfigModel();
+        EmailGlobalConfigModel emailGlobalConfigModel = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host");
         emailGlobalConfigModel.setIsSmtpPasswordSet(true);
-        EmailGlobalConfigModel configModelWithPassword = new EmailGlobalConfigModel();
+        EmailGlobalConfigModel configModelWithPassword = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host");
         configModelWithPassword.setIsSmtpPasswordSet(true);
         configModelWithPassword.setSmtpPassword("password");
         Mockito.when(configurationAccessor.getConfiguration()).thenReturn(Optional.of(configModelWithPassword));
@@ -135,7 +156,7 @@ public class EmailGlobalTestActionTest {
         @Tag(TestTags.DEFAULT_INTEGRATION),
         @Tag(TestTags.CUSTOM_EXTERNAL_CONNECTION)
     })
-    public void testSmtpPasswordMissingTestIT() {
+    void testSmtpPasswordMissingTestIT() {
         AuthorizationManager authorizationManager = createAuthorizationManager(AuthenticationTestUtils.FULL_PERMISSIONS);
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         TestProperties testProperties = new TestProperties();
@@ -145,7 +166,13 @@ public class EmailGlobalTestActionTest {
 
         JavamailPropertiesFactory javamailPropertiesFactory = new JavamailPropertiesFactory();
         EmailChannelMessagingService validEmailChannelMessagingService = createValidEmailChannelMessagingService(emailAddress);
-        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(authorizationManager, validator, validEmailChannelMessagingService, javamailPropertiesFactory, configurationAccessor);
+        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(
+            authorizationManager,
+            validator,
+            validEmailChannelMessagingService,
+            javamailPropertiesFactory,
+            configurationAccessor
+        );
 
         EmailGlobalConfigModel globalConfigModelWithoutPassword = createEmailGlobalConfigModelObfuscated(testProperties);
         EmailGlobalConfigModel globalConfigModelWithPassword = createValidEmailGlobalConfigModel(testProperties);
@@ -160,7 +187,7 @@ public class EmailGlobalTestActionTest {
         @Tag(TestTags.DEFAULT_INTEGRATION),
         @Tag(TestTags.CUSTOM_EXTERNAL_CONNECTION)
     })
-    public void testConfigITTest() {
+    void testConfigITTest() {
         AuthorizationManager authorizationManager = createAuthorizationManager(AuthenticationTestUtils.FULL_PERMISSIONS);
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         TestProperties testProperties = new TestProperties();
@@ -168,7 +195,13 @@ public class EmailGlobalTestActionTest {
 
         JavamailPropertiesFactory javamailPropertiesFactory = new JavamailPropertiesFactory();
         EmailChannelMessagingService validEmailChannelMessagingService = createValidEmailChannelMessagingService(emailAddress);
-        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(authorizationManager, validator, validEmailChannelMessagingService, javamailPropertiesFactory, configurationAccessor);
+        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(
+            authorizationManager,
+            validator,
+            validEmailChannelMessagingService,
+            javamailPropertiesFactory,
+            configurationAccessor
+        );
 
         EmailGlobalConfigModel globalConfigModel = createValidEmailGlobalConfigModel(testProperties);
 
@@ -177,21 +210,28 @@ public class EmailGlobalTestActionTest {
     }
 
     @Test
-    public void testPermissionForbiddenTest() throws AlertException {
+    void testPermissionForbiddenTest() throws AlertException {
         AuthorizationManager authorizationManager = createAuthorizationManager(0);
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailChannelMessagingService emailChannelMessagingService = Mockito.mock(EmailChannelMessagingService.class);
         Mockito.when(emailChannelMessagingService.sendMessage(Mockito.any(), Mockito.any())).thenReturn(new MessageResult("PASS"));
 
         JavamailPropertiesFactory javamailPropertiesFactory = new JavamailPropertiesFactory();
-        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(authorizationManager, validator, emailChannelMessagingService, javamailPropertiesFactory, configurationAccessor);
+        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(
+            authorizationManager,
+            validator,
+            emailChannelMessagingService,
+            javamailPropertiesFactory,
+            configurationAccessor
+        );
 
-        ActionResponse<ValidationResponseModel> response = emailGlobalTestAction.testWithPermissionCheck("noreply@synopsys.com", new EmailGlobalConfigModel());
+        ActionResponse<ValidationResponseModel> response = emailGlobalTestAction
+            .testWithPermissionCheck("noreply@synopsys.com", new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host"));
         assertEquals(HttpStatus.FORBIDDEN, response.getHttpStatus());
     }
 
     @Test
-    public void testPermissionConfigValidTest() throws AlertException {
+    void testPermissionConfigValidTest() throws AlertException {
         TestProperties testProperties = new TestProperties();
         AuthorizationManager authorizationManager = createAuthorizationManager(AuthenticationTestUtils.FULL_PERMISSIONS);
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
@@ -199,7 +239,13 @@ public class EmailGlobalTestActionTest {
         Mockito.when(emailChannelMessagingService.sendMessage(Mockito.any(), Mockito.any())).thenReturn(new MessageResult("PASS"));
 
         JavamailPropertiesFactory javamailPropertiesFactory = new JavamailPropertiesFactory();
-        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(authorizationManager, validator, emailChannelMessagingService, javamailPropertiesFactory, configurationAccessor);
+        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(
+            authorizationManager,
+            validator,
+            emailChannelMessagingService,
+            javamailPropertiesFactory,
+            configurationAccessor
+        );
 
         EmailGlobalConfigModel globalConfigModel = createValidEmailGlobalConfigModel(testProperties);
 
@@ -211,7 +257,7 @@ public class EmailGlobalTestActionTest {
     }
 
     @Test
-    public void testPermissionConfigMissingDestinationTest() {
+    void testPermissionConfigMissingDestinationTest() {
         AuthorizationManager authorizationManager = createAuthorizationManager(AuthenticationTestUtils.FULL_PERMISSIONS);
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailAddressGatherer emailAddressGatherer = Mockito.mock(EmailAddressGatherer.class);
@@ -232,9 +278,16 @@ public class EmailGlobalTestActionTest {
 
         JavamailPropertiesFactory javamailPropertiesFactory = new JavamailPropertiesFactory();
 
-        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(authorizationManager, validator, emailChannelMessagingService, javamailPropertiesFactory, configurationAccessor);
+        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(
+            authorizationManager,
+            validator,
+            emailChannelMessagingService,
+            javamailPropertiesFactory,
+            configurationAccessor
+        );
 
-        ActionResponse<ValidationResponseModel> response = emailGlobalTestAction.testWithPermissionCheck("", new EmailGlobalConfigModel());
+        ActionResponse<ValidationResponseModel> response = emailGlobalTestAction
+            .testWithPermissionCheck("", new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host"));
         assertEquals(HttpStatus.OK, response.getHttpStatus());
         assertTrue(response.hasContent());
         assertTrue(response.getContent().get().hasErrors(), "Expected the message result to not have errors");
@@ -242,12 +295,13 @@ public class EmailGlobalTestActionTest {
     }
 
     @Test
-    public void testPermissionConfigInvalidDestinationTest() {
+    void testPermissionConfigInvalidDestinationTest() {
         AuthorizationManager authorizationManager = createAuthorizationManager(AuthenticationTestUtils.FULL_PERMISSIONS);
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(authorizationManager, validator, null, null, configurationAccessor);
 
-        ActionResponse<ValidationResponseModel> response = emailGlobalTestAction.testWithPermissionCheck("not a valid email address", new EmailGlobalConfigModel());
+        ActionResponse<ValidationResponseModel> response = emailGlobalTestAction
+            .testWithPermissionCheck("not a valid email address", new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host"));
         assertEquals(HttpStatus.OK, response.getHttpStatus());
         assertTrue(response.hasContent());
         assertTrue(response.getContent().get().hasErrors(), "Expected the message result to not have errors");
@@ -258,7 +312,7 @@ public class EmailGlobalTestActionTest {
         @Tag(TestTags.DEFAULT_INTEGRATION),
         @Tag(TestTags.CUSTOM_EXTERNAL_CONNECTION)
     })
-    public void testPermissionConfigITTest() {
+    void testPermissionConfigITTest() {
         AuthorizationManager authorizationManager = createAuthorizationManager(AuthenticationTestUtils.FULL_PERMISSIONS);
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         TestProperties testProperties = new TestProperties();
@@ -266,7 +320,13 @@ public class EmailGlobalTestActionTest {
 
         JavamailPropertiesFactory javamailPropertiesFactory = new JavamailPropertiesFactory();
         EmailChannelMessagingService validEmailChannelMessagingService = createValidEmailChannelMessagingService(emailAddress);
-        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(authorizationManager, validator, validEmailChannelMessagingService, javamailPropertiesFactory, configurationAccessor);
+        EmailGlobalTestAction emailGlobalTestAction = new EmailGlobalTestAction(
+            authorizationManager,
+            validator,
+            validEmailChannelMessagingService,
+            javamailPropertiesFactory,
+            configurationAccessor
+        );
 
         EmailGlobalConfigModel globalConfigModel = createValidEmailGlobalConfigModel(testProperties);
 
@@ -303,10 +363,9 @@ public class EmailGlobalTestActionTest {
     }
 
     private EmailGlobalConfigModel createValidEmailGlobalConfigModel(TestProperties testProperties) {
-        EmailGlobalConfigModel emailGlobalConfigModel = new EmailGlobalConfigModel();
-        emailGlobalConfigModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
-        emailGlobalConfigModel.setSmtpFrom(testProperties.getProperty(TestPropertyKey.TEST_EMAIL_SMTP_FROM));
-        emailGlobalConfigModel.setSmtpHost(testProperties.getProperty(TestPropertyKey.TEST_EMAIL_SMTP_HOST));
+        String smtpFrom = testProperties.getProperty(TestPropertyKey.TEST_EMAIL_SMTP_FROM);
+        String smtpHost = testProperties.getProperty(TestPropertyKey.TEST_EMAIL_SMTP_HOST);
+        EmailGlobalConfigModel emailGlobalConfigModel = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, smtpFrom, smtpHost);
         testProperties.getOptionalProperty(TestPropertyKey.TEST_EMAIL_SMTP_PORT).map(Integer::valueOf).ifPresent(emailGlobalConfigModel::setSmtpPort);
 
         testProperties.getOptionalProperty(TestPropertyKey.TEST_EMAIL_SMTP_AUTH).map(Boolean::valueOf).ifPresent(emailGlobalConfigModel::setSmtpAuth);
@@ -314,7 +373,8 @@ public class EmailGlobalTestActionTest {
         testProperties.getOptionalProperty(TestPropertyKey.TEST_EMAIL_SMTP_PASSWORD).ifPresent(emailGlobalConfigModel::setSmtpPassword);
 
         Map<String, String> additionalPropertiesMap = new HashMap<>();
-        testProperties.getOptionalProperty(TestPropertyKey.TEST_EMAIL_SMTP_EHLO).ifPresent(prop -> additionalPropertiesMap.put(EmailPropertyKeys.JAVAMAIL_EHLO_KEY.getPropertyKey(), prop));
+        testProperties.getOptionalProperty(TestPropertyKey.TEST_EMAIL_SMTP_EHLO)
+            .ifPresent(prop -> additionalPropertiesMap.put(EmailPropertyKeys.JAVAMAIL_EHLO_KEY.getPropertyKey(), prop));
 
         emailGlobalConfigModel.setAdditionalJavaMailProperties(additionalPropertiesMap);
 

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalValidationActionTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalValidationActionTest.java
@@ -13,26 +13,26 @@ import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.persistence.model.PermissionKey;
 import com.synopsys.integration.alert.common.persistence.model.PermissionMatrixModel;
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
 import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
 import com.synopsys.integration.alert.service.email.model.EmailGlobalConfigModel;
 import com.synopsys.integration.alert.test.common.AuthenticationTestUtils;
 
-public class EmailGlobalValidationActionTest {
+class EmailGlobalValidationActionTest {
     @Test
-    public void testValidationSuccess() {
+    void testValidationSuccess() {
         AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
         DescriptorKey descriptorKey = ChannelKeys.EMAIL;
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
-        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
+        AuthorizationManager authorizationManager = authenticationTestUtils
+            .createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalValidationAction validationAction = new EmailGlobalValidationAction(validator, authorizationManager);
 
-        EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setSmtpHost("host");
-        model.setSmtpFrom("from");
+        EmailGlobalConfigModel model = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host");
         model.setSmtpAuth(true);
         model.setSmtpUsername("user");
         model.setSmtpPassword("password");
@@ -42,18 +42,17 @@ public class EmailGlobalValidationActionTest {
     }
 
     @Test
-    public void testValidationForbidden() {
+    void testValidationForbidden() {
         AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
         DescriptorKey descriptorKey = ChannelKeys.EMAIL;
         PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.NO_PERMISSIONS);
-        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
+        AuthorizationManager authorizationManager = authenticationTestUtils
+            .createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalValidationAction validationAction = new EmailGlobalValidationAction(validator, authorizationManager);
 
-        EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setSmtpHost("host");
-        model.setSmtpFrom("from");
+        EmailGlobalConfigModel model = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host");
         model.setSmtpAuth(true);
         model.setSmtpUsername("user");
         model.setSmtpPassword("password");

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelConverterTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelConverterTest.java
@@ -33,9 +33,9 @@ class EmailGlobalConfigurationModelConverterTest {
         assertEquals(Boolean.TRUE, emailModel.getSmtpAuth().orElse(Boolean.FALSE));
         assertEquals(TEST_AUTH_USER, emailModel.getSmtpUsername().orElse(null));
         assertEquals(TEST_AUTH_PASSWORD, emailModel.getSmtpPassword().orElse(null));
-        assertEquals(TEST_SMTP_HOST, emailModel.getSmtpHost().orElse(null));
+        assertEquals(TEST_SMTP_HOST, emailModel.getSmtpHost());
         assertEquals(Integer.valueOf(TEST_SMTP_PORT), emailModel.getSmtpPort().orElse(null));
-        assertEquals(TEST_FROM, emailModel.getSmtpFrom().orElse(null));
+        assertEquals(TEST_FROM, emailModel.getSmtpFrom());
 
         Map<String, String> additionalProperties = emailModel.getAdditionalJavaMailProperties().orElse(Map.of());
         assertEquals(1, additionalProperties.size());
@@ -58,16 +58,7 @@ class EmailGlobalConfigurationModelConverterTest {
         ConfigurationModel emptyModel = new ConfigurationModel(1L, 1L, "", "", ConfigContextEnum.GLOBAL, Map.of());
         EmailGlobalConfigurationModelConverter converter = new EmailGlobalConfigurationModelConverter();
         Optional<EmailGlobalConfigModel> model = converter.convert(emptyModel);
-        assertTrue(model.isPresent());
-        EmailGlobalConfigModel emailModel = model.get();
-        assertTrue(emailModel.getSmtpAuth().isEmpty());
-        assertTrue(emailModel.getSmtpUsername().isEmpty());
-        assertTrue(emailModel.getSmtpPassword().isEmpty());
-        assertTrue(emailModel.getSmtpHost().isEmpty());
-        assertTrue(emailModel.getSmtpPort().isEmpty());
-        assertTrue(emailModel.getSmtpFrom().isEmpty());
-        assertTrue(emailModel.getAdditionalJavaMailProperties().isPresent());
-        assertTrue(emailModel.getAdditionalJavaMailProperties().orElseThrow(() -> new AssertionError("Expected an additional properties map.")).isEmpty());
+        assertTrue(model.isEmpty());
     }
 
     @Test
@@ -78,11 +69,7 @@ class EmailGlobalConfigurationModelConverterTest {
         ConfigurationModel configurationModel = new ConfigurationModel(1L, 1L, "", "", ConfigContextEnum.GLOBAL, fieldValues);
         EmailGlobalConfigurationModelConverter converter = new EmailGlobalConfigurationModelConverter();
         Optional<EmailGlobalConfigModel> model = converter.convert(configurationModel);
-        assertTrue(model.isPresent());
-        EmailGlobalConfigModel emailModel = model.get();
-        Map<String, String> additionalProperties = emailModel.getAdditionalJavaMailProperties().orElse(Map.of());
-        assertEquals(0, additionalProperties.size());
-
+        assertTrue(model.isEmpty());
     }
 
     private ConfigurationModel createDefaultConfigurationModel() {

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/distribution/EmailChannelTestIT.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/distribution/EmailChannelTestIT.java
@@ -63,8 +63,12 @@ public class EmailChannelTestIT {
         EmailAddressGatherer emailAddressGatherer = new EmailAddressGatherer(null, null);
         EmailChannelMessageConverter emailChannelMessageConverter = new EmailChannelMessageConverter(new EmailChannelMessageFormatter());
 
-        EmailChannelMessageSender emailChannelMessageSender = new EmailChannelMessageSender(emailConfigurationAccessor, emailAddressGatherer, emailChannelMessagingService, emailAddressValidator,
-            javamailPropertiesFactory);
+        EmailChannelMessageSender emailChannelMessageSender = new EmailChannelMessageSender(emailConfigurationAccessor,
+            emailAddressGatherer,
+            emailChannelMessagingService,
+            emailAddressValidator,
+            javamailPropertiesFactory
+        );
         EmailChannel emailChannel = new EmailChannel(emailChannelMessageConverter, emailChannelMessageSender);
 
         List<String> emailAddresses = List.of(testEmailRecipient);
@@ -97,16 +101,22 @@ public class EmailChannelTestIT {
         EmailChannel emailChannel = new EmailChannel(emailChannelMessageConverter, emailChannelMessageSender);
 
         List<String> emailAddresses = List.of(testEmailRecipient);
-        EmailJobDetailsModel emailJobDetails = new EmailJobDetailsModel(null, EmailChannelTestIT.class.getSimpleName(), false, true, EmailAttachmentFormat.NONE.name(), emailAddresses);
+        EmailJobDetailsModel emailJobDetails = new EmailJobDetailsModel(
+            null,
+            EmailChannelTestIT.class.getSimpleName(),
+            false,
+            true,
+            EmailAttachmentFormat.NONE.name(),
+            emailAddresses
+        );
 
         EmailITTestAssertions.assertSendSimpleMessageException(emailChannel, emailJobDetails, "ERROR: Missing Email global config.");
     }
 
     private EmailGlobalConfigModel createEmailGlobalConfig() {
-        EmailGlobalConfigModel emailGlobalConfigModel = new EmailGlobalConfigModel();
-        emailGlobalConfigModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
-        emailGlobalConfigModel.setSmtpHost(testProperties.getProperty(TestPropertyKey.TEST_EMAIL_SMTP_HOST));
-        emailGlobalConfigModel.setSmtpFrom(testProperties.getProperty(TestPropertyKey.TEST_EMAIL_SMTP_FROM));
+        String smtpFrom = testProperties.getProperty(TestPropertyKey.TEST_EMAIL_SMTP_FROM);
+        String smtpHost = testProperties.getProperty(TestPropertyKey.TEST_EMAIL_SMTP_HOST);
+        EmailGlobalConfigModel emailGlobalConfigModel = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, smtpFrom, smtpHost);
         emailGlobalConfigModel.setSmtpUsername(testProperties.getProperty(TestPropertyKey.TEST_EMAIL_SMTP_USER));
         emailGlobalConfigModel.setSmtpPassword(testProperties.getProperty(TestPropertyKey.TEST_EMAIL_SMTP_PASSWORD));
 

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/validator/EmailGlobalConfigurationValidatorTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/validator/EmailGlobalConfigurationValidatorTest.java
@@ -26,10 +26,7 @@ class EmailGlobalConfigurationValidatorTest {
     @Test
     void verifyValidConfig() {
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
-        EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
-        model.setSmtpHost("host");
-        model.setSmtpFrom("from");
+        EmailGlobalConfigModel model = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host");
         model.setSmtpAuth(true);
         model.setSmtpUsername("user");
         model.setSmtpPassword("password");
@@ -42,9 +39,7 @@ class EmailGlobalConfigurationValidatorTest {
     @Test
     void verifyNameMissingConfig() {
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
-        EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setSmtpHost("host");
-        model.setSmtpFrom("from");
+        EmailGlobalConfigModel model = new EmailGlobalConfigModel(null, null, "from", "host");
         model.setSmtpAuth(true);
         model.setSmtpUsername("user");
         model.setSmtpPassword("password");
@@ -70,10 +65,7 @@ class EmailGlobalConfigurationValidatorTest {
     @Test
     void verifyMissingAuth() {
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
-        EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
-        model.setSmtpHost("host");
-        model.setSmtpFrom("from");
+        EmailGlobalConfigModel model = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host");
         model.setSmtpAuth(true);
 
         ValidationResponseModel validationResponseModel = validator.validate(model);
@@ -87,10 +79,7 @@ class EmailGlobalConfigurationValidatorTest {
     @Test
     void verifyAuthNotProvided() {
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
-        EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
-        model.setSmtpHost("host");
-        model.setSmtpFrom("from");
+        EmailGlobalConfigModel model = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host");
         model.setSmtpUsername("user");
         model.setSmtpPassword("password");
 
@@ -101,10 +90,7 @@ class EmailGlobalConfigurationValidatorTest {
     @Test
     void verifyMissingAuthPassword() {
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
-        EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
-        model.setSmtpHost("host");
-        model.setSmtpFrom("from");
+        EmailGlobalConfigModel model = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host");
         model.setSmtpAuth(true);
         model.setSmtpUsername("user");
 
@@ -120,10 +106,7 @@ class EmailGlobalConfigurationValidatorTest {
     @Test
     void verifyIsPasswordSet() {
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
-        EmailGlobalConfigModel model = new EmailGlobalConfigModel();
-        model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
-        model.setSmtpHost("host");
-        model.setSmtpFrom("from");
+        EmailGlobalConfigModel model = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host");
         model.setSmtpAuth(true);
         model.setSmtpUsername("user");
         model.setIsSmtpPasswordSet(true);

--- a/service-email/src/main/java/com/synopsys/integration/alert/service/email/JavamailPropertiesFactory.java
+++ b/service-email/src/main/java/com/synopsys/integration/alert/service/email/JavamailPropertiesFactory.java
@@ -23,20 +23,15 @@ import com.synopsys.integration.alert.service.email.enumeration.EmailPropertyKey
 import com.synopsys.integration.alert.service.email.model.EmailGlobalConfigModel;
 
 @Component
-public class JavamailPropertiesFactory {    
+public class JavamailPropertiesFactory {
     public Properties createJavaMailProperties(EmailGlobalConfigModel globalConfiguration) {
         if (globalConfiguration == null) {
             throw new IllegalArgumentException("Could not find the global Email configuration");
         }
 
         Properties javaMailProperties = new Properties();
-        globalConfiguration.getSmtpFrom()
-            .filter(StringUtils::isNotBlank)
-            .ifPresent(value -> javaMailProperties.setProperty(JAVAMAIL_FROM_KEY.getPropertyKey(), value));
-
-        globalConfiguration.getSmtpHost()
-            .filter(StringUtils::isNotBlank)
-            .ifPresent(value -> javaMailProperties.setProperty(JAVAMAIL_HOST_KEY.getPropertyKey(), value));
+        javaMailProperties.setProperty(JAVAMAIL_FROM_KEY.getPropertyKey(), globalConfiguration.getSmtpFrom());
+        javaMailProperties.setProperty(JAVAMAIL_HOST_KEY.getPropertyKey(), globalConfiguration.getSmtpHost());
 
         globalConfiguration.getSmtpPort()
             .map(String::valueOf)

--- a/service-email/src/main/java/com/synopsys/integration/alert/service/email/model/EmailGlobalConfigModel.java
+++ b/service-email/src/main/java/com/synopsys/integration/alert/service/email/model/EmailGlobalConfigModel.java
@@ -27,42 +27,65 @@ public class EmailGlobalConfigModel extends ConfigWithMetadata implements Obfusc
 
     private Map<String, String> additionalJavaMailProperties;
 
+    public EmailGlobalConfigModel() {
+        // For serialization
+    }
+
+    public EmailGlobalConfigModel(String id, String name, String smtpFrom, String smtpHost) {
+        super(id, name);
+        this.smtpFrom = smtpFrom;
+        this.smtpHost = smtpHost;
+    }
+
+    public EmailGlobalConfigModel(
+        String id,
+        String name,
+        String createdAt,
+        String lastUpdated,
+        String smtpFrom,
+        String smtpHost,
+        Integer smtpPort,
+        Boolean smtpAuth,
+        String smtpUsername,
+        String smtpPassword,
+        Boolean isSmtpPasswordSet,
+        Map<String, String> additionalJavaMailProperties
+    ) {
+        this(id, name, smtpFrom, smtpHost);
+        this.smtpPort = smtpPort;
+        this.smtpAuth = smtpAuth;
+        this.smtpUsername = smtpUsername;
+        this.smtpPassword = smtpPassword;
+        this.isSmtpPasswordSet = isSmtpPasswordSet;
+        this.additionalJavaMailProperties = additionalJavaMailProperties;
+        setCreatedAt(createdAt);
+        setLastUpdated(lastUpdated);
+    }
+
     @Override
     public EmailGlobalConfigModel obfuscate() {
-        EmailGlobalConfigModel emailGlobalConfigModel = new EmailGlobalConfigModel();
-
-        emailGlobalConfigModel.setId(getId());
-        emailGlobalConfigModel.setName(getName());
-        emailGlobalConfigModel.setLastUpdated(getLastUpdated());
-        emailGlobalConfigModel.setCreatedAt(getCreatedAt());
-
-        emailGlobalConfigModel.setSmtpFrom(smtpFrom);
-        emailGlobalConfigModel.setSmtpHost(smtpHost);
-        emailGlobalConfigModel.setSmtpPort(smtpPort);
-        emailGlobalConfigModel.setSmtpAuth(smtpAuth);
-        emailGlobalConfigModel.setSmtpUsername(smtpUsername);
-        emailGlobalConfigModel.setAdditionalJavaMailProperties(additionalJavaMailProperties);
-
-        emailGlobalConfigModel.setIsSmtpPasswordSet(StringUtils.isNotBlank(smtpPassword));
-        emailGlobalConfigModel.setSmtpPassword(null);
-
-        return emailGlobalConfigModel;
+        return new EmailGlobalConfigModel(
+            getId(),
+            getName(),
+            getCreatedAt(),
+            getLastUpdated(),
+            getSmtpFrom(),
+            getSmtpHost(),
+            smtpPort,
+            smtpAuth,
+            smtpUsername,
+            null,
+            StringUtils.isNotBlank(smtpPassword),
+            additionalJavaMailProperties
+        );
     }
 
-    public Optional<String> getSmtpFrom() {
-        return Optional.ofNullable(smtpFrom);
+    public String getSmtpFrom() {
+        return smtpFrom;
     }
 
-    public void setSmtpFrom(String smtpFrom) {
-        this.smtpFrom = smtpFrom;
-    }
-
-    public Optional<String> getSmtpHost() {
-        return Optional.ofNullable(smtpHost);
-    }
-
-    public void setSmtpHost(String smtpHost) {
-        this.smtpHost = smtpHost;
+    public String getSmtpHost() {
+        return smtpHost;
     }
 
     public Optional<Integer> getSmtpPort() {

--- a/service-email/src/test/java/com/synopsys/integration/alert/service/email/JavamailPropertiesFactoryTest.java
+++ b/service-email/src/test/java/com/synopsys/integration/alert/service/email/JavamailPropertiesFactoryTest.java
@@ -8,10 +8,11 @@ import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.service.email.enumeration.EmailPropertyKeys;
 import com.synopsys.integration.alert.service.email.model.EmailGlobalConfigModel;
 
-public class JavamailPropertiesFactoryTest {
+class JavamailPropertiesFactoryTest {
     public static final String EXPECTED_FROM_VALUE = "expectedFrom";
     public static final String EXPECTED_HOST_VALUE = "expectedHost";
     public static final int EXPECTED_PORT_VALUE = 25;
@@ -22,12 +23,9 @@ public class JavamailPropertiesFactoryTest {
     public static final String EXPECTED_PASSWORD_VALUE = "expectedPassword";
     public static final String EXPECTED_EHLO_VALUE = "expectedEhlo";
 
-
     @Test
-    public void testCreateFromEmailGlobalConfigModel() {
-        EmailGlobalConfigModel emailGlobalConfigModel = new EmailGlobalConfigModel();
-        emailGlobalConfigModel.setSmtpFrom(EXPECTED_FROM_VALUE);
-        emailGlobalConfigModel.setSmtpHost(EXPECTED_HOST_VALUE);
+    void testCreateFromEmailGlobalConfigModel() {
+        EmailGlobalConfigModel emailGlobalConfigModel = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, EXPECTED_FROM_VALUE, EXPECTED_HOST_VALUE);
         emailGlobalConfigModel.setSmtpPort(EXPECTED_PORT_VALUE);
         emailGlobalConfigModel.setSmtpAuth(EXPECTED_AUTH_VALUE);
         emailGlobalConfigModel.setSmtpUsername(EXPECTED_USERNAME_VALUE);

--- a/src/main/java/com/synopsys/integration/alert/update/UpdateEmailService.java
+++ b/src/main/java/com/synopsys/integration/alert/update/UpdateEmailService.java
@@ -50,7 +50,11 @@ public class UpdateEmailService {
 
     @Autowired
     public UpdateEmailService(
-        AlertProperties alertProperties, SettingsKeyAccessor settingsKeyAccessor, UserAccessor userAccessor, EmailGlobalConfigAccessor emailGlobalConfigAccessor, EmailMessagingService emailMessagingService,
+        AlertProperties alertProperties,
+        SettingsKeyAccessor settingsKeyAccessor,
+        UserAccessor userAccessor,
+        EmailGlobalConfigAccessor emailGlobalConfigAccessor,
+        EmailMessagingService emailMessagingService,
         JavamailPropertiesFactory javamailPropertiesFactory
     ) {
         this.alertProperties = alertProperties;
@@ -85,8 +89,8 @@ public class UpdateEmailService {
 
                 handleSend(
                     javamailPropertiesFactory.createJavaMailProperties(emailServerConfiguration),
-                    emailServerConfiguration.getSmtpFrom().orElse(StringUtils.EMPTY),
-                    emailServerConfiguration.getSmtpHost().orElse(StringUtils.EMPTY),
+                    emailServerConfiguration.getSmtpFrom(),
+                    emailServerConfiguration.getSmtpHost(),
                     emailServerConfiguration.getSmtpPort().orElse(0),
                     emailServerConfiguration.getSmtpAuth().orElse(false),
                     emailServerConfiguration.getSmtpUsername().orElse(StringUtils.EMPTY),
@@ -112,7 +116,17 @@ public class UpdateEmailService {
             .isPresent();
     }
 
-    private void handleSend(Properties javamailProperties, String smtpFrom, String smtpHost, int smtpPort, boolean smtpAuth, String smtpUsername, String smtpPassword, Map<String, Object> templateFields, String emailAddress)
+    private void handleSend(
+        Properties javamailProperties,
+        String smtpFrom,
+        String smtpHost,
+        int smtpPort,
+        boolean smtpAuth,
+        String smtpUsername,
+        String smtpPassword,
+        Map<String, Object> templateFields,
+        String emailAddress
+    )
         throws AlertException {
         try {
             String alertLogo = alertProperties.createSynopsysLogoPath();

--- a/src/test/java/com/synopsys/integration/alert/channel/email/environment/EmailEnvironmentVariableHandlerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/email/environment/EmailEnvironmentVariableHandlerTestIT.java
@@ -66,11 +66,9 @@ class EmailEnvironmentVariableHandlerTestIT {
 
     @Test
     void testExistingEmailConfig() throws AlertConfigurationException {
-        EmailGlobalConfigModel emailGlobalConfigModel = new EmailGlobalConfigModel();
+        EmailGlobalConfigModel emailGlobalConfigModel = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, TEST_FROM, TEST_SMTP_HOST);
         emailGlobalConfigModel.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
         emailGlobalConfigModel.setSmtpAuth(Boolean.valueOf(TEST_AUTH_REQUIRED));
-        emailGlobalConfigModel.setSmtpFrom(TEST_FROM);
-        emailGlobalConfigModel.setSmtpHost(TEST_SMTP_HOST);
         emailGlobalConfigModel.setSmtpPassword(TEST_PASSWORD);
         emailGlobalConfigModel.setSmtpPort(Integer.valueOf(TEST_PORT));
         emailGlobalConfigModel.setSmtpUsername(TEST_USER);

--- a/src/test/java/com/synopsys/integration/alert/web/config/EmailConfigActionTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/web/config/EmailConfigActionTestIT.java
@@ -85,8 +85,19 @@ public class EmailConfigActionTestIT {
         AuthorizationManager authorizationManager = createEmailAuthorizationManager();
         EmailGlobalCrudActions emailGlobalCrudActions = createEmailCrudActions(authorizationManager);
         GlobalConfigurationModelToConcreteConversionService globalConfigurationModelToConcreteConversionService = createConversionService(emailGlobalCrudActions);
-        ConfigActions configActions = new ConfigActions(authorizationManager, descriptorAccessor, configurationModelConfigurationAccessor, fieldModelProcessor, descriptorProcessor, configurationFieldModelConverter, descriptorMap,
-            pkixErrorResponseFactory, encryptionUtility, settingsDescriptorKey, globalConfigurationModelToConcreteConversionService);
+        ConfigActions configActions = new ConfigActions(
+            authorizationManager,
+            descriptorAccessor,
+            configurationModelConfigurationAccessor,
+            fieldModelProcessor,
+            descriptorProcessor,
+            configurationFieldModelConverter,
+            descriptorMap,
+            pkixErrorResponseFactory,
+            encryptionUtility,
+            settingsDescriptorKey,
+            globalConfigurationModelToConcreteConversionService
+        );
         FieldModel fieldModel = createEmailFieldModel();
         configActions.create(fieldModel);
 
@@ -96,9 +107,9 @@ public class EmailConfigActionTestIT {
         assertEquals(Boolean.TRUE, staticModel.getSmtpAuth().orElse(null));
         assertEquals(TEST_AUTH_USER, staticModel.getSmtpUsername().orElse(null));
         assertEquals(TEST_AUTH_PASSWORD, staticModel.getSmtpPassword().orElse(null));
-        assertEquals(TEST_SMTP_HOST, staticModel.getSmtpHost().orElse(null));
+        assertEquals(TEST_SMTP_HOST, staticModel.getSmtpHost());
         assertEquals(Integer.valueOf(TEST_SMTP_PORT), staticModel.getSmtpPort().orElse(null));
-        assertEquals(TEST_FROM, staticModel.getSmtpFrom().orElse(null));
+        assertEquals(TEST_FROM, staticModel.getSmtpFrom());
 
         String propertyValue = staticModel.getAdditionalJavaMailProperties()
             .map(map -> map.get(EmailPropertyKeys.JAVAMAIL_EHLO_KEY.getPropertyKey()))
@@ -111,8 +122,19 @@ public class EmailConfigActionTestIT {
         AuthorizationManager authorizationManager = createEmailAuthorizationManager();
         EmailGlobalCrudActions emailGlobalCrudActions = createEmailCrudActions(authorizationManager);
         GlobalConfigurationModelToConcreteConversionService globalConfigurationModelToConcreteConversionService = createConversionService(emailGlobalCrudActions);
-        ConfigActions configActions = new ConfigActions(authorizationManager, descriptorAccessor, configurationModelConfigurationAccessor, fieldModelProcessor, descriptorProcessor, configurationFieldModelConverter, descriptorMap,
-            pkixErrorResponseFactory, encryptionUtility, settingsDescriptorKey, globalConfigurationModelToConcreteConversionService);
+        ConfigActions configActions = new ConfigActions(
+            authorizationManager,
+            descriptorAccessor,
+            configurationModelConfigurationAccessor,
+            fieldModelProcessor,
+            descriptorProcessor,
+            configurationFieldModelConverter,
+            descriptorMap,
+            pkixErrorResponseFactory,
+            encryptionUtility,
+            settingsDescriptorKey,
+            globalConfigurationModelToConcreteConversionService
+        );
         FieldModel fieldModel = createEmailFieldModel();
         fieldModel = configActions.create(fieldModel).getContent().orElseThrow(() -> new AlertConfigurationException("Couldn't create configuration"));
 
@@ -129,9 +151,9 @@ public class EmailConfigActionTestIT {
         assertEquals(Boolean.TRUE, staticModel.getSmtpAuth().orElse(null));
         assertEquals(TEST_AUTH_USER, staticModel.getSmtpUsername().orElse(null));
         assertEquals(updatedPassword, staticModel.getSmtpPassword().orElse(null));
-        assertEquals(updatedHost, staticModel.getSmtpHost().orElse(null));
+        assertEquals(updatedHost, staticModel.getSmtpHost());
         assertEquals(Integer.valueOf(TEST_SMTP_PORT), staticModel.getSmtpPort().orElse(null));
-        assertEquals(TEST_FROM, staticModel.getSmtpFrom().orElse(null));
+        assertEquals(TEST_FROM, staticModel.getSmtpFrom());
 
         String propertyValue = staticModel.getAdditionalJavaMailProperties()
             .map(map -> map.get(EmailPropertyKeys.JAVAMAIL_EHLO_KEY.getPropertyKey()))
@@ -144,8 +166,19 @@ public class EmailConfigActionTestIT {
         AuthorizationManager authorizationManager = createEmailAuthorizationManager();
         EmailGlobalCrudActions emailGlobalCrudActions = createEmailCrudActions(authorizationManager);
         GlobalConfigurationModelToConcreteConversionService globalConfigurationModelToConcreteConversionService = createConversionService(emailGlobalCrudActions);
-        ConfigActions configActions = new ConfigActions(authorizationManager, descriptorAccessor, configurationModelConfigurationAccessor, fieldModelProcessor, descriptorProcessor, configurationFieldModelConverter, descriptorMap,
-            pkixErrorResponseFactory, encryptionUtility, settingsDescriptorKey, globalConfigurationModelToConcreteConversionService);
+        ConfigActions configActions = new ConfigActions(
+            authorizationManager,
+            descriptorAccessor,
+            configurationModelConfigurationAccessor,
+            fieldModelProcessor,
+            descriptorProcessor,
+            configurationFieldModelConverter,
+            descriptorMap,
+            pkixErrorResponseFactory,
+            encryptionUtility,
+            settingsDescriptorKey,
+            globalConfigurationModelToConcreteConversionService
+        );
         FieldModel fieldModel = createEmailFieldModel();
         fieldModel = configActions.create(fieldModel).getContent().orElseThrow(() -> new AlertConfigurationException("Couldn't create configuration"));
         String updatedHost = "updated." + TEST_SMTP_HOST;
@@ -159,9 +192,9 @@ public class EmailConfigActionTestIT {
         assertEquals(Boolean.TRUE, staticModel.getSmtpAuth().orElse(null));
         assertEquals(TEST_AUTH_USER, staticModel.getSmtpUsername().orElse(null));
         assertEquals(TEST_AUTH_PASSWORD, staticModel.getSmtpPassword().orElse(null));
-        assertEquals(updatedHost, staticModel.getSmtpHost().orElse(null));
+        assertEquals(updatedHost, staticModel.getSmtpHost());
         assertEquals(Integer.valueOf(TEST_SMTP_PORT), staticModel.getSmtpPort().orElse(null));
-        assertEquals(TEST_FROM, staticModel.getSmtpFrom().orElse(null));
+        assertEquals(TEST_FROM, staticModel.getSmtpFrom());
 
         String propertyValue = staticModel.getAdditionalJavaMailProperties()
             .map(map -> map.get(EmailPropertyKeys.JAVAMAIL_EHLO_KEY.getPropertyKey()))
@@ -174,8 +207,19 @@ public class EmailConfigActionTestIT {
         AuthorizationManager authorizationManager = createEmailAuthorizationManager();
         EmailGlobalCrudActions emailGlobalCrudActions = createEmailCrudActions(authorizationManager);
         GlobalConfigurationModelToConcreteConversionService globalConfigurationModelToConcreteConversionService = createConversionService(emailGlobalCrudActions);
-        ConfigActions configActions = new ConfigActions(authorizationManager, descriptorAccessor, configurationModelConfigurationAccessor, fieldModelProcessor, descriptorProcessor, configurationFieldModelConverter, descriptorMap,
-            pkixErrorResponseFactory, encryptionUtility, settingsDescriptorKey, globalConfigurationModelToConcreteConversionService);
+        ConfigActions configActions = new ConfigActions(
+            authorizationManager,
+            descriptorAccessor,
+            configurationModelConfigurationAccessor,
+            fieldModelProcessor,
+            descriptorProcessor,
+            configurationFieldModelConverter,
+            descriptorMap,
+            pkixErrorResponseFactory,
+            encryptionUtility,
+            settingsDescriptorKey,
+            globalConfigurationModelToConcreteConversionService
+        );
         FieldModel fieldModel = createEmailFieldModel();
         fieldModel = configActions.create(fieldModel).getContent().orElseThrow(() -> new AlertConfigurationException("Couldn't create configuration"));
 
@@ -199,7 +243,11 @@ public class EmailConfigActionTestIT {
 
     private GlobalConfigurationModelToConcreteConversionService createConversionService(EmailGlobalCrudActions emailGlobalCrudActions) {
         EmailGlobalConfigurationModelConverter modelConverter = new EmailGlobalConfigurationModelConverter();
-        EmailGlobalConfigurationModelSaveActions emailGlobalConfigurationModelSaveActions = new EmailGlobalConfigurationModelSaveActions(modelConverter, emailGlobalCrudActions, emailGlobalConfigAccessor);
+        EmailGlobalConfigurationModelSaveActions emailGlobalConfigurationModelSaveActions = new EmailGlobalConfigurationModelSaveActions(
+            modelConverter,
+            emailGlobalCrudActions,
+            emailGlobalConfigAccessor
+        );
         List<GlobalConfigurationModelToConcreteSaveActions> conversionActions = List.of(emailGlobalConfigurationModelSaveActions);
         return new GlobalConfigurationModelToConcreteConversionService(conversionActions, descriptorMap);
     }


### PR DESCRIPTION
EmailGlobalConfigModel requires smtp from and smtp host to be set in in order to properly save the model to the database. This change brings the email configuration in line with the changes  we created for global models in 6.10.0. 

As an aside, some formatting changes are included in this release due to the style changes.