### PR TITLE
Converter validation refactor

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/action/api/GlobalConfigurationModelToConcreteConverter.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/action/api/GlobalConfigurationModelToConcreteConverter.java
@@ -9,9 +9,36 @@ package com.synopsys.integration.alert.common.action.api;
 
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
+import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatus;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
 import com.synopsys.integration.alert.common.rest.model.ConfigWithMetadata;
 
-public interface GlobalConfigurationModelToConcreteConverter<T extends ConfigWithMetadata> {
-    Optional<T> convert(ConfigurationModel globalConfigurationModel);
+public abstract class GlobalConfigurationModelToConcreteConverter<T extends ConfigWithMetadata> {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    public Optional<T> convertAndValidate(ConfigurationModel globalConfigurationModel) {
+        Optional<T> configModel = convert(globalConfigurationModel);
+
+        if (configModel.isEmpty()) {
+            return Optional.empty();
+        }
+
+        ValidationResponseModel validationResponseModel = validate(configModel.get());
+        if (validationResponseModel.hasErrors()) {
+            logger.error("Converted field model validation failed: {}", validationResponseModel.getMessage());
+            for (AlertFieldStatus errorStatus : validationResponseModel.getErrors().values()) {
+                logger.error("Field: '{}' failed with the error: {}", errorStatus.getFieldName(), errorStatus.getFieldMessage());
+            }
+            return Optional.empty();
+        }
+        return configModel;
+    }
+
+    protected abstract Optional<T> convert(ConfigurationModel globalConfigurationModel);
+
+    protected abstract ValidationResponseModel validate(T configModel);
 }

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelSaveActions.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelSaveActions.java
@@ -17,7 +17,6 @@ import com.synopsys.integration.alert.channel.email.action.EmailGlobalCrudAction
 import com.synopsys.integration.alert.channel.email.database.accessor.EmailGlobalConfigAccessor;
 import com.synopsys.integration.alert.common.action.api.GlobalConfigurationModelToConcreteSaveActions;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
-import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
 import com.synopsys.integration.alert.service.email.model.EmailGlobalConfigModel;
@@ -48,22 +47,16 @@ public class EmailGlobalConfigurationModelSaveActions implements GlobalConfigura
         Optional<UUID> defaultConfigurationId = configurationAccessor.getConfiguration()
             .map(EmailGlobalConfigModel::getId)
             .map(UUID::fromString);
-        Optional<EmailGlobalConfigModel> emailGlobalConfigModel = emailFieldModelConverter.convert(configurationModel);
+        Optional<EmailGlobalConfigModel> emailGlobalConfigModel = emailFieldModelConverter.convertAndValidate(configurationModel);
         if (defaultConfigurationId.isPresent() && emailGlobalConfigModel.isPresent()) {
-            EmailGlobalConfigModel model = emailGlobalConfigModel.get();
-            model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
-            configurationActions.update(model);
+            emailGlobalConfigModel.ifPresent(configurationActions::update);
         }
     }
 
     @Override
     public void createConcreteModel(ConfigurationModel configurationModel) {
-        Optional<EmailGlobalConfigModel> emailGlobalConfigModel = emailFieldModelConverter.convert(configurationModel);
-        if (emailGlobalConfigModel.isPresent()) {
-            EmailGlobalConfigModel model = emailGlobalConfigModel.get();
-            model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
-            configurationActions.create(model);
-        }
+        Optional<EmailGlobalConfigModel> emailGlobalConfigModel = emailFieldModelConverter.convertAndValidate(configurationModel);
+        emailGlobalConfigModel.ifPresent(configurationActions::create);
     }
 
     @Override

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/database/accessor/EmailGlobalConfigAccessor.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/database/accessor/EmailGlobalConfigAccessor.java
@@ -104,13 +104,8 @@ public class EmailGlobalConfigAccessor implements UniqueConfigurationAccessor<Em
     }
 
     private EmailGlobalConfigModel createConfigModel(EmailConfigurationEntity emailConfiguration) {
-        if (null == emailConfiguration) {
-            return new EmailGlobalConfigModel();
-        }
-        String createdAtFormatted = "";
+        String createdAtFormatted = DateUtils.formatDate(emailConfiguration.getCreatedAt(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE);
         String lastUpdatedFormatted = "";
-
-        createdAtFormatted = DateUtils.formatDate(emailConfiguration.getCreatedAt(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE);
         if (null != emailConfiguration.getLastUpdated()) {
             lastUpdatedFormatted = DateUtils.formatDate(emailConfiguration.getLastUpdated(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE);
         }

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelConverterTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelConverterTest.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
+import com.synopsys.integration.alert.channel.email.validator.EmailGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
@@ -23,11 +24,13 @@ class EmailGlobalConfigurationModelConverterTest {
     public static final String TEST_SMTP_PORT = "2025";
     public static final String TEST_AUTH_USER = "auser";
 
+    private final EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
+
     @Test
     void validConversionTest() {
         ConfigurationModel configurationModel = createDefaultConfigurationModel();
-        EmailGlobalConfigurationModelConverter converter = new EmailGlobalConfigurationModelConverter();
-        Optional<EmailGlobalConfigModel> model = converter.convert(configurationModel);
+        EmailGlobalConfigurationModelConverter converter = new EmailGlobalConfigurationModelConverter(validator);
+        Optional<EmailGlobalConfigModel> model = converter.convertAndValidate(configurationModel);
         assertTrue(model.isPresent());
         EmailGlobalConfigModel emailModel = model.get();
         assertEquals(Boolean.TRUE, emailModel.getSmtpAuth().orElse(Boolean.FALSE));
@@ -48,16 +51,16 @@ class EmailGlobalConfigurationModelConverterTest {
         ConfigurationModel configurationModel = createDefaultConfigurationModel();
         configurationModel.getField(EmailPropertyKeys.JAVAMAIL_PORT_KEY.getPropertyKey())
             .ifPresent(field -> field.setFieldValue("twenty-five"));
-        EmailGlobalConfigurationModelConverter converter = new EmailGlobalConfigurationModelConverter();
-        Optional<EmailGlobalConfigModel> model = converter.convert(configurationModel);
+        EmailGlobalConfigurationModelConverter converter = new EmailGlobalConfigurationModelConverter(validator);
+        Optional<EmailGlobalConfigModel> model = converter.convertAndValidate(configurationModel);
         assertTrue(model.isEmpty());
     }
 
     @Test
     void emptyFieldsTest() {
         ConfigurationModel emptyModel = new ConfigurationModel(1L, 1L, "", "", ConfigContextEnum.GLOBAL, Map.of());
-        EmailGlobalConfigurationModelConverter converter = new EmailGlobalConfigurationModelConverter();
-        Optional<EmailGlobalConfigModel> model = converter.convert(emptyModel);
+        EmailGlobalConfigurationModelConverter converter = new EmailGlobalConfigurationModelConverter(validator);
+        Optional<EmailGlobalConfigModel> model = converter.convertAndValidate(emptyModel);
         assertTrue(model.isEmpty());
     }
 
@@ -67,8 +70,8 @@ class EmailGlobalConfigurationModelConverterTest {
         ConfigurationFieldModel invalidField = ConfigurationFieldModel.create(invalidFieldKey);
         Map<String, ConfigurationFieldModel> fieldValues = Map.of(invalidFieldKey, invalidField);
         ConfigurationModel configurationModel = new ConfigurationModel(1L, 1L, "", "", ConfigContextEnum.GLOBAL, fieldValues);
-        EmailGlobalConfigurationModelConverter converter = new EmailGlobalConfigurationModelConverter();
-        Optional<EmailGlobalConfigModel> model = converter.convert(configurationModel);
+        EmailGlobalConfigurationModelConverter converter = new EmailGlobalConfigurationModelConverter(validator);
+        Optional<EmailGlobalConfigModel> model = converter.convertAndValidate(configurationModel);
         assertTrue(model.isEmpty());
     }
 

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelSaveActionsTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelSaveActionsTest.java
@@ -50,8 +50,8 @@ class EmailGlobalConfigurationModelSaveActionsTest {
     private final FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, gson);
     private final EncryptionUtility encryptionUtility = new EncryptionUtility(alertProperties, filePersistenceUtil);
     private final AuthorizationManager authorizationManager = createAuthorizationManager();
-    private final EmailGlobalConfigurationModelConverter converter = new EmailGlobalConfigurationModelConverter();
     private final EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
+    private final EmailGlobalConfigurationModelConverter converter = new EmailGlobalConfigurationModelConverter(validator);
 
     @Test
     void getDescriptorKeyTest() {

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/convert/JiraServerGlobalConfigurationModelConverter.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/convert/JiraServerGlobalConfigurationModelConverter.java
@@ -10,24 +10,33 @@ package com.synopsys.integration.alert.channel.jira.server.convert;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
+import com.synopsys.integration.alert.channel.jira.server.validator.JiraServerGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.action.api.GlobalConfigurationModelToConcreteConverter;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 
 @Component
-public class JiraServerGlobalConfigurationModelConverter implements GlobalConfigurationModelToConcreteConverter<JiraServerGlobalConfigModel> {
+public class JiraServerGlobalConfigurationModelConverter extends GlobalConfigurationModelToConcreteConverter<JiraServerGlobalConfigModel> {
     public static final String URL_KEY = "jira.server.url";
     public static final String USERNAME_KEY = "jira.server.username";
     public static final String PASSWORD_KEY = "jira.server.password";
     public static final String DISABLE_PLUGIN_CHECK_KEY = "jira.server.disable.plugin.check";
 
+    private final JiraServerGlobalConfigurationValidator validator;
+
+    @Autowired
+    public JiraServerGlobalConfigurationModelConverter(JiraServerGlobalConfigurationValidator validator) {
+        this.validator = validator;
+    }
+
     @Override
     public Optional<JiraServerGlobalConfigModel> convert(ConfigurationModel globalConfigurationModel) {
-
         String url = globalConfigurationModel.getField(URL_KEY)
             .flatMap(ConfigurationFieldModel::getFieldValue)
             .orElse(null);
@@ -52,5 +61,10 @@ public class JiraServerGlobalConfigurationModelConverter implements GlobalConfig
             .ifPresent(model::setDisablePluginCheck);
 
         return Optional.of(model);
+    }
+
+    @Override
+    protected ValidationResponseModel validate(JiraServerGlobalConfigModel configModel) {
+        return validator.validate(configModel, null);
     }
 }

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/convert/JiraServerGlobalConfigurationModelSaveActions.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/convert/JiraServerGlobalConfigurationModelSaveActions.java
@@ -27,8 +27,10 @@ public class JiraServerGlobalConfigurationModelSaveActions implements GlobalConf
     private final JiraServerGlobalCrudActions configurationActions;
     private final JiraServerGlobalConfigAccessor configurationAccessor;
 
-    public JiraServerGlobalConfigurationModelSaveActions(JiraServerGlobalConfigurationModelConverter jiraFieldModelConverter, JiraServerGlobalCrudActions configurationActions,
-        JiraServerGlobalConfigAccessor configurationAccessor) {
+    public JiraServerGlobalConfigurationModelSaveActions(
+        JiraServerGlobalConfigurationModelConverter jiraFieldModelConverter, JiraServerGlobalCrudActions configurationActions,
+        JiraServerGlobalConfigAccessor configurationAccessor
+    ) {
         this.jiraFieldModelConverter = jiraFieldModelConverter;
         this.configurationActions = configurationActions;
         this.configurationAccessor = configurationAccessor;
@@ -44,7 +46,7 @@ public class JiraServerGlobalConfigurationModelSaveActions implements GlobalConf
         Optional<UUID> defaultConfigurationId = configurationAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
             .map(JiraServerGlobalConfigModel::getId)
             .map(UUID::fromString);
-        Optional<JiraServerGlobalConfigModel> jiraGlobalConfigModel = jiraFieldModelConverter.convert(configurationModel);
+        Optional<JiraServerGlobalConfigModel> jiraGlobalConfigModel = jiraFieldModelConverter.convertAndValidate(configurationModel);
         if (jiraGlobalConfigModel.isPresent()) {
             JiraServerGlobalConfigModel model = jiraGlobalConfigModel.get();
             model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
@@ -58,7 +60,7 @@ public class JiraServerGlobalConfigurationModelSaveActions implements GlobalConf
 
     @Override
     public void createConcreteModel(ConfigurationModel configurationModel) {
-        Optional<JiraServerGlobalConfigModel> jiraGlobalConfigModel = jiraFieldModelConverter.convert(configurationModel);
+        Optional<JiraServerGlobalConfigModel> jiraGlobalConfigModel = jiraFieldModelConverter.convertAndValidate(configurationModel);
         if (jiraGlobalConfigModel.isPresent()) {
             JiraServerGlobalConfigModel model = jiraGlobalConfigModel.get();
             model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/database/accessor/JiraServerGlobalConfigAccessor.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/database/accessor/JiraServerGlobalConfigAccessor.java
@@ -136,14 +136,19 @@ public class JiraServerGlobalConfigAccessor implements ConfigurationAccessor<Jir
         String password = configuration.getPassword().map(encryptionUtility::encrypt).orElse(null);
         Boolean disablePluginCheck = configuration.getDisablePluginCheck().orElse(Boolean.FALSE);
 
-        return new JiraServerConfigurationEntity(configurationId, configuration.getName(), createdTime, lastUpdated,
-            configuration.getUrl(), configuration.getUserName(), password, disablePluginCheck);
+        return new JiraServerConfigurationEntity(
+            configurationId,
+            configuration.getName(),
+            createdTime,
+            lastUpdated,
+            configuration.getUrl(),
+            configuration.getUserName(),
+            password,
+            disablePluginCheck
+        );
     }
 
     private JiraServerGlobalConfigModel createConfigModel(JiraServerConfigurationEntity jiraConfiguration) {
-        if (null == jiraConfiguration) {
-            return new JiraServerGlobalConfigModel();
-        }
         String createdAtFormatted = DateUtils.formatDate(jiraConfiguration.getCreatedAt(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE);
         String lastUpdatedFormatted = "";
         if (null != jiraConfiguration.getLastUpdated()) {

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/convert/JiraServerGlobalConfigurationModelSaveActionsTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/convert/JiraServerGlobalConfigurationModelSaveActionsTest.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -45,7 +46,16 @@ class JiraServerGlobalConfigurationModelSaveActionsTest {
     private final FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, gson);
     private final EncryptionUtility encryptionUtility = new EncryptionUtility(alertProperties, filePersistenceUtil);
     private final AuthorizationManager authorizationManager = createAuthorizationManager();
-    private final JiraServerGlobalConfigurationModelConverter converter = new JiraServerGlobalConfigurationModelConverter();
+
+    private JiraServerGlobalConfigurationModelConverter converter;
+
+    @BeforeEach
+    public void init() {
+        JiraServerGlobalConfigAccessor jiraServerGlobalConfigAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
+        Mockito.when(jiraServerGlobalConfigAccessor.getConfigurationByName(Mockito.anyString())).thenReturn(Optional.empty());
+        JiraServerGlobalConfigurationValidator validator = new JiraServerGlobalConfigurationValidator(jiraServerGlobalConfigAccessor);
+        converter = new JiraServerGlobalConfigurationModelConverter(validator);
+    }
 
     @Test
     void getDescriptorKeyTest() {

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/database/accessor/JiraServerGlobalConfigAccessorTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/database/accessor/JiraServerGlobalConfigAccessorTest.java
@@ -2,7 +2,6 @@ package com.synopsys.integration.alert.channel.jira.server.database.accessor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -61,7 +60,8 @@ class JiraServerGlobalConfigAccessorTest {
         UUID id = UUID.randomUUID();
         JiraServerConfigurationEntity entity = createEntity(id);
         Mockito.when(jiraServerConfigurationRepository.findById(id)).thenReturn(Optional.of(entity));
-        JiraServerGlobalConfigModel configModel = jiraServerGlobalConfigAccessor.getConfiguration(id).orElseThrow(() -> new AlertConfigurationException("Cannot find expected configuration"));
+        JiraServerGlobalConfigModel configModel = jiraServerGlobalConfigAccessor.getConfiguration(id)
+            .orElseThrow(() -> new AlertConfigurationException("Cannot find expected configuration"));
         assertEquals(id.toString(), configModel.getId());
         assertEquals(TEST_URL, configModel.getUrl());
         assertEquals(TEST_USERNAME, configModel.getUserName());
@@ -84,7 +84,8 @@ class JiraServerGlobalConfigAccessorTest {
         UUID id = UUID.randomUUID();
         JiraServerConfigurationEntity entity = createEntity(id);
         Mockito.when(jiraServerConfigurationRepository.findByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(entity));
-        JiraServerGlobalConfigModel configModel = jiraServerGlobalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME).orElseThrow(() -> new AlertConfigurationException("Cannot find expected configuration"));
+        JiraServerGlobalConfigModel configModel = jiraServerGlobalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
+            .orElseThrow(() -> new AlertConfigurationException("Cannot find expected configuration"));
         assertEquals(id.toString(), configModel.getId());
         assertEquals(TEST_URL, configModel.getUrl());
         assertEquals(TEST_USERNAME, configModel.getUserName());
@@ -211,7 +212,8 @@ class JiraServerGlobalConfigAccessorTest {
     void createConfigurationTest() throws AlertConfigurationException {
         UUID id = UUID.randomUUID();
         JiraServerConfigurationEntity entity = createEntity(id, OffsetDateTime.now(), OffsetDateTime.now());
-        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(null,
+        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(
+            null,
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             DateUtils.formatDate(entity.getCreatedAt(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
             DateUtils.formatDate(entity.getLastUpdated(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
@@ -219,7 +221,8 @@ class JiraServerGlobalConfigAccessorTest {
             TEST_USERNAME,
             TEST_PASSWORD,
             false,
-            true);
+            true
+        );
 
         Mockito.when(jiraServerConfigurationRepository.save(Mockito.any())).thenReturn(entity);
 
@@ -233,39 +236,22 @@ class JiraServerGlobalConfigAccessorTest {
     }
 
     @Test
-    void createConfigurationModelNullTest() throws AlertConfigurationException {
-        UUID id = UUID.randomUUID();
-        JiraServerConfigurationEntity entity = createEntity(id, OffsetDateTime.now(), OffsetDateTime.now());
-        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(null,
-            AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
-            DateUtils.formatDate(entity.getCreatedAt(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
-            DateUtils.formatDate(entity.getLastUpdated(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
-            TEST_URL,
-            TEST_USERNAME,
-            TEST_PASSWORD,
-            false,
-            true);
-
-        Mockito.when(jiraServerConfigurationRepository.save(Mockito.any())).thenReturn(null);
-
-        JiraServerGlobalConfigModel createdModel = jiraServerGlobalConfigAccessor.createConfiguration(model);
-        assertNull(createdModel.getId());
-        assertNull(createdModel.getUrl());
-        assertNull(createdModel.getUserName());
-        assertTrue(createdModel.getIsPasswordSet().isEmpty());
-        assertTrue(createdModel.getPassword().isEmpty());
-        assertTrue(createdModel.getDisablePluginCheck().isEmpty());
-    }
-
-    @Test
     void updateConfigurationTest() throws AlertConfigurationException {
         UUID id = UUID.randomUUID();
         String updatedName = "updatedName";
         String newUrl = "https://updated.example.com";
         JiraServerConfigurationEntity entity = createEntity(id, OffsetDateTime.now(), OffsetDateTime.now());
-        JiraServerConfigurationEntity updatedEntity = new JiraServerConfigurationEntity(entity.getConfigurationId(), updatedName, entity.getCreatedAt(), entity.getLastUpdated(), newUrl, entity.getUsername(), entity.getPassword(),
-            entity.getDisablePluginCheck());
-        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(null,
+        JiraServerConfigurationEntity updatedEntity = new JiraServerConfigurationEntity(entity.getConfigurationId(),
+            updatedName,
+            entity.getCreatedAt(),
+            entity.getLastUpdated(),
+            newUrl,
+            entity.getUsername(),
+            entity.getPassword(),
+            entity.getDisablePluginCheck()
+        );
+        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(
+            null,
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             DateUtils.formatDate(entity.getCreatedAt(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
             DateUtils.formatDate(entity.getLastUpdated(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
@@ -273,7 +259,8 @@ class JiraServerGlobalConfigAccessorTest {
             TEST_USERNAME,
             TEST_PASSWORD,
             false,
-            true);
+            true
+        );
         Mockito.when(jiraServerConfigurationRepository.findById(id)).thenReturn(Optional.of(entity));
         Mockito.when(jiraServerConfigurationRepository.save(Mockito.any())).thenReturn(updatedEntity);
 
@@ -292,9 +279,17 @@ class JiraServerGlobalConfigAccessorTest {
         String updatedName = "updatedName";
         String newUrl = "https://updated.example.com";
         JiraServerConfigurationEntity entity = createEntity(id, OffsetDateTime.now(), OffsetDateTime.now());
-        JiraServerConfigurationEntity updatedEntity = new JiraServerConfigurationEntity(entity.getConfigurationId(), updatedName, entity.getCreatedAt(), entity.getLastUpdated(), newUrl, entity.getUsername(), entity.getPassword(),
-            entity.getDisablePluginCheck());
-        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(null,
+        JiraServerConfigurationEntity updatedEntity = new JiraServerConfigurationEntity(entity.getConfigurationId(),
+            updatedName,
+            entity.getCreatedAt(),
+            entity.getLastUpdated(),
+            newUrl,
+            entity.getUsername(),
+            entity.getPassword(),
+            entity.getDisablePluginCheck()
+        );
+        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(
+            null,
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             DateUtils.formatDate(entity.getCreatedAt(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
             DateUtils.formatDate(entity.getLastUpdated(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
@@ -302,7 +297,8 @@ class JiraServerGlobalConfigAccessorTest {
             TEST_USERNAME,
             null,
             true,
-            true);
+            true
+        );
         Mockito.when(jiraServerConfigurationRepository.findById(id)).thenReturn(Optional.of(entity));
         Mockito.when(jiraServerConfigurationRepository.save(Mockito.any())).thenReturn(updatedEntity);
 
@@ -322,7 +318,8 @@ class JiraServerGlobalConfigAccessorTest {
         String newUrl = "https://updated.example.com";
         JiraServerConfigurationEntity entity = createEntity(id, OffsetDateTime.now(), OffsetDateTime.now());
 
-        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(null,
+        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(
+            null,
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             DateUtils.formatDate(entity.getCreatedAt(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
             DateUtils.formatDate(entity.getLastUpdated(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
@@ -330,7 +327,8 @@ class JiraServerGlobalConfigAccessorTest {
             TEST_USERNAME,
             TEST_PASSWORD,
             false,
-            true);
+            true
+        );
         Mockito.when(jiraServerConfigurationRepository.findById(id)).thenReturn(Optional.empty());
 
         try {
@@ -359,13 +357,15 @@ class JiraServerGlobalConfigAccessorTest {
     }
 
     private JiraServerConfigurationEntity createEntity(UUID id, OffsetDateTime createdAt, OffsetDateTime lastUpdated) {
-        return new JiraServerConfigurationEntity(id,
+        return new JiraServerConfigurationEntity(
+            id,
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             createdAt,
             lastUpdated,
             TEST_URL,
             TEST_USERNAME,
             encryptionUtility.encrypt(TEST_PASSWORD),
-            true);
+            true
+        );
     }
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/settings/convert/ProxyConfigurationModelSaveActions.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/settings/convert/ProxyConfigurationModelSaveActions.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.action.api.GlobalConfigurationModelToConcreteSaveActions;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
-import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.rest.model.SettingsProxyModel;
 import com.synopsys.integration.alert.component.settings.descriptor.SettingsDescriptorKey;
 import com.synopsys.integration.alert.component.settings.proxy.action.SettingsProxyCrudActions;
@@ -52,11 +51,7 @@ public class ProxyConfigurationModelSaveActions implements GlobalConfigurationMo
     }
 
     private void convertModelAndPerformAction(ConfigurationModel configurationModel, Function<SettingsProxyModel, ActionResponse<SettingsProxyModel>> configAction) {
-        Optional<SettingsProxyModel> settingsProxyModel = proxyFieldModelConverter.convert(configurationModel);
-        if (settingsProxyModel.isPresent()) {
-            SettingsProxyModel model = settingsProxyModel.get();
-            model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
-            configAction.apply(model);
-        }
+        Optional<SettingsProxyModel> settingsProxyModel = proxyFieldModelConverter.convertAndValidate(configurationModel);
+        settingsProxyModel.ifPresent(configAction::apply);
     }
 }

--- a/component/src/test/java/com/synopsys/integration/alert/component/settings/convert/ProxyConfigurationModelConverterTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/settings/convert/ProxyConfigurationModelConverterTest.java
@@ -14,6 +14,7 @@ import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
 import com.synopsys.integration.alert.common.rest.model.SettingsProxyModel;
+import com.synopsys.integration.alert.component.settings.proxy.validator.SettingsProxyValidator;
 
 class ProxyConfigurationModelConverterTest {
     public static final List<String> TEST_NON_PROXY_HOSTS = List.of("host-1.example.com", "host-2.example.com", "host-3.example.com");
@@ -22,11 +23,13 @@ class ProxyConfigurationModelConverterTest {
     public static final String TEST_SMTP_PORT = "3025";
     public static final String TEST_AUTH_USER = "auser";
 
+    private final SettingsProxyValidator validator = new SettingsProxyValidator();
+
     @Test
     void validConversionTest() {
         ConfigurationModel configurationModel = createDefaultConfigurationModel();
-        ProxyConfigurationModelConverter converter = new ProxyConfigurationModelConverter();
-        Optional<SettingsProxyModel> model = converter.convert(configurationModel);
+        ProxyConfigurationModelConverter converter = new ProxyConfigurationModelConverter(validator);
+        Optional<SettingsProxyModel> model = converter.convertAndValidate(configurationModel);
         assertTrue(model.isPresent());
         SettingsProxyModel proxyModel = model.get();
         assertEquals(TEST_AUTH_USER, proxyModel.getProxyUsername().orElse(null));
@@ -42,23 +45,17 @@ class ProxyConfigurationModelConverterTest {
         ConfigurationModel configurationModel = createDefaultConfigurationModel();
         configurationModel.getField(ProxyConfigurationModelConverter.FIELD_KEY_PORT)
             .ifPresent(field -> field.setFieldValue("twenty-five"));
-        ProxyConfigurationModelConverter converter = new ProxyConfigurationModelConverter();
-        Optional<SettingsProxyModel> model = converter.convert(configurationModel);
+        ProxyConfigurationModelConverter converter = new ProxyConfigurationModelConverter(validator);
+        Optional<SettingsProxyModel> model = converter.convertAndValidate(configurationModel);
         assertTrue(model.isEmpty());
     }
 
     @Test
     void emptyFieldsTest() {
         ConfigurationModel emptyModel = new ConfigurationModel(1L, 1L, "", "", ConfigContextEnum.GLOBAL, Map.of());
-        ProxyConfigurationModelConverter converter = new ProxyConfigurationModelConverter();
-        Optional<SettingsProxyModel> model = converter.convert(emptyModel);
-        assertTrue(model.isPresent());
-        SettingsProxyModel proxyModel = model.get();
-        assertTrue(proxyModel.getProxyUsername().isEmpty());
-        assertTrue(proxyModel.getProxyPassword().isEmpty());
-        assertTrue(proxyModel.getProxyHost().isEmpty());
-        assertTrue(proxyModel.getProxyPort().isEmpty());
-        assertTrue(proxyModel.getNonProxyHosts().isEmpty());
+        ProxyConfigurationModelConverter converter = new ProxyConfigurationModelConverter(validator);
+        Optional<SettingsProxyModel> model = converter.convertAndValidate(emptyModel);
+        assertTrue(model.isEmpty());
     }
 
     private ConfigurationModel createDefaultConfigurationModel() {

--- a/component/src/test/java/com/synopsys/integration/alert/component/settings/convert/ProxyConfigurationModelSaveActionsTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/settings/convert/ProxyConfigurationModelSaveActionsTest.java
@@ -48,8 +48,8 @@ class ProxyConfigurationModelSaveActionsTest {
     private final FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, gson);
     private final EncryptionUtility encryptionUtility = new EncryptionUtility(alertProperties, filePersistenceUtil);
     private final AuthorizationManager authorizationManager = createAuthorizationManager();
-    private final ProxyConfigurationModelConverter converter = new ProxyConfigurationModelConverter();
     private final SettingsProxyValidator validator = new SettingsProxyValidator();
+    private final ProxyConfigurationModelConverter converter = new ProxyConfigurationModelConverter(validator);
 
     @Test
     void getDescriptorKeyTest() {
@@ -75,7 +75,11 @@ class ProxyConfigurationModelSaveActionsTest {
             return List.of(savedNonProxyHostEntity.get());
         });
 
-        SettingsProxyConfigAccessor configurationAccessor = new SettingsProxyConfigAccessor(encryptionUtility, settingsProxyConfigurationRepository, nonProxyHostsConfigurationRepository);
+        SettingsProxyConfigAccessor configurationAccessor = new SettingsProxyConfigAccessor(
+            encryptionUtility,
+            settingsProxyConfigurationRepository,
+            nonProxyHostsConfigurationRepository
+        );
         SettingsProxyCrudActions settingsProxyCrudActions = new SettingsProxyCrudActions(authorizationManager, configurationAccessor, validator, settingsDescriptorKey);
         ProxyConfigurationModelSaveActions saveActions = new ProxyConfigurationModelSaveActions(converter, settingsProxyCrudActions);
         saveActions.createConcreteModel(createDefaultConfigurationModel());
@@ -109,7 +113,11 @@ class ProxyConfigurationModelSaveActionsTest {
             return List.of(savedNonProxyHostEntity.get());
         });
 
-        SettingsProxyConfigAccessor configurationAccessor = new SettingsProxyConfigAccessor(encryptionUtility, settingsProxyConfigurationRepository, nonProxyHostsConfigurationRepository);
+        SettingsProxyConfigAccessor configurationAccessor = new SettingsProxyConfigAccessor(
+            encryptionUtility,
+            settingsProxyConfigurationRepository,
+            nonProxyHostsConfigurationRepository
+        );
         SettingsProxyCrudActions settingsProxyCrudActions = new SettingsProxyCrudActions(authorizationManager, configurationAccessor, validator, settingsDescriptorKey);
         ProxyConfigurationModelSaveActions saveActions = new ProxyConfigurationModelSaveActions(converter, settingsProxyCrudActions);
         ConfigurationModel configurationModel = createDefaultConfigurationModel();
@@ -144,7 +152,11 @@ class ProxyConfigurationModelSaveActionsTest {
             return List.of(savedNonProxyHostEntity.get());
         });
 
-        SettingsProxyConfigAccessor configurationAccessor = new SettingsProxyConfigAccessor(encryptionUtility, settingsProxyConfigurationRepository, nonProxyHostsConfigurationRepository);
+        SettingsProxyConfigAccessor configurationAccessor = new SettingsProxyConfigAccessor(
+            encryptionUtility,
+            settingsProxyConfigurationRepository,
+            nonProxyHostsConfigurationRepository
+        );
         SettingsProxyCrudActions settingsProxyCrudActions = new SettingsProxyCrudActions(authorizationManager, configurationAccessor, validator, settingsDescriptorKey);
         ProxyConfigurationModelSaveActions saveActions = new ProxyConfigurationModelSaveActions(converter, settingsProxyCrudActions);
         String newHost = "updatedHost";
@@ -189,7 +201,11 @@ class ProxyConfigurationModelSaveActionsTest {
             return List.of(savedNonProxyHostEntity.get());
         });
 
-        SettingsProxyConfigAccessor configurationAccessor = new SettingsProxyConfigAccessor(encryptionUtility, settingsProxyConfigurationRepository, nonProxyHostsConfigurationRepository);
+        SettingsProxyConfigAccessor configurationAccessor = new SettingsProxyConfigAccessor(
+            encryptionUtility,
+            settingsProxyConfigurationRepository,
+            nonProxyHostsConfigurationRepository
+        );
         SettingsProxyCrudActions settingsProxyCrudActions = new SettingsProxyCrudActions(authorizationManager, configurationAccessor, validator, settingsDescriptorKey);
         ProxyConfigurationModelSaveActions saveActions = new ProxyConfigurationModelSaveActions(converter, settingsProxyCrudActions);
         String newHost = "updatedHost";
@@ -238,7 +254,11 @@ class ProxyConfigurationModelSaveActionsTest {
             return List.of(savedNonProxyHostEntity.get());
         });
 
-        SettingsProxyConfigAccessor configurationAccessor = new SettingsProxyConfigAccessor(encryptionUtility, settingsProxyConfigurationRepository, nonProxyHostsConfigurationRepository);
+        SettingsProxyConfigAccessor configurationAccessor = new SettingsProxyConfigAccessor(
+            encryptionUtility,
+            settingsProxyConfigurationRepository,
+            nonProxyHostsConfigurationRepository
+        );
         SettingsProxyCrudActions settingsProxyCrudActions = new SettingsProxyCrudActions(authorizationManager, configurationAccessor, validator, settingsDescriptorKey);
         ProxyConfigurationModelSaveActions saveActions = new ProxyConfigurationModelSaveActions(converter, settingsProxyCrudActions);
         ConfigurationModel configurationModel = createDefaultConfigurationModel();

--- a/src/test/java/com/synopsys/integration/alert/web/config/EmailConfigActionTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/web/config/EmailConfigActionTestIT.java
@@ -44,7 +44,7 @@ import com.synopsys.integration.alert.web.api.config.ConfigActions;
 import com.synopsys.integration.alert.web.api.config.GlobalConfigurationModelToConcreteConversionService;
 
 @AlertIntegrationTest
-public class EmailConfigActionTestIT {
+class EmailConfigActionTestIT {
     public static final String TEST_AUTH_REQUIRED = "true";
     public static final String TEST_FROM = "test.user@some.company.example.com";
     public static final String TEST_SMTP_HOST = "smtp.server.example.com";
@@ -72,6 +72,8 @@ public class EmailConfigActionTestIT {
     private EncryptionUtility encryptionUtility;
     @Autowired
     private EmailGlobalConfigAccessor emailGlobalConfigAccessor;
+    @Autowired
+    private EmailGlobalConfigurationValidator validator;
 
     @BeforeEach
     void deleteDefaultConfig() {
@@ -242,7 +244,7 @@ public class EmailConfigActionTestIT {
     }
 
     private GlobalConfigurationModelToConcreteConversionService createConversionService(EmailGlobalCrudActions emailGlobalCrudActions) {
-        EmailGlobalConfigurationModelConverter modelConverter = new EmailGlobalConfigurationModelConverter();
+        EmailGlobalConfigurationModelConverter modelConverter = new EmailGlobalConfigurationModelConverter(validator);
         EmailGlobalConfigurationModelSaveActions emailGlobalConfigurationModelSaveActions = new EmailGlobalConfigurationModelSaveActions(
             modelConverter,
             emailGlobalCrudActions,


### PR DESCRIPTION
This update is to refactor GlobalConfigurationModelToConcreteConverter to use inheritence to require convert and validate methods to be implemented for any field model to concrete model conversion. The purpose of this is to require using the "convertAndValidate" method to make sure that the new model that was created is verified using the new validators as well.