### PR TITLE
Add search and sort to the paging of Jira server (#2054)

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/action/api/AbstractJobResourceActions.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/action/api/AbstractJobResourceActions.java
@@ -59,6 +59,8 @@ public abstract class AbstractJobResourceActions {
         Integer pageNumber,
         Integer pageSize,
         String searchTerm,
+        String sortName,
+        String sortOrder,
         Collection<String> permittedDescriptorsForSession
     );
 
@@ -93,7 +95,7 @@ public abstract class AbstractJobResourceActions {
         return createWithoutChecks(resource);
     }
 
-    public final ActionResponse<JobPagedModel> getPage(Integer pageNumber, Integer pageSize, String searchTerm) {
+    public final ActionResponse<JobPagedModel> getPage(Integer pageNumber, Integer pageSize, String searchTerm, String sortName, String sortOrder) {
         Optional<ActionResponse<JobPagedModel>> pagingErrorResponse = PagingParamValidationUtils.createErrorActionResponseIfInvalid(pageNumber, pageSize);
         if (pagingErrorResponse.isPresent()) {
             return pagingErrorResponse.get();
@@ -111,7 +113,7 @@ public abstract class AbstractJobResourceActions {
         if (permittedDescriptorsForSession.isEmpty()) {
             return ActionResponse.createForbiddenResponse();
         }
-        return readPageWithoutChecks(pageNumber, pageSize, searchTerm, permittedDescriptorsForSession);
+        return readPageWithoutChecks(pageNumber, pageSize, searchTerm, sortName, sortOrder, permittedDescriptorsForSession);
     }
 
     @Deprecated

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/ConfigurationAccessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/ConfigurationAccessor.java
@@ -25,7 +25,9 @@ public interface ConfigurationAccessor<T extends AlertSerializableModel> {
 
     boolean existsConfigurationById(UUID id);
 
-    AlertPagedModel<T> getConfigurationPage(int page, int size);
+    AlertPagedModel<T> getConfigurationPage(
+        int page, int size, String searchTerm, String sortName, String sortOrder
+    );
 
     T createConfiguration(T configuration) throws AlertConfigurationException;
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/JobAccessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/JobAccessor.java
@@ -25,7 +25,14 @@ public interface JobAccessor {
 
     AlertPagedModel<DistributionJobModel> getPageOfJobs(int pageOffset, int pageLimit);
 
-    AlertPagedModel<DistributionJobModel> getPageOfJobs(int pageOffset, int pageLimit, String searchTerm, Collection<String> descriptorsNamesToInclude);
+    AlertPagedModel<DistributionJobModel> getPageOfJobs(
+        int pageOffset,
+        int pageLimit,
+        String searchTerm,
+        String sortName,
+        String sortOrder,
+        Collection<String> descriptorsNamesToInclude
+    );
 
     Optional<DistributionJobModel> getJobById(UUID jobId);
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/ReadPageController.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/ReadPageController.java
@@ -17,7 +17,9 @@ public interface ReadPageController<P extends AlertPagedModel<?>> {
     P getPage(
         @RequestParam(defaultValue = AlertPagedModel.DEFAULT_PAGE_NUMBER_STRING) Integer pageNumber,
         @RequestParam(defaultValue = AlertPagedModel.DEFAULT_PAGE_SIZE_STRING) Integer pageSize,
-        @RequestParam(required = false) String searchTerm
+        @RequestParam(required = false) String searchTerm,
+        @RequestParam(required = false) String sortName,
+        @RequestParam(required = false) String sortOrder
     );
 
 }

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/util/SortUtil.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/util/SortUtil.java
@@ -1,0 +1,35 @@
+/*
+ * alert-common
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.alert.common.util;
+
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.domain.Sort;
+
+public final class SortUtil {
+
+    public static Sort createSortByFieldName(String fieldName, String direction) {
+        Sort sort = Sort.unsorted();
+        if (StringUtils.isNotBlank(fieldName) && StringUtils.isNotBlank(direction)) {
+            Optional<Sort.Direction> sortDirection = Sort.Direction.fromOptionalString(direction);
+            if (sortDirection.isPresent()) {
+                sort = sortDirection
+                    .filter(Sort.Direction::isAscending)
+                    .map(ignored -> Sort.by(Sort.Order.asc(fieldName)))
+                    .orElse(Sort.by(Sort.Order.desc(fieldName)));
+            }
+        }
+
+        return sort;
+    }
+
+    private SortUtil() {
+        // prevent construction of new instances.
+    }
+}

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/ConfigurationFieldModelTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/ConfigurationFieldModelTest.java
@@ -24,7 +24,7 @@ import com.synopsys.integration.alert.common.security.EncryptionUtility;
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
 import com.synopsys.integration.alert.mock.MockDescriptorAccessor;
 
-public class ConfigurationFieldModelTest {
+class ConfigurationFieldModelTest {
     public static final String KEY_FIELD_1 = "field_1";
     public static final String KEY_FIELD_2 = "field_2";
     public static final String VALUE_FIELD_1 = "value_1";
@@ -32,7 +32,8 @@ public class ConfigurationFieldModelTest {
 
     private FieldModel createFieldModel() {
         Map<String, FieldValueModel> valueModelMap = Map.of(KEY_FIELD_1, new FieldValueModel(List.of(VALUE_FIELD_1), false),
-            KEY_FIELD_2, new FieldValueModel(List.of(VALUE_FIELD_2), false));
+            KEY_FIELD_2, new FieldValueModel(List.of(VALUE_FIELD_2), false)
+        );
         return new FieldModel("descriptor", "GLOBAL", valueModelMap);
     }
 
@@ -49,7 +50,7 @@ public class ConfigurationFieldModelTest {
     }
 
     @Test
-    public void convertToFieldAccessorTest() throws Exception {
+    void convertToFieldAccessorTest() throws Exception {
         FieldModel fieldModel = createFieldModel();
         List<DefinedFieldModel> configFields = createConfigFields();
         EncryptionUtility encryptionUtility = Mockito.mock(EncryptionUtility.class);
@@ -64,7 +65,7 @@ public class ConfigurationFieldModelTest {
     }
 
     @Test
-    public void convertFromFieldModelTest() throws Exception {
+    void convertFromFieldModelTest() throws Exception {
         FieldModel fieldModel = createFieldModel();
         List<DefinedFieldModel> configFields = createConfigFields();
         EncryptionUtility encryptionUtility = Mockito.mock(EncryptionUtility.class);
@@ -80,7 +81,7 @@ public class ConfigurationFieldModelTest {
     }
 
     @Test
-    public void convertFromFieldModelEmptyFieldsTest() throws Exception {
+    void convertFromFieldModelEmptyFieldsTest() throws Exception {
         FieldModel fieldModel = createFieldModel();
         EncryptionUtility encryptionUtility = Mockito.mock(EncryptionUtility.class);
         DescriptorAccessor descriptorAccessor = new MockDescriptorAccessor(List.of());
@@ -91,14 +92,18 @@ public class ConfigurationFieldModelTest {
     }
 
     @Test
-    public void convertDefinedFieldModelTest() throws Exception {
+    void convertDefinedFieldModelTest() throws Exception {
         List<DefinedFieldModel> configFields = createConfigFields();
         EncryptionUtility encryptionUtility = Mockito.mock(EncryptionUtility.class);
         Mockito.when(encryptionUtility.isInitialized()).thenReturn(true);
         DescriptorAccessor descriptorAccessor = new MockDescriptorAccessor(configFields);
         List<DescriptorKey> descriptorKeys = createDescriptorKeyList();
         ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorKeys);
-        Optional<ConfigurationFieldModel> optionalModel = modelConverter.convertFromDefinedFieldModel(new DefinedFieldModel(KEY_FIELD_1, ConfigContextEnum.GLOBAL, false), VALUE_FIELD_1, true);
+        Optional<ConfigurationFieldModel> optionalModel = modelConverter.convertFromDefinedFieldModel(
+            new DefinedFieldModel(KEY_FIELD_1, ConfigContextEnum.GLOBAL, false),
+            VALUE_FIELD_1,
+            true
+        );
 
         assertTrue(optionalModel.isPresent());
         ConfigurationFieldModel actualModel = optionalModel.get();
@@ -116,25 +121,33 @@ public class ConfigurationFieldModelTest {
     }
 
     @Test
-    public void convertDefinedFieldModelEmptyTest() throws Exception {
+    void convertDefinedFieldModelEmptyTest() throws Exception {
         List<DefinedFieldModel> configFields = createConfigFields();
         EncryptionUtility encryptionUtility = Mockito.mock(EncryptionUtility.class);
         DescriptorAccessor descriptorAccessor = new MockDescriptorAccessor(configFields);
         List<DescriptorKey> descriptorKeys = createDescriptorKeyList();
         ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorKeys);
-        Optional<ConfigurationFieldModel> optionalModel = modelConverter.convertFromDefinedFieldModel(new DefinedFieldModel(KEY_FIELD_1, ConfigContextEnum.GLOBAL, true), VALUE_FIELD_1, true);
+        Optional<ConfigurationFieldModel> optionalModel = modelConverter.convertFromDefinedFieldModel(
+            new DefinedFieldModel(KEY_FIELD_1, ConfigContextEnum.GLOBAL, true),
+            VALUE_FIELD_1,
+            true
+        );
         assertTrue(optionalModel.isEmpty());
     }
 
     @Test
-    public void convertDefinedFieldModelWithValuesTest() throws Exception {
+    void convertDefinedFieldModelWithValuesTest() throws Exception {
         List<DefinedFieldModel> configFields = createConfigFields();
         EncryptionUtility encryptionUtility = Mockito.mock(EncryptionUtility.class);
         Mockito.when(encryptionUtility.isInitialized()).thenReturn(true);
         DescriptorAccessor descriptorAccessor = new MockDescriptorAccessor(configFields);
         List<DescriptorKey> descriptorKeys = createDescriptorKeyList();
         ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorKeys);
-        Optional<ConfigurationFieldModel> optionalModel = modelConverter.convertFromDefinedFieldModel(new DefinedFieldModel(KEY_FIELD_1, ConfigContextEnum.GLOBAL, false), List.of(VALUE_FIELD_1, VALUE_FIELD_2), true);
+        Optional<ConfigurationFieldModel> optionalModel = modelConverter.convertFromDefinedFieldModel(
+            new DefinedFieldModel(KEY_FIELD_1, ConfigContextEnum.GLOBAL, false),
+            List.of(VALUE_FIELD_1, VALUE_FIELD_2),
+            true
+        );
 
         assertTrue(optionalModel.isPresent());
         ConfigurationFieldModel actualModel = optionalModel.get();
@@ -152,13 +165,17 @@ public class ConfigurationFieldModelTest {
     }
 
     @Test
-    public void convertDefinedFieldModelWithValuesEmptyTest() throws Exception {
+    void convertDefinedFieldModelWithValuesEmptyTest() throws Exception {
         List<DefinedFieldModel> configFields = createConfigFields();
         EncryptionUtility encryptionUtility = Mockito.mock(EncryptionUtility.class);
         DescriptorAccessor descriptorAccessor = new MockDescriptorAccessor(configFields);
         List<DescriptorKey> descriptorKeys = createDescriptorKeyList();
         ConfigurationFieldModelConverter modelConverter = new ConfigurationFieldModelConverter(encryptionUtility, descriptorAccessor, descriptorKeys);
-        Optional<ConfigurationFieldModel> optionalModel = modelConverter.convertFromDefinedFieldModel(new DefinedFieldModel(KEY_FIELD_1, ConfigContextEnum.GLOBAL, true), List.of(VALUE_FIELD_1, VALUE_FIELD_2), true);
+        Optional<ConfigurationFieldModel> optionalModel = modelConverter.convertFromDefinedFieldModel(
+            new DefinedFieldModel(KEY_FIELD_1, ConfigContextEnum.GLOBAL, true),
+            List.of(VALUE_FIELD_1, VALUE_FIELD_2),
+            true
+        );
         assertTrue(optionalModel.isEmpty());
     }
 

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/util/DataStructureUtilsTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/util/DataStructureUtilsTest.java
@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test;
 
 import com.synopsys.integration.util.Stringable;
 
-public class DataStructureUtilsTest {
+class DataStructureUtilsTest {
 
     @Test
-    public void convertListWithNameKey() {
+    void convertListWithNameKey() {
         String key1 = "key1";
         String key2 = "key2";
         TestObject testObject1 = new TestObject(key1, "something");
@@ -30,7 +30,7 @@ public class DataStructureUtilsTest {
     }
 
     @Test
-    public void convertListWithObjectKey() {
+    void convertListWithObjectKey() {
         String key1 = "key1";
         String key2 = "key2";
         TestObject testObject1 = new TestObject(key1, "something");
@@ -45,7 +45,7 @@ public class DataStructureUtilsTest {
     }
 
     @Test
-    public void convertListWithNameAndObject() {
+    void convertListWithNameAndObject() {
         String key1 = "key1";
         String key2 = "key2";
         TestObject testObject1 = new TestObject(key1, "something");

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/util/DateUtilsTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/util/DateUtilsTest.java
@@ -13,66 +13,66 @@ import org.junit.jupiter.api.Test;
 
 import com.synopsys.integration.rest.RestConstants;
 
-public class DateUtilsTest {
-    @Test
-    public void createCurrentDateTimestampOffsetTest() {
-        OffsetDateTime alertDateTime = DateUtils.createCurrentDateTimestamp();
-        assertEquals(ZoneOffset.UTC, alertDateTime.getOffset());
-    }
+ class DateUtilsTest {
+     @Test
+     void createCurrentDateTimestampOffsetTest() {
+         OffsetDateTime alertDateTime = DateUtils.createCurrentDateTimestamp();
+         assertEquals(ZoneOffset.UTC, alertDateTime.getOffset());
+     }
 
-    @Test
-    public void createCurrentDateTimestampZonedDateTimeTest() {
-        OffsetDateTime alertDateTime = DateUtils.createCurrentDateTimestamp();
-        ZonedDateTime localZonedDateTime = ZonedDateTime.now();
+     @Test
+     void createCurrentDateTimestampZonedDateTimeTest() {
+         OffsetDateTime alertDateTime = DateUtils.createCurrentDateTimestamp();
+         ZonedDateTime localZonedDateTime = ZonedDateTime.now();
 
-        ZonedDateTime reZonedLocalTime = localZonedDateTime.withZoneSameInstant(alertDateTime.getOffset());
-        assertEquals(alertDateTime.getHour(), reZonedLocalTime.getHour());
-        assertEquals(alertDateTime.getMinute(), reZonedLocalTime.getMinute());
-    }
+         ZonedDateTime reZonedLocalTime = localZonedDateTime.withZoneSameInstant(alertDateTime.getOffset());
+         assertEquals(alertDateTime.getHour(), reZonedLocalTime.getHour());
+         assertEquals(alertDateTime.getMinute(), reZonedLocalTime.getMinute());
+     }
 
-    @Test
-    public void convertDateToAndFromStringTest() throws ParseException {
-        String dateFormat = RestConstants.JSON_DATE_FORMAT;
-        OffsetDateTime alertDateTime = DateUtils.createCurrentDateTimestamp();
+     @Test
+     void convertDateToAndFromStringTest() throws ParseException {
+         String dateFormat = RestConstants.JSON_DATE_FORMAT;
+         OffsetDateTime alertDateTime = DateUtils.createCurrentDateTimestamp();
 
-        String jsonDateString = DateUtils.formatDate(alertDateTime, dateFormat);
-        OffsetDateTime jsonDateTime = DateUtils.parseDate(jsonDateString, dateFormat);
+         String jsonDateString = DateUtils.formatDate(alertDateTime, dateFormat);
+         OffsetDateTime jsonDateTime = DateUtils.parseDate(jsonDateString, dateFormat);
 
-        if (!alertDateTime.getOffset().equals(jsonDateTime.getOffset())) {
-            assertTrue(alertDateTime.getHour() != jsonDateTime.getHour() || alertDateTime.getMinute() != alertDateTime.getMinute(), "Either hour or minute cannot match");
-        }
+         if (!alertDateTime.getOffset().equals(jsonDateTime.getOffset())) {
+             assertTrue(alertDateTime.getHour() != jsonDateTime.getHour() || alertDateTime.getMinute() != alertDateTime.getMinute(), "Either hour or minute cannot match");
+         }
 
-        OffsetDateTime expectedDateTime = OffsetDateTime.ofInstant(alertDateTime.toInstant(), ZoneOffset.UTC);
+         OffsetDateTime expectedDateTime = OffsetDateTime.ofInstant(alertDateTime.toInstant(), ZoneOffset.UTC);
         assertEquals(expectedDateTime.getHour(), jsonDateTime.getHour());
         assertEquals(expectedDateTime.getMinute(), jsonDateTime.getMinute());
     }
 
-    @Test
-    public void checkCurrentTime() throws InterruptedException {
-        OffsetDateTime firstTimeStamp = DateUtils.createCurrentDateTimestamp();
-        TimeUnit.SECONDS.sleep(1);
-        OffsetDateTime currentDateTimestamp = DateUtils.createCurrentDateTimestamp();
+     @Test
+     void checkCurrentTime() throws InterruptedException {
+         OffsetDateTime firstTimeStamp = DateUtils.createCurrentDateTimestamp();
+         TimeUnit.SECONDS.sleep(1);
+         OffsetDateTime currentDateTimestamp = DateUtils.createCurrentDateTimestamp();
 
-        assertTrue(currentDateTimestamp.isAfter(firstTimeStamp));
-        assertTrue(firstTimeStamp.isBefore(currentDateTimestamp));
-    }
+         assertTrue(currentDateTimestamp.isAfter(firstTimeStamp));
+         assertTrue(firstTimeStamp.isBefore(currentDateTimestamp));
+     }
 
-    @Test
-    public void formatDateAsJsonStringTest() {
-        OffsetDateTime dateTime = OffsetDateTime.now();
-        String formattedDateTimeString = DateUtils.formatDate(dateTime, RestConstants.JSON_DATE_FORMAT);
-        String jsonDateTimeString = DateUtils.formatDateAsJsonString(dateTime);
-        assertEquals(formattedDateTimeString, jsonDateTimeString);
-    }
+     @Test
+     void formatDateAsJsonStringTest() {
+         OffsetDateTime dateTime = OffsetDateTime.now();
+         String formattedDateTimeString = DateUtils.formatDate(dateTime, RestConstants.JSON_DATE_FORMAT);
+         String jsonDateTimeString = DateUtils.formatDateAsJsonString(dateTime);
+         assertEquals(formattedDateTimeString, jsonDateTimeString);
+     }
 
-    @Test
-    public void parseDateFromJsonString() throws ParseException {
-        OffsetDateTime dateTime = OffsetDateTime.now();
-        String formattedDateTimeString = DateUtils.formatDate(dateTime, RestConstants.JSON_DATE_FORMAT);
+     @Test
+     void parseDateFromJsonString() throws ParseException {
+         OffsetDateTime dateTime = OffsetDateTime.now();
+         String formattedDateTimeString = DateUtils.formatDate(dateTime, RestConstants.JSON_DATE_FORMAT);
 
-        OffsetDateTime parsedDate = DateUtils.parseDate(formattedDateTimeString, RestConstants.JSON_DATE_FORMAT);
-        OffsetDateTime jsonDateTime = DateUtils.parseDateFromJsonString(formattedDateTimeString);
-        assertEquals(parsedDate, jsonDateTime);
-    }
+         OffsetDateTime parsedDate = DateUtils.parseDate(formattedDateTimeString, RestConstants.JSON_DATE_FORMAT);
+         OffsetDateTime jsonDateTime = DateUtils.parseDateFromJsonString(formattedDateTimeString);
+         assertEquals(parsedDate, jsonDateTime);
+     }
 
 }

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/util/MarkupEncoderTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/util/MarkupEncoderTest.java
@@ -7,10 +7,10 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-public class MarkupEncoderTest {
+class MarkupEncoderTest {
 
     @Test
-    public void testEncoder() {
+    void testEncoder() {
         MarkupEncoderUtil markupEncoderUtil = new MarkupEncoderUtil();
         Map<Character, String> encoding = Map.of('*', "\\*", '~', "\\~", '#', "\\#", '-', "\\-", '_', "\\_");
 
@@ -34,7 +34,7 @@ public class MarkupEncoderTest {
     }
 
     @Test
-    public void testSlackEncoder() {
+    void testSlackEncoder() {
         MarkupEncoderUtil markupEncoderUtil = new MarkupEncoderUtil();
         LinkedHashMap<Character, String> encodingMap = new LinkedHashMap<>();
         encodingMap.put('&', "&amp;");

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/util/PagingParamValidationUtilsTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/util/PagingParamValidationUtilsTest.java
@@ -14,7 +14,7 @@ import org.springframework.http.HttpStatus;
 
 import com.synopsys.integration.alert.common.action.ActionResponse;
 
-public class PagingParamValidationUtilsTest {
+class PagingParamValidationUtilsTest {
     private static final Integer VALID_PAGE_NUMBER = 0;
     private static final Integer INVALID_PAGE_NUMBER = -1;
     private static final Integer VALID_PAGE_SIZE = 10;
@@ -29,14 +29,14 @@ public class PagingParamValidationUtilsTest {
     }
 
     @Test
-    public void validParamsTest() {
+    void validParamsTest() {
         Optional<ActionResponse<Object>> result = PagingParamValidationUtils.createErrorActionResponseIfInvalid(VALID_PAGE_NUMBER, VALID_PAGE_SIZE);
         assertTrue(result.isEmpty(), "Expected the Optional ActionResponse to be empty");
     }
 
     @ParameterizedTest
     @MethodSource("providePageNumberAndPageSizePairs")
-    public void invalidPageNumberTest(Pair<Integer, Integer> pageNumberAndPageSize) {
+    void invalidPageNumberTest(Pair<Integer, Integer> pageNumberAndPageSize) {
         Optional<ActionResponse<Object>> result = PagingParamValidationUtils.createErrorActionResponseIfInvalid(pageNumberAndPageSize.getLeft(), pageNumberAndPageSize.getRight());
         assertTrue(result.isPresent(), "Expected the Optional ActionResponse to be present");
         ActionResponse<Object> actionResponse = result.get();

--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/util/SortUtilTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/util/SortUtilTest.java
@@ -1,0 +1,67 @@
+package com.synopsys.integration.alert.common.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+
+class SortUtilTest {
+
+    @Test
+    void testNullArguments() {
+        Sort sort = SortUtil.createSortByFieldName(null, null);
+        assertEquals(Sort.unsorted(), sort);
+    }
+
+    @Test
+    void testNullDirection() {
+        Sort sort = SortUtil.createSortByFieldName("fieldName", null);
+        assertEquals(Sort.unsorted(), sort);
+    }
+
+    @Test
+    void testEmptyDirection() {
+        Sort sort = SortUtil.createSortByFieldName("fieldName", "    \t\n\r      ");
+        assertEquals(Sort.unsorted(), sort);
+    }
+
+    @Test
+    void testNullFieldName() {
+        Sort sort = SortUtil.createSortByFieldName(null, "asc");
+        assertEquals(Sort.unsorted(), sort);
+    }
+
+    @Test
+    void testEmptyFieldName() {
+        Sort sort = SortUtil.createSortByFieldName("    \t\n\r      ", "asc");
+        assertEquals(Sort.unsorted(), sort);
+    }
+
+    @Test
+    void testAscendingSort() {
+        String fieldName = "fieldName";
+        Sort sort = SortUtil.createSortByFieldName(fieldName, "asc");
+        Sort.Order sortOrder = sort.getOrderFor(fieldName);
+        assertNotNull(sortOrder);
+        assertTrue(sortOrder.isAscending());
+    }
+
+    @Test
+    void testDescendingSort() {
+        String fieldName = "fieldName";
+        Sort sort = SortUtil.createSortByFieldName(fieldName, "desc");
+        Sort.Order sortOrder = sort.getOrderFor(fieldName);
+        assertNotNull(sortOrder);
+        assertTrue(sortOrder.isDescending());
+    }
+
+    @Test
+    void testInvalidDirection() {
+        String fieldName = "fieldName";
+        Sort sort = SortUtil.createSortByFieldName(fieldName, "wrongway");
+        assertEquals(Sort.unsorted(), sort);
+    }
+
+}

--- a/alert-database-job/src/main/java/com/synopsys/integration/alert/database/api/StaticJobAccessor.java
+++ b/alert-database-job/src/main/java/com/synopsys/integration/alert/database/api/StaticJobAccessor.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,6 +40,7 @@ import com.synopsys.integration.alert.common.persistence.model.job.details.Slack
 import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 import com.synopsys.integration.alert.common.util.DataStructureUtils;
 import com.synopsys.integration.alert.common.util.DateUtils;
+import com.synopsys.integration.alert.common.util.SortUtil;
 import com.synopsys.integration.alert.database.job.DistributionJobEntity;
 import com.synopsys.integration.alert.database.job.DistributionJobRepository;
 import com.synopsys.integration.alert.database.job.azure.boards.AzureBoardsJobDetailsEntity;
@@ -117,12 +119,20 @@ public class StaticJobAccessor implements JobAccessor {
 
     @Override
     @Transactional(readOnly = true)
-    public AlertPagedModel<DistributionJobModel> getPageOfJobs(int pageNumber, int pageLimit, String searchTerm, Collection<String> descriptorsNamesToInclude) {
+    public AlertPagedModel<DistributionJobModel> getPageOfJobs(
+        int pageNumber,
+        int pageLimit,
+        String searchTerm,
+        String sortName,
+        String sortOrder,
+        Collection<String> descriptorsNamesToInclude
+    ) {
         if (!descriptorsNamesToInclude.contains(blackDuckProviderKey.getUniversalKey())) {
             return new AlertPagedModel<>(0, pageNumber, pageLimit, List.of());
         }
 
-        PageRequest pageRequest = PageRequest.of(pageNumber, pageLimit);
+        Sort sort = SortUtil.createSortByFieldName(sortName, sortOrder);
+        PageRequest pageRequest = PageRequest.of(pageNumber, pageLimit, sort);
         Page<DistributionJobEntity> pageOfJobsWithDescriptorNames;
         if (StringUtils.isBlank(searchTerm)) {
             pageOfJobsWithDescriptorNames = distributionJobRepository.findByChannelDescriptorNameIn(descriptorsNamesToInclude, pageRequest);

--- a/alert-database-job/src/test/java/com/synopsys/integration/alert/database/api/StaticJobAccessorTest.java
+++ b/alert-database-job/src/test/java/com/synopsys/integration/alert/database/api/StaticJobAccessorTest.java
@@ -291,7 +291,28 @@ class StaticJobAccessorTest {
         Page<DistributionJobEntity> page = new PageImpl<>(List.of(distributionJobEntity));
         Mockito.when(distributionJobRepository.findByChannelDescriptorNamesAndSearchTerm(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(page);
 
-        AlertPagedModel<DistributionJobModel> pageOfJobs = jobAccessor.getPageOfJobs(0, 10, "test-search-term", List.of(providerKey.getUniversalKey()));
+        AlertPagedModel<DistributionJobModel> pageOfJobs = jobAccessor.getPageOfJobs(0, 10, "test-search-term", null, null, List.of(providerKey.getUniversalKey()));
+
+        assertEquals(1, pageOfJobs.getTotalPages());
+        List<DistributionJobModel> models = pageOfJobs.getModels();
+        assertEquals(1, models.size());
+        DistributionJobModel distributionJobModel = models.get(0);
+        assertEquals(jobId, distributionJobModel.getJobId());
+        assertEquals(jobName, distributionJobModel.getName());
+    }
+
+    @Test
+    void getPageOfJobsSearchAndDefaultSortTest() {
+        ProviderKey providerKey = new BlackDuckProviderKey();
+        UUID jobId = UUID.randomUUID();
+
+        DistributionJobEntity distributionJobEntity = createSlackDistributionJobEntity(jobId);
+        distributionJobEntity.setBlackDuckJobDetails(new BlackDuckJobDetailsEntity(jobId, 3L, true, "*", "*"));
+
+        Page<DistributionJobEntity> page = new PageImpl<>(List.of(distributionJobEntity));
+        Mockito.when(distributionJobRepository.findByChannelDescriptorNamesAndSearchTerm(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(page);
+
+        AlertPagedModel<DistributionJobModel> pageOfJobs = jobAccessor.getPageOfJobs(0, 10, "test-search-term", "name", "asc", List.of(providerKey.getUniversalKey()));
 
         assertEquals(1, pageOfJobs.getTotalPages());
         List<DistributionJobModel> models = pageOfJobs.getModels();
@@ -312,7 +333,7 @@ class StaticJobAccessorTest {
         Page<DistributionJobEntity> page = new PageImpl<>(List.of(distributionJobEntity));
         Mockito.when(distributionJobRepository.findByChannelDescriptorNameIn(Mockito.any(), Mockito.any())).thenReturn(page);
 
-        AlertPagedModel<DistributionJobModel> pageOfJobs = jobAccessor.getPageOfJobs(0, 10, " ", List.of(providerKey.getUniversalKey()));
+        AlertPagedModel<DistributionJobModel> pageOfJobs = jobAccessor.getPageOfJobs(0, 10, " ", null, null, List.of(providerKey.getUniversalKey()));
 
         assertEquals(1, pageOfJobs.getTotalPages());
         List<DistributionJobModel> models = pageOfJobs.getModels();
@@ -324,7 +345,7 @@ class StaticJobAccessorTest {
 
     @Test
     void getPageOfJobsExcludedDescriptorTest() {
-        AlertPagedModel<DistributionJobModel> pageOfJobs = jobAccessor.getPageOfJobs(0, 10, null, List.of("invalid-descriptor-key"));
+        AlertPagedModel<DistributionJobModel> pageOfJobs = jobAccessor.getPageOfJobs(0, 10, null, null, null, List.of("invalid-descriptor-key"));
 
         assertEquals(0, pageOfJobs.getTotalPages());
         assertEquals(0, pageOfJobs.getCurrentPage());

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/action/JiraServerGlobalCrudActions.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/action/JiraServerGlobalCrudActions.java
@@ -43,8 +43,10 @@ public class JiraServerGlobalCrudActions {
         return configurationHelper.getOne(() -> configurationAccessor.getConfiguration(id));
     }
 
-    public ActionResponse<AlertPagedModel<JiraServerGlobalConfigModel>> getPaged(int page, int size) {
-        return configurationHelper.getPage(() -> configurationAccessor.getConfigurationPage(page, size));
+    public ActionResponse<AlertPagedModel<JiraServerGlobalConfigModel>> getPaged(
+        int page, int size, String searchTerm, String sortName, String sortOrder
+    ) {
+        return configurationHelper.getPage(() -> configurationAccessor.getConfigurationPage(page, size, searchTerm, sortName, sortOrder));
     }
 
     public ActionResponse<JiraServerGlobalConfigModel> create(JiraServerGlobalConfigModel resource) {

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/database/configuration/JiraServerConfigurationRepository.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/database/configuration/JiraServerConfigurationRepository.java
@@ -10,7 +10,11 @@ package com.synopsys.integration.alert.channel.jira.server.database.configuratio
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JiraServerConfigurationRepository extends JpaRepository<JiraServerConfigurationEntity, UUID> {
     Optional<JiraServerConfigurationEntity> findByName(String name);
@@ -18,4 +22,12 @@ public interface JiraServerConfigurationRepository extends JpaRepository<JiraSer
     boolean existsByName(String name);
 
     boolean existsByConfigurationId(UUID uuid);
+
+    @Query("SELECT jiraEntity FROM JiraServerConfigurationEntity jiraEntity"
+        + " WHERE jiraEntity.name LIKE %:searchTerm%"
+        + "   OR jiraEntity.url LIKE %:searchTerm%"
+        + "   OR COALESCE(to_char(jiraEntity.createdAt, 'MM/DD/YYYY, HH24:MI:SS'), '') LIKE %:searchTerm%"
+        + "   OR (jiraEntity.lastUpdated != NULL AND COALESCE(to_char(jiraEntity.lastUpdated, 'MM/DD/YYYY, HH24:MI:SS'), '') LIKE %:searchTerm%)"
+    )
+    Page<JiraServerConfigurationEntity> findBySearchTerm(@Param("searchTerm") String searchTerm, Pageable pageable);
 }

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerGlobalConfigController.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerGlobalConfigController.java
@@ -54,8 +54,14 @@ public class JiraServerGlobalConfigController implements StaticConfigResourceCon
     }
 
     @Override
-    public AlertPagedModel<JiraServerGlobalConfigModel> getPage(Integer pageNumber, Integer pageSize, String searchTerm) {
-        return ResponseFactory.createContentResponseFromAction(configActions.getPaged(pageNumber, pageSize));
+    public AlertPagedModel<JiraServerGlobalConfigModel> getPage(
+        Integer pageNumber,
+        Integer pageSize,
+        String searchTerm,
+        String sortName,
+        String sortOrder
+    ) {
+        return ResponseFactory.createContentResponseFromAction(configActions.getPaged(pageNumber, pageSize, searchTerm, sortName, sortOrder));
     }
 
     @Override

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/action/JiraServerGlobalCrudActionsTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/action/JiraServerGlobalCrudActionsTest.java
@@ -29,7 +29,7 @@ import com.synopsys.integration.alert.descriptor.api.JiraServerChannelKey;
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
 import com.synopsys.integration.alert.test.common.AuthenticationTestUtils;
 
-public class JiraServerGlobalCrudActionsTest {
+class JiraServerGlobalCrudActionsTest {
     private final String CREATED_AT = String.valueOf(DateUtils.createCurrentDateTimestamp().minusMinutes(5L));
     private final String UPDATED_AT = String.valueOf(DateUtils.createCurrentDateTimestamp());
     private final String URL = "https://someUrl";
@@ -75,10 +75,16 @@ public class JiraServerGlobalCrudActionsTest {
         );
 
         JiraServerGlobalConfigAccessor configAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
-        Mockito.when(configAccessor.getConfigurationPage(AlertPagedModel.DEFAULT_PAGE_NUMBER, AlertPagedModel.DEFAULT_PAGE_SIZE)).thenReturn(alertPagedModel);
+        Mockito.when(configAccessor.getConfigurationPage(AlertPagedModel.DEFAULT_PAGE_NUMBER, AlertPagedModel.DEFAULT_PAGE_SIZE, null, null, null)).thenReturn(alertPagedModel);
 
         JiraServerGlobalCrudActions crudActions = new JiraServerGlobalCrudActions(authorizationManager, configAccessor, createValidator());
-        ActionResponse<AlertPagedModel<JiraServerGlobalConfigModel>> actionResponse = crudActions.getPaged(AlertPagedModel.DEFAULT_PAGE_NUMBER, AlertPagedModel.DEFAULT_PAGE_SIZE);
+        ActionResponse<AlertPagedModel<JiraServerGlobalConfigModel>> actionResponse = crudActions.getPaged(
+            AlertPagedModel.DEFAULT_PAGE_NUMBER,
+            AlertPagedModel.DEFAULT_PAGE_SIZE,
+            null,
+            null,
+            null
+        );
 
         assertTrue(actionResponse.isSuccessful());
         assertTrue(actionResponse.hasContent());
@@ -88,6 +94,127 @@ public class JiraServerGlobalCrudActionsTest {
         AlertPagedModel<JiraServerGlobalConfigModel> pagedModel = actionResponse.getContent().get();
         assertEquals(1, pagedModel.getModels().size());
         assertModelObfuscated(pagedModel.getModels().get(0));
+    }
+
+    @Test
+    void getPagedSearchTermTest() {
+        JiraServerGlobalConfigModel jiraServerGlobalConfigModel = createJiraServerGlobalConfigModel(id);
+        AlertPagedModel<JiraServerGlobalConfigModel> alertPagedModel = new AlertPagedModel<>(
+            1,
+            AlertPagedModel.DEFAULT_PAGE_NUMBER,
+            AlertPagedModel.DEFAULT_PAGE_SIZE,
+            List.of(jiraServerGlobalConfigModel)
+        );
+
+        JiraServerGlobalConfigAccessor configAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
+        Mockito.when(configAccessor.getConfigurationPage(AlertPagedModel.DEFAULT_PAGE_NUMBER, AlertPagedModel.DEFAULT_PAGE_SIZE, null, null, null)).thenReturn(alertPagedModel);
+
+        JiraServerGlobalCrudActions crudActions = new JiraServerGlobalCrudActions(authorizationManager, configAccessor, createValidator());
+        ActionResponse<AlertPagedModel<JiraServerGlobalConfigModel>> actionResponse = crudActions.getPaged(
+            AlertPagedModel.DEFAULT_PAGE_NUMBER,
+            AlertPagedModel.DEFAULT_PAGE_SIZE,
+            null,
+            null,
+            null
+        );
+
+        assertTrue(actionResponse.isSuccessful());
+        assertTrue(actionResponse.hasContent());
+        assertEquals(HttpStatus.OK, actionResponse.getHttpStatus());
+
+        assertTrue(actionResponse.getContent().isPresent());
+        AlertPagedModel<JiraServerGlobalConfigModel> pagedModel = actionResponse.getContent().get();
+        assertEquals(1, pagedModel.getModels().size());
+        assertModelObfuscated(pagedModel.getModels().get(0));
+    }
+
+    @Test
+    void getPagedSortAscendingTest() {
+        JiraServerGlobalConfigModel jiraServerGlobalConfigModel = createJiraServerGlobalConfigModel(id);
+        JiraServerGlobalConfigModel jiraServerGlobalConfigModel2 = new JiraServerGlobalConfigModel(
+            String.valueOf(UUID.randomUUID()),
+            "Another Job",
+            CREATED_AT,
+            UPDATED_AT,
+            URL,
+            USER_NAME,
+            PASSWORD,
+            Boolean.TRUE,
+            Boolean.TRUE
+        );
+        AlertPagedModel<JiraServerGlobalConfigModel> alertPagedModel = new AlertPagedModel<>(
+            1,
+            AlertPagedModel.DEFAULT_PAGE_NUMBER,
+            AlertPagedModel.DEFAULT_PAGE_SIZE,
+            List.of(jiraServerGlobalConfigModel2, jiraServerGlobalConfigModel)
+        );
+
+        JiraServerGlobalConfigAccessor configAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
+        Mockito.when(configAccessor.getConfigurationPage(AlertPagedModel.DEFAULT_PAGE_NUMBER, AlertPagedModel.DEFAULT_PAGE_SIZE, "", "name", "asc")).thenReturn(alertPagedModel);
+
+        JiraServerGlobalCrudActions crudActions = new JiraServerGlobalCrudActions(authorizationManager, configAccessor, createValidator());
+        ActionResponse<AlertPagedModel<JiraServerGlobalConfigModel>> actionResponse = crudActions.getPaged(
+            AlertPagedModel.DEFAULT_PAGE_NUMBER,
+            AlertPagedModel.DEFAULT_PAGE_SIZE,
+            "",
+            "name",
+            "asc"
+        );
+
+        assertTrue(actionResponse.isSuccessful());
+        assertTrue(actionResponse.hasContent());
+        assertEquals(HttpStatus.OK, actionResponse.getHttpStatus());
+
+        assertTrue(actionResponse.getContent().isPresent());
+        AlertPagedModel<JiraServerGlobalConfigModel> pagedModel = actionResponse.getContent().get();
+        assertEquals(2, pagedModel.getModels().size());
+        assertEquals("Another Job", pagedModel.getModels().get(0).getName());
+        assertEquals(AlertRestConstants.DEFAULT_CONFIGURATION_NAME, pagedModel.getModels().get(1).getName());
+
+    }
+
+    @Test
+    void getPagedSortDescendingTest() {
+        JiraServerGlobalConfigModel jiraServerGlobalConfigModel = createJiraServerGlobalConfigModel(id);
+        JiraServerGlobalConfigModel jiraServerGlobalConfigModel2 = new JiraServerGlobalConfigModel(
+            String.valueOf(UUID.randomUUID()),
+            "Another Job",
+            CREATED_AT,
+            UPDATED_AT,
+            URL,
+            USER_NAME,
+            PASSWORD,
+            Boolean.TRUE,
+            Boolean.TRUE
+        );
+        AlertPagedModel<JiraServerGlobalConfigModel> alertPagedModel = new AlertPagedModel<>(
+            1,
+            AlertPagedModel.DEFAULT_PAGE_NUMBER,
+            AlertPagedModel.DEFAULT_PAGE_SIZE,
+            List.of(jiraServerGlobalConfigModel, jiraServerGlobalConfigModel2)
+        );
+
+        JiraServerGlobalConfigAccessor configAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
+        Mockito.when(configAccessor.getConfigurationPage(AlertPagedModel.DEFAULT_PAGE_NUMBER, AlertPagedModel.DEFAULT_PAGE_SIZE, "", "name", "desc")).thenReturn(alertPagedModel);
+
+        JiraServerGlobalCrudActions crudActions = new JiraServerGlobalCrudActions(authorizationManager, configAccessor, createValidator());
+        ActionResponse<AlertPagedModel<JiraServerGlobalConfigModel>> actionResponse = crudActions.getPaged(
+            AlertPagedModel.DEFAULT_PAGE_NUMBER,
+            AlertPagedModel.DEFAULT_PAGE_SIZE,
+            "",
+            "name",
+            "desc"
+        );
+
+        assertTrue(actionResponse.isSuccessful());
+        assertTrue(actionResponse.hasContent());
+        assertEquals(HttpStatus.OK, actionResponse.getHttpStatus());
+
+        assertTrue(actionResponse.getContent().isPresent());
+        AlertPagedModel<JiraServerGlobalConfigModel> pagedModel = actionResponse.getContent().get();
+        assertEquals(2, pagedModel.getModels().size());
+        assertEquals(AlertRestConstants.DEFAULT_CONFIGURATION_NAME, pagedModel.getModels().get(0).getName());
+        assertEquals("Another Job", pagedModel.getModels().get(1).getName());
     }
 
     @Test

--- a/src/test/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerGlobalConfigControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerGlobalConfigControllerTestIT.java
@@ -29,7 +29,7 @@ import com.synopsys.integration.alert.util.AlertIntegrationTest;
 import com.synopsys.integration.alert.util.AlertIntegrationTestConstants;
 
 @AlertIntegrationTest
-public class JiraServerGlobalConfigControllerTestIT {
+class JiraServerGlobalConfigControllerTestIT {
     private static final MediaType MEDIA_TYPE = new MediaType(MediaType.APPLICATION_JSON.getType(), MediaType.APPLICATION_JSON.getSubtype(), StandardCharsets.UTF_8);
     private static final String REQUEST_URL = AlertRestConstants.JIRA_SERVER_CONFIGURATION_PATH;
 
@@ -51,7 +51,7 @@ public class JiraServerGlobalConfigControllerTestIT {
 
     @AfterEach
     public void cleanup() {
-        jiraServerGlobalConfigAccessor.getConfigurationPage(0, 100)
+        jiraServerGlobalConfigAccessor.getConfigurationPage(0, 100, null, null, null)
             .getModels()
             .stream()
             .map(JiraServerGlobalConfigModel::getId)
@@ -61,7 +61,7 @@ public class JiraServerGlobalConfigControllerTestIT {
 
     @Test
     @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
-    public void verifyGetOneEndpointTest() throws Exception {
+    void verifyGetOneEndpointTest() throws Exception {
         JiraServerGlobalConfigModel jiraServerGlobalConfigModel = saveConfigModel(createConfigModel(UUID.randomUUID()));
         String urlPath = REQUEST_URL + "/" + jiraServerGlobalConfigModel.getId();
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(urlPath)
@@ -72,7 +72,7 @@ public class JiraServerGlobalConfigControllerTestIT {
 
     @Test
     @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
-    public void verifyGetPageEndpointTest() throws Exception {
+    void verifyGetPageEndpointTest() throws Exception {
         int pageNumber = 0;
         int pageSize = 10;
 
@@ -85,7 +85,46 @@ public class JiraServerGlobalConfigControllerTestIT {
 
     @Test
     @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
-    public void verifyCreateEndpointTest() throws Exception {
+    void verifyGetPageWithSearchTermEndpointTest() throws Exception {
+        int pageNumber = 0;
+        int pageSize = 10;
+
+        String urlPath = String.format("%s?pageNumber=%s&pageSize=%s&searchTerm=aname&sortName=name&sortOrder=asc", REQUEST_URL, pageNumber, pageSize);
+        MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(urlPath)
+            .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTestConstants.ROLE_ALERT_ADMIN))
+            .with(SecurityMockMvcRequestPostProcessors.csrf());
+        mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
+    void verifyGetPageWithSortAscendingEndpointTest() throws Exception {
+        int pageNumber = 0;
+        int pageSize = 10;
+
+        String urlPath = String.format("%s?pageNumber=%s&pageSize=%s&sortName=name&sortOrder=asc", REQUEST_URL, pageNumber, pageSize);
+        MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(urlPath)
+            .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTestConstants.ROLE_ALERT_ADMIN))
+            .with(SecurityMockMvcRequestPostProcessors.csrf());
+        mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
+    void verifyGetPageWithSortDescendingEndpointTest() throws Exception {
+        int pageNumber = 0;
+        int pageSize = 10;
+
+        String urlPath = String.format("%s?pageNumber=%s&pageSize=%s&sortName=name&sortOrder=desc", REQUEST_URL, pageNumber, pageSize);
+        MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(urlPath)
+            .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTestConstants.ROLE_ALERT_ADMIN))
+            .with(SecurityMockMvcRequestPostProcessors.csrf());
+        mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
+    void verifyCreateEndpointTest() throws Exception {
         String urlPath = REQUEST_URL;
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(urlPath)
             .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTestConstants.ROLE_ALERT_ADMIN))
@@ -101,7 +140,7 @@ public class JiraServerGlobalConfigControllerTestIT {
 
     @Test
     @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
-    public void verifyUpdateEndpointTest() throws Exception {
+    void verifyUpdateEndpointTest() throws Exception {
         JiraServerGlobalConfigModel configModel = createConfigModel(UUID.randomUUID());
         JiraServerGlobalConfigModel jiraServerGlobalConfigModel = saveConfigModel(configModel);
 
@@ -118,7 +157,7 @@ public class JiraServerGlobalConfigControllerTestIT {
 
     @Test
     @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
-    public void verifyValidateEndpointTest() throws Exception {
+    void verifyValidateEndpointTest() throws Exception {
         String urlPath = REQUEST_URL + "/validate";
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(urlPath)
             .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTestConstants.ROLE_ALERT_ADMIN))
@@ -134,7 +173,7 @@ public class JiraServerGlobalConfigControllerTestIT {
 
     @Test
     @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
-    public void verifyDeleteEndpointTest() throws Exception {
+    void verifyDeleteEndpointTest() throws Exception {
         JiraServerGlobalConfigModel jiraServerGlobalConfigModel = saveConfigModel(createConfigModel(UUID.randomUUID()));
 
         String urlPath = REQUEST_URL + "/" + jiraServerGlobalConfigModel.getId();
@@ -148,7 +187,7 @@ public class JiraServerGlobalConfigControllerTestIT {
     @Disabled("Test action not yet implemented")
     @Test
     @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
-    public void verifyTestEndpointTest() throws Exception {
+    void verifyTestEndpointTest() throws Exception {
         String urlPath = REQUEST_URL + "/test";
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(urlPath)
             .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTestConstants.ROLE_ALERT_ADMIN))
@@ -164,7 +203,7 @@ public class JiraServerGlobalConfigControllerTestIT {
 
     @Test
     @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
-    public void verifyDisablePluginEndpointTest() throws Exception {
+    void verifyDisablePluginEndpointTest() throws Exception {
         String urlPath = REQUEST_URL + "/install-plugin";
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(urlPath)
             .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTestConstants.ROLE_ALERT_ADMIN))

--- a/src/test/java/com/synopsys/integration/alert/database/api/StaticJobAccessorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/database/api/StaticJobAccessorTestIT.java
@@ -4,10 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -25,17 +27,16 @@ import com.synopsys.integration.alert.common.persistence.model.job.details.JiraC
 import com.synopsys.integration.alert.common.persistence.model.job.details.JiraServerJobDetailsModel;
 import com.synopsys.integration.alert.common.persistence.model.job.details.MSTeamsJobDetailsModel;
 import com.synopsys.integration.alert.common.persistence.model.job.details.SlackJobDetailsModel;
-import com.synopsys.integration.alert.descriptor.api.AzureBoardsChannelKey;
-import com.synopsys.integration.alert.descriptor.api.EmailChannelKey;
-import com.synopsys.integration.alert.descriptor.api.JiraServerChannelKey;
-import com.synopsys.integration.alert.descriptor.api.MsTeamsKey;
-import com.synopsys.integration.alert.descriptor.api.SlackChannelKey;
+import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
+import com.synopsys.integration.alert.descriptor.api.BlackDuckProviderKey;
 import com.synopsys.integration.alert.descriptor.api.model.ChannelKey;
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
+import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
 import com.synopsys.integration.alert.util.AlertIntegrationTest;
 import com.synopsys.integration.blackduck.api.manual.enumeration.NotificationType;
 
 @AlertIntegrationTest
-public class StaticJobAccessorTestIT {
+class StaticJobAccessorTestIT {
     private static final List<UUID> createdJobIds = new LinkedList<>();
 
     @Autowired
@@ -49,7 +50,7 @@ public class StaticJobAccessorTestIT {
 
     @Test
     @Transactional
-    public void verifyAzureSavesTest() {
+    void verifyAzureSavesTest() {
         AzureBoardsJobDetailsModel azureBoardsJobDetailsModel = new AzureBoardsJobDetailsModel(
             UUID.randomUUID(),
             true,
@@ -59,12 +60,12 @@ public class StaticJobAccessorTestIT {
             "workItemReopenState"
         );
 
-        DistributionJobRequestModel jobRequestModel = createJobRequestModel(azureBoardsJobDetailsModel, new AzureBoardsChannelKey());
+        DistributionJobRequestModel jobRequestModel = createJobRequestModel(azureBoardsJobDetailsModel, ChannelKeys.AZURE_BOARDS);
         createAndAssertJob(jobRequestModel);
     }
 
     @Test
-    public void verifyJiraServerSavesTest() {
+    void verifyJiraServerSavesTest() {
         JiraServerJobDetailsModel jiraServerJobDetailsModel = new JiraServerJobDetailsModel(
             UUID.randomUUID(),
             true,
@@ -77,12 +78,12 @@ public class StaticJobAccessorTestIT {
             "issueSummary"
         );
 
-        DistributionJobRequestModel jobRequestModel = createJobRequestModel(jiraServerJobDetailsModel, new JiraServerChannelKey());
+        DistributionJobRequestModel jobRequestModel = createJobRequestModel(jiraServerJobDetailsModel, ChannelKeys.JIRA_SERVER);
         createAndAssertJob(jobRequestModel);
     }
 
     @Test
-    public void verifyJiraCloudSavesTest() {
+    void verifyJiraCloudSavesTest() {
         JiraCloudJobDetailsModel jiraCloudJobDetailsModel = new JiraCloudJobDetailsModel(
             UUID.randomUUID(),
             true,
@@ -95,12 +96,12 @@ public class StaticJobAccessorTestIT {
             "issueSummary"
         );
 
-        DistributionJobRequestModel jobRequestModel = createJobRequestModel(jiraCloudJobDetailsModel, new JiraServerChannelKey());
+        DistributionJobRequestModel jobRequestModel = createJobRequestModel(jiraCloudJobDetailsModel, ChannelKeys.JIRA_CLOUD);
         createAndAssertJob(jobRequestModel);
     }
 
     @Test
-    public void verifyEmailSavesTest() {
+    void verifyEmailSavesTest() {
         EmailJobDetailsModel emailJobDetailsModel = new EmailJobDetailsModel(
             UUID.randomUUID(),
             "subjectLine",
@@ -110,12 +111,12 @@ public class StaticJobAccessorTestIT {
             List.of()
         );
 
-        DistributionJobRequestModel jobRequestModel = createJobRequestModel(emailJobDetailsModel, new EmailChannelKey());
+        DistributionJobRequestModel jobRequestModel = createJobRequestModel(emailJobDetailsModel, ChannelKeys.EMAIL);
         createAndAssertJob(jobRequestModel);
     }
 
     @Test
-    public void verifySlackSavesTest() {
+    void verifySlackSavesTest() {
         SlackJobDetailsModel slackJobDetailsModel = new SlackJobDetailsModel(
             UUID.randomUUID(),
             "webhook",
@@ -123,19 +124,95 @@ public class StaticJobAccessorTestIT {
             "channelUsername"
         );
 
-        DistributionJobRequestModel jobRequestModel = createJobRequestModel(slackJobDetailsModel, new SlackChannelKey());
+        DistributionJobRequestModel jobRequestModel = createJobRequestModel(slackJobDetailsModel, ChannelKeys.SLACK);
         createAndAssertJob(jobRequestModel);
     }
 
     @Test
-    public void verifyMSTeamsSavesTest() {
+    void verifyMSTeamsSavesTest() {
         MSTeamsJobDetailsModel msTeamsJobDetailsModel = new MSTeamsJobDetailsModel(
             UUID.randomUUID(),
             "webhook"
         );
 
-        DistributionJobRequestModel jobRequestModel = createJobRequestModel(msTeamsJobDetailsModel, new MsTeamsKey());
+        DistributionJobRequestModel jobRequestModel = createJobRequestModel(msTeamsJobDetailsModel, ChannelKeys.MS_TEAMS);
         createAndAssertJob(jobRequestModel);
+    }
+
+    @Test
+    void verifySearchAndAscendingSortTest() {
+        List<String> descriptorNames = createMultipleJobs().stream()
+            .map(DescriptorKey::getUniversalKey)
+            .collect(Collectors.toList());
+
+        AlertPagedModel<DistributionJobModel> pageOfJobs = staticJobAccessor.getPageOfJobs(0, 10, "", "name", "asc", descriptorNames);
+        assertEquals(3, pageOfJobs.getModels().size());
+        assertTrue(pageOfJobs.getModels().get(0).getDistributionJobDetails().isA(ChannelKeys.EMAIL));
+        assertTrue(pageOfJobs.getModels().get(1).getDistributionJobDetails().isA(ChannelKeys.MS_TEAMS));
+        assertTrue(pageOfJobs.getModels().get(2).getDistributionJobDetails().isA(ChannelKeys.SLACK));
+    }
+
+    @Test
+    void verifySearchAndDescendingSortTest() {
+        List<String> descriptorNames = createMultipleJobs().stream()
+            .map(DescriptorKey::getUniversalKey)
+            .collect(Collectors.toList());
+
+        AlertPagedModel<DistributionJobModel> pageOfJobs = staticJobAccessor.getPageOfJobs(0, 10, "", "name", "desc", descriptorNames);
+        assertEquals(3, pageOfJobs.getModels().size());
+        assertTrue(pageOfJobs.getModels().get(2).getDistributionJobDetails().isA(ChannelKeys.EMAIL));
+        assertTrue(pageOfJobs.getModels().get(1).getDistributionJobDetails().isA(ChannelKeys.MS_TEAMS));
+        assertTrue(pageOfJobs.getModels().get(0).getDistributionJobDetails().isA(ChannelKeys.SLACK));
+    }
+
+    @Test
+    void verifySearchAndSortTest() {
+        List<String> descriptorNames = createMultipleJobs().stream()
+            .map(DescriptorKey::getUniversalKey)
+            .collect(Collectors.toList());
+
+        AlertPagedModel<DistributionJobModel> pageOfJobs = staticJobAccessor.getPageOfJobs(0, 10, "MS Teams", "name", "desc", descriptorNames);
+        assertEquals(1, pageOfJobs.getModels().size());
+        assertTrue(pageOfJobs.getModels().get(0).getDistributionJobDetails().isA(ChannelKeys.MS_TEAMS));
+    }
+
+    private List<DescriptorKey> createMultipleJobs() {
+        List<DescriptorKey> descriptorKeys = new ArrayList<>();
+        descriptorKeys.add(new BlackDuckProviderKey());
+        MSTeamsJobDetailsModel msTeamsJobDetailsModel = new MSTeamsJobDetailsModel(
+            UUID.randomUUID(),
+            "webhook"
+        );
+
+        DistributionJobRequestModel jobRequestModel = createJobRequestModel(msTeamsJobDetailsModel, ChannelKeys.MS_TEAMS);
+        descriptorKeys.add(ChannelKeys.MS_TEAMS);
+        createAndAssertJob(jobRequestModel);
+
+        SlackJobDetailsModel slackJobDetailsModel = new SlackJobDetailsModel(
+            UUID.randomUUID(),
+            "webhook",
+            "channelName",
+            "channelUsername"
+        );
+
+        jobRequestModel = createJobRequestModel(slackJobDetailsModel, ChannelKeys.SLACK);
+        descriptorKeys.add(ChannelKeys.SLACK);
+        createAndAssertJob(jobRequestModel);
+
+        EmailJobDetailsModel emailJobDetailsModel = new EmailJobDetailsModel(
+            UUID.randomUUID(),
+            "subjectLine",
+            false,
+            false,
+            "attachmentFileType",
+            List.of()
+        );
+
+        jobRequestModel = createJobRequestModel(emailJobDetailsModel, ChannelKeys.EMAIL);
+        descriptorKeys.add(ChannelKeys.EMAIL);
+        createAndAssertJob(jobRequestModel);
+
+        return descriptorKeys;
     }
 
     private void createAndAssertJob(DistributionJobRequestModel jobRequestModel) {

--- a/web/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigActions.java
+++ b/web/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigActions.java
@@ -123,8 +123,11 @@ public class JobConfigActions extends AbstractJobResourceActions {
     }
 
     @Override
-    public final ActionResponse<JobPagedModel> readPageWithoutChecks(Integer pageNumber, Integer pageSize, String searchTerm, Collection<String> permittedDescriptorsForSession) {
-        AlertPagedModel<DistributionJobModel> pageOfJobs = jobAccessor.getPageOfJobs(pageNumber, pageSize, searchTerm, permittedDescriptorsForSession);
+    public final ActionResponse<JobPagedModel> readPageWithoutChecks(
+        Integer pageNumber, Integer pageSize, String searchTerm, String sortName,
+        String sortOrder, Collection<String> permittedDescriptorsForSession
+    ) {
+        AlertPagedModel<DistributionJobModel> pageOfJobs = jobAccessor.getPageOfJobs(pageNumber, pageSize, searchTerm, sortName, sortOrder, permittedDescriptorsForSession);
         List<DistributionJobModel> distributionJobModels = pageOfJobs.getModels();
 
         List<JobFieldModel> jobFieldModels = new ArrayList<>(distributionJobModels.size());

--- a/web/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigController.java
+++ b/web/src/main/java/com/synopsys/integration/alert/web/api/job/JobConfigController.java
@@ -51,8 +51,8 @@ public class JobConfigController implements BaseJobResourceController, ReadPageC
     }
 
     @Override
-    public JobPagedModel getPage(Integer pageNumber, Integer pageSize, String searchTerm) {
-        return ResponseFactory.createContentResponseFromAction(jobConfigActions.getPage(pageNumber, pageSize, searchTerm));
+    public JobPagedModel getPage(Integer pageNumber, Integer pageSize, String searchTerm, String sortName, String sortOrder) {
+        return ResponseFactory.createContentResponseFromAction(jobConfigActions.getPage(pageNumber, pageSize, searchTerm, sortName, sortOrder));
     }
 
     @Override

--- a/web/src/test/java/com/synopsys/integration/alert/web/api/job/JobConfigActionsTest.java
+++ b/web/src/test/java/com/synopsys/integration/alert/web/api/job/JobConfigActionsTest.java
@@ -67,7 +67,7 @@ import com.synopsys.integration.rest.HttpMethod;
 import com.synopsys.integration.rest.HttpUrl;
 import com.synopsys.integration.rest.exception.IntegrationRestException;
 
-public class JobConfigActionsTest {
+class JobConfigActionsTest {
     private static final String DESCRIPTOR_KEY_STRING = "descriptorName";
     private static final String FIELD_VALUE = "fieldValue";
     private static final DescriptorType DESCRIPTOR_TYPE = DescriptorType.CHANNEL;
@@ -136,7 +136,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void createTest() throws Exception {
+    void createTest() throws Exception {
         Mockito.when(mockedFieldModelProcessor.performBeforeSaveAction(Mockito.any())).thenReturn(fieldModel);
         Mockito.when(mockedConfigurationFieldModelConverter.convertToConfigurationFieldModelMap(Mockito.any())).thenReturn(Map.of("Key", configurationFieldModel));
         Mockito.when(mockedConfigurationFieldModelConverter.convertToFieldModel(Mockito.any())).thenReturn(fieldModel);
@@ -151,7 +151,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void createServerErrorTest() throws Exception {
+    void createServerErrorTest() throws Exception {
         Mockito.doThrow(new AlertException("Exception for test")).when(mockedFieldModelProcessor).performBeforeSaveAction(Mockito.any());
 
         ActionResponse<JobFieldModel> jobFieldModelActionResponse = defaultJobConfigActions.create(jobFieldModel);
@@ -162,7 +162,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void getPageTest() throws Exception {
+    void getPageTest() throws Exception {
         int totalPages = 1;
         int pageNumber = 0;
         int pageSize = 10;
@@ -170,10 +170,11 @@ public class JobConfigActionsTest {
         AlertPagedModel<DistributionJobModel> pageOfJobs = new AlertPagedModel<>(totalPages, pageNumber, pageSize, List.of(distributionJobModel));
 
         Mockito.when(mockedDescriptorAccessor.getRegisteredDescriptors()).thenReturn(List.of(registeredDescriptorModel));
-        Mockito.when(mockedJobAccessor.getPageOfJobs(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyCollection())).thenReturn(pageOfJobs);
+        Mockito.when(mockedJobAccessor.getPageOfJobs(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyCollection()))
+            .thenReturn(pageOfJobs);
         Mockito.when(mockedConfigurationFieldModelConverter.convertToFieldModel(Mockito.any())).thenReturn(fieldModel);
 
-        ActionResponse<JobPagedModel> jobPagedModelActionResponse = defaultJobConfigActions.getPage(pageNumber, pageSize, "");
+        ActionResponse<JobPagedModel> jobPagedModelActionResponse = defaultJobConfigActions.getPage(pageNumber, pageSize, "", "", "");
 
         assertTrue(jobPagedModelActionResponse.isSuccessful());
         assertTrue(jobPagedModelActionResponse.hasContent());
@@ -181,7 +182,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void getOneTest() {
+    void getOneTest() {
         Mockito.when(mockedJobAccessor.getJobById(Mockito.any())).thenReturn(Optional.of(distributionJobModel));
 
         ActionResponse<JobFieldModel> jobFieldModelActionResponse = defaultJobConfigActions.getOne(jobId);
@@ -192,7 +193,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void getOneErrorTest() throws Exception {
+    void getOneErrorTest() throws Exception {
         Mockito.doThrow(new AlertException("Exception for Alert")).when(mockedFieldModelProcessor).performAfterReadAction(Mockito.any());
 
         ActionResponse<JobFieldModel> jobFieldModelActionResponse = defaultJobConfigActions.getOne(jobId);
@@ -203,7 +204,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void updateTest() throws Exception {
+    void updateTest() throws Exception {
         Mockito.when(mockedJobAccessor.getJobById(jobId)).thenReturn(Optional.of(distributionJobModel));
         Mockito.when(mockedJobAccessor.updateJob(Mockito.eq(distributionJobModel.getJobId()), Mockito.any())).thenReturn(distributionJobModel);
         Mockito.when(mockedFieldModelProcessor.performBeforeUpdateAction(Mockito.any())).thenReturn(fieldModel);
@@ -218,7 +219,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void updateServerErrorTest() throws Exception {
+    void updateServerErrorTest() throws Exception {
         Mockito.when(mockedJobAccessor.getJobById(jobId)).thenReturn(Optional.of(distributionJobModel));
         Mockito.doThrow(new AlertConfigurationException("Exception for Alert test")).when(mockedFieldModelProcessor).performBeforeUpdateAction(Mockito.any());
 
@@ -230,7 +231,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void deleteTest() throws Exception {
+    void deleteTest() throws Exception {
         Mockito.when(mockedJobAccessor.getJobById(Mockito.any())).thenReturn(Optional.of(distributionJobModel));
         Mockito.when(mockedFieldModelProcessor.performBeforeDeleteAction(Mockito.any())).thenReturn(fieldModel);
 
@@ -245,7 +246,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void deleteServerErrorTest() throws Exception {
+    void deleteServerErrorTest() throws Exception {
         Mockito.when(mockedJobAccessor.getJobById(Mockito.any())).thenReturn(Optional.of(distributionJobModel));
         Mockito.doThrow(new AlertException("Exception for Alert test")).when(mockedFieldModelProcessor).performBeforeDeleteAction(Mockito.any());
 
@@ -257,7 +258,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void testTest() throws Exception {
+    void testTest() throws Exception {
         JobConfigActions jobConfigActionsForTest = new JobConfigActions(
             mockedAuthorizationManager,
             mockedDescriptorAccessor,
@@ -290,13 +291,14 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void testWithProviderWarningsTest() throws Exception {
+    void testWithProviderWarningsTest() throws Exception {
         fieldModel.setId("testID");
         Mockito.when(mockedDescriptorProcessor.retrieveDescriptor(Mockito.any())).thenReturn(Optional.of(descriptor));
         Mockito.when(mockedFieldModelProcessor.createCustomMessageFieldModel(Mockito.any())).thenReturn(fieldModel);
 
         Mockito.when(mockedDescriptorProcessor.retrieveTestAction(Mockito.any())).thenReturn(Optional.of(createTestActionWithErrors()));
-        Mockito.when(mockedConfigurationFieldModelConverter.convertToConfigurationFieldModelMap(Mockito.any())).thenReturn(Map.of(ChannelDescriptor.KEY_PROVIDER_TYPE, configurationFieldModel));
+        Mockito.when(mockedConfigurationFieldModelConverter.convertToConfigurationFieldModelMap(Mockito.any()))
+            .thenReturn(Map.of(ChannelDescriptor.KEY_PROVIDER_TYPE, configurationFieldModel));
         Mockito.when(mockedDescriptorProcessor.retrieveTestAction(Mockito.any(), Mockito.any())).thenReturn(Optional.of(createTestActionWithErrors()));
 
         ValidationActionResponse validationActionResponse = defaultJobConfigActions.test(jobFieldModel);
@@ -310,7 +312,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void testBadRequestTest() {
+    void testBadRequestTest() {
         fieldModel.setId("testID");
 
         ValidationActionResponse validationActionResponse = defaultJobConfigActions.test(jobFieldModel);
@@ -323,11 +325,12 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void testAlertFieldExceptionTest() throws Exception {
+    void testAlertFieldExceptionTest() throws Exception {
         Mockito.when(mockedDescriptorProcessor.retrieveDescriptor(Mockito.any())).thenReturn(Optional.of(descriptor));
 
         AlertFieldStatus alertFieldStatus = AlertFieldStatus.error("fieldNameTest", "Alert Error Message");
-        Mockito.doThrow(new AlertFieldException("AlertFieldException for Alert test", List.of(alertFieldStatus))).when(mockedFieldModelProcessor).createCustomMessageFieldModel(Mockito.any());
+        Mockito.doThrow(new AlertFieldException("AlertFieldException for Alert test", List.of(alertFieldStatus))).when(mockedFieldModelProcessor)
+            .createCustomMessageFieldModel(Mockito.any());
 
         ValidationActionResponse validationActionResponse = defaultJobConfigActions.test(jobFieldModel);
 
@@ -339,7 +342,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void testIntegrationExceptionTest() throws Exception {
+    void testIntegrationExceptionTest() throws Exception {
         Mockito.when(mockedDescriptorProcessor.retrieveDescriptor(Mockito.any())).thenReturn(Optional.of(descriptor));
 
         Mockito.doThrow(new AlertException("IntegrationException for Alert test")).when(mockedFieldModelProcessor).createCustomMessageFieldModel(Mockito.any());
@@ -354,13 +357,14 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void testIntegrationRestExceptionTest() throws Exception {
+    void testIntegrationRestExceptionTest() throws Exception {
         fieldModel.setId("testID");
         Mockito.when(mockedDescriptorProcessor.retrieveDescriptor(Mockito.any())).thenReturn(Optional.of(descriptor));
         Mockito.when(mockedFieldModelProcessor.createCustomMessageFieldModel(Mockito.any())).thenReturn(fieldModel);
 
         Mockito.when(mockedDescriptorProcessor.retrieveTestAction(Mockito.any())).thenReturn(Optional.of(createTestActionWithErrors()));
-        Mockito.when(mockedConfigurationFieldModelConverter.convertToConfigurationFieldModelMap(Mockito.any())).thenReturn(Map.of(ChannelDescriptor.KEY_PROVIDER_TYPE, configurationFieldModel));
+        Mockito.when(mockedConfigurationFieldModelConverter.convertToConfigurationFieldModelMap(Mockito.any()))
+            .thenReturn(Map.of(ChannelDescriptor.KEY_PROVIDER_TYPE, configurationFieldModel));
         Mockito.when(mockedDescriptorProcessor.retrieveTestAction(Mockito.any(), Mockito.any())).thenReturn(Optional.of(createTestActionWithIntegrationRestException()));
 
         ValidationActionResponse validationActionResponse = defaultJobConfigActions.test(jobFieldModel);
@@ -373,7 +377,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void testExceptionTest() throws Exception {
+    void testExceptionTest() throws Exception {
         Mockito.when(mockedDescriptorProcessor.retrieveDescriptor(Mockito.any())).thenReturn(Optional.of(descriptor));
 
         Mockito.doThrow(new NullPointerException("RuntimeException for Alert test")).when(mockedFieldModelProcessor).createCustomMessageFieldModel(Mockito.any());
@@ -388,7 +392,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void oldValidateTest() {
+    void oldValidateTest() {
 
         ValidationActionResponse validationActionResponse = defaultJobConfigActions.validate(jobFieldModel);
 
@@ -400,7 +404,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void validateTest() {
+    void validateTest() {
         Descriptor descriptorWithValidator = createDescriptor(Optional::empty, () -> Optional.of(jobFieldModel -> Set.of()));
         JobConfigActions jobConfigActionsForTest = createJobConfigActions(new DescriptorMap(List.of(descriptorKey), List.of(descriptorWithValidator)), List.of());
 
@@ -414,7 +418,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void oldValidateBadRequestTest() {
+    void oldValidateBadRequestTest() {
         Mockito.when(mockedJobAccessor.getJobByName(Mockito.anyString())).thenReturn(Optional.of(distributionJobModel));
 
         ValidationActionResponse validationActionResponse = defaultJobConfigActions.validate(jobFieldModel);
@@ -427,7 +431,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void validateBadRequestTest() {
+    void validateBadRequestTest() {
         Descriptor descriptorWithValidator = createDescriptor(Optional::empty, () -> Optional.of(jobFieldModel -> Set.of()));
 
         JobConfigActions jobConfigActionsForTest = createJobConfigActions(new DescriptorMap(List.of(descriptorKey), List.of(descriptorWithValidator)), List.of());
@@ -444,7 +448,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void validateBadRequestWithFieldStatusTest() {
+    void validateBadRequestWithFieldStatusTest() {
         AlertFieldStatus alertFieldStatus = AlertFieldStatus.error("fieldNameTest", "Alert Error Message");
 
         Descriptor mockDescriptor = Mockito.mock(Descriptor.class);
@@ -454,7 +458,21 @@ public class JobConfigActionsTest {
         Mockito.when(mockDescriptorMap.getDescriptorKey(Mockito.anyString())).thenReturn(Optional.of(descriptorKey));
         Mockito.when(mockDescriptorMap.getDescriptor(descriptorKey)).thenReturn(Optional.of(mockDescriptor));
 
-        JobConfigActions testJobConfigActions = new JobConfigActions(mockedAuthorizationManager, null, null, mockedJobAccessor, null, null, null, null, null, mockDescriptorMap, null, List.of(), null);
+        JobConfigActions testJobConfigActions = new JobConfigActions(
+            mockedAuthorizationManager,
+            null,
+            null,
+            mockedJobAccessor,
+            null,
+            null,
+            null,
+            null,
+            null,
+            mockDescriptorMap,
+            null,
+            List.of(),
+            null
+        );
         ValidationActionResponse validationActionResponse = testJobConfigActions.validate(jobFieldModel);
 
         assertTrue(validationActionResponse.isSuccessful());
@@ -465,7 +483,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void validateJobsByIdTest() throws Exception {
+    void validateJobsByIdTest() throws Exception {
         JobIdsRequestModel jobIdsRequestModel = new JobIdsRequestModel(List.of(jobId));
         Mockito.when(mockedAuthorizationManager.anyReadPermission(Mockito.any())).thenReturn(true);
         Mockito.when(mockedConfigurationFieldModelConverter.convertToFieldModel(Mockito.any())).thenReturn(fieldModel);
@@ -479,7 +497,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void validateJobsByIdForbiddenTest() {
+    void validateJobsByIdForbiddenTest() {
         JobIdsRequestModel jobIdsRequestModel = new JobIdsRequestModel(List.of(jobId));
         Mockito.when(mockedAuthorizationManager.anyReadPermission(Mockito.any())).thenReturn(false);
 
@@ -491,7 +509,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void validateJobsByIdEmptyListTest() {
+    void validateJobsByIdEmptyListTest() {
         JobIdsRequestModel jobIdsRequestModel = new JobIdsRequestModel(List.of());
         Mockito.when(mockedAuthorizationManager.anyReadPermission(Mockito.any())).thenReturn(true);
 
@@ -503,7 +521,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void checkGlobalConfigExistsTest() {
+    void checkGlobalConfigExistsTest() {
         Mockito.when(mockedGlobalConfigExistsValidator.validate(Mockito.any())).thenReturn(Optional.empty());
 
         ActionResponse<String> actionResponse = defaultJobConfigActions.checkGlobalConfigExists(DESCRIPTOR_KEY_STRING);
@@ -514,7 +532,7 @@ public class JobConfigActionsTest {
     }
 
     @Test
-    public void checkGlobalConfigExistsBadRequestTest() {
+    void checkGlobalConfigExistsBadRequestTest() {
         String configMissingMessage = "configMissingMessageTest";
 
         Mockito.when(mockedGlobalConfigExistsValidator.validate(Mockito.any())).thenReturn(Optional.of(configMissingMessage));


### PR DESCRIPTION
This was already added to the master branch in PR 2054.  Back porting to v6.10.0

* feat: Add paging to the job and configuration accessor.

* refactor: Rename sortField to sortName.

* feat: Add search and sort to database query for jira server.

* chore: Clean up some code smells.

* test: Add tests for the search and sort of jobs.

* test: Add search and sort tests to crud actions.

* test: Add tests for search and sort.

* refactor: Encapsulate sort object creation.

* chore: Clean up code smells.

* chore: Adjust some formatting.
