### PR TITLE
jira server api fix

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/util/SortUtil.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/util/SortUtil.java
@@ -10,11 +10,12 @@ package com.synopsys.integration.alert.common.util;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
 import org.springframework.data.domain.Sort;
 
 public final class SortUtil {
 
-    public static Sort createSortByFieldName(String fieldName, String direction) {
+    public static Sort createSortByFieldName(@Nullable String fieldName, @Nullable String direction) {
         Sort sort = Sort.unsorted();
         if (StringUtils.isNotBlank(fieldName) && StringUtils.isNotBlank(direction)) {
             Optional<Sort.Direction> sortDirection = Sort.Direction.fromOptionalString(direction);

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerCustomFunctionAction.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerCustomFunctionAction.java
@@ -73,7 +73,7 @@ public class JiraServerCustomFunctionAction extends CustomFunctionAction<String>
                     String.format("Jira Server configuration not found.  Please include the Jira Server configuration id in the request body.")
                 );
             }
-            JiraServerProperties jiraProperties = jiraServerPropertiesFactory.createJiraPropertiesWithJobId(configurationID.get());
+            JiraServerProperties jiraProperties = jiraServerPropertiesFactory.createJiraProperties(configurationID.get());
             JiraServerServiceFactory jiraServicesFactory = jiraProperties.createJiraServicesServerFactory(logger, gson);
             PluginManagerService jiraAppService = jiraServicesFactory.createPluginManagerService();
             try {

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerCustomFunctionAction.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerCustomFunctionAction.java
@@ -8,8 +8,10 @@
 package com.synopsys.integration.alert.channel.jira.server.web;
 
 import java.util.Collection;
+import java.util.Optional;
 import java.util.UUID;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,9 +24,12 @@ import com.synopsys.integration.alert.api.channel.jira.util.JiraPluginCheckUtils
 import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatus;
 import com.synopsys.integration.alert.channel.jira.server.JiraServerProperties;
 import com.synopsys.integration.alert.channel.jira.server.JiraServerPropertiesFactory;
+import com.synopsys.integration.alert.channel.jira.server.database.accessor.JiraServerGlobalConfigAccessor;
+import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
 import com.synopsys.integration.alert.channel.jira.server.validator.JiraServerGlobalConfigurationFieldModelValidator;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.action.CustomFunctionAction;
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.rest.HttpServletContentWrapper;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
@@ -41,19 +46,34 @@ public class JiraServerCustomFunctionAction extends CustomFunctionAction<String>
     private final JiraServerGlobalConfigurationFieldModelValidator globalConfigurationValidator;
     private final JiraServerPropertiesFactory jiraServerPropertiesFactory;
     private final Gson gson;
+    private final JiraServerGlobalConfigAccessor globalConfigAccessor;
 
     @Autowired
-    public JiraServerCustomFunctionAction(AuthorizationManager authorizationManager, JiraServerGlobalConfigurationFieldModelValidator globalConfigurationValidator, JiraServerPropertiesFactory jiraServerPropertiesFactory, Gson gson) {
+    public JiraServerCustomFunctionAction(
+        AuthorizationManager authorizationManager,
+        JiraServerGlobalConfigurationFieldModelValidator globalConfigurationValidator,
+        JiraServerPropertiesFactory jiraServerPropertiesFactory,
+        Gson gson,
+        JiraServerGlobalConfigAccessor jiraServerGlobalConfigAccessor
+    ) {
         super(authorizationManager);
         this.globalConfigurationValidator = globalConfigurationValidator;
         this.jiraServerPropertiesFactory = jiraServerPropertiesFactory;
         this.gson = gson;
+        this.globalConfigAccessor = jiraServerGlobalConfigAccessor;
     }
 
     @Override
     public ActionResponse<String> createActionResponse(FieldModel fieldModel, HttpServletContentWrapper ignoredServletContent) {
         try {
-            JiraServerProperties jiraProperties = jiraServerPropertiesFactory.createJiraPropertiesWithJobId(UUID.fromString(fieldModel.getId()));
+            Optional<UUID> configurationID = getConfigurationId(fieldModel);
+            if (configurationID.isEmpty()) {
+                return new ActionResponse<>(
+                    HttpStatus.NOT_FOUND,
+                    String.format("Jira Server configuration not found.  Please include the Jira Server configuration id in the request body.")
+                );
+            }
+            JiraServerProperties jiraProperties = jiraServerPropertiesFactory.createJiraPropertiesWithJobId(configurationID.get());
             JiraServerServiceFactory jiraServicesFactory = jiraProperties.createJiraServicesServerFactory(logger, gson);
             PluginManagerService jiraAppService = jiraServicesFactory.createPluginManagerService();
             try {
@@ -61,7 +81,10 @@ public class JiraServerCustomFunctionAction extends CustomFunctionAction<String>
             } catch (IntegrationRestException e) {
                 if (RestConstants.NOT_FOUND_404 == e.getHttpStatusCode()) {
                     return new ActionResponse<>(HttpStatus.NOT_FOUND, String.format(
-                        "The marketplace listing of the '%s' app may not support your version of Jira. Please install the app manually or request a compatibility update. Error: %s", JiraConstants.JIRA_ALERT_APP_NAME, e.getMessage()));
+                        "The marketplace listing of the '%s' app may not support your version of Jira. Please install the app manually or request a compatibility update. Error: %s",
+                        JiraConstants.JIRA_ALERT_APP_NAME,
+                        e.getMessage()
+                    ));
                 }
                 return createBadRequestIntegrationException(e);
             }
@@ -89,4 +112,27 @@ public class JiraServerCustomFunctionAction extends CustomFunctionAction<String>
         return new ActionResponse<>(HttpStatus.BAD_REQUEST, "The following error occurred when connecting to Jira server: " + error.getMessage());
     }
 
+    private Optional<UUID> getConfigurationId(FieldModel fieldModel) {
+        return parseConfigIdFromFieldModel(fieldModel)
+            .or(this::readIDFromDatabase);
+    }
+
+    private Optional<UUID> parseConfigIdFromFieldModel(FieldModel fieldModel) {
+        if (StringUtils.isBlank(fieldModel.getId())) {
+            return Optional.empty();
+        }
+        UUID configId = null;
+        try {
+            configId = UUID.fromString(fieldModel.getId());
+        } catch (IllegalArgumentException ex) {
+            logger.error("FieldModel cannot parse id for Jira Server Config UUID from id field.", ex);
+        }
+        return Optional.ofNullable(configId);
+    }
+
+    private Optional<UUID> readIDFromDatabase() {
+        return globalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
+            .map(JiraServerGlobalConfigModel::getId)
+            .map(UUID::fromString);
+    }
 }

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerCustomFunctionActionTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerCustomFunctionActionTest.java
@@ -1,7 +1,9 @@
 package com.synopsys.integration.alert.channel.jira.server.web;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -10,8 +12,10 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
 
 import com.google.gson.Gson;
+import com.synopsys.integration.alert.channel.jira.server.JiraServerProperties;
 import com.synopsys.integration.alert.channel.jira.server.JiraServerPropertiesFactory;
 import com.synopsys.integration.alert.channel.jira.server.database.accessor.JiraServerGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.jira.server.descriptor.JiraServerDescriptor;
@@ -19,9 +23,13 @@ import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobal
 import com.synopsys.integration.alert.channel.jira.server.validator.JiraServerGlobalConfigurationFieldModelValidator;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.enumeration.FrequencyType;
+import com.synopsys.integration.alert.common.enumeration.ProcessingType;
 import com.synopsys.integration.alert.common.persistence.accessor.JobAccessor;
 import com.synopsys.integration.alert.common.persistence.model.PermissionKey;
 import com.synopsys.integration.alert.common.persistence.model.PermissionMatrixModel;
+import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobModel;
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.rest.HttpServletContentWrapper;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
@@ -29,6 +37,9 @@ import com.synopsys.integration.alert.common.rest.proxy.ProxyManager;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
 import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
 import com.synopsys.integration.alert.test.common.AuthenticationTestUtils;
+import com.synopsys.integration.jira.common.rest.service.PluginManagerService;
+import com.synopsys.integration.jira.common.server.service.JiraServerServiceFactory;
+import com.synopsys.integration.rest.exception.IntegrationRestException;
 
 class JiraServerCustomFunctionActionTest {
     private final Gson gson = new Gson();
@@ -44,23 +55,46 @@ class JiraServerCustomFunctionActionTest {
     }
 
     @Test
-    void testInstallPlugin() {
+    void testInstallPluginReadIDFromDB() throws Exception {
         AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "ALERT_ADMIN", () -> fullPermissions);
         HttpServletContentWrapper contentWrapper = Mockito.mock(HttpServletContentWrapper.class);
         JiraServerGlobalConfigurationFieldModelValidator jiraServerGlobalConfigurationFieldModelValidator = Mockito.mock(JiraServerGlobalConfigurationFieldModelValidator.class);
-        ProxyManager proxyManager = Mockito.mock(ProxyManager.class);
         JiraServerGlobalConfigAccessor globalConfigAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
-        Mockito.when(globalConfigAccessor.getConfiguration(Mockito.any())).thenReturn(Optional.of(
-            new JiraServerGlobalConfigModel(
-                UUID.randomUUID().toString(),
-                "Jira Server Config",
-                "http://jira.server.example.com/jira",
-                "user",
-                "password"
-            )));
+        UUID jiraGlobalConfigId = UUID.randomUUID();
+        JiraServerGlobalConfigModel configModel = new JiraServerGlobalConfigModel(
+            jiraGlobalConfigId.toString(),
+            AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
+            "http://jira.server.example.com/jira",
+            "user",
+            "password"
+        );
+        DistributionJobModel jobModel = DistributionJobModel.builder()
+            .jobId(UUID.randomUUID())
+            .enabled(true)
+            .name("A Job")
+            .distributionFrequency(FrequencyType.REAL_TIME)
+            .processingType(ProcessingType.DEFAULT)
+            .channelDescriptorName(ChannelKeys.JIRA_SERVER.getUniversalKey())
+            .blackDuckGlobalConfigId(1L)
+            .channelGlobalConfigId(jiraGlobalConfigId)
+            .createdAt(OffsetDateTime.now())
+            .notificationTypes(List.of("irrelevant_string"))
+            .build();
+
+        Mockito.when(globalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(configModel));
+        Mockito.when(globalConfigAccessor.getConfiguration(Mockito.any())).thenReturn(Optional.of(configModel));
         JobAccessor jobAccessor = Mockito.mock(JobAccessor.class);
-        Mockito.when(jobAccessor.getJobById(Mockito.any()));
-        JiraServerPropertiesFactory jiraServerPropertiesFactory = new JiraServerPropertiesFactory(proxyManager, globalConfigAccessor, jobAccessor);
+        Mockito.when(jobAccessor.getJobById(Mockito.any())).thenReturn(Optional.of(jobModel));
+        JiraServerPropertiesFactory jiraServerPropertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
+        JiraServerProperties jiraProperties = Mockito.mock(JiraServerProperties.class);
+        JiraServerServiceFactory serviceFactory = Mockito.mock(JiraServerServiceFactory.class);
+        PluginManagerService pluginManagerService = Mockito.mock(PluginManagerService.class);
+        Mockito.when(jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jiraGlobalConfigId)).thenReturn(jiraProperties);
+        Mockito.when(jiraProperties.createJiraServicesServerFactory(Mockito.any(), Mockito.any())).thenReturn(serviceFactory);
+        Mockito.when(serviceFactory.createPluginManagerService()).thenReturn(pluginManagerService);
+        Mockito.when(pluginManagerService.installMarketplaceServerApp(Mockito.any())).thenReturn(HttpStatus.OK.value());
+        Mockito.when(pluginManagerService.isAppInstalled(Mockito.any())).thenReturn(Boolean.TRUE);
+
         JiraServerCustomFunctionAction action = new JiraServerCustomFunctionAction(
             authorizationManager,
             jiraServerGlobalConfigurationFieldModelValidator,
@@ -72,6 +106,284 @@ class JiraServerCustomFunctionActionTest {
         ActionResponse<String> response = action.createActionResponse(fieldModel, contentWrapper);
 
         assertTrue(response.isSuccessful());
+    }
+
+    @Test
+    void testInstallPluginReadIdFromModel() throws Exception {
+        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "ALERT_ADMIN", () -> fullPermissions);
+        HttpServletContentWrapper contentWrapper = Mockito.mock(HttpServletContentWrapper.class);
+        JiraServerGlobalConfigurationFieldModelValidator jiraServerGlobalConfigurationFieldModelValidator = Mockito.mock(JiraServerGlobalConfigurationFieldModelValidator.class);
+        JiraServerGlobalConfigAccessor globalConfigAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
+        UUID jiraGlobalConfigId = UUID.randomUUID();
+        JiraServerGlobalConfigModel configModel = new JiraServerGlobalConfigModel(
+            jiraGlobalConfigId.toString(),
+            AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
+            "http://jira.server.example.com/jira",
+            "user",
+            "password"
+        );
+        DistributionJobModel jobModel = DistributionJobModel.builder()
+            .jobId(UUID.randomUUID())
+            .enabled(true)
+            .name("A Job")
+            .distributionFrequency(FrequencyType.REAL_TIME)
+            .processingType(ProcessingType.DEFAULT)
+            .channelDescriptorName(ChannelKeys.JIRA_SERVER.getUniversalKey())
+            .blackDuckGlobalConfigId(1L)
+            .channelGlobalConfigId(jiraGlobalConfigId)
+            .createdAt(OffsetDateTime.now())
+            .notificationTypes(List.of("irrelevant_string"))
+            .build();
+
+        Mockito.when(globalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(configModel));
+        Mockito.when(globalConfigAccessor.getConfiguration(Mockito.any())).thenReturn(Optional.of(configModel));
+        JobAccessor jobAccessor = Mockito.mock(JobAccessor.class);
+        Mockito.when(jobAccessor.getJobById(Mockito.any())).thenReturn(Optional.of(jobModel));
+        JiraServerPropertiesFactory jiraServerPropertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
+        JiraServerProperties jiraProperties = Mockito.mock(JiraServerProperties.class);
+        JiraServerServiceFactory serviceFactory = Mockito.mock(JiraServerServiceFactory.class);
+        PluginManagerService pluginManagerService = Mockito.mock(PluginManagerService.class);
+        Mockito.when(jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jiraGlobalConfigId)).thenReturn(jiraProperties);
+        Mockito.when(jiraProperties.createJiraServicesServerFactory(Mockito.any(), Mockito.any())).thenReturn(serviceFactory);
+        Mockito.when(serviceFactory.createPluginManagerService()).thenReturn(pluginManagerService);
+        Mockito.when(pluginManagerService.installMarketplaceServerApp(Mockito.any())).thenReturn(HttpStatus.OK.value());
+        Mockito.when(pluginManagerService.isAppInstalled(Mockito.any())).thenReturn(Boolean.TRUE);
+
+        JiraServerCustomFunctionAction action = new JiraServerCustomFunctionAction(
+            authorizationManager,
+            jiraServerGlobalConfigurationFieldModelValidator,
+            jiraServerPropertiesFactory,
+            gson,
+            globalConfigAccessor
+        );
+        FieldModel fieldModel = createFieldModel();
+        fieldModel.setId(jiraGlobalConfigId.toString());
+        ActionResponse<String> response = action.createActionResponse(fieldModel, contentWrapper);
+
+        assertTrue(response.isSuccessful());
+    }
+
+    @Test
+    void testInstallPluginReadIdFromModelInvalid() throws Exception {
+        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "ALERT_ADMIN", () -> fullPermissions);
+        HttpServletContentWrapper contentWrapper = Mockito.mock(HttpServletContentWrapper.class);
+        JiraServerGlobalConfigurationFieldModelValidator jiraServerGlobalConfigurationFieldModelValidator = Mockito.mock(JiraServerGlobalConfigurationFieldModelValidator.class);
+        JiraServerGlobalConfigAccessor globalConfigAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
+        UUID jiraGlobalConfigId = UUID.randomUUID();
+        JiraServerGlobalConfigModel configModel = new JiraServerGlobalConfigModel(
+            jiraGlobalConfigId.toString(),
+            AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
+            "http://jira.server.example.com/jira",
+            "user",
+            "password"
+        );
+        DistributionJobModel jobModel = DistributionJobModel.builder()
+            .jobId(UUID.randomUUID())
+            .enabled(true)
+            .name("A Job")
+            .distributionFrequency(FrequencyType.REAL_TIME)
+            .processingType(ProcessingType.DEFAULT)
+            .channelDescriptorName(ChannelKeys.JIRA_SERVER.getUniversalKey())
+            .blackDuckGlobalConfigId(1L)
+            .channelGlobalConfigId(jiraGlobalConfigId)
+            .createdAt(OffsetDateTime.now())
+            .notificationTypes(List.of("irrelevant_string"))
+            .build();
+
+        Mockito.when(globalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(configModel));
+        Mockito.when(globalConfigAccessor.getConfiguration(Mockito.any())).thenReturn(Optional.of(configModel));
+        JobAccessor jobAccessor = Mockito.mock(JobAccessor.class);
+        Mockito.when(jobAccessor.getJobById(Mockito.any())).thenReturn(Optional.of(jobModel));
+        JiraServerPropertiesFactory jiraServerPropertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
+        JiraServerProperties jiraProperties = Mockito.mock(JiraServerProperties.class);
+        JiraServerServiceFactory serviceFactory = Mockito.mock(JiraServerServiceFactory.class);
+        PluginManagerService pluginManagerService = Mockito.mock(PluginManagerService.class);
+        Mockito.when(jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jiraGlobalConfigId)).thenReturn(jiraProperties);
+        Mockito.when(jiraProperties.createJiraServicesServerFactory(Mockito.any(), Mockito.any())).thenReturn(serviceFactory);
+        Mockito.when(serviceFactory.createPluginManagerService()).thenReturn(pluginManagerService);
+        Mockito.when(pluginManagerService.installMarketplaceServerApp(Mockito.any())).thenReturn(HttpStatus.OK.value());
+        Mockito.when(pluginManagerService.isAppInstalled(Mockito.any())).thenReturn(Boolean.TRUE);
+
+        JiraServerCustomFunctionAction action = new JiraServerCustomFunctionAction(
+            authorizationManager,
+            jiraServerGlobalConfigurationFieldModelValidator,
+            jiraServerPropertiesFactory,
+            gson,
+            globalConfigAccessor
+        );
+        FieldModel fieldModel = createFieldModel();
+        fieldModel.setId("Unparseable id");
+        ActionResponse<String> response = action.createActionResponse(fieldModel, contentWrapper);
+
+        assertTrue(response.isSuccessful());
+    }
+
+    @Test
+    void testInstallPluginThrowsNotFoundException() throws Exception {
+        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "ALERT_ADMIN", () -> fullPermissions);
+        HttpServletContentWrapper contentWrapper = Mockito.mock(HttpServletContentWrapper.class);
+        JiraServerGlobalConfigurationFieldModelValidator jiraServerGlobalConfigurationFieldModelValidator = Mockito.mock(JiraServerGlobalConfigurationFieldModelValidator.class);
+        JiraServerGlobalConfigAccessor globalConfigAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
+        UUID jiraGlobalConfigId = UUID.randomUUID();
+        JiraServerGlobalConfigModel configModel = new JiraServerGlobalConfigModel(
+            jiraGlobalConfigId.toString(),
+            AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
+            "http://jira.server.example.com/jira",
+            "user",
+            "password"
+        );
+        DistributionJobModel jobModel = DistributionJobModel.builder()
+            .jobId(UUID.randomUUID())
+            .enabled(true)
+            .name("A Job")
+            .distributionFrequency(FrequencyType.REAL_TIME)
+            .processingType(ProcessingType.DEFAULT)
+            .channelDescriptorName(ChannelKeys.JIRA_SERVER.getUniversalKey())
+            .blackDuckGlobalConfigId(1L)
+            .channelGlobalConfigId(jiraGlobalConfigId)
+            .createdAt(OffsetDateTime.now())
+            .notificationTypes(List.of("irrelevant_string"))
+            .build();
+
+        Mockito.when(globalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(configModel));
+        Mockito.when(globalConfigAccessor.getConfiguration(Mockito.any())).thenReturn(Optional.of(configModel));
+        JobAccessor jobAccessor = Mockito.mock(JobAccessor.class);
+        Mockito.when(jobAccessor.getJobById(Mockito.any())).thenReturn(Optional.of(jobModel));
+        JiraServerPropertiesFactory jiraServerPropertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
+        JiraServerProperties jiraProperties = Mockito.mock(JiraServerProperties.class);
+        JiraServerServiceFactory serviceFactory = Mockito.mock(JiraServerServiceFactory.class);
+        PluginManagerService pluginManagerService = Mockito.mock(PluginManagerService.class);
+        Mockito.when(jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jiraGlobalConfigId)).thenReturn(jiraProperties);
+        Mockito.when(jiraProperties.createJiraServicesServerFactory(Mockito.any(), Mockito.any())).thenReturn(serviceFactory);
+        Mockito.when(serviceFactory.createPluginManagerService()).thenReturn(pluginManagerService);
+        Mockito.when(pluginManagerService.installMarketplaceServerApp(Mockito.any()))
+            .thenThrow(new IntegrationRestException(null, null, HttpStatus.NOT_FOUND.value(), "", "", ""));
+
+        JiraServerCustomFunctionAction action = new JiraServerCustomFunctionAction(
+            authorizationManager,
+            jiraServerGlobalConfigurationFieldModelValidator,
+            jiraServerPropertiesFactory,
+            gson,
+            globalConfigAccessor
+        );
+        FieldModel fieldModel = createFieldModel();
+        fieldModel.setId(jiraGlobalConfigId.toString());
+        ActionResponse<String> response = action.createActionResponse(fieldModel, contentWrapper);
+
+        assertTrue(response.isError());
+        assertEquals(HttpStatus.NOT_FOUND, response.getHttpStatus());
+    }
+
+    @Test
+    void testInstallPluginThrowsRestException() throws Exception {
+        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "ALERT_ADMIN", () -> fullPermissions);
+        HttpServletContentWrapper contentWrapper = Mockito.mock(HttpServletContentWrapper.class);
+        JiraServerGlobalConfigurationFieldModelValidator jiraServerGlobalConfigurationFieldModelValidator = Mockito.mock(JiraServerGlobalConfigurationFieldModelValidator.class);
+        JiraServerGlobalConfigAccessor globalConfigAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
+        UUID jiraGlobalConfigId = UUID.randomUUID();
+        JiraServerGlobalConfigModel configModel = new JiraServerGlobalConfigModel(
+            jiraGlobalConfigId.toString(),
+            AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
+            "http://jira.server.example.com/jira",
+            "user",
+            "password"
+        );
+        DistributionJobModel jobModel = DistributionJobModel.builder()
+            .jobId(UUID.randomUUID())
+            .enabled(true)
+            .name("A Job")
+            .distributionFrequency(FrequencyType.REAL_TIME)
+            .processingType(ProcessingType.DEFAULT)
+            .channelDescriptorName(ChannelKeys.JIRA_SERVER.getUniversalKey())
+            .blackDuckGlobalConfigId(1L)
+            .channelGlobalConfigId(jiraGlobalConfigId)
+            .createdAt(OffsetDateTime.now())
+            .notificationTypes(List.of("irrelevant_string"))
+            .build();
+
+        Mockito.when(globalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(configModel));
+        Mockito.when(globalConfigAccessor.getConfiguration(Mockito.any())).thenReturn(Optional.of(configModel));
+        JobAccessor jobAccessor = Mockito.mock(JobAccessor.class);
+        Mockito.when(jobAccessor.getJobById(Mockito.any())).thenReturn(Optional.of(jobModel));
+        JiraServerPropertiesFactory jiraServerPropertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
+        JiraServerProperties jiraProperties = Mockito.mock(JiraServerProperties.class);
+        JiraServerServiceFactory serviceFactory = Mockito.mock(JiraServerServiceFactory.class);
+        PluginManagerService pluginManagerService = Mockito.mock(PluginManagerService.class);
+        Mockito.when(jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jiraGlobalConfigId)).thenReturn(jiraProperties);
+        Mockito.when(jiraProperties.createJiraServicesServerFactory(Mockito.any(), Mockito.any())).thenReturn(serviceFactory);
+        Mockito.when(serviceFactory.createPluginManagerService()).thenReturn(pluginManagerService);
+        Mockito.when(pluginManagerService.installMarketplaceServerApp(Mockito.any()))
+            .thenThrow(new IntegrationRestException(null, null, HttpStatus.BAD_REQUEST.value(), "", "", ""));
+
+        JiraServerCustomFunctionAction action = new JiraServerCustomFunctionAction(
+            authorizationManager,
+            jiraServerGlobalConfigurationFieldModelValidator,
+            jiraServerPropertiesFactory,
+            gson,
+            globalConfigAccessor
+        );
+        FieldModel fieldModel = createFieldModel();
+        fieldModel.setId(jiraGlobalConfigId.toString());
+        ActionResponse<String> response = action.createActionResponse(fieldModel, contentWrapper);
+
+        assertTrue(response.isError());
+        assertEquals(HttpStatus.BAD_REQUEST, response.getHttpStatus());
+    }
+
+    @Test
+    void testInstallPluginAppNotInstalled() throws Exception {
+        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "ALERT_ADMIN", () -> fullPermissions);
+        HttpServletContentWrapper contentWrapper = Mockito.mock(HttpServletContentWrapper.class);
+        JiraServerGlobalConfigurationFieldModelValidator jiraServerGlobalConfigurationFieldModelValidator = Mockito.mock(JiraServerGlobalConfigurationFieldModelValidator.class);
+        JiraServerGlobalConfigAccessor globalConfigAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
+        UUID jiraGlobalConfigId = UUID.randomUUID();
+        JiraServerGlobalConfigModel configModel = new JiraServerGlobalConfigModel(
+            jiraGlobalConfigId.toString(),
+            AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
+            "http://jira.server.example.com/jira",
+            "user",
+            "password"
+        );
+        DistributionJobModel jobModel = DistributionJobModel.builder()
+            .jobId(UUID.randomUUID())
+            .enabled(true)
+            .name("A Job")
+            .distributionFrequency(FrequencyType.REAL_TIME)
+            .processingType(ProcessingType.DEFAULT)
+            .channelDescriptorName(ChannelKeys.JIRA_SERVER.getUniversalKey())
+            .blackDuckGlobalConfigId(1L)
+            .channelGlobalConfigId(jiraGlobalConfigId)
+            .createdAt(OffsetDateTime.now())
+            .notificationTypes(List.of("irrelevant_string"))
+            .build();
+
+        Mockito.when(globalConfigAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)).thenReturn(Optional.of(configModel));
+        Mockito.when(globalConfigAccessor.getConfiguration(Mockito.any())).thenReturn(Optional.of(configModel));
+        JobAccessor jobAccessor = Mockito.mock(JobAccessor.class);
+        Mockito.when(jobAccessor.getJobById(Mockito.any())).thenReturn(Optional.of(jobModel));
+        JiraServerPropertiesFactory jiraServerPropertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
+        JiraServerProperties jiraProperties = Mockito.mock(JiraServerProperties.class);
+        JiraServerServiceFactory serviceFactory = Mockito.mock(JiraServerServiceFactory.class);
+        PluginManagerService pluginManagerService = Mockito.mock(PluginManagerService.class);
+        Mockito.when(jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jiraGlobalConfigId)).thenReturn(jiraProperties);
+        Mockito.when(jiraProperties.createJiraServicesServerFactory(Mockito.any(), Mockito.any())).thenReturn(serviceFactory);
+        Mockito.when(serviceFactory.createPluginManagerService()).thenReturn(pluginManagerService);
+        Mockito.when(pluginManagerService.installMarketplaceServerApp(Mockito.any())).thenReturn(HttpStatus.OK.value());
+        Mockito.when(pluginManagerService.isAppInstalled(Mockito.any())).thenReturn(Boolean.FALSE);
+
+        JiraServerCustomFunctionAction action = new JiraServerCustomFunctionAction(
+            authorizationManager,
+            jiraServerGlobalConfigurationFieldModelValidator,
+            jiraServerPropertiesFactory,
+            gson,
+            globalConfigAccessor
+        );
+        FieldModel fieldModel = createFieldModel();
+        fieldModel.setId(jiraGlobalConfigId.toString());
+        ActionResponse<String> response = action.createActionResponse(fieldModel, contentWrapper);
+
+        assertTrue(response.isError());
+        assertEquals(HttpStatus.NOT_FOUND, response.getHttpStatus());
     }
 
     @Test
@@ -95,7 +407,8 @@ class JiraServerCustomFunctionActionTest {
         FieldModel fieldModel = createFieldModel();
         ActionResponse<String> response = action.createActionResponse(fieldModel, contentWrapper);
 
-        assertTrue(response.isSuccessful());
+        assertTrue(response.isError());
+        assertEquals(HttpStatus.NOT_FOUND, response.getHttpStatus());
     }
 
     FieldModel createFieldModel() {

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerCustomFunctionActionTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerCustomFunctionActionTest.java
@@ -89,7 +89,7 @@ class JiraServerCustomFunctionActionTest {
         JiraServerProperties jiraProperties = Mockito.mock(JiraServerProperties.class);
         JiraServerServiceFactory serviceFactory = Mockito.mock(JiraServerServiceFactory.class);
         PluginManagerService pluginManagerService = Mockito.mock(PluginManagerService.class);
-        Mockito.when(jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jiraGlobalConfigId)).thenReturn(jiraProperties);
+        Mockito.when(jiraServerPropertiesFactory.createJiraProperties(jiraGlobalConfigId)).thenReturn(jiraProperties);
         Mockito.when(jiraProperties.createJiraServicesServerFactory(Mockito.any(), Mockito.any())).thenReturn(serviceFactory);
         Mockito.when(serviceFactory.createPluginManagerService()).thenReturn(pluginManagerService);
         Mockito.when(pluginManagerService.installMarketplaceServerApp(Mockito.any())).thenReturn(HttpStatus.OK.value());
@@ -143,7 +143,7 @@ class JiraServerCustomFunctionActionTest {
         JiraServerProperties jiraProperties = Mockito.mock(JiraServerProperties.class);
         JiraServerServiceFactory serviceFactory = Mockito.mock(JiraServerServiceFactory.class);
         PluginManagerService pluginManagerService = Mockito.mock(PluginManagerService.class);
-        Mockito.when(jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jiraGlobalConfigId)).thenReturn(jiraProperties);
+        Mockito.when(jiraServerPropertiesFactory.createJiraProperties(jiraGlobalConfigId)).thenReturn(jiraProperties);
         Mockito.when(jiraProperties.createJiraServicesServerFactory(Mockito.any(), Mockito.any())).thenReturn(serviceFactory);
         Mockito.when(serviceFactory.createPluginManagerService()).thenReturn(pluginManagerService);
         Mockito.when(pluginManagerService.installMarketplaceServerApp(Mockito.any())).thenReturn(HttpStatus.OK.value());
@@ -198,7 +198,7 @@ class JiraServerCustomFunctionActionTest {
         JiraServerProperties jiraProperties = Mockito.mock(JiraServerProperties.class);
         JiraServerServiceFactory serviceFactory = Mockito.mock(JiraServerServiceFactory.class);
         PluginManagerService pluginManagerService = Mockito.mock(PluginManagerService.class);
-        Mockito.when(jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jiraGlobalConfigId)).thenReturn(jiraProperties);
+        Mockito.when(jiraServerPropertiesFactory.createJiraProperties(jiraGlobalConfigId)).thenReturn(jiraProperties);
         Mockito.when(jiraProperties.createJiraServicesServerFactory(Mockito.any(), Mockito.any())).thenReturn(serviceFactory);
         Mockito.when(serviceFactory.createPluginManagerService()).thenReturn(pluginManagerService);
         Mockito.when(pluginManagerService.installMarketplaceServerApp(Mockito.any())).thenReturn(HttpStatus.OK.value());
@@ -253,7 +253,7 @@ class JiraServerCustomFunctionActionTest {
         JiraServerProperties jiraProperties = Mockito.mock(JiraServerProperties.class);
         JiraServerServiceFactory serviceFactory = Mockito.mock(JiraServerServiceFactory.class);
         PluginManagerService pluginManagerService = Mockito.mock(PluginManagerService.class);
-        Mockito.when(jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jiraGlobalConfigId)).thenReturn(jiraProperties);
+        Mockito.when(jiraServerPropertiesFactory.createJiraProperties(jiraGlobalConfigId)).thenReturn(jiraProperties);
         Mockito.when(jiraProperties.createJiraServicesServerFactory(Mockito.any(), Mockito.any())).thenReturn(serviceFactory);
         Mockito.when(serviceFactory.createPluginManagerService()).thenReturn(pluginManagerService);
         Mockito.when(pluginManagerService.installMarketplaceServerApp(Mockito.any()))
@@ -309,7 +309,7 @@ class JiraServerCustomFunctionActionTest {
         JiraServerProperties jiraProperties = Mockito.mock(JiraServerProperties.class);
         JiraServerServiceFactory serviceFactory = Mockito.mock(JiraServerServiceFactory.class);
         PluginManagerService pluginManagerService = Mockito.mock(PluginManagerService.class);
-        Mockito.when(jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jiraGlobalConfigId)).thenReturn(jiraProperties);
+        Mockito.when(jiraServerPropertiesFactory.createJiraProperties(jiraGlobalConfigId)).thenReturn(jiraProperties);
         Mockito.when(jiraProperties.createJiraServicesServerFactory(Mockito.any(), Mockito.any())).thenReturn(serviceFactory);
         Mockito.when(serviceFactory.createPluginManagerService()).thenReturn(pluginManagerService);
         Mockito.when(pluginManagerService.installMarketplaceServerApp(Mockito.any()))
@@ -365,7 +365,7 @@ class JiraServerCustomFunctionActionTest {
         JiraServerProperties jiraProperties = Mockito.mock(JiraServerProperties.class);
         JiraServerServiceFactory serviceFactory = Mockito.mock(JiraServerServiceFactory.class);
         PluginManagerService pluginManagerService = Mockito.mock(PluginManagerService.class);
-        Mockito.when(jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jiraGlobalConfigId)).thenReturn(jiraProperties);
+        Mockito.when(jiraServerPropertiesFactory.createJiraProperties(jiraGlobalConfigId)).thenReturn(jiraProperties);
         Mockito.when(jiraProperties.createJiraServicesServerFactory(Mockito.any(), Mockito.any())).thenReturn(serviceFactory);
         Mockito.when(serviceFactory.createPluginManagerService()).thenReturn(pluginManagerService);
         Mockito.when(pluginManagerService.installMarketplaceServerApp(Mockito.any())).thenReturn(HttpStatus.OK.value());

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerCustomFunctionActionTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerCustomFunctionActionTest.java
@@ -1,0 +1,111 @@
+package com.synopsys.integration.alert.channel.jira.server.web;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.channel.jira.server.JiraServerPropertiesFactory;
+import com.synopsys.integration.alert.channel.jira.server.database.accessor.JiraServerGlobalConfigAccessor;
+import com.synopsys.integration.alert.channel.jira.server.descriptor.JiraServerDescriptor;
+import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
+import com.synopsys.integration.alert.channel.jira.server.validator.JiraServerGlobalConfigurationFieldModelValidator;
+import com.synopsys.integration.alert.common.action.ActionResponse;
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.persistence.accessor.JobAccessor;
+import com.synopsys.integration.alert.common.persistence.model.PermissionKey;
+import com.synopsys.integration.alert.common.persistence.model.PermissionMatrixModel;
+import com.synopsys.integration.alert.common.rest.HttpServletContentWrapper;
+import com.synopsys.integration.alert.common.rest.model.FieldModel;
+import com.synopsys.integration.alert.common.rest.model.FieldValueModel;
+import com.synopsys.integration.alert.common.rest.proxy.ProxyManager;
+import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
+import com.synopsys.integration.alert.test.common.AuthenticationTestUtils;
+
+class JiraServerCustomFunctionActionTest {
+    private final Gson gson = new Gson();
+    private AuthenticationTestUtils authenticationTestUtils;
+    private PermissionMatrixModel fullPermissions;
+
+    @BeforeEach
+    public void initAuthManager() {
+        authenticationTestUtils = new AuthenticationTestUtils();
+        authenticationTestUtils.addUserWithRole("admin", "ALERT_ADMIN");
+        PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), ChannelKeys.JIRA_SERVER.getUniversalKey());
+        fullPermissions = new PermissionMatrixModel(Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS));
+    }
+
+    @Test
+    void testInstallPlugin() {
+        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "ALERT_ADMIN", () -> fullPermissions);
+        HttpServletContentWrapper contentWrapper = Mockito.mock(HttpServletContentWrapper.class);
+        JiraServerGlobalConfigurationFieldModelValidator jiraServerGlobalConfigurationFieldModelValidator = Mockito.mock(JiraServerGlobalConfigurationFieldModelValidator.class);
+        ProxyManager proxyManager = Mockito.mock(ProxyManager.class);
+        JiraServerGlobalConfigAccessor globalConfigAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
+        Mockito.when(globalConfigAccessor.getConfiguration(Mockito.any())).thenReturn(Optional.of(
+            new JiraServerGlobalConfigModel(
+                UUID.randomUUID().toString(),
+                "Jira Server Config",
+                "http://jira.server.example.com/jira",
+                "user",
+                "password"
+            )));
+        JobAccessor jobAccessor = Mockito.mock(JobAccessor.class);
+        Mockito.when(jobAccessor.getJobById(Mockito.any()));
+        JiraServerPropertiesFactory jiraServerPropertiesFactory = new JiraServerPropertiesFactory(proxyManager, globalConfigAccessor, jobAccessor);
+        JiraServerCustomFunctionAction action = new JiraServerCustomFunctionAction(
+            authorizationManager,
+            jiraServerGlobalConfigurationFieldModelValidator,
+            jiraServerPropertiesFactory,
+            gson,
+            globalConfigAccessor
+        );
+        FieldModel fieldModel = createFieldModel();
+        ActionResponse<String> response = action.createActionResponse(fieldModel, contentWrapper);
+
+        assertTrue(response.isSuccessful());
+    }
+
+    @Test
+    void testDefaultConfigMissing() {
+        AuthorizationManager authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "ALERT_ADMIN", () -> fullPermissions);
+        HttpServletContentWrapper contentWrapper = Mockito.mock(HttpServletContentWrapper.class);
+        JiraServerGlobalConfigurationFieldModelValidator jiraServerGlobalConfigurationFieldModelValidator = Mockito.mock(JiraServerGlobalConfigurationFieldModelValidator.class);
+        ProxyManager proxyManager = Mockito.mock(ProxyManager.class);
+        JiraServerGlobalConfigAccessor globalConfigAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
+        JobAccessor jobAccessor = Mockito.mock(JobAccessor.class);
+        Mockito.when(jobAccessor.getJobById(Mockito.any())).thenReturn(Optional.empty());
+
+        JiraServerPropertiesFactory jiraServerPropertiesFactory = new JiraServerPropertiesFactory(proxyManager, globalConfigAccessor, jobAccessor);
+        JiraServerCustomFunctionAction action = new JiraServerCustomFunctionAction(
+            authorizationManager,
+            jiraServerGlobalConfigurationFieldModelValidator,
+            jiraServerPropertiesFactory,
+            gson,
+            globalConfigAccessor
+        );
+        FieldModel fieldModel = createFieldModel();
+        ActionResponse<String> response = action.createActionResponse(fieldModel, contentWrapper);
+
+        assertTrue(response.isSuccessful());
+    }
+
+    FieldModel createFieldModel() {
+        Map<String, FieldValueModel> fieldValues = Map.of(
+            JiraServerDescriptor.KEY_SERVER_URL, new FieldValueModel(List.of("http://jira.server.example.com/jira"), true),
+            JiraServerDescriptor.KEY_SERVER_USERNAME, new FieldValueModel(List.of("user"), true),
+            JiraServerDescriptor.KEY_SERVER_PASSWORD, new FieldValueModel(List.of("password"), true),
+            JiraServerDescriptor.KEY_JIRA_DISABLE_PLUGIN_CHECK, new FieldValueModel(List.of("false"), true),
+            JiraServerDescriptor.KEY_JIRA_SERVER_CONFIGURE_PLUGIN, new FieldValueModel(List.of("true"), true)
+        );
+        return new FieldModel(ChannelKeys.JIRA_SERVER.getUniversalKey(), ConfigContextEnum.GLOBAL.name(), fieldValues);
+    }
+}


### PR DESCRIPTION
Fix the Old Jira Server Plugin install API.

Check if an id with a UUID is in the request payload.
Check if a configuration named "default-configuration" exists.  When upgrading from the prior version the upgrade will migrate the Jira Server configuration to the new table structure  and supply the name "default-configuration" 