### PR TITLE
Dev Server Refresh to Current Page

### DIFF
--- a/ui/webpack.common.config.js
+++ b/ui/webpack.common.config.js
@@ -16,7 +16,7 @@ module.exports = {
     output: {
         path: buildDir,
         filename: 'js/bundle.js',
-        publicPath: '/alert/'
+        publicPath: '/'
     },
     module: {
         rules: [{


### PR DESCRIPTION
**Issue:**  
When on a dev server, we were unable to refresh the page to redirect when testing.  We'd have to redirect to `/alert/`, then navigate to the given page to see changes.  
  
**Fix:**  
Simply provide a `/` path for publicPath in the webpack.config file to direct back to the given page.    
  
See more, https://webpack.js.org/guides/public-path/