### PR TITLE
Reverting PR:2090

### DIFF
--- a/ui/webpack.common.config.js
+++ b/ui/webpack.common.config.js
@@ -19,7 +19,7 @@ module.exports = {
     output: {
         path: buildDir,
         filename: 'js/bundle.js',
-        publicPath: '/'
+        publicPath: '/alert/'
     },
     module: {
         rules: [{


### PR DESCRIPTION
This PR reverts https://github.com/blackducksoftware/blackduck-alert/pull/2090.  I should not have touched the webpack.common.config file.  Instead I should have adjusted the webpack.dev.config file.