### PR TITLE
Reverting css direct path declaration in webpack common config file

### DIFF
--- a/ui/src/main/js/page/audit/AuditPage.js
+++ b/ui/src/main/js/page/audit/AuditPage.js
@@ -13,7 +13,7 @@ import * as DescriptorUtilities from 'common/util/descriptorUtilities';
 import PageHeader from 'common/component/navigation/PageHeader';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import StatusMessage from 'common/component/StatusMessage';
-import 'css/audit.scss';
+import '../../../css/audit.scss';
 import { AUDIT_INFO } from 'page/audit/AuditModel';
 import { EXISTING_CHANNELS, EXISTING_PROVIDERS } from 'common/DescriptorInfo';
 import { ProgressIcon } from 'common/component/table/ProgressIcon';

--- a/ui/webpack.common.config.js
+++ b/ui/webpack.common.config.js
@@ -10,10 +10,7 @@ const buildDir = path.resolve(__dirname, 'build', 'resources', 'main', 'static')
 module.exports = {
     resolve: {
         modules: [path.resolve(__dirname, 'src', 'main', 'js'), 'node_modules'],
-        alias: {
-            'css': path.resolve(srcDir, 'main', 'css')
-        },
-        extensions: ['.js', '.scss']
+        extensions: ['.js']
     },
     entry: ['@babel/polyfill', 'whatwg-fetch', path.resolve(jsDir, 'Index')],
     output: {


### PR DESCRIPTION
This PR reverts the changes to the direct vs relative path for css files in the `webpack.common.config.js` file.