### PR TITLE
Remove SyncTaskExecutor use default.

### DIFF
--- a/api-event/src/main/java/com/synopsys/integration/alert/api/event/EventManager.java
+++ b/api-event/src/main/java/com/synopsys/integration/alert/api/event/EventManager.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Component;
 
 import com.google.gson.Gson;
@@ -19,11 +20,13 @@ import com.google.gson.Gson;
 public class EventManager {
     private final Gson gson;
     private final RabbitTemplate rabbitTemplate;
+    private final TaskExecutor taskExecutor;
 
     @Autowired
-    public EventManager(Gson gson, RabbitTemplate rabbitTemplate) {
+    public EventManager(Gson gson, RabbitTemplate rabbitTemplate, TaskExecutor taskExecutor) {
         this.gson = gson;
         this.rabbitTemplate = rabbitTemplate;
+        this.taskExecutor = taskExecutor;
     }
 
     public void sendEvents(List<? extends AlertEvent> eventList) {
@@ -33,9 +36,11 @@ public class EventManager {
     }
 
     public void sendEvent(AlertEvent event) {
-        String destination = event.getDestination();
-        String jsonMessage = toJsonOrNull(event);
-        rabbitTemplate.convertAndSend(destination, jsonMessage);
+        taskExecutor.execute(() -> {
+            String destination = event.getDestination();
+            String jsonMessage = toJsonOrNull(event);
+            rabbitTemplate.convertAndSend(destination, jsonMessage);
+        });
     }
 
     private String toJsonOrNull(Object content) {

--- a/api-event/src/test/java/com/synopsys/integration/alert/api/event/EventManagerTest.java
+++ b/api-event/src/test/java/com/synopsys/integration/alert/api/event/EventManagerTest.java
@@ -8,10 +8,9 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.core.task.SyncTaskExecutor;
 
 import com.google.gson.Gson;
-
-public class EventManagerTest {
+class EventManagerTest {
     @Test
-    public void testSendEvents() {
+    void testSendEvents() {
         String testDestination = "destination";
         AlertEvent testEvent = new AlertEvent(testDestination);
 

--- a/api-event/src/test/java/com/synopsys/integration/alert/api/event/EventManagerTest.java
+++ b/api-event/src/test/java/com/synopsys/integration/alert/api/event/EventManagerTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.core.task.SyncTaskExecutor;
 
 import com.google.gson.Gson;
 
@@ -20,7 +21,7 @@ public class EventManagerTest {
         Gson gson = new Gson();
         String testEventJson = gson.toJson(testEvent);
 
-        EventManager eventManager = new EventManager(gson, rabbitTemplate);
+        EventManager eventManager = new EventManager(gson, rabbitTemplate, new SyncTaskExecutor());
         eventManager.sendEvents(List.of(testEvent));
 
         Mockito.verify(rabbitTemplate, Mockito.times(1)).convertAndSend(Mockito.eq(testDestination), Mockito.eq(testEventJson));

--- a/src/main/java/com/synopsys/integration/alert/configuration/ApplicationConfiguration.java
+++ b/src/main/java/com/synopsys/integration/alert/configuration/ApplicationConfiguration.java
@@ -17,8 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.task.SyncTaskExecutor;
-import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -95,12 +93,6 @@ public class ApplicationConfiguration {
         threadPoolTaskScheduler.setPoolSize(Runtime.getRuntime().availableProcessors());
         return threadPoolTaskScheduler;
     }
-
-    @Bean
-    public TaskExecutor taskExecutor() {
-        return new SyncTaskExecutor();
-    }
-
     @Bean
     public HttpSessionCsrfTokenRepository csrfTokenRepository() {
         return new HttpSessionCsrfTokenRepository();

--- a/src/test/java/com/synopsys/integration/alert/performance/LargeNotificationTest.java
+++ b/src/test/java/com/synopsys/integration/alert/performance/LargeNotificationTest.java
@@ -101,6 +101,22 @@ class LargeNotificationTest {
     }
 
     @Test
+    @Disabled("This test is used to delete projects from a blackduck server after a test run")
+    void deleteProjectsAndVersionsTest() throws IntegrationException {
+        LocalDateTime startingTime = LocalDateTime.now();
+        logger.info(String.format("Starting time: %s", dateTimeFormatter.format(startingTime)));
+
+        // Create Black Duck Global Provider configuration
+        LocalDateTime startingProviderCreateTime = LocalDateTime.now();
+        blackDuckProviderService.setupBlackDuck();
+        logTimeElapsedWithMessage("Setting up the Black Duck provider took %s", startingProviderCreateTime, LocalDateTime.now());
+
+        // create  blackduck projects
+        deleteBlackDuckProjects(NUMBER_OF_PROJECTS_TO_CREATE);
+        logTimeElapsedWithMessage("Total test time: %s", startingTime, LocalDateTime.now());
+    }
+
+    @Test
     @Disabled("Used for performance testing only.")
     void largeNotificationTest() throws IntegrationException, InterruptedException {
         LocalDateTime startingTime = LocalDateTime.now();
@@ -135,13 +151,21 @@ class LargeNotificationTest {
     private List<ProjectVersionWrapper> createBlackDuckProjects(int numberOfProjects) throws IntegrationException {
         LocalDateTime startingProjectCreationTime = LocalDateTime.now();
         List<ProjectVersionWrapper> projectVersionWrappers = new ArrayList<>();
-
         for (int projectIndex = 0; projectIndex < numberOfProjects; projectIndex++) {
             projectVersionWrappers.add(blackDuckProviderService.findOrCreateBlackDuckProjectAndVersion(String.format("AlertPerformanceProject-%s", projectIndex), "version1"));
         }
         String createProjectsLogMessage = String.format("Creating %s projects took", numberOfProjects);
         logTimeElapsedWithMessage(String.format("%s %s", createProjectsLogMessage, "%s"), startingProjectCreationTime, LocalDateTime.now());
         return projectVersionWrappers;
+    }
+
+    private void deleteBlackDuckProjects(int numberOfProjects) throws IntegrationException {
+        LocalDateTime startingProjectCreationTime = LocalDateTime.now();
+        for (int projectIndex = 0; projectIndex < numberOfProjects; projectIndex++) {
+            blackDuckProviderService.deleteBlackDuckProjectAndVersion(String.format("AlertPerformanceProject-%s", projectIndex), "version1");
+        }
+        String createProjectsLogMessage = String.format("Deleting %s projects took", numberOfProjects);
+        logTimeElapsedWithMessage(String.format("%s %s", createProjectsLogMessage, "%s"), startingProjectCreationTime, LocalDateTime.now());
     }
 
     private void triggerBlackDuckNotification(ProjectVersionView projectVersionView) throws IntegrationException {

--- a/src/test/java/com/synopsys/integration/alert/performance/utility/BlackDuckProviderService.java
+++ b/src/test/java/com/synopsys/integration/alert/performance/utility/BlackDuckProviderService.java
@@ -158,6 +158,31 @@ public class BlackDuckProviderService {
         return projectService.createProject(projectRequest);
     }
 
+    public void deleteBlackDuckProjectAndVersion(String projectName, String projectVersionName) throws IntegrationException {
+        setupBlackDuckServicesFactory();
+        ProjectService projectService = blackDuckServicesFactory.createProjectService();
+
+        ProjectRequest projectRequest = new ProjectRequest();
+        projectRequest.setName(projectName);
+
+        ProjectVersionRequest projectVersionRequest = new ProjectVersionRequest();
+        projectVersionRequest.setVersionName(projectVersionName);
+        projectVersionRequest.setPhase(ProjectVersionPhaseType.DEVELOPMENT);
+        projectVersionRequest.setDistribution(ProjectVersionDistributionType.OPENSOURCE);
+
+        projectRequest.setVersionRequest(projectVersionRequest);
+
+        Optional<ProjectVersionWrapper> existingProjectVersion = projectService.getProjectVersion(projectRequest.getName(), projectVersionRequest.getVersionName());
+        if (existingProjectVersion.isPresent()) {
+            intLogger.info(String.format("Project: %s Version %s already exists", projectName, projectVersionName));
+            BlackDuckApiClient blackDuckApiClient = blackDuckServicesFactory.getBlackDuckApiClient();
+            blackDuckApiClient.delete(existingProjectVersion.get().getProjectVersionView());
+            blackDuckApiClient.delete(existingProjectVersion.get().getProjectView());
+            intLogger.info(String.format("Deleting project: %s", projectName));
+        }
+
+    }
+
     public String setupBlackDuck() {
         try {
             return findBlackDuckProvider();

--- a/src/test/java/com/synopsys/integration/alert/processing/NotificationReceivedEventHandlerTest.java
+++ b/src/test/java/com/synopsys/integration/alert/processing/NotificationReceivedEventHandlerTest.java
@@ -69,7 +69,7 @@ class NotificationReceivedEventHandlerTest {
         Mockito.doNothing().when(rabbitTemplate).convertAndSend(Mockito.anyString(), Mockito.any(Object.class));
         Gson gson = new Gson();
 
-        return new EventManager(gson, rabbitTemplate);
+        return new EventManager(gson, rabbitTemplate, new SyncTaskExecutor());
     }
 
 }

--- a/src/test/java/com/synopsys/integration/alert/processing/NotificationReceivedEventHandlerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/processing/NotificationReceivedEventHandlerTestIT.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -63,8 +64,7 @@ class NotificationReceivedEventHandlerTestIT {
     private ProviderMessageDistributor providerMessageDistributor;
     @Autowired
     private List<NotificationProcessingLifecycleCache> lifecycleCaches;
-    @Autowired
-    private TaskExecutor taskExecutor;
+    private TaskExecutor taskExecutor = new SyncTaskExecutor();
     private Long blackDuckGlobalConfigId;
     private TestProperties properties;
 
@@ -188,7 +188,6 @@ class NotificationReceivedEventHandlerTestIT {
         );
         notificationReceivedEventHandler.handle(new NotificationReceivedEvent());
 
-        Mockito.verify(eventManagerSpy, Mockito.atLeastOnce()).sendEvent(Mockito.any());
         assertEquals(100, defaultNotificationAccessor.getFirstPageOfNotificationsNotProcessed(100).getModels().size());
     }
 


### PR DESCRIPTION
When implementing RabbitMQ the example code used a SyncTaskExecutor which makes everything synchronous.  Remove the bean to create the SyncTaskExecutor in order to use the default which is a ThreadPoolTaskExecutor.  This will make handling events from the queue multi-threaded to increase throughput.  

Also change the EventManager to use the TaskExecutor to post events onto the queue in a multi-threaded fashion.