### PR TITLE
IALERT-3051 - Only perform provider validation when configuring provider

### DIFF
--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckProperties.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/BlackDuckProperties.java
@@ -26,6 +26,7 @@ import com.synopsys.integration.alert.common.rest.proxy.ProxyManager;
 import com.synopsys.integration.alert.provider.blackduck.descriptor.BlackDuckDescriptor;
 import com.synopsys.integration.blackduck.configuration.BlackDuckServerConfig;
 import com.synopsys.integration.blackduck.configuration.BlackDuckServerConfigBuilder;
+import com.synopsys.integration.blackduck.http.client.ApiTokenBlackDuckHttpClient;
 import com.synopsys.integration.blackduck.http.client.BlackDuckHttpClient;
 import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
 import com.synopsys.integration.log.IntLogger;
@@ -55,19 +56,19 @@ public class BlackDuckProperties extends ProviderProperties {
         this.alertProperties = alertProperties;
         this.proxyManager = proxyManager;
         this.url = fieldUtility
-                       .getString(BlackDuckDescriptor.KEY_BLACKDUCK_URL)
-                       .filter(StringUtils::isNotBlank)
-                       .orElse(null);
+            .getString(BlackDuckDescriptor.KEY_BLACKDUCK_URL)
+            .filter(StringUtils::isNotBlank)
+            .orElse(null);
         this.timeout = fieldUtility
-                           .getInteger(BlackDuckDescriptor.KEY_BLACKDUCK_TIMEOUT)
-                           .orElse(DEFAULT_TIMEOUT);
+            .getInteger(BlackDuckDescriptor.KEY_BLACKDUCK_TIMEOUT)
+            .orElse(DEFAULT_TIMEOUT);
         this.apiToken = fieldUtility.getStringOrNull(BlackDuckDescriptor.KEY_BLACKDUCK_API_KEY);
     }
 
     private static FieldUtility createFieldUtility(ConfigurationModel configurationModel) {
         return Optional.ofNullable(configurationModel)
-                   .map(config -> new FieldUtility(config.getCopyOfKeyToFieldMap()))
-                   .orElse(new FieldUtility(Map.of()));
+            .map(config -> new FieldUtility(config.getCopyOfKeyToFieldMap()))
+            .orElse(new FieldUtility(Map.of()));
     }
 
     public Optional<String> getBlackDuckUrl() {
@@ -154,6 +155,10 @@ public class BlackDuckProperties extends ProviderProperties {
         blackDuckServerConfigBuilder.setUrl(blackDuckUrl);
 
         return blackDuckServerConfigBuilder;
+    }
+
+    public ApiTokenBlackDuckHttpClient createApiTokenBlackDuckHttpClient(IntLogger logger) throws AlertException {
+        return createBlackDuckServerConfig(logger).createApiTokenBlackDuckHttpClient(logger);
     }
 
     private Map<String, String> createBlackDuckProperties(String blackDuckUrl) {

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/action/BlackDuckDistributionFieldModelTestAction.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/action/BlackDuckDistributionFieldModelTestAction.java
@@ -126,12 +126,9 @@ public class BlackDuckDistributionFieldModelTestAction extends FieldModelTestAct
             boolean foundResult = false;
             while (!foundResult && currentPage < projectsByProviderConfigId.getTotalPages()) {
                 List<String> providerProjects = projectsByProviderConfigId.getModels();
-                foundResult = providerProjects.stream().anyMatch(href ->
-                                                                     iteratePagesAndCheck(
-                                                                         versionCurrentPage -> blackDuckDataAccessor.getProjectVersionNamesByHref(providerConfigId, href, versionCurrentPage),
-                                                                         versionNames -> versionNames.stream().anyMatch(versionName -> compiledProjectVersionPattern.matcher(versionName).matches()),
-                                                                         Boolean.FALSE
-                                                                     ).isEmpty());
+                foundResult = providerProjects.stream().anyMatch(href -> iteratePagesAndCheck(versionCurrentPage -> blackDuckDataAccessor.getProjectVersionNamesByHref(providerConfigId, href, versionCurrentPage),
+                    versionNames -> versionNames.stream().anyMatch(versionName -> compiledProjectVersionPattern.matcher(versionName).matches()),
+                    Boolean.FALSE).isEmpty());
                 currentPage++;
                 projectsByProviderConfigId = filterAndMapHrefs(providerConfigId, currentPage, configuredProjects, compiledProjectNamePattern);
             }

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/action/BlackDuckDistributionFieldModelTestAction.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/action/BlackDuckDistributionFieldModelTestAction.java
@@ -40,6 +40,7 @@ import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProvider;
 import com.synopsys.integration.alert.provider.blackduck.validator.BlackDuckApiTokenValidator;
+import com.synopsys.integration.alert.provider.blackduck.validator.BlackDuckSystemValidator;
 import com.synopsys.integration.exception.IntegrationException;
 
 @Component
@@ -49,16 +50,18 @@ public class BlackDuckDistributionFieldModelTestAction extends FieldModelTestAct
     private final ProviderDataAccessor blackDuckDataAccessor;
     private final BlackDuckProvider blackDuckProvider;
     private final ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor;
+    private final BlackDuckSystemValidator blackDuckSystemValidator;
 
     @Autowired
     public BlackDuckDistributionFieldModelTestAction(
         ProviderDataAccessor blackDuckDataAccessor,
         BlackDuckProvider blackDuckProvider,
-        ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor
-    ) {
+        ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor,
+        BlackDuckSystemValidator blackDuckSystemValidator) {
         this.blackDuckDataAccessor = blackDuckDataAccessor;
         this.blackDuckProvider = blackDuckProvider;
         this.configurationModelConfigurationAccessor = configurationModelConfigurationAccessor;
+        this.blackDuckSystemValidator = blackDuckSystemValidator;
     }
 
     @Override
@@ -94,9 +97,8 @@ public class BlackDuckDistributionFieldModelTestAction extends FieldModelTestAct
 
             }
             if (null != blackDuckProperties) {
-                BlackDuckApiTokenValidator blackDuckAPITokenValidator = new BlackDuckApiTokenValidator(blackDuckProperties);
-                if (!blackDuckAPITokenValidator.isApiTokenValid()) {
-                    fieldStatuses.add(AlertFieldStatus.error(ProviderDescriptor.KEY_PROVIDER_CONFIG_ID, "User permission failed, cannot read notifications from Black Duck."));
+                if (!blackDuckSystemValidator.canConnect(blackDuckProperties, new BlackDuckApiTokenValidator(blackDuckProperties))) {
+                    fieldStatuses.add(AlertFieldStatus.error(ProviderDescriptor.KEY_PROVIDER_CONFIG_ID, "Unable to establish connection with BlackDuck."));
                 }
             }
         } else {
@@ -125,11 +127,11 @@ public class BlackDuckDistributionFieldModelTestAction extends FieldModelTestAct
             while (!foundResult && currentPage < projectsByProviderConfigId.getTotalPages()) {
                 List<String> providerProjects = projectsByProviderConfigId.getModels();
                 foundResult = providerProjects.stream().anyMatch(href ->
-                    iteratePagesAndCheck(
-                        versionCurrentPage -> blackDuckDataAccessor.getProjectVersionNamesByHref(providerConfigId, href, versionCurrentPage),
-                        versionNames -> versionNames.stream().anyMatch(versionName -> compiledProjectVersionPattern.matcher(versionName).matches()),
-                        Boolean.FALSE
-                    ).isEmpty());
+                                                                     iteratePagesAndCheck(
+                                                                         versionCurrentPage -> blackDuckDataAccessor.getProjectVersionNamesByHref(providerConfigId, href, versionCurrentPage),
+                                                                         versionNames -> versionNames.stream().anyMatch(versionName -> compiledProjectVersionPattern.matcher(versionName).matches()),
+                                                                         Boolean.FALSE
+                                                                     ).isEmpty());
                 currentPage++;
                 projectsByProviderConfigId = filterAndMapHrefs(providerConfigId, currentPage, configuredProjects, compiledProjectNamePattern);
             }

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckAccumulator.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckAccumulator.java
@@ -33,6 +33,7 @@ import com.synopsys.integration.alert.common.util.DateUtils;
 import com.synopsys.integration.alert.descriptor.api.BlackDuckProviderKey;
 import com.synopsys.integration.alert.processor.api.filter.StatefulAlertPage;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
+import com.synopsys.integration.alert.provider.blackduck.validator.BlackDuckApiTokenValidator;
 import com.synopsys.integration.alert.provider.blackduck.validator.BlackDuckSystemValidator;
 import com.synopsys.integration.blackduck.api.manual.enumeration.NotificationType;
 import com.synopsys.integration.blackduck.api.manual.view.NotificationUserView;
@@ -81,7 +82,8 @@ public class BlackDuckAccumulator extends ProviderTask {
 
     @Override
     protected void runProviderTask() {
-        if (blackDuckSystemValidator.validate(getProviderProperties())) {
+        BlackDuckProperties blackDuckProperties = getProviderProperties();
+        if (blackDuckSystemValidator.canConnect(blackDuckProperties, new BlackDuckApiTokenValidator(blackDuckProperties))) {
             accumulateNotifications();
         }
     }

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/validator/BlackDuckApiTokenValidator.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/validator/BlackDuckApiTokenValidator.java
@@ -16,10 +16,12 @@ import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
 import com.synopsys.integration.blackduck.api.generated.discovery.ApiDiscovery;
 import com.synopsys.integration.blackduck.api.generated.view.RoleAssignmentView;
 import com.synopsys.integration.blackduck.api.generated.view.UserView;
+import com.synopsys.integration.blackduck.http.client.ApiTokenBlackDuckHttpClient;
 import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
 import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.log.Slf4jIntLogger;
+import com.synopsys.integration.rest.response.Response;
 
 public class BlackDuckApiTokenValidator {
     public static final String ROLE_NAME_GLOBAL_PROJECT_VIEWER = "Global Project Viewer";
@@ -44,12 +46,18 @@ public class BlackDuckApiTokenValidator {
         this.blackDuckProperties = blackDuckProperties;
     }
 
+    public Response attemptAuthentication() throws IntegrationException {
+        Slf4jIntLogger intLogger = new Slf4jIntLogger(logger);
+        ApiTokenBlackDuckHttpClient apiTokenBlackDuckHttpClient = blackDuckProperties.createApiTokenBlackDuckHttpClient(intLogger);
+        return apiTokenBlackDuckHttpClient.attemptAuthentication();
+    }
+
     public boolean isApiTokenValid() {
         Slf4jIntLogger intLogger = new Slf4jIntLogger(logger);
         return blackDuckProperties.createBlackDuckHttpClientAndLogErrors(logger)
-                   .map(httpClient -> blackDuckProperties.createBlackDuckServicesFactory(httpClient, intLogger))
-                   .map(this::hasPermittedRole)
-                   .orElse(false);
+            .map(httpClient -> blackDuckProperties.createBlackDuckServicesFactory(httpClient, intLogger))
+            .map(this::hasPermittedRole)
+            .orElse(false);
     }
 
     private boolean hasPermittedRole(BlackDuckServicesFactory blackDuckServicesFactory) {
@@ -67,8 +75,8 @@ public class BlackDuckApiTokenValidator {
         try {
             List<RoleAssignmentView> allRolesForCurrentUser = blackDuckApiClient.getAllResponses(currentUser.metaRolesLink());
             return allRolesForCurrentUser
-                       .stream()
-                       .anyMatch(this::isPermittedRole);
+                .stream()
+                .anyMatch(this::isPermittedRole);
         } catch (IntegrationException integrationException) {
             logger.error("Failed to GET the currently authenticated Black Duck user's roles", integrationException);
         }

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/validator/BlackDuckSystemValidator.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/validator/BlackDuckSystemValidator.java
@@ -97,7 +97,12 @@ public class BlackDuckSystemValidator extends BaseSystemValidator {
     }
 
     public boolean canConnect(BlackDuckProperties blackDuckProperties, BlackDuckApiTokenValidator blackDuckAPITokenValidator) {
-        String blackduckServerName = blackDuckProperties.getBlackDuckUrl().orElse(null);
+        if (blackDuckProperties.getBlackDuckUrl().isEmpty()) {
+            logger.error("Black Duck URL not configured.");
+            return false;
+        }
+
+        String blackduckServerName = blackDuckProperties.getBlackDuckUrl().get();
         Response authenticationResponse;
 
         logger.info("  -> Attempting connection to {}", blackduckServerName);

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/action/BlackDuckDistributionFieldModelTestActionTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/action/BlackDuckDistributionFieldModelTestActionTest.java
@@ -24,6 +24,7 @@ import com.synopsys.integration.alert.common.persistence.model.ConfigurationFiel
 import com.synopsys.integration.alert.common.persistence.model.ProviderProject;
 import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 import com.synopsys.integration.alert.common.util.DataStructureUtils;
+import com.synopsys.integration.alert.provider.blackduck.validator.BlackDuckSystemValidator;
 import com.synopsys.integration.alert.test.common.TestTags;
 import com.synopsys.integration.exception.IntegrationException;
 
@@ -116,7 +117,8 @@ public class BlackDuckDistributionFieldModelTestActionTest {
     private BlackDuckDistributionFieldModelTestAction createTestAction() {
         ProviderDataAccessor providerDataAccessor = createProviderDataAccessor();
         ConfigurationModelConfigurationAccessor configurationAccessor = createConfigurationAccessor();
-        return new BlackDuckDistributionFieldModelTestAction(providerDataAccessor, null, configurationAccessor);
+        BlackDuckSystemValidator blackDuckSystemValidator = new BlackDuckSystemValidator(null);
+        return new BlackDuckDistributionFieldModelTestAction(providerDataAccessor, null, configurationAccessor, blackDuckSystemValidator);
     }
 
     private ProviderDataAccessor createProviderDataAccessor() {

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckAccumulatorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckAccumulatorTest.java
@@ -50,8 +50,7 @@ public class BlackDuckAccumulatorTest {
         EventManager eventManager = Mockito.mock(EventManager.class);
         Mockito.doNothing().when(eventManager).sendEvent(Mockito.any(NotificationReceivedEvent.class));
 
-        BlackDuckAccumulator accumulator = new BlackDuckAccumulator(BLACK_DUCK_PROVIDER_KEY, null, notificationAccessor, taskPropertiesAccessor, blackDuckProperties, validator, eventManager,
-            notificationRetrieverFactory);
+        BlackDuckAccumulator accumulator = new BlackDuckAccumulator(BLACK_DUCK_PROVIDER_KEY, null, notificationAccessor, taskPropertiesAccessor, blackDuckProperties, validator, eventManager, notificationRetrieverFactory);
         accumulator.run();
 
         Mockito.verify(notificationAccessor, Mockito.times(1)).saveAllNotifications(Mockito.anyList());

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckAccumulatorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckAccumulatorTest.java
@@ -1,5 +1,7 @@
 package com.synopsys.integration.alert.provider.blackduck.task.accumulator;
 
+import static org.mockito.Mockito.spy;
+
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -17,6 +19,7 @@ import com.synopsys.integration.alert.descriptor.api.BlackDuckProviderKey;
 import com.synopsys.integration.alert.processor.api.filter.PageRetriever;
 import com.synopsys.integration.alert.processor.api.filter.StatefulAlertPage;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
+import com.synopsys.integration.alert.provider.blackduck.validator.BlackDuckApiTokenValidator;
 import com.synopsys.integration.alert.provider.blackduck.validator.BlackDuckSystemValidator;
 import com.synopsys.integration.blackduck.api.manual.enumeration.NotificationType;
 import com.synopsys.integration.blackduck.api.manual.view.NotificationUserView;
@@ -29,7 +32,7 @@ public class BlackDuckAccumulatorTest {
      * This test should simulate a normal run of the accumulator with notifications present.
      */
     @Test
-    public void runTest() throws Exception {
+    public void runValidAccumulatorTest() throws Exception {
         ProviderTaskPropertiesAccessor taskPropertiesAccessor = Mockito.mock(ProviderTaskPropertiesAccessor.class);
         BlackDuckProperties blackDuckProperties = createBlackDuckProperties();
         BlackDuckSystemValidator validator = createBlackDuckValidator(blackDuckProperties, true);
@@ -47,7 +50,8 @@ public class BlackDuckAccumulatorTest {
         EventManager eventManager = Mockito.mock(EventManager.class);
         Mockito.doNothing().when(eventManager).sendEvent(Mockito.any(NotificationReceivedEvent.class));
 
-        BlackDuckAccumulator accumulator = new BlackDuckAccumulator(BLACK_DUCK_PROVIDER_KEY, null, notificationAccessor, taskPropertiesAccessor, blackDuckProperties, validator, eventManager, notificationRetrieverFactory);
+        BlackDuckAccumulator accumulator = new BlackDuckAccumulator(BLACK_DUCK_PROVIDER_KEY, null, notificationAccessor, taskPropertiesAccessor, blackDuckProperties, validator, eventManager,
+            notificationRetrieverFactory);
         accumulator.run();
 
         Mockito.verify(notificationAccessor, Mockito.times(1)).saveAllNotifications(Mockito.anyList());
@@ -103,9 +107,11 @@ public class BlackDuckAccumulatorTest {
     }
 
     private BlackDuckSystemValidator createBlackDuckValidator(BlackDuckProperties blackDuckProperties, boolean validationResult) {
-        BlackDuckSystemValidator validator = Mockito.mock(BlackDuckSystemValidator.class);
-        Mockito.when(validator.validate(Mockito.eq(blackDuckProperties))).thenReturn(validationResult);
-        return validator;
+        BlackDuckSystemValidator blackDuckSystemValidator = Mockito.mock(BlackDuckSystemValidator.class);
+        Mockito.when(blackDuckSystemValidator.validate(Mockito.eq(blackDuckProperties))).thenReturn(validationResult);
+        BlackDuckSystemValidator spiedBlackDuckSystemValidator = spy(blackDuckSystemValidator);
+        Mockito.doReturn(validationResult).when(spiedBlackDuckSystemValidator).canConnect(Mockito.eq(blackDuckProperties), Mockito.any(BlackDuckApiTokenValidator.class));
+        return spiedBlackDuckSystemValidator;
     }
 
     private BlackDuckNotificationRetrieverFactory createBlackDuckNotificationRetrieverFactory(BlackDuckProperties blackDuckProperties, @Nullable BlackDuckNotificationRetriever notificationRetriever) {
@@ -114,7 +120,7 @@ public class BlackDuckAccumulatorTest {
         return notificationRetrieverFactory;
     }
 
-    private StatefulAlertPage<NotificationUserView, IntegrationException> createMockNotificationPage(PageRetriever pageRetriever) throws IntegrationException {
+    private StatefulAlertPage<NotificationUserView, IntegrationException> createMockNotificationPage(PageRetriever pageRetriever) {
         NotificationUserView notificationView = createMockNotificationView();
         AlertPagedDetails<NotificationUserView> alertPagedDetails = new AlertPagedDetails<>(1, 0, 1, List.of(notificationView));
         return new StatefulAlertPage<>(alertPagedDetails, pageRetriever, BlackDuckNotificationRetriever.HAS_NEXT_PAGE);

--- a/src/test/java/com/synopsys/integration/alert/startup/component/SystemValidatorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/startup/component/SystemValidatorTest.java
@@ -1,6 +1,8 @@
 package com.synopsys.integration.alert.startup.component;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
 
 import java.io.IOException;
 import java.util.List;
@@ -22,17 +24,22 @@ import com.synopsys.integration.alert.component.users.UserSystemValidator;
 import com.synopsys.integration.alert.database.system.DefaultSystemMessageAccessor;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProperties;
 import com.synopsys.integration.alert.provider.blackduck.BlackDuckProvider;
+import com.synopsys.integration.alert.provider.blackduck.validator.BlackDuckApiTokenValidator;
 import com.synopsys.integration.alert.provider.blackduck.validator.BlackDuckSystemValidator;
 import com.synopsys.integration.alert.test.common.OutputLogger;
 import com.synopsys.integration.blackduck.configuration.BlackDuckServerConfig;
+import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.rest.credentials.Credentials;
 import com.synopsys.integration.rest.credentials.CredentialsBuilder;
 import com.synopsys.integration.rest.proxy.ProxyInfo;
 import com.synopsys.integration.rest.proxy.ProxyInfoBuilder;
+import com.synopsys.integration.rest.response.Response;
 
 public class SystemValidatorTest {
     private static final String DEFAULT_CONFIG_NAME = "Default";
+    private static final String LOCALHOST = "https://localhost:443";
+
     private OutputLogger outputLogger;
 
     @BeforeEach
@@ -79,7 +86,7 @@ public class SystemValidatorTest {
     }
 
     @Test
-    public void testvalidateBlackDuckProviderNullURL() throws Exception {
+    public void testValidateBlackDuckProviderNullURL() throws Exception {
         long configId = 1L;
         BlackDuckProperties blackDuckProperties = Mockito.mock(BlackDuckProperties.class);
         Mockito.when(blackDuckProperties.getBlackDuckUrl()).thenReturn(Optional.empty());
@@ -102,12 +109,12 @@ public class SystemValidatorTest {
     }
 
     @Test
-    public void testvalidateBlackDuckProviderLocalhostURL() throws Exception {
+    public void testValidateBlackDuckProviderLocalhostURL() throws Exception {
         long configId = 1L;
         ProxyManager proxyManager = Mockito.mock(ProxyManager.class);
         Mockito.when(proxyManager.createProxyInfoForHost(Mockito.anyString())).thenReturn(ProxyInfo.NO_PROXY_INFO);
         BlackDuckProperties blackDuckProperties = Mockito.mock(BlackDuckProperties.class);
-        Mockito.when(blackDuckProperties.getBlackDuckUrl()).thenReturn(Optional.of("https://localhost:443"));
+        Mockito.when(blackDuckProperties.getBlackDuckUrl()).thenReturn(Optional.of(LOCALHOST));
         Mockito.when(blackDuckProperties.getBlackDuckTimeout()).thenReturn(BlackDuckProperties.DEFAULT_TIMEOUT);
         Mockito.when(blackDuckProperties.getConfigName()).thenReturn(DEFAULT_CONFIG_NAME);
         Mockito.when(blackDuckProperties.getConfigId()).thenReturn(configId);
@@ -123,7 +130,10 @@ public class SystemValidatorTest {
 
         String localhostMessageType = BlackDuckSystemValidator.createProviderSystemMessageType(blackDuckProperties, SystemMessageType.BLACKDUCK_PROVIDER_LOCALHOST);
         BlackDuckSystemValidator blackDuckSystemValidator = new BlackDuckSystemValidator(defaultSystemMessageUtility);
-        blackDuckSystemValidator.validate(blackDuckProperties);
+        BlackDuckSystemValidator spiedBlackDuckSystemValidator = spy(blackDuckSystemValidator);
+        Mockito.doReturn(true).when(spiedBlackDuckSystemValidator).canConnect(Mockito.eq(blackDuckProperties), Mockito.any(BlackDuckApiTokenValidator.class));
+        spiedBlackDuckSystemValidator.validate(blackDuckProperties);
+
         Mockito.verify(defaultSystemMessageUtility)
             .addSystemMessage(Mockito.eq(String.format(BlackDuckSystemValidator.BLACKDUCK_LOCALHOST_ERROR_FORMAT, DEFAULT_CONFIG_NAME)), Mockito.eq(SystemMessageSeverity.WARNING), Mockito.eq(localhostMessageType));
     }
@@ -134,7 +144,7 @@ public class SystemValidatorTest {
         ProxyManager proxyManager = Mockito.mock(ProxyManager.class);
         Mockito.when(proxyManager.createProxyInfoForHost(Mockito.anyString())).thenReturn(ProxyInfo.NO_PROXY_INFO);
         BlackDuckProperties blackDuckProperties = Mockito.mock(BlackDuckProperties.class);
-        Mockito.when(blackDuckProperties.getBlackDuckUrl()).thenReturn(Optional.of("https://localhost:443/alert"));
+        Mockito.when(blackDuckProperties.getBlackDuckUrl()).thenReturn(Optional.of(LOCALHOST));
         Mockito.when(blackDuckProperties.getApiToken()).thenReturn("Test Api Key");
         Mockito.when(blackDuckProperties.getBlackDuckTimeout()).thenReturn(BlackDuckProperties.DEFAULT_TIMEOUT);
         Mockito.when(blackDuckProperties.getConfigName()).thenReturn(DEFAULT_CONFIG_NAME);
@@ -154,7 +164,10 @@ public class SystemValidatorTest {
         String connectivityMessageType = BlackDuckSystemValidator.createProviderSystemMessageType(blackDuckProperties, SystemMessageType.BLACKDUCK_PROVIDER_CONNECTIVITY);
 
         BlackDuckSystemValidator blackDuckSystemValidator = new BlackDuckSystemValidator(defaultSystemMessageUtility);
-        blackDuckSystemValidator.validate(blackDuckProperties);
+        BlackDuckSystemValidator spiedBlackDuckSystemValidator = spy(blackDuckSystemValidator);
+        Mockito.doReturn(false).when(spiedBlackDuckSystemValidator).canConnect(Mockito.eq(blackDuckProperties), Mockito.any(BlackDuckApiTokenValidator.class));
+        spiedBlackDuckSystemValidator.validate(blackDuckProperties);
+
         Mockito.verify(defaultSystemMessageUtility)
             .addSystemMessage(Mockito.eq(String.format(BlackDuckSystemValidator.BLACKDUCK_LOCALHOST_ERROR_FORMAT, DEFAULT_CONFIG_NAME)), Mockito.eq(SystemMessageSeverity.WARNING), Mockito.eq(localhostMessageType));
         Mockito.verify(defaultSystemMessageUtility)
@@ -182,7 +195,10 @@ public class SystemValidatorTest {
         Mockito.when(statefulProvider.getProperties()).thenReturn(blackDuckProperties);
 
         BlackDuckSystemValidator blackDuckSystemValidator = new BlackDuckSystemValidator(defaultSystemMessageUtility);
-        blackDuckSystemValidator.validate(blackDuckProperties);
+        BlackDuckSystemValidator spiedBlackDuckSystemValidator = spy(blackDuckSystemValidator);
+        Mockito.doReturn(true).when(spiedBlackDuckSystemValidator).canConnect(Mockito.eq(blackDuckProperties), Mockito.any(BlackDuckApiTokenValidator.class));
+        spiedBlackDuckSystemValidator.validate(blackDuckProperties);
+
         Mockito.verify(defaultSystemMessageUtility, Mockito.times(0)).addSystemMessage(Mockito.anyString(), Mockito.any(SystemMessageSeverity.class), Mockito.any(SystemMessageType.class));
     }
 
@@ -223,4 +239,70 @@ public class SystemValidatorTest {
         Mockito.verify(defaultSystemMessageUtility, Mockito.times(0)).addSystemMessage(Mockito.anyString(), Mockito.any(SystemMessageSeverity.class), Mockito.any(SystemMessageType.class));
     }
 
+    @Test
+    public void testCanConnectTrue() throws IOException, IntegrationException {
+        BlackDuckProperties blackDuckProperties = createMockBlackDuckProperties(Optional.of(LOCALHOST));
+
+        DefaultSystemMessageAccessor defaultSystemMessageUtility = Mockito.mock(DefaultSystemMessageAccessor.class);
+        BlackDuckSystemValidator blackDuckSystemValidator = new BlackDuckSystemValidator(defaultSystemMessageUtility);
+
+        Response canConnectResponse = Mockito.mock(Response.class);
+        Mockito.when(canConnectResponse.isStatusCodeSuccess()).thenReturn(true);
+
+        BlackDuckApiTokenValidator spiedBlackDuckApiTokenValidator = spy(new BlackDuckApiTokenValidator(blackDuckProperties));
+        Mockito.doReturn(canConnectResponse).when(spiedBlackDuckApiTokenValidator).attemptAuthentication();
+
+        boolean canConnectResult = blackDuckSystemValidator.canConnect(blackDuckProperties, spiedBlackDuckApiTokenValidator);
+
+        assertTrue(canConnectResult);
+        assertTrue(outputLogger.isLineContainingText("Attempting connection to " + LOCALHOST));
+        assertTrue(outputLogger.isLineContainingText("Successfully connected to " + LOCALHOST));
+    }
+
+    @Test
+    public void testCanConnectFalse() throws IOException, IntegrationException {
+        int httpResponseCode = 409;
+        BlackDuckProperties blackDuckProperties = createMockBlackDuckProperties(Optional.of(LOCALHOST));
+
+        DefaultSystemMessageAccessor mockDefaultSystemMessageAccessor = Mockito.mock(DefaultSystemMessageAccessor.class);
+        BlackDuckSystemValidator blackDuckSystemValidator = new BlackDuckSystemValidator(mockDefaultSystemMessageAccessor);
+
+        Response mockResponse = Mockito.mock(Response.class);
+        Mockito.when(mockResponse.isStatusCodeSuccess()).thenReturn(false);
+        Mockito.when(mockResponse.getStatusCode()).thenReturn(httpResponseCode);
+
+        BlackDuckApiTokenValidator spiedBlackDuckApiTokenValidator = spy(new BlackDuckApiTokenValidator(blackDuckProperties));
+        Mockito.doReturn(mockResponse).when(spiedBlackDuckApiTokenValidator).attemptAuthentication();
+
+        boolean canConnectResult = blackDuckSystemValidator.canConnect(blackDuckProperties, spiedBlackDuckApiTokenValidator);
+
+        assertFalse(canConnectResult);
+        assertTrue(outputLogger.isLineContainingText(String.format("Failed to make connection to %s; http status code: %d", LOCALHOST, httpResponseCode)));
+    }
+
+    @Test
+    public void testCanConnectThrowException() throws IOException, IntegrationException {
+        BlackDuckProperties blackDuckProperties = createMockBlackDuckProperties(Optional.of(LOCALHOST));
+
+        DefaultSystemMessageAccessor mockDefaultSystemMessageAccessor = Mockito.mock(DefaultSystemMessageAccessor.class);
+        BlackDuckSystemValidator blackDuckSystemValidator = new BlackDuckSystemValidator(mockDefaultSystemMessageAccessor);
+
+        BlackDuckApiTokenValidator spiedBlackDuckApiTokenValidator = spy(new BlackDuckApiTokenValidator(blackDuckProperties));
+        Mockito.doThrow(IntegrationException.class).when(spiedBlackDuckApiTokenValidator).attemptAuthentication();
+
+        boolean canConnectResult = blackDuckSystemValidator.canConnect(blackDuckProperties, spiedBlackDuckApiTokenValidator);
+
+        assertFalse(canConnectResult);
+        assertTrue(outputLogger.isLineContainingText(String.format("Failed to make connection to %s; cause: ", LOCALHOST)));
+    }
+
+    private BlackDuckProperties createMockBlackDuckProperties(Optional<String> blackDuckUrl) {
+        BlackDuckProperties blackDuckProperties = Mockito.mock(BlackDuckProperties.class);
+        Mockito.when(blackDuckProperties.getBlackDuckUrl()).thenReturn(blackDuckUrl);
+        Mockito.when(blackDuckProperties.getBlackDuckTimeout()).thenReturn(BlackDuckProperties.DEFAULT_TIMEOUT);
+        Mockito.when(blackDuckProperties.getConfigName()).thenReturn(DEFAULT_CONFIG_NAME);
+        Mockito.when(blackDuckProperties.getConfigId()).thenReturn(1L);
+
+        return blackDuckProperties;
+    }
 }

--- a/src/test/java/com/synopsys/integration/alert/startup/component/SystemValidatorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/startup/component/SystemValidatorTest.java
@@ -296,6 +296,22 @@ public class SystemValidatorTest {
         assertTrue(outputLogger.isLineContainingText(String.format("Failed to make connection to %s; cause: ", LOCALHOST)));
     }
 
+    @Test
+    public void testCanConnectNullBDUrl() throws IOException, IntegrationException {
+        BlackDuckProperties blackDuckProperties = createMockBlackDuckProperties(Optional.empty());
+
+        DefaultSystemMessageAccessor mockDefaultSystemMessageAccessor = Mockito.mock(DefaultSystemMessageAccessor.class);
+        BlackDuckSystemValidator blackDuckSystemValidator = new BlackDuckSystemValidator(mockDefaultSystemMessageAccessor);
+
+        BlackDuckApiTokenValidator spiedBlackDuckApiTokenValidator = spy(new BlackDuckApiTokenValidator(blackDuckProperties));
+        Mockito.doThrow(IntegrationException.class).when(spiedBlackDuckApiTokenValidator).attemptAuthentication();
+
+        boolean canConnectResult = blackDuckSystemValidator.canConnect(blackDuckProperties, spiedBlackDuckApiTokenValidator);
+
+        assertFalse(canConnectResult);
+        assertTrue(outputLogger.isLineContainingText("Black Duck URL not configured."));
+    }
+
     private BlackDuckProperties createMockBlackDuckProperties(Optional<String> blackDuckUrl) {
         BlackDuckProperties blackDuckProperties = Mockito.mock(BlackDuckProperties.class);
         Mockito.when(blackDuckProperties.getBlackDuckUrl()).thenReturn(blackDuckUrl);


### PR DESCRIPTION
In the current implementation of Alert, we perform the full provider validation, which includes checking user/role permissions in BD, when configuring a provider, configuring a distribution, and on each launch of the accumulator.

Changes:
- New canConnect() method which checks the return http status code of connecting to BD using an API token.
- Use canConnect() first when communicating with an instance of BD
- Only call isApiTokenValid() from provider
- Update tests to reflect changes
- Add full coverage for canConnect()

