### PR TITLE
Wait for when jobs are processing only.

### DIFF
--- a/src/test/java/com/synopsys/integration/alert/performance/utility/NotificationWaitJobTaskV2.java
+++ b/src/test/java/com/synopsys/integration/alert/performance/utility/NotificationWaitJobTaskV2.java
@@ -73,11 +73,12 @@ public class NotificationWaitJobTaskV2 implements WaitJobCondition {
         }
         intLogger.info(String.format("Performance: Found %s audit entries, expected %s. ", totalNotificationsCreatedPageModel.getTotalPages(), numberOfExpectedNotifications));
 
-        Set<String> jobIds = getJobIdsFromAuditEntries();
-
-        intLogger.info(String.format("Performance: Job IDs discovered in audit: %s", jobIds.toString()));
-        intLogger.info(String.format("Performance: Expected Job Ids:            %s", expectedJobIds.toString()));
-        return expectedJobIds.size() == jobIds.size() && expectedJobIds.containsAll(jobIds);
+        return true;
+        //        Set<String> jobIds = getJobIdsFromAuditEntries();
+        //
+        //        intLogger.info(String.format("Performance: Job IDs discovered in audit: %s", jobIds.toString()));
+        //        intLogger.info(String.format("Performance: Expected Job Ids:            %s", expectedJobIds.toString()));
+        //        return expectedJobIds.size() == jobIds.size() && expectedJobIds.containsAll(jobIds);
     }
 
     private Set<String> getJobIdsFromAuditEntries() throws IntegrationException {


### PR DESCRIPTION
Make the same change to wait for audit entries to be processing only.  That will measure how fast it takes to process the notifications.