### PR TITLE
IALERT-3001: Use corrected api link and succeed fast (Predicate)

### DIFF
--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/validator/BlackDuckApiTokenValidator.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/validator/BlackDuckApiTokenValidator.java
@@ -8,6 +8,7 @@
 package com.synopsys.integration.alert.provider.blackduck.validator;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,19 +74,12 @@ public class BlackDuckApiTokenValidator {
         }
 
         try {
-            List<RoleAssignmentView> allRolesForCurrentUser = blackDuckApiClient.getAllResponses(currentUser.metaRolesLink());
-            return allRolesForCurrentUser
-                .stream()
-                .anyMatch(this::isPermittedRole);
+            Predicate<RoleAssignmentView> predicate = role -> PERMITTED_ROLE_NAMES.contains(role.getName());
+            return !blackDuckApiClient.getSomeMatchingResponses(currentUser.metaInheritedRolesLink(), predicate, 1).isEmpty();
         } catch (IntegrationException integrationException) {
             logger.error("Failed to GET the currently authenticated Black Duck user's roles", integrationException);
         }
         return false;
-    }
-
-    private boolean isPermittedRole(RoleAssignmentView role) {
-        String roleName = role.getName();
-        return PERMITTED_ROLE_NAMES.contains(roleName);
     }
 
 }


### PR DESCRIPTION
Update validation to use the inherited roles link instead of checking each project
Update validation to use a Predicate so the validation will succeed as soon as it finds a role that Alert requires.