### PR TITLE
diagnostic endpoint

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/DiagnosticAccessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/DiagnosticAccessor.java
@@ -1,0 +1,7 @@
+package com.synopsys.integration.alert.common.persistence.accessor;
+
+import com.synopsys.integration.alert.api.common.model.AlertSerializableModel;
+
+public interface DiagnosticAccessor<T extends AlertSerializableModel> {
+    T getDiagnosticInfo();
+}

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/AlertRestConstants.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/AlertRestConstants.java
@@ -20,6 +20,7 @@ public final class AlertRestConstants {
     public static final String SETTINGS_PATH = AlertRestConstants.BASE_PATH + "/settings";
     public static final String SETTINGS_ENCRYPTION_PATH = AlertRestConstants.SETTINGS_PATH + "/encryption";
     public static final String SETTINGS_PROXY_PATH = AlertRestConstants.SETTINGS_PATH + "/proxy";
+    public static final String DIAGNOSTIC_PATH = AlertRestConstants.BASE_PATH + "/diagnostic";
 
     public static final String DEFAULT_CONFIGURATION_NAME = "default-configuration";
 

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/notification/NotificationContentRepository.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/notification/NotificationContentRepository.java
@@ -45,21 +45,21 @@ public interface NotificationContentRepository extends JpaRepository<Notificatio
     Page<NotificationEntity> findMatchingNotification(@Param("searchTerm") String searchTerm, Pageable pageable);
 
     @Query(value = "SELECT DISTINCT notificationRow "
-                       + "FROM NotificationEntity notificationRow "
-                       + "LEFT JOIN notificationRow.auditNotificationRelations relation ON notificationRow.id = relation.notificationId "
-                       + "LEFT JOIN relation.auditEntryEntity auditEntry ON auditEntry.id = relation.auditEntryId "
-                       + "LEFT JOIN DistributionJobEntity jobEntity ON auditEntry.commonConfigId = jobEntity.jobId "
-                       + "WHERE notificationRow.id IN (SELECT notificationId FROM notificationRow.auditNotificationRelations WHERE notificationRow.id = notificationId) AND "
-                       + "("
-                       + "LOWER(notificationRow.provider) LIKE %:searchTerm% OR "
-                       + "LOWER(notificationRow.notificationType) LIKE %:searchTerm% OR "
-                       + "LOWER(notificationRow.content) LIKE %:searchTerm% OR "
-                       + "COALESCE(to_char(notificationRow.createdAt, 'MM-DD-YYYY HH24:MI:SS'), '') LIKE %:searchTerm% OR "
-                       + "COALESCE(to_char(auditEntry.timeLastSent, 'MM-DD-YYYY HH24:MI:SS'), '') LIKE %:searchTerm% OR "
-                       + "LOWER(auditEntry.status) LIKE %:searchTerm% OR "
-                       + "LOWER(jobEntity.name) LIKE %:searchTerm% OR "
-                       + "LOWER(jobEntity.channelDescriptorName) LIKE %:searchTerm%"
-                       + ")"
+        + "FROM NotificationEntity notificationRow "
+        + "LEFT JOIN notificationRow.auditNotificationRelations relation ON notificationRow.id = relation.notificationId "
+        + "LEFT JOIN relation.auditEntryEntity auditEntry ON auditEntry.id = relation.auditEntryId "
+        + "LEFT JOIN DistributionJobEntity jobEntity ON auditEntry.commonConfigId = jobEntity.jobId "
+        + "WHERE notificationRow.id IN (SELECT notificationId FROM notificationRow.auditNotificationRelations WHERE notificationRow.id = notificationId) AND "
+        + "("
+        + "LOWER(notificationRow.provider) LIKE %:searchTerm% OR "
+        + "LOWER(notificationRow.notificationType) LIKE %:searchTerm% OR "
+        + "LOWER(notificationRow.content) LIKE %:searchTerm% OR "
+        + "COALESCE(to_char(notificationRow.createdAt, 'MM-DD-YYYY HH24:MI:SS'), '') LIKE %:searchTerm% OR "
+        + "COALESCE(to_char(auditEntry.timeLastSent, 'MM-DD-YYYY HH24:MI:SS'), '') LIKE %:searchTerm% OR "
+        + "LOWER(auditEntry.status) LIKE %:searchTerm% OR "
+        + "LOWER(jobEntity.name) LIKE %:searchTerm% OR "
+        + "LOWER(jobEntity.channelDescriptorName) LIKE %:searchTerm%"
+        + ")"
     )
     Page<NotificationEntity> findMatchingSentNotification(@Param("searchTerm") String searchTerm, Pageable pageable);
 
@@ -67,16 +67,20 @@ public interface NotificationContentRepository extends JpaRepository<Notificatio
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE NotificationEntity entity "
-               + "SET entity.processed = true "
-               + "WHERE entity.id IN :notificationIds"
+        + "SET entity.processed = true "
+        + "WHERE entity.id IN :notificationIds"
     )
     void setProcessedByIds(@Param("notificationIds") Set<Long> notificationIds);
 
     @Query("DELETE FROM NotificationEntity notification"
-               + " WHERE notification.createdAt < :date"
+        + " WHERE notification.createdAt < :date"
     )
     @Modifying
     int bulkDeleteCreatedAtBefore(@Param("date") OffsetDateTime date);
 
     boolean existsByProcessedFalse();
+
+    long countByProcessedIsFalse();
+
+    long countByProcessedIsTrue();
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/action/DiagnosticCrudActions.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/action/DiagnosticCrudActions.java
@@ -1,0 +1,34 @@
+package com.synopsys.integration.alert.component.diagnostic.action;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.common.action.ActionResponse;
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.rest.api.ConfigurationCrudHelper;
+import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
+import com.synopsys.integration.alert.component.diagnostic.database.DefaultDiagnosticAccessor;
+import com.synopsys.integration.alert.component.diagnostic.model.DiagnosticModel;
+import com.synopsys.integration.alert.component.settings.descriptor.SettingsDescriptorKey;
+
+@Component
+public class DiagnosticCrudActions {
+    private final ConfigurationCrudHelper configurationHelper;
+    private final DefaultDiagnosticAccessor diagnosticAccessor;
+
+    @Autowired
+    public DiagnosticCrudActions(AuthorizationManager authorizationManager, SettingsDescriptorKey settingsDescriptorKey, DefaultDiagnosticAccessor diagnosticAccessor) {
+        this.configurationHelper = new ConfigurationCrudHelper(authorizationManager, ConfigContextEnum.GLOBAL, settingsDescriptorKey);
+        this.diagnosticAccessor = diagnosticAccessor;
+    }
+
+    public ActionResponse<DiagnosticModel> getOne() {
+        return configurationHelper.getOne(this::getDiagnosticModel);
+    }
+
+    private Optional<DiagnosticModel> getDiagnosticModel() {
+        return Optional.of(diagnosticAccessor.getDiagnosticInfo());
+    }
+}

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/database/DefaultDiagnosticAccessor.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/database/DefaultDiagnosticAccessor.java
@@ -1,0 +1,31 @@
+package com.synopsys.integration.alert.component.diagnostic.database;
+
+import java.time.LocalDateTime;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.synopsys.integration.alert.common.persistence.accessor.DiagnosticAccessor;
+import com.synopsys.integration.alert.component.diagnostic.model.DiagnosticModel;
+import com.synopsys.integration.alert.database.notification.NotificationContentRepository;
+
+@Component
+public class DefaultDiagnosticAccessor implements DiagnosticAccessor {
+    private final NotificationContentRepository notificationContentRepository;
+
+    @Autowired
+    public DefaultDiagnosticAccessor(NotificationContentRepository notificationContentRepository) {
+        this.notificationContentRepository = notificationContentRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public DiagnosticModel getDiagnosticInfo() {
+        long numberOfNotifications = notificationContentRepository.count();
+        long numberOfNotificationsProcessed = notificationContentRepository.countByProcessedIsTrue();
+        long numberOfNotificationsUnprocessed = notificationContentRepository.countByProcessedIsFalse();
+
+        return new DiagnosticModel(numberOfNotifications, numberOfNotificationsProcessed, numberOfNotificationsUnprocessed, LocalDateTime.now().toString());
+    }
+}

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/DiagnosticModel.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/DiagnosticModel.java
@@ -1,0 +1,51 @@
+package com.synopsys.integration.alert.component.diagnostic.model;
+
+import com.synopsys.integration.alert.api.common.model.AlertSerializableModel;
+import com.synopsys.integration.alert.api.common.model.Obfuscated;
+
+public class DiagnosticModel extends AlertSerializableModel implements Obfuscated<DiagnosticModel> {
+    private static final long serialVersionUID = 6714869824373312126L;
+    private Long numberOfNotifications;
+    private Long numberOfNotificationsProcessed;
+    private Long numberOfNotificationsUnprocessed;
+
+    private String requestTimestamp;
+
+    public DiagnosticModel() {
+        // For serialization
+    }
+
+    public DiagnosticModel(
+        Long numberOfNotifications,
+        Long numberOfNotificationsProcessed,
+        Long numberOfNotificationsUnprocessed,
+        String requestTimestamp
+    ) {
+        this.numberOfNotifications = numberOfNotifications;
+        this.numberOfNotificationsProcessed = numberOfNotificationsProcessed;
+        this.numberOfNotificationsUnprocessed = numberOfNotificationsUnprocessed;
+        this.requestTimestamp = requestTimestamp;
+    }
+
+    public Long getNumberOfNotifications() {
+        return numberOfNotifications;
+    }
+
+    public Long getNumberOfNotificationsProcessed() {
+        return numberOfNotificationsProcessed;
+    }
+
+    public Long getNumberOfNotificationsUnprocessed() {
+        return numberOfNotificationsUnprocessed;
+    }
+
+    public String getRequestTimestamp() {
+        return requestTimestamp;
+    }
+
+    @Override
+    public DiagnosticModel obfuscate() {
+        // Diagnostic model does not handle sensitive data and therefore does not need any fields to be obfuscated
+        return new DiagnosticModel(numberOfNotifications, numberOfNotificationsProcessed, numberOfNotificationsUnprocessed, requestTimestamp);
+    }
+}

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/web/DiagnosticController.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/web/DiagnosticController.java
@@ -1,0 +1,27 @@
+package com.synopsys.integration.alert.component.diagnostic.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
+import com.synopsys.integration.alert.common.rest.ResponseFactory;
+import com.synopsys.integration.alert.component.diagnostic.action.DiagnosticCrudActions;
+import com.synopsys.integration.alert.component.diagnostic.model.DiagnosticModel;
+
+@RestController
+@RequestMapping(AlertRestConstants.DIAGNOSTIC_PATH)
+public class DiagnosticController {
+    private final DiagnosticCrudActions diagnosticCrudActions;
+
+    @Autowired
+    public DiagnosticController(DiagnosticCrudActions diagnosticCrudActions) {
+        this.diagnosticCrudActions = diagnosticCrudActions;
+    }
+
+    @GetMapping
+    public DiagnosticModel getOne() {
+        return ResponseFactory.createContentResponseFromAction(diagnosticCrudActions.getOne());
+    }
+}

--- a/src/test/java/com/synopsys/integration/alert/component/diagnostic/web/DiagnosticControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/diagnostic/web/DiagnosticControllerTestIT.java
@@ -1,0 +1,55 @@
+package com.synopsys.integration.alert.component.diagnostic.web;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
+import com.synopsys.integration.alert.database.notification.NotificationContentRepository;
+import com.synopsys.integration.alert.util.AlertIntegrationTest;
+import com.synopsys.integration.alert.util.AlertIntegrationTestConstants;
+
+@Transactional
+@AlertIntegrationTest
+class DiagnosticControllerTestIT {
+    @Autowired
+    protected WebApplicationContext webApplicationContext;
+    @Autowired
+    private NotificationContentRepository notificationContentRepository;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void init() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).apply(SecurityMockMvcConfigurers.springSecurity()).build();
+    }
+
+    @AfterEach
+    public void cleanup() {
+        notificationContentRepository.deleteAllInBatch();
+        notificationContentRepository.flush();
+    }
+
+    @Test
+    @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
+    void testGetOne() throws Exception {
+        String url = AlertRestConstants.DIAGNOSTIC_PATH;
+        MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(new URI(url))
+            .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTestConstants.ROLE_ALERT_ADMIN))
+            .with(SecurityMockMvcRequestPostProcessors.csrf());
+        mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk());
+    }
+}


### PR DESCRIPTION
Adding a new endpoint for /api/diagnostic. This endpoint will be used to gather information related to diagnostic details as they exist in Alert. Currently, we will gather information based on the processing status of notifications in the alert database.

As the changes here are additive, unit tests and integration tests will be added once additional fields are added.