### PR TITLE
IALERT-3064 - Update DailyTask to leverage new logic

### DIFF
--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/NotificationMappingProcessor.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/NotificationMappingProcessor.java
@@ -26,8 +26,7 @@ import com.synopsys.integration.alert.processor.api.detail.NotificationDetailExt
 import com.synopsys.integration.alert.processor.api.mapping.JobNotificationMapper2;
 
 @Component
-public class NotificationProcessor2 {
-
+public class NotificationMappingProcessor {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final Logger notificationLogger = AlertLoggerFactory.getNotificationLogger(getClass());
     private final NotificationDetailExtractionDelegator notificationDetailExtractionDelegator;
@@ -35,7 +34,7 @@ public class NotificationProcessor2 {
     private final NotificationAccessor notificationAccessor;
 
     @Autowired
-    public NotificationProcessor2(
+    public NotificationMappingProcessor(
         NotificationDetailExtractionDelegator notificationDetailExtractionDelegator,
         JobNotificationMapper2 jobNotificationMapper,
         NotificationAccessor notificationAccessor

--- a/component/src/main/java/com/synopsys/integration/alert/component/scheduling/workflow/DailyTask.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/scheduling/workflow/DailyTask.java
@@ -14,14 +14,13 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.api.task.TaskManager;
 import com.synopsys.integration.alert.common.enumeration.FrequencyType;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationModelConfigurationAccessor;
-import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.JobAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.NotificationAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.component.scheduling.descriptor.SchedulingDescriptor;
 import com.synopsys.integration.alert.component.scheduling.descriptor.SchedulingDescriptorKey;
 import com.synopsys.integration.alert.component.tasks.ProcessingTask;
-import com.synopsys.integration.alert.processor.api.NotificationProcessor;
+import com.synopsys.integration.alert.processor.api.NotificationMappingProcessor;
 
 @Component
 public class DailyTask extends ProcessingTask {
@@ -36,12 +35,12 @@ public class DailyTask extends ProcessingTask {
         SchedulingDescriptorKey schedulingDescriptorKey,
         TaskScheduler taskScheduler,
         NotificationAccessor notificationAccessor,
-        NotificationProcessor notificationProcessor,
+        NotificationMappingProcessor notificationMappingProcessor,
         TaskManager taskManager,
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor,
         JobAccessor jobAccessor
     ) {
-        super(taskScheduler, taskManager, notificationAccessor, notificationProcessor, jobAccessor, FrequencyType.DAILY);
+        super(taskScheduler, taskManager, notificationAccessor, notificationMappingProcessor, jobAccessor, FrequencyType.DAILY);
         this.schedulingDescriptorKey = schedulingDescriptorKey;
         this.configurationModelConfigurationAccessor = configurationModelConfigurationAccessor;
     }
@@ -49,11 +48,11 @@ public class DailyTask extends ProcessingTask {
     @Override
     public String scheduleCronExpression() {
         String dailySavedCronValue = configurationModelConfigurationAccessor.getConfigurationsByDescriptorKey(schedulingDescriptorKey)
-                                         .stream()
-                                         .findFirst()
-                                         .flatMap(configurationModel -> configurationModel.getField(SchedulingDescriptor.KEY_DAILY_PROCESSOR_HOUR_OF_DAY))
-                                         .flatMap(ConfigurationFieldModel::getFieldValue)
-                                         .orElse(String.valueOf(DEFAULT_HOUR_OF_DAY));
+            .stream()
+            .findFirst()
+            .flatMap(configurationModel -> configurationModel.getField(SchedulingDescriptor.KEY_DAILY_PROCESSOR_HOUR_OF_DAY))
+            .flatMap(ConfigurationFieldModel::getFieldValue)
+            .orElse(String.valueOf(DEFAULT_HOUR_OF_DAY));
         return String.format(CRON_FORMAT, dailySavedCronValue);
     }
 

--- a/src/main/java/com/synopsys/integration/alert/processing/NotificationReceivedEventHandler.java
+++ b/src/main/java/com/synopsys/integration/alert/processing/NotificationReceivedEventHandler.java
@@ -23,8 +23,7 @@ import com.synopsys.integration.alert.common.enumeration.FrequencyType;
 import com.synopsys.integration.alert.common.persistence.accessor.NotificationAccessor;
 import com.synopsys.integration.alert.common.rest.model.AlertNotificationModel;
 import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
-import com.synopsys.integration.alert.processor.api.NotificationProcessor;
-import com.synopsys.integration.alert.processor.api.NotificationProcessor2;
+import com.synopsys.integration.alert.processor.api.NotificationMappingProcessor;
 import com.synopsys.integration.alert.processor.api.event.JobNotificationMappedEvent;
 
 @Component
@@ -34,20 +33,17 @@ public class NotificationReceivedEventHandler implements AlertEventHandler<Notif
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final NotificationAccessor notificationAccessor;
-    private final NotificationProcessor notificationProcessor;
-    private final NotificationProcessor2 notificationProcessor2;
+    private final NotificationMappingProcessor notificationMappingProcessor;
     private final EventManager eventManager;
 
     @Autowired
     public NotificationReceivedEventHandler(
         NotificationAccessor notificationAccessor,
-        NotificationProcessor notificationProcessor,
-        NotificationProcessor2 notificationProcessor2,
+        NotificationMappingProcessor notificationMappingProcessor,
         EventManager eventManager
     ) {
         this.notificationAccessor = notificationAccessor;
-        this.notificationProcessor = notificationProcessor;
-        this.notificationProcessor2 = notificationProcessor2;
+        this.notificationMappingProcessor = notificationMappingProcessor;
         this.eventManager = eventManager;
     }
 
@@ -55,7 +51,6 @@ public class NotificationReceivedEventHandler implements AlertEventHandler<Notif
     public void handle(NotificationReceivedEvent event) {
         logger.debug("Event {}", event);
         logger.info("Processing event {} for notifications.", event.getEventId());
-        logger.info("Processing event for notifications.");
         processNotifications(event.getCorrelationId());
         logger.info("Finished processing event {} for notifications.", event.getEventId());
     }
@@ -65,8 +60,7 @@ public class NotificationReceivedEventHandler implements AlertEventHandler<Notif
         if (!CollectionUtils.isEmpty(pageOfAlertNotificationModels.getModels())) {
             List<AlertNotificationModel> notifications = pageOfAlertNotificationModels.getModels();
             logger.info("Starting to process batch: {} = {} notifications.", correlationID, notifications.size());
-            //notificationProcessor.processNotifications(notifications, List.of(FrequencyType.REAL_TIME));
-            notificationProcessor2.processNotifications(correlationID, notifications, List.of(FrequencyType.REAL_TIME));
+            notificationMappingProcessor.processNotifications(correlationID, notifications, List.of(FrequencyType.REAL_TIME));
             boolean hasMoreNotificationsToProcess = notificationAccessor.hasMoreNotificationsToProcess();
             if (hasMoreNotificationsToProcess) {
                 eventManager.sendEvent(new NotificationReceivedEvent(correlationID));

--- a/src/test/java/com/synopsys/integration/alert/processing/NotificationReceivedEventHandlerTest.java
+++ b/src/test/java/com/synopsys/integration/alert/processing/NotificationReceivedEventHandlerTest.java
@@ -4,13 +4,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.core.task.SyncTaskExecutor;
-import org.springframework.core.task.TaskExecutor;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.event.EventManager;
@@ -18,27 +16,19 @@ import com.synopsys.integration.alert.api.event.NotificationReceivedEvent;
 import com.synopsys.integration.alert.common.persistence.accessor.NotificationAccessor;
 import com.synopsys.integration.alert.common.rest.model.AlertNotificationModel;
 import com.synopsys.integration.alert.common.util.DateUtils;
-import com.synopsys.integration.alert.processor.api.NotificationProcessor;
-import com.synopsys.integration.alert.processor.api.NotificationProcessor2;
-import com.synopsys.integration.alert.processor.api.detail.NotificationDetailExtractionDelegator;
-import com.synopsys.integration.alert.processor.api.filter.JobNotificationMapper;
+import com.synopsys.integration.alert.processor.api.NotificationMappingProcessor;
 import com.synopsys.integration.alert.test.common.TestResourceUtils;
-import com.synopsys.integration.blackduck.http.transform.subclass.BlackDuckResponseResolver;
 
 class NotificationReceivedEventHandlerTest {
-    private final Gson gson = new Gson();
-    private final BlackDuckResponseResolver blackDuckResponseResolver = new BlackDuckResponseResolver(gson);
-    private final TaskExecutor taskExecutor = new SyncTaskExecutor();
 
     @Test
     void handleEventTest() throws IOException {
         AlertNotificationModel alertNotificationModel = createAlertNotificationModel(1L, false);
         List<AlertNotificationModel> alertNotificationModels = List.of(alertNotificationModel);
         NotificationAccessor notificationAccessor = new MockNotificationAccessor(alertNotificationModels);
-        NotificationProcessor notificationProcessor = mockNotificationProcessor(notificationAccessor);
-        NotificationProcessor2 notificationProcessor2 = Mockito.mock(NotificationProcessor2.class);
+        NotificationMappingProcessor notificationMappingProcessor = Mockito.mock(NotificationMappingProcessor.class);
         EventManager eventManager = mockEventManager();
-        NotificationReceivedEventHandler eventHandler = new NotificationReceivedEventHandler(notificationAccessor, notificationProcessor, notificationProcessor2, eventManager);
+        NotificationReceivedEventHandler eventHandler = new NotificationReceivedEventHandler(notificationAccessor, notificationMappingProcessor, eventManager);
 
         try {
             eventHandler.handle(new NotificationReceivedEvent());
@@ -57,13 +47,6 @@ class NotificationReceivedEventHandlerTest {
         return new AlertNotificationModel(id, providerConfigId, provider, providerConfigName, notificationType, content, DateUtils.createCurrentDateTimestamp(),
             DateUtils.createCurrentDateTimestamp(), processed
         );
-    }
-
-    private NotificationProcessor mockNotificationProcessor(NotificationAccessor notificationAccessor) {
-        NotificationDetailExtractionDelegator detailExtractionDelegator = new NotificationDetailExtractionDelegator(blackDuckResponseResolver, List.of());
-        JobNotificationMapper jobNotificationMapper = Mockito.mock(JobNotificationMapper.class);
-        Mockito.when(jobNotificationMapper.mapJobsToNotifications(Mockito.anyList(), Mockito.anyList())).thenReturn(Set.of());
-        return new NotificationProcessor(detailExtractionDelegator, jobNotificationMapper, null, null, List.of(), notificationAccessor);
     }
 
     private EventManager mockEventManager() {


### PR DESCRIPTION
* Rename NotificationProcessor2 --> NotificationMappingProcessor
* Update DailyTask to use NotificationMappingProcessor
* Correct when lastRunTime is captured to ensure next execution starts at correct time.
* Update tests for NotificationMappingProcessor usage
* Update tests for stale code, and rename some objects for readability