### PR TITLE
IALERT-3072: Break up diagnostic model into sub-components 

### DIFF
--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/database/DefaultDiagnosticAccessor.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/database/DefaultDiagnosticAccessor.java
@@ -1,5 +1,7 @@
 package com.synopsys.integration.alert.component.diagnostic.database;
 
+import java.time.LocalDateTime;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,10 +30,7 @@ public class DefaultDiagnosticAccessor implements DiagnosticAccessor {
     public DiagnosticModel getDiagnosticInfo() {
         NotificationDiagnosticModel notificationDiagnosticModel = getNotificationDiagnosticInfo();
         AuditDiagnosticModel auditDiagnosticModel = getAuditDiagnosticInfo();
-        return new DiagnosticModel.Builder()
-            .notificationDiagnosticModel(notificationDiagnosticModel)
-            .auditDiagnosticModel(auditDiagnosticModel)
-            .build();
+        return new DiagnosticModel(LocalDateTime.now().toString(), notificationDiagnosticModel, auditDiagnosticModel);
     }
 
     private NotificationDiagnosticModel getNotificationDiagnosticInfo() {

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/database/DefaultDiagnosticAccessor.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/database/DefaultDiagnosticAccessor.java
@@ -1,14 +1,14 @@
 package com.synopsys.integration.alert.component.diagnostic.database;
 
-import java.time.LocalDateTime;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.common.enumeration.AuditEntryStatus;
 import com.synopsys.integration.alert.common.persistence.accessor.DiagnosticAccessor;
+import com.synopsys.integration.alert.component.diagnostic.model.AuditDiagnosticModel;
 import com.synopsys.integration.alert.component.diagnostic.model.DiagnosticModel;
+import com.synopsys.integration.alert.component.diagnostic.model.NotificationDiagnosticModel;
 import com.synopsys.integration.alert.database.audit.AuditEntryRepository;
 import com.synopsys.integration.alert.database.notification.NotificationContentRepository;
 
@@ -26,23 +26,30 @@ public class DefaultDiagnosticAccessor implements DiagnosticAccessor {
     @Override
     @Transactional(readOnly = true)
     public DiagnosticModel getDiagnosticInfo() {
+        NotificationDiagnosticModel notificationDiagnosticModel = getNotificationDiagnosticInfo();
+        AuditDiagnosticModel auditDiagnosticModel = getAuditDiagnosticInfo();
+        return new DiagnosticModel.Builder()
+            .notificationDiagnosticModel(notificationDiagnosticModel)
+            .auditDiagnosticModel(auditDiagnosticModel)
+            .build();
+    }
+
+    private NotificationDiagnosticModel getNotificationDiagnosticInfo() {
         long numberOfNotifications = notificationContentRepository.count();
         long numberOfNotificationsProcessed = notificationContentRepository.countByProcessed(true);
         long numberOfNotificationsUnprocessed = notificationContentRepository.countByProcessed(false);
+        return new NotificationDiagnosticModel(numberOfNotifications, numberOfNotificationsProcessed, numberOfNotificationsUnprocessed);
+    }
 
+    private AuditDiagnosticModel getAuditDiagnosticInfo() {
         long numberOfAuditEntriesSuccessful = auditEntryRepository.countByStatus(AuditEntryStatus.SUCCESS.name());
         long numberOfAuditEntriesFailed = auditEntryRepository.countByStatus(AuditEntryStatus.FAILURE.name());
         long numberOfAuditEntriesPending = auditEntryRepository.countByStatus(AuditEntryStatus.PENDING.name());
-
-        return new DiagnosticModel(
-            numberOfNotifications,
-            numberOfNotificationsProcessed,
-            numberOfNotificationsUnprocessed,
+        return new AuditDiagnosticModel(
             numberOfAuditEntriesSuccessful,
             numberOfAuditEntriesFailed,
             numberOfAuditEntriesPending,
-            LocalDateTime.now().toString(),
-            auditEntryRepository.getAverageAuditEntryCompletionTime().orElse(null)
+            auditEntryRepository.getAverageAuditEntryCompletionTime().orElse(AuditDiagnosticModel.NO_AUDIT_CONTENT_MESSAGE)
         );
     }
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/AuditDiagnosticModel.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/AuditDiagnosticModel.java
@@ -1,0 +1,45 @@
+package com.synopsys.integration.alert.component.diagnostic.model;
+
+import org.jetbrains.annotations.Nullable;
+
+import com.synopsys.integration.alert.api.common.model.AlertSerializableModel;
+
+public class AuditDiagnosticModel extends AlertSerializableModel implements DiagnosticComponentModel {
+    private static final long serialVersionUID = 6608629673526467492L;
+
+    public static final String NO_AUDIT_CONTENT_MESSAGE = "No audit content found";
+
+    private final Long numberOfAuditEntriesSuccessful;
+    private final Long numberOfAuditEntriesFailed;
+    private final Long numberOfAuditEntriesPending;
+    @Nullable
+    private final String averageAuditTime;
+
+    public AuditDiagnosticModel(
+        Long numberOfAuditEntriesSuccessful,
+        Long numberOfAuditEntriesFailed,
+        Long numberOfAuditEntriesPending,
+        @Nullable String averageAuditTime
+    ) {
+        this.numberOfAuditEntriesSuccessful = numberOfAuditEntriesSuccessful;
+        this.numberOfAuditEntriesFailed = numberOfAuditEntriesFailed;
+        this.numberOfAuditEntriesPending = numberOfAuditEntriesPending;
+        this.averageAuditTime = averageAuditTime;
+    }
+
+    public Long getNumberOfAuditEntriesSuccessful() {
+        return numberOfAuditEntriesSuccessful;
+    }
+
+    public Long getNumberOfAuditEntriesFailed() {
+        return numberOfAuditEntriesFailed;
+    }
+
+    public Long getNumberOfAuditEntriesPending() {
+        return numberOfAuditEntriesPending;
+    }
+
+    public String getAverageAuditTime() {
+        return averageAuditTime;
+    }
+}

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/AuditDiagnosticModel.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/AuditDiagnosticModel.java
@@ -1,10 +1,12 @@
 package com.synopsys.integration.alert.component.diagnostic.model;
 
+import java.util.Optional;
+
 import org.jetbrains.annotations.Nullable;
 
 import com.synopsys.integration.alert.api.common.model.AlertSerializableModel;
 
-public class AuditDiagnosticModel extends AlertSerializableModel implements DiagnosticComponentModel {
+public class AuditDiagnosticModel extends AlertSerializableModel {
     private static final long serialVersionUID = 6608629673526467492L;
 
     public static final String NO_AUDIT_CONTENT_MESSAGE = "No audit content found";
@@ -39,7 +41,7 @@ public class AuditDiagnosticModel extends AlertSerializableModel implements Diag
         return numberOfAuditEntriesPending;
     }
 
-    public String getAverageAuditTime() {
-        return averageAuditTime;
+    public Optional<String> getAverageAuditTime() {
+        return Optional.ofNullable(averageAuditTime);
     }
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/DiagnosticComponentModel.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/DiagnosticComponentModel.java
@@ -1,0 +1,4 @@
+package com.synopsys.integration.alert.component.diagnostic.model;
+
+public interface DiagnosticComponentModel {
+}

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/DiagnosticComponentModel.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/DiagnosticComponentModel.java
@@ -1,4 +1,0 @@
-package com.synopsys.integration.alert.component.diagnostic.model;
-
-public interface DiagnosticComponentModel {
-}

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/DiagnosticModel.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/DiagnosticModel.java
@@ -1,7 +1,5 @@
 package com.synopsys.integration.alert.component.diagnostic.model;
 
-import java.time.LocalDateTime;
-
 import com.synopsys.integration.alert.api.common.model.AlertSerializableModel;
 import com.synopsys.integration.alert.api.common.model.Obfuscated;
 
@@ -12,11 +10,11 @@ public class DiagnosticModel extends AlertSerializableModel implements Obfuscate
     private AuditDiagnosticModel auditDiagnosticModel;
     private String requestTimestamp;
 
-    private DiagnosticModel() {
+    public DiagnosticModel() {
         // For serialization
     }
 
-    private DiagnosticModel(String requestTimestamp, NotificationDiagnosticModel notificationDiagnosticModel, AuditDiagnosticModel auditDiagnosticModel) {
+    public DiagnosticModel(String requestTimestamp, NotificationDiagnosticModel notificationDiagnosticModel, AuditDiagnosticModel auditDiagnosticModel) {
         this.requestTimestamp = requestTimestamp;
         this.notificationDiagnosticModel = notificationDiagnosticModel;
         this.auditDiagnosticModel = auditDiagnosticModel;
@@ -37,28 +35,5 @@ public class DiagnosticModel extends AlertSerializableModel implements Obfuscate
     @Override
     public DiagnosticModel obfuscate() {
         return new DiagnosticModel(requestTimestamp, notificationDiagnosticModel, auditDiagnosticModel);
-    }
-
-    public static class Builder {
-        private NotificationDiagnosticModel notificationDiagnosticModel;
-        private AuditDiagnosticModel auditDiagnosticModel;
-
-        public DiagnosticModel build() {
-            return new DiagnosticModel(
-                LocalDateTime.now().toString(),
-                notificationDiagnosticModel,
-                auditDiagnosticModel
-            );
-        }
-
-        public Builder notificationDiagnosticModel(NotificationDiagnosticModel notificationDiagnosticModel) {
-            this.notificationDiagnosticModel = notificationDiagnosticModel;
-            return this;
-        }
-
-        public Builder auditDiagnosticModel(AuditDiagnosticModel auditDiagnosticModel) {
-            this.auditDiagnosticModel = auditDiagnosticModel;
-            return this;
-        }
     }
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/DiagnosticModel.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/DiagnosticModel.java
@@ -1,95 +1,64 @@
 package com.synopsys.integration.alert.component.diagnostic.model;
 
-import java.util.Optional;
-
-import org.jetbrains.annotations.Nullable;
+import java.time.LocalDateTime;
 
 import com.synopsys.integration.alert.api.common.model.AlertSerializableModel;
 import com.synopsys.integration.alert.api.common.model.Obfuscated;
 
 public class DiagnosticModel extends AlertSerializableModel implements Obfuscated<DiagnosticModel> {
     private static final long serialVersionUID = 6714869824373312126L;
-    private static final String NO_AUDIT_CONTENT_MESSAGE = "No audit content found";
 
-    private Long numberOfNotifications;
-    private Long numberOfNotificationsProcessed;
-    private Long numberOfNotificationsUnprocessed;
-    private Long numberOfAuditEntriesSuccessful;
-    private Long numberOfAuditEntriesFailed;
-    private Long numberOfAuditEntriesPending;
-    @Nullable
-    private String averageAuditTime;
-
+    private NotificationDiagnosticModel notificationDiagnosticModel;
+    private AuditDiagnosticModel auditDiagnosticModel;
     private String requestTimestamp;
 
-    public DiagnosticModel() {
+    private DiagnosticModel() {
         // For serialization
     }
 
-    public DiagnosticModel(
-        Long numberOfNotifications,
-        Long numberOfNotificationsProcessed,
-        Long numberOfNotificationsUnprocessed,
-        Long numberOfAuditEntriesSuccessful,
-        Long numberOfAuditEntriesFailed,
-        Long numberOfAuditEntriesPending,
-        String requestTimestamp,
-        @Nullable String averageAuditTime
-    ) {
-        this.numberOfNotifications = numberOfNotifications;
-        this.numberOfNotificationsProcessed = numberOfNotificationsProcessed;
-        this.numberOfNotificationsUnprocessed = numberOfNotificationsUnprocessed;
-        this.numberOfAuditEntriesSuccessful = numberOfAuditEntriesSuccessful;
-        this.numberOfAuditEntriesFailed = numberOfAuditEntriesFailed;
-        this.numberOfAuditEntriesPending = numberOfAuditEntriesPending;
+    private DiagnosticModel(String requestTimestamp, NotificationDiagnosticModel notificationDiagnosticModel, AuditDiagnosticModel auditDiagnosticModel) {
         this.requestTimestamp = requestTimestamp;
-        this.averageAuditTime = averageAuditTime;
+        this.notificationDiagnosticModel = notificationDiagnosticModel;
+        this.auditDiagnosticModel = auditDiagnosticModel;
     }
 
-    public Long getNumberOfNotifications() {
-        return numberOfNotifications;
+    public NotificationDiagnosticModel getNotificationDiagnosticModel() {
+        return notificationDiagnosticModel;
     }
 
-    public Long getNumberOfNotificationsProcessed() {
-        return numberOfNotificationsProcessed;
-    }
-
-    public Long getNumberOfNotificationsUnprocessed() {
-        return numberOfNotificationsUnprocessed;
-    }
-
-    public Long getNumberOfAuditEntriesSuccessful() {
-        return numberOfAuditEntriesSuccessful;
-    }
-
-    public Long getNumberOfAuditEntriesFailed() {
-        return numberOfAuditEntriesFailed;
-    }
-
-    public Long getNumberOfAuditEntriesPending() {
-        return numberOfAuditEntriesPending;
+    public AuditDiagnosticModel getAuditDiagnosticModel() {
+        return auditDiagnosticModel;
     }
 
     public String getRequestTimestamp() {
         return requestTimestamp;
     }
 
-    public Optional<String> getAverageAuditTime() {
-        return Optional.ofNullable(averageAuditTime);
-    }
-
     @Override
     public DiagnosticModel obfuscate() {
-        // Diagnostic model does not handle sensitive data and therefore does not need any fields to be obfuscated
-        return new DiagnosticModel(
-            numberOfNotifications,
-            numberOfNotificationsProcessed,
-            numberOfNotificationsUnprocessed,
-            numberOfAuditEntriesSuccessful,
-            numberOfAuditEntriesFailed,
-            numberOfAuditEntriesPending,
-            requestTimestamp,
-            getAverageAuditTime().orElse(NO_AUDIT_CONTENT_MESSAGE)
-        );
+        return new DiagnosticModel(requestTimestamp, notificationDiagnosticModel, auditDiagnosticModel);
+    }
+
+    public static class Builder {
+        private NotificationDiagnosticModel notificationDiagnosticModel;
+        private AuditDiagnosticModel auditDiagnosticModel;
+
+        public DiagnosticModel build() {
+            return new DiagnosticModel(
+                LocalDateTime.now().toString(),
+                notificationDiagnosticModel,
+                auditDiagnosticModel
+            );
+        }
+
+        public Builder notificationDiagnosticModel(NotificationDiagnosticModel notificationDiagnosticModel) {
+            this.notificationDiagnosticModel = notificationDiagnosticModel;
+            return this;
+        }
+
+        public Builder auditDiagnosticModel(AuditDiagnosticModel auditDiagnosticModel) {
+            this.auditDiagnosticModel = auditDiagnosticModel;
+            return this;
+        }
     }
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/NotificationDiagnosticModel.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/NotificationDiagnosticModel.java
@@ -2,9 +2,9 @@ package com.synopsys.integration.alert.component.diagnostic.model;
 
 import com.synopsys.integration.alert.api.common.model.AlertSerializableModel;
 
-public class NotificationDiagnosticModel extends AlertSerializableModel implements DiagnosticComponentModel {
+public class NotificationDiagnosticModel extends AlertSerializableModel {
     private static final long serialVersionUID = -6054332942386217935L;
-    
+
     private final Long numberOfNotifications;
     private final Long numberOfNotificationsProcessed;
     private final Long numberOfNotificationsUnprocessed;

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/NotificationDiagnosticModel.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/NotificationDiagnosticModel.java
@@ -1,0 +1,29 @@
+package com.synopsys.integration.alert.component.diagnostic.model;
+
+import com.synopsys.integration.alert.api.common.model.AlertSerializableModel;
+
+public class NotificationDiagnosticModel extends AlertSerializableModel implements DiagnosticComponentModel {
+    private static final long serialVersionUID = -6054332942386217935L;
+    
+    private final Long numberOfNotifications;
+    private final Long numberOfNotificationsProcessed;
+    private final Long numberOfNotificationsUnprocessed;
+
+    public NotificationDiagnosticModel(Long numberOfNotifications, Long numberOfNotificationsProcessed, Long numberOfNotificationsUnprocessed) {
+        this.numberOfNotifications = numberOfNotifications;
+        this.numberOfNotificationsProcessed = numberOfNotificationsProcessed;
+        this.numberOfNotificationsUnprocessed = numberOfNotificationsUnprocessed;
+    }
+
+    public Long getNumberOfNotifications() {
+        return numberOfNotifications;
+    }
+
+    public Long getNumberOfNotificationsProcessed() {
+        return numberOfNotificationsProcessed;
+    }
+
+    public Long getNumberOfNotificationsUnprocessed() {
+        return numberOfNotificationsUnprocessed;
+    }
+}

--- a/component/src/test/java/com/synopsys/integration/alert/component/diagnostic/database/DefaultDiagnosticAccessorTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/diagnostic/database/DefaultDiagnosticAccessorTest.java
@@ -1,0 +1,60 @@
+package com.synopsys.integration.alert.component.diagnostic.database;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.synopsys.integration.alert.common.enumeration.AuditEntryStatus;
+import com.synopsys.integration.alert.component.diagnostic.model.AuditDiagnosticModel;
+import com.synopsys.integration.alert.component.diagnostic.model.DiagnosticModel;
+import com.synopsys.integration.alert.component.diagnostic.model.NotificationDiagnosticModel;
+import com.synopsys.integration.alert.database.audit.AuditEntryRepository;
+import com.synopsys.integration.alert.database.notification.NotificationContentRepository;
+
+class DefaultDiagnosticAccessorTest {
+    private NotificationContentRepository notificationContentRepository;
+    private AuditEntryRepository auditEntryRepository;
+
+    @BeforeEach
+    public void init() {
+        notificationContentRepository = Mockito.mock(NotificationContentRepository.class);
+        auditEntryRepository = Mockito.mock(AuditEntryRepository.class);
+    }
+
+    @Test
+    void testGetDiagnosticInfo() {
+        DefaultDiagnosticAccessor diagnosticAccessor = new DefaultDiagnosticAccessor(notificationContentRepository, auditEntryRepository);
+        NotificationDiagnosticModel notificationDiagnosticModel = createNotificationDiagnosticModel();
+        AuditDiagnosticModel auditDiagnosticModel = createAuditDiagnosticModel();
+        DiagnosticModel diagnosticModel = diagnosticAccessor.getDiagnosticInfo();
+
+        assertEquals(notificationDiagnosticModel, diagnosticModel.getNotificationDiagnosticModel());
+        assertEquals(auditDiagnosticModel, diagnosticModel.getAuditDiagnosticModel());
+    }
+
+    private NotificationDiagnosticModel createNotificationDiagnosticModel() {
+        long numberOfNotifications = 10L;
+        long numberOfNotificationsProcessed = 5L;
+        long numberOfNotificationsUnprocessed = 5L;
+        Mockito.when(notificationContentRepository.count()).thenReturn(numberOfNotifications);
+        Mockito.when(notificationContentRepository.countByProcessed(true)).thenReturn(numberOfNotificationsProcessed);
+        Mockito.when(notificationContentRepository.countByProcessed(false)).thenReturn(numberOfNotificationsUnprocessed);
+        return new NotificationDiagnosticModel(numberOfNotifications, numberOfNotificationsProcessed, numberOfNotificationsUnprocessed);
+    }
+
+    private AuditDiagnosticModel createAuditDiagnosticModel() {
+        long numberOfAuditEntriesSuccessful = 10L;
+        long numberOfAuditEntriesFailed = 15L;
+        long numberOfAuditEntriesPending = 20L;
+        String averageAuditProcessingTime = AuditDiagnosticModel.NO_AUDIT_CONTENT_MESSAGE;
+        Mockito.when(auditEntryRepository.countByStatus(AuditEntryStatus.SUCCESS.name())).thenReturn(numberOfAuditEntriesSuccessful);
+        Mockito.when(auditEntryRepository.countByStatus(AuditEntryStatus.FAILURE.name())).thenReturn(numberOfAuditEntriesFailed);
+        Mockito.when(auditEntryRepository.countByStatus(AuditEntryStatus.PENDING.name())).thenReturn(numberOfAuditEntriesPending);
+        Mockito.when(auditEntryRepository.getAverageAuditEntryCompletionTime()).thenReturn(Optional.of(averageAuditProcessingTime));
+        return new AuditDiagnosticModel(numberOfAuditEntriesSuccessful, numberOfAuditEntriesFailed, numberOfAuditEntriesPending, averageAuditProcessingTime);
+    }
+}

--- a/src/test/java/com/synopsys/integration/alert/component/diagnostic/action/DiagnosticCrudActionsTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/diagnostic/action/DiagnosticCrudActionsTestIT.java
@@ -1,0 +1,49 @@
+package com.synopsys.integration.alert.component.diagnostic.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import com.synopsys.integration.alert.common.action.ActionResponse;
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.persistence.model.PermissionKey;
+import com.synopsys.integration.alert.common.persistence.model.PermissionMatrixModel;
+import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
+import com.synopsys.integration.alert.component.diagnostic.database.DefaultDiagnosticAccessor;
+import com.synopsys.integration.alert.component.diagnostic.model.DiagnosticModel;
+import com.synopsys.integration.alert.component.settings.descriptor.SettingsDescriptorKey;
+import com.synopsys.integration.alert.test.common.AuthenticationTestUtils;
+import com.synopsys.integration.alert.util.AlertIntegrationTest;
+
+@AlertIntegrationTest
+class DiagnosticCrudActionsTestIT {
+    @Autowired
+    private DefaultDiagnosticAccessor diagnosticAccessor;
+
+    private final SettingsDescriptorKey descriptorKey = new SettingsDescriptorKey();
+    private AuthorizationManager authorizationManager;
+
+    @BeforeEach
+    public void init() {
+        AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
+        PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
+        Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
+        authorizationManager = authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
+    }
+
+    @Test
+    void getOneEmptyTest() {
+        DiagnosticCrudActions crudActions = new DiagnosticCrudActions(authorizationManager, descriptorKey, diagnosticAccessor);
+        ActionResponse<DiagnosticModel> actionResponse = crudActions.getOne();
+
+        assertTrue(actionResponse.isSuccessful());
+        assertTrue(actionResponse.hasContent());
+        assertEquals(HttpStatus.OK, actionResponse.getHttpStatus());
+    }
+}


### PR DESCRIPTION
- DiagnosticModel is now made up of two new models, NotificationDiagnosticModel and AuditDiagnosticModel
- Added test coverage for diagnostic classes
- Added test coverage to repositories for new diagnostic calls