### PR TITLE
test: Add new property and test to create projects only

### DIFF
--- a/src/test/java/com/synopsys/integration/alert/performance/LargeNotificationTest.java
+++ b/src/test/java/com/synopsys/integration/alert/performance/LargeNotificationTest.java
@@ -49,6 +49,7 @@ import com.synopsys.integration.exception.IntegrationException;
 class LargeNotificationTest {
     private static final JiraServerChannelKey CHANNEL_KEY = new JiraServerChannelKey();
     private static final int DEFAULT_NUMBER_OF_PROJECTS_TO_CREATE = 10;
+    private static final int DEFAULT_STARTING_PROJECT_NUMBER = 1;
     private static final String PERFORMANCE_POLICY_NAME = "PerformanceTestPolicy";
     private static final String DEFAULT_JOB_NAME = "JiraPerformanceJob";
 
@@ -93,6 +94,32 @@ class LargeNotificationTest {
 
     @Test
     @EnabledIfEnvironmentVariable(named = "ALERT_RUN_PERFORMANCE", matches = "true")
+    void createTestProjects() throws IntegrationException {
+        int startingProjectNumber = testProperties.getOptionalProperty(TestPropertyKey.TEST_PERFORMANCE_BLACKDUCK_START_PROJECT_NUMBER)
+            .map(Integer::parseInt)
+            .orElse(DEFAULT_STARTING_PROJECT_NUMBER);
+
+        if (startingProjectNumber < DEFAULT_STARTING_PROJECT_NUMBER) {
+            logger.info(String.format("Starting project number invalid. Setting to default: %s", DEFAULT_STARTING_PROJECT_NUMBER));
+            startingProjectNumber = DEFAULT_STARTING_PROJECT_NUMBER;
+        }
+
+        LocalDateTime startingTime = LocalDateTime.now();
+        logger.info(String.format("Starting time: %s", dateTimeFormatter.format(startingTime)));
+
+        // Create Black Duck Global Provider configuration
+        LocalDateTime startingProviderCreateTime = LocalDateTime.now();
+        blackDuckProviderService.setupBlackDuck();
+        logTimeElapsedWithMessage("Setting up the Black Duck provider took %s", startingProviderCreateTime, LocalDateTime.now());
+
+        // create blackduck projects
+        createBlackDuckProjects(numberOfProjectsToCreate, startingProjectNumber);
+
+        logTimeElapsedWithMessage("Total test time: %s", startingTime, LocalDateTime.now());
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "ALERT_RUN_PERFORMANCE", matches = "true")
     void createProjectsAndNotificationsTest() throws IntegrationException {
         LocalDateTime startingTime = LocalDateTime.now();
         logger.info(String.format("Starting time: %s", dateTimeFormatter.format(startingTime)));
@@ -106,7 +133,6 @@ class LargeNotificationTest {
         createBlackDuckProjects(numberOfProjectsToCreate);
 
         //trigger a notification on each project
-
         for (int index = 0; index < numberOfProjectsToCreate; index++) {
             ProjectVersionWrapper projectVersionWrapper = findOrCreateBlackDuckProject(index);
             triggerBlackDuckNotification(projectVersionWrapper.getProjectVersionView());
@@ -213,23 +239,31 @@ class LargeNotificationTest {
         return blackDuckProviderService.findOrCreateBlackDuckProjectAndVersion(String.format("AlertPerformanceProject-%s", index), "version1");
     }
 
-    private void createBlackDuckProjects(int numberOfProjects) throws IntegrationException {
+    private void createBlackDuckProjects(int numberOfProjects, int startingProjectNumber) throws IntegrationException {
+        logger.info(String.format("Creating %s projects, starting with project number %s", numberOfProjects, startingProjectNumber));
         LocalDateTime startingProjectCreationTime = LocalDateTime.now();
-
-        for (int projectIndex = 1; projectIndex <= numberOfProjects; projectIndex++) {
+        for (int projectIndex = startingProjectNumber; projectIndex < (numberOfProjects + startingProjectNumber); projectIndex++) {
             findOrCreateBlackDuckProject(projectIndex);
         }
         String createProjectsLogMessage = String.format("Creating %s projects took", numberOfProjects);
         logTimeElapsedWithMessage(String.format("%s %s", createProjectsLogMessage, "%s"), startingProjectCreationTime, LocalDateTime.now());
     }
 
-    private void deleteBlackDuckProjects(int numberOfProjects) throws IntegrationException {
+    private void createBlackDuckProjects(int numberOfProjects) throws IntegrationException {
+        createBlackDuckProjects(numberOfProjects, DEFAULT_STARTING_PROJECT_NUMBER);
+    }
+
+    private void deleteBlackDuckProjects(int numberOfProjects, int startingProjectNumber) throws IntegrationException {
         LocalDateTime startingProjectCreationTime = LocalDateTime.now();
-        for (int projectIndex = 1; projectIndex <= numberOfProjects; projectIndex++) {
+        for (int projectIndex = startingProjectNumber; projectIndex < (numberOfProjects + startingProjectNumber); projectIndex++) {
             blackDuckProviderService.deleteBlackDuckProjectAndVersion(String.format("AlertPerformanceProject-%s", projectIndex), "version1");
         }
         String createProjectsLogMessage = String.format("Deleting %s projects took", numberOfProjects);
         logTimeElapsedWithMessage(String.format("%s %s", createProjectsLogMessage, "%s"), startingProjectCreationTime, LocalDateTime.now());
+    }
+
+    private void deleteBlackDuckProjects(int numberOfProjects) throws IntegrationException {
+        deleteBlackDuckProjects(numberOfProjects, DEFAULT_STARTING_PROJECT_NUMBER);
     }
 
     private void triggerBlackDuckNotification(ProjectVersionView projectVersionView) throws IntegrationException {

--- a/src/test/java/com/synopsys/integration/alert/performance/LargeNotificationTest.java
+++ b/src/test/java/com/synopsys/integration/alert/performance/LargeNotificationTest.java
@@ -113,7 +113,7 @@ class LargeNotificationTest {
         logTimeElapsedWithMessage("Setting up the Black Duck provider took %s", startingProviderCreateTime, LocalDateTime.now());
 
         // create blackduck projects
-        createBlackDuckProjects(numberOfProjectsToCreate, startingProjectNumber);
+        createProjectAndTriggerNotification(numberOfProjectsToCreate, startingProjectNumber);
 
         logTimeElapsedWithMessage("Total test time: %s", startingTime, LocalDateTime.now());
     }
@@ -251,6 +251,17 @@ class LargeNotificationTest {
 
     private void createBlackDuckProjects(int numberOfProjects) throws IntegrationException {
         createBlackDuckProjects(numberOfProjects, DEFAULT_STARTING_PROJECT_NUMBER);
+    }
+
+    private void createProjectAndTriggerNotification(int numberOfProjects, int startingProjectNumber) throws IntegrationException {
+        logger.info(String.format("Creating and triggering a notification for %s projects, starting with project number %s", numberOfProjects, startingProjectNumber));
+        LocalDateTime startingProjectCreationTime = LocalDateTime.now();
+        for (int projectIndex = startingProjectNumber; projectIndex < (numberOfProjects + startingProjectNumber); projectIndex++) {
+            ProjectVersionWrapper projectVersionWrapper = findOrCreateBlackDuckProject(projectIndex);
+            triggerBlackDuckNotification(projectVersionWrapper.getProjectVersionView());
+        }
+        String createProjectsLogMessage = String.format("Creating and triggering a notification for %s projects took", numberOfProjects);
+        logTimeElapsedWithMessage(String.format("%s %s", createProjectsLogMessage, "%s"), startingProjectCreationTime, LocalDateTime.now());
     }
 
     private void deleteBlackDuckProjects(int numberOfProjects, int startingProjectNumber) throws IntegrationException {

--- a/src/test/java/com/synopsys/integration/alert/performance/utility/BlackDuckProviderService.java
+++ b/src/test/java/com/synopsys/integration/alert/performance/utility/BlackDuckProviderService.java
@@ -210,7 +210,7 @@ public class BlackDuckProviderService {
             intLogger.info(String.format("Project: %s Version %s already exists", projectName, projectVersionName));
             return existingProjectVersion.get();
         }
-        intLogger.info(String.format("Creating project: %s", projectName));
+        intLogger.info(String.format("Creating project: %s with version: %s", projectName, projectVersionName));
         return projectService.createProject(projectRequest);
     }
 

--- a/test-common/src/main/java/com/synopsys/integration/alert/test/common/TestPropertyKey.java
+++ b/test-common/src/main/java/com/synopsys/integration/alert/test/common/TestPropertyKey.java
@@ -28,6 +28,7 @@ public enum TestPropertyKey {
     TEST_REALTIME_DIGEST("alert.digest.realtime.cron"),
 
     TEST_PERFORMANCE_BLACKDUCK_PROJECT_COUNT("alert.performance.blackduck.project.count"),
+    TEST_PERFORMANCE_BLACKDUCK_START_PROJECT_NUMBER("alert.performance.blackduck.start.project.number"),
     TEST_PERFORMANCE_ALERT_DISTRIBUTION_JOB_COUNT("alert.performance.alert.distribution.job.count"),
     TEST_PERFORMANCE_ALERT_SERVER_URL("alert.performance.alert.server.url"),
     TEST_PERFORMANCE_WAIT_TIMEOUT_SECONDS("alert.performance.wait.timeout.seconds"),


### PR DESCRIPTION
* Add new property 'TEST_PERFORMANCE_BLACKDUCK_START_PROJECT_NUMBER' to control what the starting project number should be
* Add createTestProjects to only create the projects without triggering a notification

The thinking/intention behind this change is to allow us to configure a job in Jenkins to run createTestProjects multiple times simultaneously. I tested created 10K projects and it took 230. I then ran the job 5 times at once, with different values for the new property, and each creating 2K projects. The total runtime was 97 minutes.

If this is approved, I will create a Jenkins job that will run this based on some information from the user:
- BD server to run against
- BD API key
- Number of jobs to execute
- Number of projects to create in each job
- Starting project number