### PR TITLE
IALERT-3082: CSV with commas fix

### DIFF
--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/attachment/MessageContentGroupCsvCreator.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/attachment/MessageContentGroupCsvCreator.java
@@ -125,14 +125,14 @@ public class MessageContentGroupCsvCreator {
 
     private List<String> createColumnValues(String providerName, String providerValue, String topicValue, String subTopicValue, ComponentItem componentItem) {
         List<String> columnValues = new ArrayList<>();
-        columnValues.add(providerName);
-        columnValues.add(providerValue);
-        columnValues.add(topicValue);
-        columnValues.add(subTopicValue);
+        addWithEscapeQuotes(columnValues, providerName);
+        addWithEscapeQuotes(columnValues, providerValue);
+        addWithEscapeQuotes(columnValues, topicValue);
+        addWithEscapeQuotes(columnValues, subTopicValue);
 
-        columnValues.add(componentItem.getComponent().getValue());
+        addWithEscapeQuotes(columnValues, componentItem.getComponent().getValue());
         String subComponentString = createOptionalValueString(componentItem.getSubComponent(), LinkableItem::getValue);
-        columnValues.add(subComponentString);
+        addWithEscapeQuotes(columnValues, subComponentString);
         String componentUrl;
         if (UNDEFINED_VALUE.equals(subComponentString)) {
             componentUrl = componentItem.getComponent().getUrl().orElse(null);
@@ -148,11 +148,15 @@ public class MessageContentGroupCsvCreator {
         columnValues.add(categoryGroupingAttribute);
 
         String additionalAttributes = createFlattenedItemsString(componentItem.getComponentAttributes());
-        columnValues.add(String.format("\"%s\"", additionalAttributes));
+        addWithEscapeQuotes(columnValues, additionalAttributes);
 
         String categoryItemUrl = componentItem.getCategoryItem().getUrl().orElse(UNDEFINED_VALUE);
         columnValues.add(categoryItemUrl);
         return columnValues;
+    }
+
+    private void addWithEscapeQuotes(List<String> columnValues, String field) {
+        columnValues.add(String.format("\"%s\"", field));
     }
 
     private <T> String createOptionalColumnNameString(List<T> objects, Function<T, Optional<LinkableItem>> linkableItemMapper) {

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/MessageContentGroup.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/MessageContentGroup.java
@@ -19,7 +19,7 @@ import com.synopsys.integration.alert.common.message.model.LinkableItem;
 public class MessageContentGroup extends AlertSerializableModel {
     private final List<ProviderMessageContent> subContent;
 
-    private LinkableItem comonProvider;
+    private LinkableItem commonProvider;
     private LinkableItem commonTopic;
 
     public MessageContentGroup() {
@@ -29,10 +29,11 @@ public class MessageContentGroup extends AlertSerializableModel {
 
     public void add(ProviderMessageContent message) {
         if (null == commonTopic) {
-            comonProvider = message.getProvider();
+            commonProvider = message.getProvider();
             commonTopic = message.getTopic();
         } else if (!commonTopic.getValue().equals(message.getTopic().getValue())) {
-            throw new IllegalArgumentException(String.format("The topic of this message did not match the group topic. Expected: %s. Actual: %s.", commonTopic.getValue(), message.getTopic().getValue()));
+            throw new IllegalArgumentException(String
+                .format("The topic of this message did not match the group topic. Expected: %s. Actual: %s.", commonTopic.getValue(), message.getTopic().getValue()));
         }
 
         if (commonTopic.getUrl().isEmpty() && message.getTopic().getUrl().isPresent()) {
@@ -51,7 +52,7 @@ public class MessageContentGroup extends AlertSerializableModel {
     }
 
     public LinkableItem getCommonProvider() {
-        return comonProvider;
+        return commonProvider;
     }
 
     public LinkableItem getCommonTopic() {

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/MessageContentGroupCsvCreatorTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/MessageContentGroupCsvCreatorTest.java
@@ -10,9 +10,9 @@ import com.synopsys.integration.alert.channel.email.attachment.compatibility.Mes
 import com.synopsys.integration.alert.channel.email.attachment.compatibility.ProviderMessageContent;
 import com.synopsys.integration.alert.common.enumeration.ItemOperation;
 
-public class MessageContentGroupCsvCreatorTest {
+class MessageContentGroupCsvCreatorTest {
     @Test
-    public void createCsvStringTest() throws AlertException {
+    void createCsvStringTest() throws AlertException {
         MessageContentGroup messageContentGroup = new MessageContentGroup();
 
         ProviderMessageContent.Builder providerMessageBuilder = new ProviderMessageContent.Builder();
@@ -36,4 +36,28 @@ public class MessageContentGroupCsvCreatorTest {
         assertNotNull(csvString);
     }
 
+    @Test
+    void createCsvStringWithCommasTest() throws AlertException {
+        MessageContentGroup messageContentGroup = new MessageContentGroup();
+
+        ProviderMessageContent.Builder providerMessageBuilder = new ProviderMessageContent.Builder();
+        providerMessageBuilder.applyProvider("Example Provider", 1L, "Example Config");
+        providerMessageBuilder.applyTopic("Example Topic Name", "Example Topic Value");
+
+        ComponentItem.Builder componentItemBuilder = new ComponentItem.Builder();
+        componentItemBuilder.applyNotificationId(1L);
+        componentItemBuilder.applyOperation(ItemOperation.INFO);
+        componentItemBuilder.applyCategory("Category");
+        componentItemBuilder.applyComponentData("Component", "Component,With,Commas", "https://google.com");
+        componentItemBuilder.applySubComponent("SubComponent", "SubComponent,With,Commas", "https://google.com");
+        componentItemBuilder.applyCategoryItem("Example Category Item Name", "Example Category Item Value");
+        componentItemBuilder.applyCategoryGroupingAttribute("CategoryGroupingAttributeName", "testGroupingName");
+
+        providerMessageBuilder.applyComponentItem(componentItemBuilder.build());
+        messageContentGroup.add(providerMessageBuilder.build());
+
+        MessageContentGroupCsvCreator messageContentGroupCsvCreator = new MessageContentGroupCsvCreator();
+        String csvString = messageContentGroupCsvCreator.createCsvString(messageContentGroup);
+        assertNotNull(csvString);
+    }
 }


### PR DESCRIPTION
Previous we fixed potential issues where commas in the additional attributes  would cause CSV files to break as the values contained a comma. This is resolved by encapsulating the values in quotes which the csv then filters out.