### PR TITLE
IALERT-3084 Warning messages when testing global channels

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ConcreteGlobalConfigExistsValidator.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ConcreteGlobalConfigExistsValidator.java
@@ -1,0 +1,9 @@
+package com.synopsys.integration.alert.common.descriptor.config;
+
+import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
+
+public interface ConcreteGlobalConfigExistsValidator {
+    boolean exists();
+
+    DescriptorKey getDescriptorKey();
+}

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ConcreteGlobalConfigExistsValidator.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/ConcreteGlobalConfigExistsValidator.java
@@ -1,3 +1,10 @@
+/*
+ * alert-common
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.alert.common.descriptor.config;
 
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/validator/EmailGlobalConfigExistsValidator.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/validator/EmailGlobalConfigExistsValidator.java
@@ -1,0 +1,34 @@
+package com.synopsys.integration.alert.channel.email.validator;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.channel.email.database.accessor.EmailGlobalConfigAccessor;
+import com.synopsys.integration.alert.common.descriptor.config.ConcreteGlobalConfigExistsValidator;
+import com.synopsys.integration.alert.descriptor.api.EmailChannelKey;
+import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
+
+@Component
+public class EmailGlobalConfigExistsValidator implements ConcreteGlobalConfigExistsValidator {
+    private final EmailChannelKey emailChannelKey;
+    private final EmailGlobalConfigAccessor emailGlobalConfigAccessor;
+
+    @Autowired
+    public EmailGlobalConfigExistsValidator(
+        EmailChannelKey emailChannelKey,
+        EmailGlobalConfigAccessor emailGlobalConfigAccessor
+    ) {
+        this.emailChannelKey = emailChannelKey;
+        this.emailGlobalConfigAccessor = emailGlobalConfigAccessor;
+    }
+
+    @Override
+    public boolean exists() {
+        return emailGlobalConfigAccessor.doesConfigurationExist();
+    }
+
+    @Override
+    public DescriptorKey getDescriptorKey() {
+        return emailChannelKey;
+    }
+}

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/validator/EmailGlobalConfigExistsValidator.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/validator/EmailGlobalConfigExistsValidator.java
@@ -1,3 +1,10 @@
+/*
+ * channel-email
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.alert.channel.email.validator;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/validator/JiraServerGlobalConfigExistsValidator.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/validator/JiraServerGlobalConfigExistsValidator.java
@@ -1,3 +1,10 @@
+/*
+ * channel-jira-server
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.alert.channel.jira.server.validator;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/validator/JiraServerGlobalConfigExistsValidator.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/validator/JiraServerGlobalConfigExistsValidator.java
@@ -1,0 +1,34 @@
+package com.synopsys.integration.alert.channel.jira.server.validator;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.channel.jira.server.database.accessor.JiraServerGlobalConfigAccessor;
+import com.synopsys.integration.alert.common.descriptor.config.ConcreteGlobalConfigExistsValidator;
+import com.synopsys.integration.alert.descriptor.api.JiraServerChannelKey;
+import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
+
+@Component
+public class JiraServerGlobalConfigExistsValidator implements ConcreteGlobalConfigExistsValidator {
+    private final JiraServerChannelKey jiraServerChannelKey;
+    private final JiraServerGlobalConfigAccessor jiraServerGlobalConfigAccessor;
+
+    @Autowired
+    public JiraServerGlobalConfigExistsValidator(
+        JiraServerChannelKey jiraServerChannelKey,
+        JiraServerGlobalConfigAccessor jiraServerGlobalConfigAccessor
+    ) {
+        this.jiraServerChannelKey = jiraServerChannelKey;
+        this.jiraServerGlobalConfigAccessor = jiraServerGlobalConfigAccessor;
+    }
+
+    @Override
+    public boolean exists() {
+        return jiraServerGlobalConfigAccessor.getConfigurationCount() > 0;
+    }
+
+    @Override
+    public DescriptorKey getDescriptorKey() {
+        return jiraServerChannelKey;
+    }
+}

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/AuditDiagnosticModel.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/AuditDiagnosticModel.java
@@ -1,3 +1,10 @@
+/*
+ * component
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.alert.component.diagnostic.model;
 
 import java.util.Optional;

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/NotificationDiagnosticModel.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/NotificationDiagnosticModel.java
@@ -1,3 +1,10 @@
+/*
+ * component
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.alert.component.diagnostic.model;
 
 import com.synopsys.integration.alert.api.common.model.AlertSerializableModel;


### PR DESCRIPTION
Since we updated the email and jira models in 6.10.0 we broke the global config check when configuring a distribution job. This fix adds another validator simply stating if a global config exists for any concrete model.