### PR TITLE
IALERT-3084 Fix for existing global configurations in old database tables

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/GlobalConfigExistsValidator.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/config/GlobalConfigExistsValidator.java
@@ -74,9 +74,7 @@ public class GlobalConfigExistsValidator {
     private boolean doesValidGlobalModelExists(String descriptorName, DescriptorKey descriptorKey) {
         if (concreteGlobalConfigModelValidatorMap.containsKey(descriptorKey)) {
             ConcreteGlobalConfigExistsValidator validator = concreteGlobalConfigModelValidatorMap.get(descriptorKey);
-            if (validator.exists()) {
-                return true;
-            }
+            return validator.exists();
         }
 
         List<ConfigurationModel> configurations = configurationModelConfigurationAccessor.getConfigurationsByDescriptorNameAndContext(descriptorName, ConfigContextEnum.GLOBAL);


### PR DESCRIPTION
Bug fix for dealing with validation failures when a configuration is created through environment variables.

The cause of this is when  we create a new configuration via environment variables we populate the old database as well. When validation occurs we check if new configurations have ConcreteGlobalConfigExistsValidator and use those results. 

Previously we would default to the old system which, even when deleting configurations from the new table, would still have results in the old table. This fix just takes and returns the result of the new validators while still allowing un-migrated channels to still use the old database for global config validation.