### PR TITLE
IALERT-3099: Send the event to indicate jobs are mapped to notifications

### DIFF
--- a/component/src/main/java/com/synopsys/integration/alert/component/scheduling/workflow/DailyTask.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/scheduling/workflow/DailyTask.java
@@ -64,6 +64,7 @@ public class DailyTask extends ProcessingTask {
 
     @Override
     public DateRange getDateRange() {
+        // the hour of the daily task is configurable so zero out the minutes, seconds, and nanoseconds.
         OffsetDateTime endDate = DateUtils.createCurrentDateTimestamp()
             .withMinute(0)
             .withSecond(0)

--- a/component/src/main/java/com/synopsys/integration/alert/component/scheduling/workflow/DailyTask.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/scheduling/workflow/DailyTask.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 
+import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.api.task.TaskManager;
 import com.synopsys.integration.alert.common.enumeration.FrequencyType;
 import com.synopsys.integration.alert.common.message.model.DateRange;
@@ -42,9 +43,10 @@ public class DailyTask extends ProcessingTask {
         NotificationMappingProcessor notificationMappingProcessor,
         TaskManager taskManager,
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor,
-        JobAccessor jobAccessor
+        JobAccessor jobAccessor,
+        EventManager eventManager
     ) {
-        super(taskScheduler, taskManager, notificationAccessor, notificationMappingProcessor, jobAccessor, FrequencyType.DAILY);
+        super(taskScheduler, taskManager, notificationAccessor, notificationMappingProcessor, jobAccessor, FrequencyType.DAILY, eventManager);
         this.schedulingDescriptorKey = schedulingDescriptorKey;
         this.configurationModelConfigurationAccessor = configurationModelConfigurationAccessor;
     }
@@ -62,9 +64,15 @@ public class DailyTask extends ProcessingTask {
 
     @Override
     public DateRange getDateRange() {
-        OffsetDateTime endDate = DateUtils.createCurrentDateTimestamp();
-        OffsetDateTime startDate = endDate.minusDays(1);
+        OffsetDateTime endDate = DateUtils.createCurrentDateTimestamp()
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0);
+        OffsetDateTime startDate = endDate.minusDays(1)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0);
+
         return DateRange.of(startDate, endDate);
     }
-
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/scheduling/workflow/DailyTask.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/scheduling/workflow/DailyTask.java
@@ -7,16 +7,20 @@
  */
 package com.synopsys.integration.alert.component.scheduling.workflow;
 
+import java.time.OffsetDateTime;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.api.task.TaskManager;
 import com.synopsys.integration.alert.common.enumeration.FrequencyType;
+import com.synopsys.integration.alert.common.message.model.DateRange;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationModelConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.JobAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.NotificationAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
+import com.synopsys.integration.alert.common.util.DateUtils;
 import com.synopsys.integration.alert.component.scheduling.descriptor.SchedulingDescriptor;
 import com.synopsys.integration.alert.component.scheduling.descriptor.SchedulingDescriptorKey;
 import com.synopsys.integration.alert.component.tasks.ProcessingTask;
@@ -48,12 +52,19 @@ public class DailyTask extends ProcessingTask {
     @Override
     public String scheduleCronExpression() {
         String dailySavedCronValue = configurationModelConfigurationAccessor.getConfigurationsByDescriptorKey(schedulingDescriptorKey)
-                                         .stream()
-                                         .findFirst()
-                                         .flatMap(configurationModel -> configurationModel.getField(SchedulingDescriptor.KEY_DAILY_PROCESSOR_HOUR_OF_DAY))
-                                         .flatMap(ConfigurationFieldModel::getFieldValue)
-                                         .orElse(String.valueOf(DEFAULT_HOUR_OF_DAY));
+            .stream()
+            .findFirst()
+            .flatMap(configurationModel -> configurationModel.getField(SchedulingDescriptor.KEY_DAILY_PROCESSOR_HOUR_OF_DAY))
+            .flatMap(ConfigurationFieldModel::getFieldValue)
+            .orElse(String.valueOf(DEFAULT_HOUR_OF_DAY));
         return String.format(CRON_FORMAT, dailySavedCronValue);
+    }
+
+    @Override
+    public DateRange getDateRange() {
+        OffsetDateTime endDate = DateUtils.createCurrentDateTimestamp();
+        OffsetDateTime startDate = endDate.minusDays(1);
+        return DateRange.of(startDate, endDate);
     }
 
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/tasks/ProcessingTask.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/tasks/ProcessingTask.java
@@ -41,8 +41,13 @@ public abstract class ProcessingTask extends StartupScheduledTask {
     private OffsetDateTime lastRunTime;
 
     protected ProcessingTask(
-        TaskScheduler taskScheduler, TaskManager taskManager, NotificationAccessor notificationAccessor, NotificationMappingProcessor notificationMappingProcessor,
-        JobAccessor jobAccessor, FrequencyType frequencyType, EventManager eventManager
+        TaskScheduler taskScheduler,
+        TaskManager taskManager,
+        NotificationAccessor notificationAccessor,
+        NotificationMappingProcessor notificationMappingProcessor,
+        JobAccessor jobAccessor,
+        FrequencyType frequencyType,
+        EventManager eventManager
     ) {
         super(taskScheduler, taskManager);
         this.notificationAccessor = notificationAccessor;

--- a/component/src/main/java/com/synopsys/integration/alert/component/tasks/ProcessingTask.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/tasks/ProcessingTask.java
@@ -37,25 +37,23 @@ public abstract class ProcessingTask extends StartupScheduledTask {
 
     private OffsetDateTime lastRunTime;
 
-    public ProcessingTask(TaskScheduler taskScheduler, TaskManager taskManager, NotificationAccessor notificationAccessor, NotificationMappingProcessor notificationMappingProcessor,
-        JobAccessor jobAccessor, FrequencyType frequencyType) {
+    protected ProcessingTask(
+        TaskScheduler taskScheduler, TaskManager taskManager, NotificationAccessor notificationAccessor, NotificationMappingProcessor notificationMappingProcessor,
+        JobAccessor jobAccessor, FrequencyType frequencyType
+    ) {
         super(taskScheduler, taskManager);
         this.notificationAccessor = notificationAccessor;
         this.notificationMappingProcessor = notificationMappingProcessor;
         this.jobAccessor = jobAccessor;
         this.frequencyType = frequencyType;
-        lastRunTime = DateUtils.createCurrentDateTimestamp();
+        this.lastRunTime = DateUtils.createCurrentDateTimestamp();
     }
 
     public OffsetDateTime getLastRunTime() {
         return lastRunTime;
     }
 
-    public DateRange getDateRange() {
-        OffsetDateTime startDate = lastRunTime;
-        OffsetDateTime endDate = DateUtils.createCurrentDateTimestamp();
-        return DateRange.of(startDate, endDate);
-    }
+    public abstract DateRange getDateRange();
 
     @Override
     public void runTask() {

--- a/component/src/test/java/com/synopsys/integration/alert/component/scheduling/DailyTaskTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/scheduling/DailyTaskTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.api.task.ScheduledTask;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationModelConfigurationAccessor;
@@ -23,7 +24,8 @@ class DailyTaskTest {
 
     @Test
     void testGetTaskName() {
-        DailyTask task = new DailyTask(SCHEDULING_DESCRIPTOR_KEY, null, null, null, null, null, null);
+        EventManager eventManager = Mockito.mock(EventManager.class);
+        DailyTask task = new DailyTask(SCHEDULING_DESCRIPTOR_KEY, null, null, null, null, null, null, eventManager);
         assertEquals(ScheduledTask.computeTaskName(task.getClass()), task.getTaskName());
     }
 
@@ -39,8 +41,8 @@ class DailyTaskTest {
         StaticJobAccessor jobAccessor = Mockito.mock(StaticJobAccessor.class);
         Mockito.when(jobAccessor.hasJobsByFrequency(Mockito.any())).thenReturn(true);
 
-
-        DailyTask task = new DailyTask(SCHEDULING_DESCRIPTOR_KEY, null, null, null, null, configurationModelConfigurationAccessor, jobAccessor);
+        EventManager eventManager = Mockito.mock(EventManager.class);
+        DailyTask task = new DailyTask(SCHEDULING_DESCRIPTOR_KEY, null, null, null, null, configurationModelConfigurationAccessor, jobAccessor, eventManager);
         String cronWithNotDefault = task.scheduleCronExpression();
         String expectedCron = String.format(DailyTask.CRON_FORMAT, notDefaultValue);
 

--- a/component/src/test/java/com/synopsys/integration/alert/component/tasks/ProcessingTaskTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/tasks/ProcessingTaskTest.java
@@ -251,6 +251,10 @@ class ProcessingTaskTest {
                 return null;
             }
 
+            @Override
+            public DateRange getDateRange() {
+                return DateRange.of(getLastRunTime(), DateUtils.createCurrentDateTimestamp());
+            }
         };
     }
 }

--- a/component/src/test/java/com/synopsys/integration/alert/component/tasks/ProcessingTaskTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/tasks/ProcessingTaskTest.java
@@ -21,6 +21,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.scheduling.TaskScheduler;
 
 import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.api.task.TaskManager;
 import com.synopsys.integration.alert.common.enumeration.FrequencyType;
 import com.synopsys.integration.alert.common.message.model.DateRange;
@@ -245,7 +246,7 @@ class ProcessingTaskTest {
         TaskManager taskManager,
         JobAccessor jobAccessor
     ) {
-        return new ProcessingTask(taskScheduler, taskManager, notificationManager, notificationMappingProcessor, jobAccessor, FrequencyType.DAILY) {
+        return new ProcessingTask(taskScheduler, taskManager, notificationManager, notificationMappingProcessor, jobAccessor, FrequencyType.DAILY, createEventManager()) {
             @Override
             public String scheduleCronExpression() {
                 return null;
@@ -256,5 +257,9 @@ class ProcessingTaskTest {
                 return DateRange.of(getLastRunTime(), DateUtils.createCurrentDateTimestamp());
             }
         };
+    }
+
+    private EventManager createEventManager() {
+        return Mockito.mock(EventManager.class);
     }
 }


### PR DESCRIPTION
The DailyTask was not sending an event to indicate jobs were mapped to notifications to begin the process for sending messages to the channels.  Also the time range isn't calculated correctly.  It would only run the daily task if notifications came in since it started running. 