### PR TITLE
Issue Tracker callback events

### DIFF
--- a/api-channel-issue-tracker/build.gradle
+++ b/api-channel-issue-tracker/build.gradle
@@ -12,4 +12,5 @@ dependencies {
     implementation 'org.springframework.amqp:spring-amqp'
 
     testImplementation project(':test-common')
+    testImplementation 'org.springframework.amqp:spring-rabbit'
 }

--- a/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/callback/ProviderCallbackIssueTrackerResponsePostProcessor.java
+++ b/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/callback/ProviderCallbackIssueTrackerResponsePostProcessor.java
@@ -18,28 +18,22 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.api.channel.issue.IssueTrackerResponsePostProcessor;
 import com.synopsys.integration.alert.api.channel.issue.model.IssueTrackerIssueResponseModel;
 import com.synopsys.integration.alert.api.channel.issue.model.IssueTrackerResponse;
-import com.synopsys.integration.alert.api.event.AlertEventHandler;
+import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.common.channel.issuetracker.IssueTrackerCallbackEvent;
 
 @Component
 public class ProviderCallbackIssueTrackerResponsePostProcessor implements IssueTrackerResponsePostProcessor {
-    private final AlertEventHandler<IssueTrackerCallbackEvent> handler;
+    private final EventManager eventManager;
 
     @Autowired
-    public ProviderCallbackIssueTrackerResponsePostProcessor(AlertEventHandler<IssueTrackerCallbackEvent> handler) {
-        this.handler = handler;
+    public ProviderCallbackIssueTrackerResponsePostProcessor(EventManager eventManager) {
+        this.eventManager = eventManager;
     }
 
     @Override
     public <T extends Serializable> void postProcess(IssueTrackerResponse<T> response) {
         List<IssueTrackerCallbackEvent> callbackEvents = createCallbackEvents(response);
-        // This code is executed from inside an event handler for an issue tracker channel.
-        // In the short term we cannot post an event from inside an event handler because it is a consumer of events.
-        // no memory can be freed for other consumers to run since a consumer is blocked trying to produce an event onto a queue.
-        // call the handler directly for now which will make the same post-processing calls in the same thread then the consumer thread should free up.
-        for (IssueTrackerCallbackEvent event : callbackEvents) {
-            handler.handle(event);
-        }
+        eventManager.sendEvents(callbackEvents);
     }
 
     private <T extends Serializable> List<IssueTrackerCallbackEvent> createCallbackEvents(IssueTrackerResponse<T> issueTrackerResponse) {

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckNotificationRetriever.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckNotificationRetriever.java
@@ -27,7 +27,7 @@ import com.synopsys.integration.exception.IntegrationException;
 
 public class BlackDuckNotificationRetriever {
     public static final String PAGE_SORT_FIELD = "notification.createdOn";
-    public static final int DEFAULT_PAGE_SIZE = 100;
+    public static final int DEFAULT_PAGE_SIZE = 200;
     public static final int INITIAL_PAGE_OFFSET = 0;
 
     // (offset + limit) < total

--- a/src/main/java/com/synopsys/integration/alert/processing/ProcessingJobEventHandler.java
+++ b/src/main/java/com/synopsys/integration/alert/processing/ProcessingJobEventHandler.java
@@ -96,7 +96,7 @@ public class ProcessingJobEventHandler implements AlertEventHandler<JobProcessin
         UUID correlationId = event.getCorrelationId();
         UUID jobId = event.getJobId();
         int pageNumber = 0;
-        int pageSize = 100;
+        int pageSize = 200;
         AlertPagedModel<JobToNotificationMappingModel> jobNotificationMappings = jobNotificationMappingAccessor.getJobNotificationMappings(
             correlationId,
             jobId,


### PR DESCRIPTION
Update the issue tracker post processor to use the event manager to post events onto a queue to update blackduck.