### PR TITLE
IALERT-3107 - Update dependencies #2

### DIFF
--- a/alert-database/src/test/java/com/synopsys/integration/alert/database/api/mock/MockCustomCertificateRepository.java
+++ b/alert-database/src/test/java/com/synopsys/integration/alert/database/api/mock/MockCustomCertificateRepository.java
@@ -8,6 +8,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+
+import org.springframework.data.domain.Example;
+import org.springframework.data.repository.query.FluentQuery;
 
 import com.synopsys.integration.alert.database.certificates.CustomCertificateEntity;
 import com.synopsys.integration.alert.database.certificates.CustomCertificateRepository;
@@ -91,7 +95,19 @@ public class MockCustomCertificateRepository extends DefaultMockJPARepository<Cu
     }
 
     @Override
+    public CustomCertificateEntity getReferenceById(Long aLong) {
+        return getById(aLong);
+    }
+
+    @Override
     public void deleteAllById(Iterable<? extends Long> longs) {
         longs.forEach(this::deleteById);
+    }
+
+    @Override
+    public <S extends CustomCertificateEntity, R> R findBy(
+        Example<S> example, Function<FluentQuery.FetchableFluentQuery<S>, R> queryFunction
+    ) {
+        return null;
     }
 }

--- a/alert-database/src/test/java/com/synopsys/integration/alert/database/api/mock/MockProviderTaskPropertiesRepository.java
+++ b/alert-database/src/test/java/com/synopsys/integration/alert/database/api/mock/MockProviderTaskPropertiesRepository.java
@@ -6,6 +6,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+
+import org.springframework.data.domain.Example;
+import org.springframework.data.repository.query.FluentQuery;
 
 import com.synopsys.integration.alert.database.provider.task.ProviderTaskPropertiesEntity;
 import com.synopsys.integration.alert.database.provider.task.ProviderTaskPropertiesRepository;
@@ -61,7 +65,19 @@ public class MockProviderTaskPropertiesRepository extends DefaultMockJPAReposito
     }
 
     @Override
+    public ProviderTaskPropertiesEntity getReferenceById(Long aLong) {
+        return getById(aLong);
+    }
+
+    @Override
     public void deleteAllById(Iterable<? extends Long> longs) {
         longs.forEach(this::deleteById);
+    }
+
+    @Override
+    public <S extends ProviderTaskPropertiesEntity, R> R findBy(
+        Example<S> example, Function<FluentQuery.FetchableFluentQuery<S>, R> queryFunction
+    ) {
+        return null;
     }
 }

--- a/alert-database/src/test/java/com/synopsys/integration/alert/database/api/mock/MockSettingsKeyRepository.java
+++ b/alert-database/src/test/java/com/synopsys/integration/alert/database/api/mock/MockSettingsKeyRepository.java
@@ -7,6 +7,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+
+import org.springframework.data.domain.Example;
+import org.springframework.data.repository.query.FluentQuery;
 
 import com.synopsys.integration.alert.database.settings.SettingsKeyEntity;
 import com.synopsys.integration.alert.database.settings.SettingsKeyRepository;
@@ -70,7 +74,19 @@ public class MockSettingsKeyRepository extends DefaultMockJPARepository<Settings
     }
 
     @Override
+    public SettingsKeyEntity getReferenceById(Long aLong) {
+        return getById(aLong);
+    }
+
+    @Override
     public void deleteAllById(Iterable<? extends Long> longs) {
         longs.forEach(this::deleteById);
+    }
+
+    @Override
+    public <S extends SettingsKeyEntity, R> R findBy(
+        Example<S> example, Function<FluentQuery.FetchableFluentQuery<S>, R> queryFunction
+    ) {
+        return null;
     }
 }

--- a/alert-database/src/test/java/com/synopsys/integration/alert/database/api/mock/MockSystemStatusRepository.java
+++ b/alert-database/src/test/java/com/synopsys/integration/alert/database/api/mock/MockSystemStatusRepository.java
@@ -4,6 +4,10 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
+
+import org.springframework.data.domain.Example;
+import org.springframework.data.repository.query.FluentQuery;
 
 import com.synopsys.integration.alert.common.util.DateUtils;
 import com.synopsys.integration.alert.database.system.SystemStatusEntity;
@@ -63,8 +67,19 @@ public class MockSystemStatusRepository extends DefaultMockJPARepository<SystemS
     }
 
     @Override
+    public SystemStatusEntity getReferenceById(Long aLong) {
+        return getById(aLong);
+    }
+
+    @Override
     public void deleteAllById(Iterable<? extends Long> longs) {
         longs.forEach(this::deleteById);
     }
 
+    @Override
+    public <S extends SystemStatusEntity, R> R findBy(
+        Example<S> example, Function<FluentQuery.FetchableFluentQuery<S>, R> queryFunction
+    ) {
+        return null;
+    }
 }

--- a/alert-platform/build.gradle
+++ b/alert-platform/build.gradle
@@ -12,7 +12,7 @@ dependencies {
         api 'org.springframework.cloud:spring-cloud-starter-bootstrap:3.0.1'
         api 'org.springframework.boot:spring-boot-starter-amqp:2.5.12'
 
-        api 'org.jsoup:jsoup:1.9.2'
+        api 'org.jsoup:jsoup:1.15.2'
         api 'com.sun.mail:javax.mail:1.6.2'
         api 'javax.mail:javax.mail-api:1.6.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,7 @@ dependencies {
     testImplementation project(':test-common-channel')
 
     implementation 'com.synopsys.integration:blackduck-common', rootProject.ext.blackduckCommonExcludes
+    implementation 'org.apache.tomcat.embed:tomcat-embed-core'
 
     // Logging
     runtimeOnly 'ch.qos.logback:logback-classic'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.5.12'
+        springBootVersion = '2.7.1'
     }
 
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-repositories.gradle', to: buildscript
@@ -123,7 +123,6 @@ dependencies {
     testImplementation project(':test-common-channel')
 
     implementation 'com.synopsys.integration:blackduck-common', rootProject.ext.blackduckCommonExcludes
-    implementation 'org.apache.tomcat.embed:tomcat-embed-core'
 
     // Logging
     runtimeOnly 'ch.qos.logback:logback-classic'

--- a/buildSrc/src/main/java/com/synopsys/integration/alert/build/CreateKeystoreTask.java
+++ b/buildSrc/src/main/java/com/synopsys/integration/alert/build/CreateKeystoreTask.java
@@ -3,6 +3,7 @@ package com.synopsys.integration.alert.build;
 import java.util.List;
 
 import org.gradle.api.tasks.Exec;
+import org.gradle.api.tasks.Internal;
 
 public class CreateKeystoreTask extends Exec {
 
@@ -14,6 +15,7 @@ public class CreateKeystoreTask extends Exec {
         super.exec();
     }
 
+    @Internal
     public List<String> getKeytoolVariables() {
         return List.of(
             "keytool",

--- a/buildSrc/src/main/java/com/synopsys/integration/alert/build/RunServerTask.java
+++ b/buildSrc/src/main/java/com/synopsys/integration/alert/build/RunServerTask.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import org.gradle.api.Project;
 import org.gradle.api.tasks.Exec;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.options.Option;
 
 public class RunServerTask extends Exec {
@@ -144,6 +145,7 @@ public class RunServerTask extends Exec {
         super.exec();
     }
 
+    @Internal
     public List<String> getDebugVariables() {
         return List.of(
             "-Xdebug",
@@ -182,6 +184,7 @@ public class RunServerTask extends Exec {
         return variables;
     }
 
+    @Internal
     public List<String> getDatabaseVariables() {
         if (externalDb) {
             return List.of(
@@ -213,6 +216,7 @@ public class RunServerTask extends Exec {
         );
     }
 
+    @Internal
     public List<String> getMessageQueueVariables() {
         if (externalRabbitmq) {
             return List.of(

--- a/channel-email/build.gradle
+++ b/channel-email/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     api 'org.springframework.data:spring-data-jpa'
     implementation 'jakarta.persistence:jakarta.persistence-api'
     implementation 'org.springframework:spring-web'
-    implementation 'org.apache.tomcat.embed:tomcat-embed-core'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
     implementation 'javax.mail:javax.mail-api'

--- a/service-email/build.gradle
+++ b/service-email/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation 'org.springframework:spring-context'
     implementation 'javax.mail:javax.mail-api'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
+    implementation 'jakarta.activation:jakarta.activation-api'
 
     testImplementation project(':test-common')
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,6 +25,8 @@ spring.datasource.username=${ALERT_DB_USERNAME:sa}
 spring.datasource.password=${ALERT_DB_PASSWORD:blackduck}
 spring.datasource.initialization-mode=never
 spring.liquibase.change-log=classpath:liquibase/changelog-postgres-master.xml
+# Swagger
+spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
 # JMS
 spring.jms.template.qos-enabled=true
 spring.jms.template.time-to-live=14400000ms


### PR DESCRIPTION
Update springboot -> 2.7.1
Update jsoup -> 1.15.2
Update implementation of JPA in Mock test classes
Remove/Add dependencies where applicable
Add new spring property to allow Swagger to work with springboot versions > 2.6
Annotate custom task properties with "@Internal" as required by Gradle 7. * This was missed in Gradle upgrade *

This branch was run successfully in the dev & comprehensive builds, as well as running runServer locally