### PR TITLE
Azure stack overflow fix and cache fixes

### DIFF
--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultConfigurationModelConfigurationAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultConfigurationModelConfigurationAccessor.java
@@ -189,8 +189,10 @@ public class DefaultConfigurationModelConfigurationAccessor implements Configura
         DescriptorConfigEntity descriptorConfigEntity = descriptorConfigsRepository.findById(descriptorConfigId)
             .orElseThrow(() -> new AlertConfigurationException(String.format("Config with id '%d' did not exist", descriptorConfigId)));
         List<FieldValueEntity> oldValues = fieldValueRepository.findByConfigId(descriptorConfigId);
-        fieldValueRepository.deleteAll(oldValues);
-        fieldValueRepository.flush();
+        if (!oldValues.isEmpty()) {
+            fieldValueRepository.deleteAll(oldValues);
+            fieldValueRepository.flush();
+        }
 
         ConfigurationModelMutable updatedConfig = createEmptyConfigModel(descriptorConfigEntity.getDescriptorId(), descriptorConfigEntity.getId(),
             descriptorConfigEntity.getCreatedAt(), descriptorConfigEntity.getLastUpdated(), descriptorConfigEntity.getContextId()

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/AzureBoardsMessageSenderFactory.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/AzureBoardsMessageSenderFactory.java
@@ -116,7 +116,7 @@ public class AzureBoardsMessageSenderFactory implements IssueTrackerMessageSende
         AzureBoardsJobDetailsModel distributionDetails, UUID globalId, UUID parentEventId,
         Set<Long> notificationIds
     ) throws AlertException {
-        return createAsyncMessageSender(distributionDetails, globalId, parentEventId, notificationIds);
+        return createAsyncMessageSender(distributionDetails, parentEventId, notificationIds);
     }
 
     public IssueTrackerMessageSender<Integer> createMessageSender(

--- a/src/main/java/com/synopsys/integration/alert/processing/ProcessingJobEventHandler.java
+++ b/src/main/java/com/synopsys/integration/alert/processing/ProcessingJobEventHandler.java
@@ -86,8 +86,8 @@ public class ProcessingJobEventHandler implements AlertEventHandler<JobProcessin
                 providerMessageDistributor.distribute(processedNotificationDetails, processedMessageHolder);
             }
         } finally {
-            clearCaches(correlationId);
             jobNotificationMappingAccessor.removeJobMapping(correlationId, jobId);
+            clearCaches(correlationId);
         }
     }
 

--- a/src/test/java/com/synopsys/integration/alert/database/api/configuration/ConfigurationModelConfigurationAccessorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/database/api/configuration/ConfigurationModelConfigurationAccessorTestIT.java
@@ -37,7 +37,7 @@ import com.synopsys.integration.alert.util.DescriptorMocker;
 
 @Transactional
 @AlertIntegrationTest
-public class ConfigurationModelConfigurationAccessorTestIT {
+class ConfigurationModelConfigurationAccessorTestIT {
     public static final String DESCRIPTOR_NAME = "Test Descriptor";
     public static final String FIELD_KEY_INSENSITIVE = "testInsensitiveField";
     public static final String FIELD_KEY_SENSITIVE = "testSensitiveField";
@@ -81,11 +81,12 @@ public class ConfigurationModelConfigurationAccessorTestIT {
     }
 
     @Test
-    public void createConfigTest() {
+    void createConfigTest() {
         ConfigurationFieldModel configField1 = ConfigurationFieldModel.create(FIELD_KEY_INSENSITIVE);
         ConfigurationFieldModel configField2 = ConfigurationFieldModel.createSensitive(FIELD_KEY_SENSITIVE);
         DescriptorKey descriptorKey = createDescriptorKey(DESCRIPTOR_NAME);
-        ConfigurationModel createdConfig = configurationModelConfigurationAccessor.createConfiguration(descriptorKey, ConfigContextEnum.DISTRIBUTION, List.of(configField1, configField2));
+        ConfigurationModel createdConfig = configurationModelConfigurationAccessor
+            .createConfiguration(descriptorKey, ConfigContextEnum.DISTRIBUTION, List.of(configField1, configField2));
         assertTrue(createdConfig.getCopyOfFieldList().contains(configField1));
         assertTrue(createdConfig.getCopyOfFieldList().contains(configField2));
 
@@ -94,7 +95,7 @@ public class ConfigurationModelConfigurationAccessorTestIT {
     }
 
     @Test
-    public void getConfigsByNameTest() {
+    void getConfigsByNameTest() {
         ConfigurationFieldModel configField1 = ConfigurationFieldModel.create(FIELD_KEY_INSENSITIVE);
         ConfigurationFieldModel configField2 = ConfigurationFieldModel.createSensitive(FIELD_KEY_SENSITIVE);
         DescriptorKey descriptorKey = createDescriptorKey(DESCRIPTOR_NAME);
@@ -106,12 +107,14 @@ public class ConfigurationModelConfigurationAccessorTestIT {
     }
 
     @Test
-    public void getConfigurationByIdTest() {
+    void getConfigurationByIdTest() {
         ConfigurationFieldModel configField1 = ConfigurationFieldModel.create(FIELD_KEY_INSENSITIVE);
         ConfigurationFieldModel configField2 = ConfigurationFieldModel.createSensitive(FIELD_KEY_SENSITIVE);
         DescriptorKey descriptorKey = createDescriptorKey(DESCRIPTOR_NAME);
-        ConfigurationModel configurationModel1 = configurationModelConfigurationAccessor.createConfiguration(descriptorKey, ConfigContextEnum.DISTRIBUTION, Arrays.asList(configField1));
-        ConfigurationModel configurationModel2 = configurationModelConfigurationAccessor.createConfiguration(descriptorKey, ConfigContextEnum.DISTRIBUTION, Arrays.asList(configField2));
+        ConfigurationModel configurationModel1 = configurationModelConfigurationAccessor
+            .createConfiguration(descriptorKey, ConfigContextEnum.DISTRIBUTION, Arrays.asList(configField1));
+        ConfigurationModel configurationModel2 = configurationModelConfigurationAccessor
+            .createConfiguration(descriptorKey, ConfigContextEnum.DISTRIBUTION, Arrays.asList(configField2));
 
         Optional<ConfigurationModel> optionalFoundConfig1 = configurationModelConfigurationAccessor.getConfigurationById(configurationModel1.getConfigurationId());
         assertTrue(optionalFoundConfig1.isPresent());
@@ -127,7 +130,7 @@ public class ConfigurationModelConfigurationAccessorTestIT {
     }
 
     @Test
-    public void getConfigurationsByDescriptorTypeTest() {
+    void getConfigurationsByDescriptorTypeTest() {
         List<ConfigurationModel> configurationModels = configurationModelConfigurationAccessor.getConfigurationsByDescriptorType(DescriptorType.CHANNEL);
         assertTrue(configurationModels.isEmpty());
         ConfigurationFieldModel configField1 = ConfigurationFieldModel.create(FIELD_KEY_INSENSITIVE);
@@ -140,7 +143,7 @@ public class ConfigurationModelConfigurationAccessorTestIT {
     }
 
     @Test
-    public void updateConfigurationMultipleValueTest() throws AlertConfigurationException {
+    void updateConfigurationMultipleValueTest() throws AlertConfigurationException {
         final String initialValue = "initial value";
         ConfigurationFieldModel originalField = ConfigurationFieldModel.create(FIELD_KEY_INSENSITIVE);
         originalField.setFieldValue(initialValue);
@@ -156,7 +159,8 @@ public class ConfigurationModelConfigurationAccessorTestIT {
         ConfigurationFieldModel newFieldWithSameKey = ConfigurationFieldModel.create(FIELD_KEY_INSENSITIVE);
         newFieldWithSameKey.setFieldValue(additionalValue);
 
-        ConfigurationModel updatedModel = configurationModelConfigurationAccessor.updateConfiguration(createdModel.getConfigurationId(), Arrays.asList(originalField, newFieldWithSameKey));
+        ConfigurationModel updatedModel = configurationModelConfigurationAccessor
+            .updateConfiguration(createdModel.getConfigurationId(), Arrays.asList(originalField, newFieldWithSameKey));
         List<ConfigurationFieldModel> configuredFields = updatedModel.getCopyOfFieldList();
         assertEquals(1, configuredFields.size());
         ConfigurationFieldModel configuredField = configuredFields.get(0);
@@ -170,7 +174,7 @@ public class ConfigurationModelConfigurationAccessorTestIT {
     }
 
     @Test
-    public void updateConfigurationReplaceValueTest() throws AlertConfigurationException {
+    void updateConfigurationReplaceValueTest() throws AlertConfigurationException {
         final String initialValue = "initial value";
         ConfigurationFieldModel originalField = ConfigurationFieldModel.create(FIELD_KEY_INSENSITIVE);
         originalField.setFieldValue(initialValue);
@@ -199,7 +203,7 @@ public class ConfigurationModelConfigurationAccessorTestIT {
     }
 
     @Test
-    public void updateConfigurationWithInvalidIdTest() {
+    void updateConfigurationWithInvalidIdTest() {
         final Long invalidId = Long.MAX_VALUE;
         try {
             configurationModelConfigurationAccessor.updateConfiguration(invalidId, null);
@@ -210,7 +214,7 @@ public class ConfigurationModelConfigurationAccessorTestIT {
     }
 
     @Test
-    public void deleteConfigurationTest() {
+    void deleteConfigurationTest() {
         DescriptorKey descriptorKey = createDescriptorKey(DESCRIPTOR_NAME);
         ConfigurationModel createdModel1 = configurationModelConfigurationAccessor.createConfiguration(descriptorKey, ConfigContextEnum.DISTRIBUTION, List.of());
         ConfigurationModel createdModel2 = configurationModelConfigurationAccessor.createConfiguration(descriptorKey, ConfigContextEnum.DISTRIBUTION, List.of());
@@ -227,7 +231,7 @@ public class ConfigurationModelConfigurationAccessorTestIT {
     }
 
     @Test
-    public void configurationModelTest() {
+    void configurationModelTest() {
         DescriptorKey descriptorKey = createDescriptorKey(DESCRIPTOR_NAME);
         ConfigurationModel configurationModel = configurationModelConfigurationAccessor.createConfiguration(descriptorKey, ConfigContextEnum.DISTRIBUTION, List.of());
         assertNotNull(configurationModel.getConfigurationId());


### PR DESCRIPTION
Fixed a stack overflow when creating an Async message sender where we were recursively calling the same create method.
Reordered cache cleanup in the processor to happen after we remove the job mappings.
Fixed an issue where the field model repository would attempt to delete an empty list of items.