### PR TITLE
Add test coverage to channel-email

### DIFF
--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ProviderMessageContent.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ProviderMessageContent.java
@@ -156,10 +156,8 @@ public class ProviderMessageContent extends AlertSerializableModel implements Bu
         }
 
         public Builder applyProvider(String providerName, Long providerConfigId, String providerConfigName, String providerUrl) {
-            this.providerName = providerName;
-            this.providerConfigId = providerConfigId;
-            this.providerConfigName = providerConfigName;
-            this.providerUrl = providerUrl;
+            applyProvider(providerName, providerConfigId, providerConfigName);
+            applyProviderUrl(providerUrl);
             return this;
         }
 
@@ -175,9 +173,8 @@ public class ProviderMessageContent extends AlertSerializableModel implements Bu
         }
 
         public Builder applyTopic(String topicName, String topicValue, String topicUrl) {
-            this.topicName = topicName;
-            this.topicValue = topicValue;
-            this.topicUrl = topicUrl;
+            applyTopic(topicName, topicValue);
+            applyTopicUrl(topicUrl);
             return this;
         }
 
@@ -193,9 +190,8 @@ public class ProviderMessageContent extends AlertSerializableModel implements Bu
         }
 
         public Builder applySubTopic(String subTopicName, String subTopicValue, String subTopicUrl) {
-            this.subTopicName = subTopicName;
-            this.subTopicValue = subTopicValue;
-            this.subTopicUrl = subTopicUrl;
+            applySubTopic(subTopicName, subTopicValue);
+            applySubTopicUrl(subTopicUrl);
             return this;
         }
 

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ComponentItemTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ComponentItemTest.java
@@ -20,38 +20,34 @@ import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.descriptor.api.model.ProviderKey;
 
 public class ComponentItemTest {
-    public static final String CATEGORY = "test-category";
+    private static final String CATEGORY = "test-category";
 
-    public static final String COMPONENT_LABEL = "test-componentLabel";
-    public static final String COMPONENT_VALUE = "test-componentValue";
-    public static final String COMPONENT_URL = "test-componentUrl";
-    public static final LinkableItem COMPONENT_LINKABLE_ITEM = new LinkableItem(COMPONENT_LABEL, COMPONENT_VALUE, COMPONENT_URL);
+    private static final String COMPONENT_LABEL = "test-componentLabel";
+    private static final String COMPONENT_VALUE = "test-componentValue";
+    private static final String COMPONENT_URL = "test-componentUrl";
+    private static final LinkableItem COMPONENT_LINKABLE_ITEM = new LinkableItem(COMPONENT_LABEL, COMPONENT_VALUE, COMPONENT_URL);
 
-    public static final String SUB_COMPONENT_LABEL = "test-subComponentLabel";
-    public static final String SUB_COMPONENT_VALUE = "test-subComponentValue";
-    public static final String SUB_COMPONENT_URL = "test-subComponentUrl";
-    public static final LinkableItem SUB_COMPONENT_LINKABLE_ITEM = new LinkableItem(SUB_COMPONENT_LABEL, SUB_COMPONENT_VALUE, SUB_COMPONENT_URL);
+    private static final String SUB_COMPONENT_LABEL = "test-subComponentLabel";
+    private static final String SUB_COMPONENT_VALUE = "test-subComponentValue";
+    private static final String SUB_COMPONENT_URL = "test-subComponentUrl";
+    private static final LinkableItem SUB_COMPONENT_LINKABLE_ITEM = new LinkableItem(SUB_COMPONENT_LABEL, SUB_COMPONENT_VALUE, SUB_COMPONENT_URL);
 
-    public static final String CATEGORY_ITEM_LABEL = "test-categoryItemLabel";
-    public static final String CATEGORY_ITEM_VALUE = "test-categoryItemValue";
-    public static final String CATEGORY_ITEM_URL = "test-categoryItemUrl";
-    public static final LinkableItem CATEGORY_ITEM_LINKABLE_ITEM = new LinkableItem(CATEGORY_ITEM_LABEL, CATEGORY_ITEM_VALUE, CATEGORY_ITEM_URL);
+    private static final String CATEGORY_ITEM_LABEL = "test-categoryItemLabel";
+    private static final String CATEGORY_ITEM_VALUE = "test-categoryItemValue";
+    private static final String CATEGORY_ITEM_URL = "test-categoryItemUrl";
+    private static final LinkableItem CATEGORY_ITEM_LINKABLE_ITEM = new LinkableItem(CATEGORY_ITEM_LABEL, CATEGORY_ITEM_VALUE, CATEGORY_ITEM_URL);
 
-    public static final String CATEGORY_ITEM_ATTR_LABEL = "test-categoryGroupingAttributeLabel";
-    public static final String CATEGORY_ITEM_ATTR_VALUE = "test-categoryGroupingAttributeValue";
-    public static final LinkableItem SUB_CATEGORY_ITEM_LINKABLE_ITEM = new LinkableItem(CATEGORY_ITEM_ATTR_LABEL, CATEGORY_ITEM_ATTR_VALUE);
+    private static final String CATEGORY_ITEM_ATTR_LABEL = "test-categoryGroupingAttributeLabel";
+    private static final LinkableItem SUB_CATEGORY_ITEM_LINKABLE_ITEM = new LinkableItem(CATEGORY_ITEM_ATTR_LABEL, "test-categoryGroupingAttributeValue");
 
-    public static final ItemOperation ITEM_OPERATION = ItemOperation.DELETE;
-    public static final ComponentItemPriority COMPONENT_ITEM_PRIORITY = ComponentItemPriority.MEDIUM;
+    private static final ItemOperation ITEM_OPERATION = ItemOperation.DELETE;
+    private static final ComponentItemPriority COMPONENT_ITEM_PRIORITY = ComponentItemPriority.MEDIUM;
 
-    public static final String COMPONENT_CALLBACK_URL = "test-componentCallbackUrl";
-    public static final String UNIVERSAL_KEY = "universalKey";
-    public static final String DISPLAY_NAME = "displayName";
-    public static final ProviderKey PROVIDER_KEY = new ProviderKey(UNIVERSAL_KEY, DISPLAY_NAME);
-    public static final String COMPONENT_CALLBACK_NOTIFICATION_TYPE = "test-componentCallbackNotificationType";
-    public static final ComponentItemCallbackInfo CALL_BACK_INFO = new ComponentItemCallbackInfo(COMPONENT_CALLBACK_URL, PROVIDER_KEY, COMPONENT_CALLBACK_NOTIFICATION_TYPE);
+    private static final String COMPONENT_CALLBACK_URL = "test-componentCallbackUrl";
+    private static final ProviderKey PROVIDER_KEY = new ProviderKey("universalKey", "displayName");
+    private static final ComponentItemCallbackInfo CALL_BACK_INFO = new ComponentItemCallbackInfo(COMPONENT_CALLBACK_URL, PROVIDER_KEY, "test-componentCallbackNotificationType");
 
-    public final ComponentItem.Builder validBuilder = new ComponentItem.Builder();
+    private final ComponentItem.Builder validBuilder = new ComponentItem.Builder();
 
     @BeforeEach
     public void init() {
@@ -66,12 +62,8 @@ public class ComponentItemTest {
         ComponentItem componentItem = assertDoesNotThrow(validBuilder::build);
         assertEquals(CATEGORY, componentItem.getCategory());
         assertEquals(ITEM_OPERATION, componentItem.getOperation());
-        assertEquals(COMPONENT_LINKABLE_ITEM.getLabel(), componentItem.getComponent().getLabel());
-        assertEquals(COMPONENT_LINKABLE_ITEM.getValue(), componentItem.getComponent().getValue());
-        assertEquals(COMPONENT_LINKABLE_ITEM.getUrl().get(), componentItem.getComponent().getUrl().orElse(null));
-        assertEquals(CATEGORY_ITEM_LINKABLE_ITEM.getLabel(), componentItem.getCategoryItem().getLabel());
-        assertEquals(CATEGORY_ITEM_LINKABLE_ITEM.getValue(), componentItem.getCategoryItem().getValue());
-        assertEquals(CATEGORY_ITEM_LINKABLE_ITEM.getUrl().get(), componentItem.getCategoryItem().getUrl().orElse(null));
+        assertEquals(COMPONENT_LINKABLE_ITEM, componentItem.getComponent());
+        assertEquals(CATEGORY_ITEM_LINKABLE_ITEM, componentItem.getCategoryItem());
     }
 
     @Test
@@ -127,9 +119,7 @@ public class ComponentItemTest {
         validBuilder.applySubComponent(SUB_COMPONENT_LINKABLE_ITEM);
         componentItem = assertDoesNotThrow(validBuilder::build);
         assertTrue(componentItem.getSubComponent().isPresent());
-        assertEquals(SUB_COMPONENT_LINKABLE_ITEM.getLabel(), componentItem.getSubComponent().get().getLabel());
-        assertEquals(SUB_COMPONENT_LINKABLE_ITEM.getValue(), componentItem.getSubComponent().get().getValue());
-        assertEquals(SUB_COMPONENT_LINKABLE_ITEM.getUrl().get(), componentItem.getSubComponent().get().getUrl().orElse(null));
+        assertEquals(Optional.of(SUB_COMPONENT_LINKABLE_ITEM), componentItem.getSubComponent());
     }
 
     @Test
@@ -149,9 +139,7 @@ public class ComponentItemTest {
         validBuilder.applyCategoryGroupingAttribute(SUB_CATEGORY_ITEM_LINKABLE_ITEM);
         componentItem = assertDoesNotThrow(validBuilder::build);
         assertTrue(componentItem.getCategoryGroupingAttribute().isPresent());
-        assertEquals(SUB_CATEGORY_ITEM_LINKABLE_ITEM.getLabel(), componentItem.getCategoryGroupingAttribute().get().getLabel());
-        assertEquals(SUB_CATEGORY_ITEM_LINKABLE_ITEM.getValue(), componentItem.getCategoryGroupingAttribute().get().getValue());
-        assertEquals(Optional.empty(), componentItem.getCategoryGroupingAttribute().get().getUrl());
+        assertEquals(Optional.of(SUB_CATEGORY_ITEM_LINKABLE_ITEM), componentItem.getCategoryGroupingAttribute());
     }
 
     @Test
@@ -175,11 +163,7 @@ public class ComponentItemTest {
         validBuilder.applyComponentItemCallbackInfo(CALL_BACK_INFO);
         componentItem = assertDoesNotThrow(validBuilder::build);
         assertTrue(componentItem.getCallbackInfo().isPresent());
-        assertEquals(CALL_BACK_INFO.getCallbackUrl(), componentItem.getCallbackInfo().get().getCallbackUrl());
-        assertEquals(CALL_BACK_INFO.getProviderKey(), componentItem.getCallbackInfo().get().getProviderKey());
-        assertEquals(CALL_BACK_INFO.getProviderKey().getUniversalKey(), componentItem.getCallbackInfo().get().getProviderKey().getUniversalKey());
-        assertEquals(CALL_BACK_INFO.getProviderKey().getDisplayName(), componentItem.getCallbackInfo().get().getProviderKey().getDisplayName());
-        assertEquals(CALL_BACK_INFO.getNotificationType(), componentItem.getCallbackInfo().get().getNotificationType());
+        assertEquals(Optional.of(CALL_BACK_INFO), componentItem.getCallbackInfo());
     }
 
     @Test

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ComponentItemTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ComponentItemTest.java
@@ -19,7 +19,7 @@ import com.synopsys.integration.alert.common.enumeration.ItemOperation;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.descriptor.api.model.ProviderKey;
 
-public class ComponentItemTest {
+class ComponentItemTest {
     private static final String CATEGORY = "test-category";
 
     private static final String COMPONENT_LABEL = "test-componentLabel";
@@ -50,7 +50,7 @@ public class ComponentItemTest {
     private final ComponentItem.Builder validBuilder = new ComponentItem.Builder();
 
     @BeforeEach
-    public void init() {
+    void init() {
         validBuilder.applyCategory(CATEGORY)
             .applyOperation(ITEM_OPERATION)
             .applyComponentData(COMPONENT_LINKABLE_ITEM)
@@ -58,7 +58,7 @@ public class ComponentItemTest {
     }
 
     @Test
-    public void validateRequiredFieldsPresentTest() {
+    void validateRequiredFieldsPresentTest() {
         ComponentItem componentItem = assertDoesNotThrow(validBuilder::build);
         assertEquals(CATEGORY, componentItem.getCategory());
         assertEquals(ITEM_OPERATION, componentItem.getOperation());
@@ -67,7 +67,7 @@ public class ComponentItemTest {
     }
 
     @Test
-    public void validateRequiredFieldsMissingTest() {
+    void validateRequiredFieldsMissingTest() {
         // Test category null
         ComponentItem.Builder builder = new ComponentItem.Builder();
         assertThrows(AlertException.class, builder::build);
@@ -103,7 +103,7 @@ public class ComponentItemTest {
     }
 
     @Test
-    public void validateSubcomponentTest() {
+    void validateSubcomponentTest() {
         validBuilder.applySubComponent(null);
         ComponentItem componentItem = assertDoesNotThrow(validBuilder::build);
         assertTrue(componentItem.getSubComponent().isEmpty());
@@ -123,7 +123,7 @@ public class ComponentItemTest {
     }
 
     @Test
-    public void validateSubCategoryTest() {
+    void validateSubCategoryTest() {
         validBuilder.applyCategoryGroupingAttribute(null);
         ComponentItem componentItem = assertDoesNotThrow(validBuilder::build);
         assertTrue(componentItem.getCategoryGroupingAttribute().isEmpty());
@@ -143,7 +143,7 @@ public class ComponentItemTest {
     }
 
     @Test
-    public void validateCallBackTest() {
+    void validateCallBackTest() {
         validBuilder.applyComponentItemCallbackInfo(null);
         ComponentItem componentItem = assertDoesNotThrow(validBuilder::build);
         assertTrue(componentItem.getCallbackInfo().isEmpty());
@@ -167,14 +167,14 @@ public class ComponentItemTest {
     }
 
     @Test
-    public void validatePriorityTest() {
+    void validatePriorityTest() {
         validBuilder.applyPriority(COMPONENT_ITEM_PRIORITY);
         ComponentItem componentItem = assertDoesNotThrow(validBuilder::build);
         assertEquals(COMPONENT_ITEM_PRIORITY, componentItem.getPriority());
     }
 
     @Test
-    public void validateCollapseOnCategoryTest() {
+    void validateCollapseOnCategoryTest() {
         validBuilder.applyCollapseOnCategory(true);
         ComponentItem componentItem = assertDoesNotThrow(validBuilder::build);
         assertTrue(componentItem.collapseOnCategory());
@@ -182,7 +182,7 @@ public class ComponentItemTest {
     }
 
     @Test
-    public void validateNotificationIdTest() {
+    void validateNotificationIdTest() {
         Set<Long> expectedNotificationIds = new LinkedHashSet<>();
         expectedNotificationIds.add(123456789L);
         expectedNotificationIds.add(987654321L);
@@ -199,7 +199,7 @@ public class ComponentItemTest {
     }
 
     @Test
-    public void validateComponentAttributesTest() {
+    void validateComponentAttributesTest() {
         LinkableItem linkableItem1 = new LinkableItem("label1", "value1");
         LinkableItem linkableItem2 = new LinkableItem("label2", "value2");
         LinkedHashSet<LinkableItem> expectedComponentAttributes = new LinkedHashSet<>();
@@ -218,7 +218,7 @@ public class ComponentItemTest {
     }
 
     @Test
-    public void validateEqualsTest() {
+    void validateEqualsTest() {
         ComponentItem componentItem1 = assertDoesNotThrow(validBuilder::build);
         ComponentItem componentItem2 = assertDoesNotThrow(validBuilder::build);
 
@@ -227,7 +227,7 @@ public class ComponentItemTest {
     }
 
     @Test
-    public void validateCompareOptionalItemsTest() {
+    void validateCompareOptionalItemsTest() {
         ComponentItem.Builder builderNoSubComponent = validBuilder;
         ComponentItem componentItemNoSubComponent1 = assertDoesNotThrow(builderNoSubComponent::build);
         ComponentItem componentItemNoSubComponent2 = assertDoesNotThrow(builderNoSubComponent::build);
@@ -244,7 +244,7 @@ public class ComponentItemTest {
     }
 
     @Test
-    public void validateCreateKeyCollapseTrueTest() {
+    void validateCreateKeyCollapseTrueTest() {
         validBuilder.applyCollapseOnCategory(true);
         validBuilder.applySubComponent(SUB_COMPONENT_LINKABLE_ITEM);
         ComponentItem componentItem = assertDoesNotThrow(validBuilder::build);
@@ -275,7 +275,7 @@ public class ComponentItemTest {
     }
 
     @Test
-    public void validateCreateKeyCollapseFalseTest() {
+    void validateCreateKeyCollapseFalseTest() {
         validBuilder.applyCollapseOnCategory(false);
         ComponentItem componentItem = assertDoesNotThrow(validBuilder::build);
         String key = componentItem.createKey(true, false);

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ContentKeyTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ContentKeyTest.java
@@ -1,0 +1,56 @@
+package com.synopsys.integration.alert.channel.email.attachment.compatibility;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.alert.common.enumeration.ItemOperation;
+
+public class ContentKeyTest {
+    public static final String PROVIDER_NAME = "test-providerName";
+    public static final Long PROVIDER_CONFIG_ID = 1234567890L;
+    public static final String TOPIC_NAME = "test-topicName";
+    public static final String TOPIC_VALUE = "test-topicValue";
+    public static final String SUB_TOPIC_NAME = "test-subTopicName";
+    public static final String SUB_TOPIC_VALUE = "test-subTopicValue";
+    public static final ItemOperation ITEM_OPERATION = ItemOperation.DELETE;
+
+    @Test
+    public void noNullDataTest() {
+        ContentKey contentKey = ContentKey.of(PROVIDER_NAME, PROVIDER_CONFIG_ID, TOPIC_NAME, TOPIC_VALUE, SUB_TOPIC_NAME, SUB_TOPIC_VALUE, ITEM_OPERATION);
+        String contentKeyValue = contentKey.getValue();
+        assertEquals(PROVIDER_NAME, contentKey.getProviderName());
+        assertEquals(PROVIDER_CONFIG_ID, contentKey.getProviderConfigId());
+        assertEquals(TOPIC_NAME, contentKey.getTopicName());
+        assertEquals(TOPIC_VALUE, contentKey.getTopicValue());
+        assertEquals(SUB_TOPIC_NAME, contentKey.getSubTopicName());
+        assertEquals(SUB_TOPIC_VALUE, contentKey.getSubTopicValue());
+        assertTrue(contentKeyValue.contains(PROVIDER_NAME));
+        assertTrue(contentKeyValue.contains(PROVIDER_CONFIG_ID.toString()));
+        assertTrue(contentKeyValue.contains(TOPIC_NAME));
+        assertTrue(contentKeyValue.contains(TOPIC_VALUE));
+        assertTrue(contentKeyValue.contains(SUB_TOPIC_NAME));
+        assertTrue(contentKeyValue.contains(SUB_TOPIC_VALUE));
+        assertTrue(contentKeyValue.contains(ITEM_OPERATION.toString()));
+        System.out.println(contentKeyValue);
+    }
+
+    @Test
+    public void nullDataTest() {
+        List<String> keyParts = new ArrayList<>();
+        keyParts.add(PROVIDER_NAME);
+        keyParts.add(TOPIC_NAME);
+        keyParts.add(TOPIC_VALUE);
+        String expectedContentKeyValue = StringUtils.join(keyParts, "_");
+
+        ContentKey contentKey = new ContentKey(PROVIDER_NAME, null, TOPIC_NAME, TOPIC_VALUE, null, SUB_TOPIC_VALUE, null);
+        assertEquals(expectedContentKeyValue, contentKey.getValue());
+        assertFalse(contentKey.getValue().contains(SUB_TOPIC_VALUE));
+    }
+}

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ContentKeyTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ContentKeyTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import com.synopsys.integration.alert.common.enumeration.ItemOperation;
 
-public class ContentKeyTest {
+class ContentKeyTest {
     private static final String PROVIDER_NAME = "test-providerName";
     private static final Long PROVIDER_CONFIG_ID = 1234567890L;
     private static final String TOPIC_NAME = "test-topicName";
@@ -22,7 +22,7 @@ public class ContentKeyTest {
     private static final ItemOperation ITEM_OPERATION = ItemOperation.DELETE;
 
     @Test
-    public void noNullDataTest() {
+    void noNullDataTest() {
         ContentKey contentKey = ContentKey.of(PROVIDER_NAME, PROVIDER_CONFIG_ID, TOPIC_NAME, TOPIC_VALUE, SUB_TOPIC_NAME, SUB_TOPIC_VALUE, ITEM_OPERATION);
         String contentKeyValue = contentKey.getValue();
         assertEquals(PROVIDER_NAME, contentKey.getProviderName());
@@ -42,7 +42,7 @@ public class ContentKeyTest {
     }
 
     @Test
-    public void nullDataTest() {
+    void nullDataTest() {
         List<String> keyParts = new ArrayList<>();
         keyParts.add(PROVIDER_NAME);
         keyParts.add(TOPIC_NAME);

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ContentKeyTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ContentKeyTest.java
@@ -13,13 +13,13 @@ import org.junit.jupiter.api.Test;
 import com.synopsys.integration.alert.common.enumeration.ItemOperation;
 
 public class ContentKeyTest {
-    public static final String PROVIDER_NAME = "test-providerName";
-    public static final Long PROVIDER_CONFIG_ID = 1234567890L;
-    public static final String TOPIC_NAME = "test-topicName";
-    public static final String TOPIC_VALUE = "test-topicValue";
-    public static final String SUB_TOPIC_NAME = "test-subTopicName";
-    public static final String SUB_TOPIC_VALUE = "test-subTopicValue";
-    public static final ItemOperation ITEM_OPERATION = ItemOperation.DELETE;
+    private static final String PROVIDER_NAME = "test-providerName";
+    private static final Long PROVIDER_CONFIG_ID = 1234567890L;
+    private static final String TOPIC_NAME = "test-topicName";
+    private static final String TOPIC_VALUE = "test-topicValue";
+    private static final String SUB_TOPIC_NAME = "test-subTopicName";
+    private static final String SUB_TOPIC_VALUE = "test-subTopicValue";
+    private static final ItemOperation ITEM_OPERATION = ItemOperation.DELETE;
 
     @Test
     public void noNullDataTest() {

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/MessageContentGroupTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/MessageContentGroupTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import com.synopsys.integration.alert.common.enumeration.ItemOperation;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 
-public class MessageContentGroupTest {
+class MessageContentGroupTest {
     private static final String PROVIDER_NAME = "test-providerName";
     private static final String PROVIDER_CONFIG_NAME = "test-providerConfigName";
     private static final String PROVIDER_URL = "test-providerUrl";
@@ -30,13 +30,13 @@ public class MessageContentGroupTest {
     private final ProviderMessageContent.Builder validBuilder = new ProviderMessageContent.Builder();
 
     @BeforeEach
-    public void init() {
+    void init() {
         validBuilder.applyProvider(PROVIDER_NAME, 12345L, PROVIDER_CONFIG_NAME, PROVIDER_URL)
             .applyTopic(TOPIC_NAME, TOPIC_VALUE, TOPIC_URL);
     }
 
     @Test
-    public void addOneValidProviderMessageTest() {
+    void addOneValidProviderMessageTest() {
         MessageContentGroup messageContentGroup = new MessageContentGroup();
         assertNull(messageContentGroup.getCommonProvider());
         assertNull(messageContentGroup.getCommonTopic());
@@ -53,7 +53,7 @@ public class MessageContentGroupTest {
     }
 
     @Test
-    public void addMultipleProviderMessageGoodValueTest() {
+    void addMultipleProviderMessageGoodValueTest() {
         ProviderMessageContent providerMessageContent1 = assertDoesNotThrow(validBuilder::build);
         validBuilder.applyAction(ItemOperation.ADD);
         ProviderMessageContent providerMessageContent2 = assertDoesNotThrow(validBuilder::build);
@@ -68,7 +68,7 @@ public class MessageContentGroupTest {
     }
 
     @Test
-    public void addMultipleProviderMessageBadValueTest() {
+    void addMultipleProviderMessageBadValueTest() {
         ProviderMessageContent providerMessageContent1 = assertDoesNotThrow(validBuilder::build);
         validBuilder.applyTopic(TOPIC_NAME, "cause failure", TOPIC_URL);
         ProviderMessageContent providerMessageContent2 = assertDoesNotThrow(validBuilder::build);
@@ -79,7 +79,7 @@ public class MessageContentGroupTest {
     }
 
     @Test
-    public void commonTopicUrlBothNullTest() {
+    void commonTopicUrlBothNullTest() {
         validBuilder.applyTopicUrl(null);
         ProviderMessageContent providerMessageContent1 = assertDoesNotThrow(validBuilder::build);
         validBuilder.applyTopicUrl(null);
@@ -93,7 +93,7 @@ public class MessageContentGroupTest {
     }
 
     @Test
-    public void commonTopicUrlBothPresentTest() {
+    void commonTopicUrlBothPresentTest() {
         validBuilder.applyTopicUrl(TOPIC_URL);
         ProviderMessageContent providerMessageContent1 = assertDoesNotThrow(validBuilder::build);
         validBuilder.applyTopicUrl("valid url");
@@ -107,7 +107,7 @@ public class MessageContentGroupTest {
     }
 
     @Test
-    public void commonTopicUrlSecondNullTest() {
+    void commonTopicUrlSecondNullTest() {
         validBuilder.applyTopicUrl(TOPIC_URL);
         ProviderMessageContent providerMessageContent1 = assertDoesNotThrow(validBuilder::build);
         validBuilder.applyTopicUrl(null);
@@ -121,7 +121,7 @@ public class MessageContentGroupTest {
     }
 
     @Test
-    public void commonTopicUrlFirstNullTest() {
+    void commonTopicUrlFirstNullTest() {
         validBuilder.applyTopicUrl(null);
         ProviderMessageContent providerMessageContent1 = assertDoesNotThrow(validBuilder::build);
         String topicUrl = "should see this";

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/MessageContentGroupTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/MessageContentGroupTest.java
@@ -1,0 +1,137 @@
+package com.synopsys.integration.alert.channel.email.attachment.compatibility;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashSet;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.alert.common.enumeration.ItemOperation;
+import com.synopsys.integration.alert.common.message.model.LinkableItem;
+
+public class MessageContentGroupTest {
+    public static final String PROVIDER_NAME = "test-providerName";
+    public static final String PROVIDER_CONFIG_NAME = "test-providerConfigName";
+    public static final String PROVIDER_URL = "test-providerUrl";
+    public static final LinkableItem PROVIDER_LINKABLE_ITEM = new LinkableItem(PROVIDER_NAME, PROVIDER_CONFIG_NAME, PROVIDER_URL);
+
+    public static final String TOPIC_NAME = "test-topicName";
+    public static final String TOPIC_VALUE = "test-topicValue";
+    public static final String TOPIC_URL = "test-topicUrl";
+    public static final LinkableItem TOPIC_LINKABLE_ITEM = new LinkableItem(TOPIC_NAME, TOPIC_VALUE, TOPIC_URL);
+
+    public final ProviderMessageContent.Builder validBuilder = new ProviderMessageContent.Builder();
+
+    @BeforeEach
+    public void init() {
+        validBuilder.applyProvider(PROVIDER_NAME, 12345L, PROVIDER_CONFIG_NAME, PROVIDER_URL)
+            .applyTopic(TOPIC_NAME, TOPIC_VALUE, TOPIC_URL);
+    }
+
+    @Test
+    public void addOneValidProviderMessageTest() {
+        MessageContentGroup messageContentGroup = new MessageContentGroup();
+        assertNull(messageContentGroup.getCommonProvider());
+        assertNull(messageContentGroup.getCommonTopic());
+        assertEquals(0, messageContentGroup.getSubContent().size());
+        assertTrue(messageContentGroup.isEmpty());
+
+        ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
+
+        messageContentGroup.add(providerMessageContent);
+        assertEquals(PROVIDER_LINKABLE_ITEM, messageContentGroup.getCommonProvider());
+        assertEquals(TOPIC_LINKABLE_ITEM, messageContentGroup.getCommonTopic());
+        assertTrue(messageContentGroup.getSubContent().contains(providerMessageContent));
+        assertFalse(messageContentGroup.isEmpty());
+    }
+
+    @Test
+    public void addMultipleProviderMessageGoodValueTest() {
+        ProviderMessageContent providerMessageContent1 = assertDoesNotThrow(validBuilder::build);
+        validBuilder.applyAction(ItemOperation.ADD);
+        ProviderMessageContent providerMessageContent2 = assertDoesNotThrow(validBuilder::build);
+        LinkedHashSet<ProviderMessageContent> providerMessageContents = new LinkedHashSet<>();
+        providerMessageContents.add(providerMessageContent1);
+        providerMessageContents.add(providerMessageContent2);
+
+        MessageContentGroup messageContentGroup = new MessageContentGroup();
+        messageContentGroup.addAll(providerMessageContents);
+        assertTrue(messageContentGroup.getSubContent().contains(providerMessageContent1));
+        assertTrue(messageContentGroup.getSubContent().contains(providerMessageContent2));
+    }
+
+    @Test
+    public void addMultipleProviderMessageBadValueTest() {
+        ProviderMessageContent providerMessageContent1 = assertDoesNotThrow(validBuilder::build);
+        validBuilder.applyTopic(TOPIC_NAME, "cause failure", TOPIC_URL);
+        ProviderMessageContent providerMessageContent2 = assertDoesNotThrow(validBuilder::build);
+
+        MessageContentGroup messageContentGroup = new MessageContentGroup();
+        messageContentGroup.add(providerMessageContent1);
+        assertThrows(IllegalArgumentException.class, () -> messageContentGroup.add(providerMessageContent2));
+    }
+
+    @Test
+    public void commonTopicUrlBothNullTest() {
+        validBuilder.applyTopicUrl(null);
+        ProviderMessageContent providerMessageContent1 = assertDoesNotThrow(validBuilder::build);
+        validBuilder.applyTopicUrl(null);
+        ProviderMessageContent providerMessageContent2 = assertDoesNotThrow(validBuilder::build);
+
+        MessageContentGroup messageContentGroup = new MessageContentGroup();
+        messageContentGroup.add(providerMessageContent1);
+        assertEquals(Optional.empty(), messageContentGroup.getCommonTopic().getUrl());
+        messageContentGroup.add(providerMessageContent2);
+        assertEquals(Optional.empty(), messageContentGroup.getCommonTopic().getUrl());
+    }
+
+    @Test
+    public void commonTopicUrlBothPresentTest() {
+        validBuilder.applyTopicUrl(TOPIC_URL);
+        ProviderMessageContent providerMessageContent1 = assertDoesNotThrow(validBuilder::build);
+        validBuilder.applyTopicUrl("valid url");
+        ProviderMessageContent providerMessageContent2 = assertDoesNotThrow(validBuilder::build);
+
+        MessageContentGroup messageContentGroup = new MessageContentGroup();
+        messageContentGroup.add(providerMessageContent1);
+        assertEquals(TOPIC_URL, messageContentGroup.getCommonTopic().getUrl().orElse(null));
+        messageContentGroup.add(providerMessageContent2);
+        assertEquals(TOPIC_URL, messageContentGroup.getCommonTopic().getUrl().orElse(null));
+    }
+
+    @Test
+    public void commonTopicUrlSecondNullTest() {
+        validBuilder.applyTopicUrl(TOPIC_URL);
+        ProviderMessageContent providerMessageContent1 = assertDoesNotThrow(validBuilder::build);
+        validBuilder.applyTopicUrl(null);
+        ProviderMessageContent providerMessageContent2 = assertDoesNotThrow(validBuilder::build);
+
+        MessageContentGroup messageContentGroup = new MessageContentGroup();
+        messageContentGroup.add(providerMessageContent1);
+        assertEquals(TOPIC_URL, messageContentGroup.getCommonTopic().getUrl().orElse(null));
+        messageContentGroup.add(providerMessageContent2);
+        assertEquals(TOPIC_URL, messageContentGroup.getCommonTopic().getUrl().orElse(null));
+    }
+
+    @Test
+    public void commonTopicUrlFirstNullTest() {
+        validBuilder.applyTopicUrl(null);
+        ProviderMessageContent providerMessageContent1 = assertDoesNotThrow(validBuilder::build);
+        String topicUrl = "should see this";
+        validBuilder.applyTopicUrl(topicUrl);
+        ProviderMessageContent providerMessageContent2 = assertDoesNotThrow(validBuilder::build);
+
+        MessageContentGroup messageContentGroup = new MessageContentGroup();
+        messageContentGroup.add(providerMessageContent1);
+        assertEquals(Optional.empty(), messageContentGroup.getCommonTopic().getUrl());
+        messageContentGroup.add(providerMessageContent2);
+        assertEquals(topicUrl, messageContentGroup.getCommonTopic().getUrl().orElse(null));
+    }
+}

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/MessageContentGroupTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/MessageContentGroupTest.java
@@ -17,17 +17,17 @@ import com.synopsys.integration.alert.common.enumeration.ItemOperation;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 
 public class MessageContentGroupTest {
-    public static final String PROVIDER_NAME = "test-providerName";
-    public static final String PROVIDER_CONFIG_NAME = "test-providerConfigName";
-    public static final String PROVIDER_URL = "test-providerUrl";
-    public static final LinkableItem PROVIDER_LINKABLE_ITEM = new LinkableItem(PROVIDER_NAME, PROVIDER_CONFIG_NAME, PROVIDER_URL);
+    private static final String PROVIDER_NAME = "test-providerName";
+    private static final String PROVIDER_CONFIG_NAME = "test-providerConfigName";
+    private static final String PROVIDER_URL = "test-providerUrl";
+    private static final LinkableItem PROVIDER_LINKABLE_ITEM = new LinkableItem(PROVIDER_NAME, PROVIDER_CONFIG_NAME, PROVIDER_URL);
 
-    public static final String TOPIC_NAME = "test-topicName";
-    public static final String TOPIC_VALUE = "test-topicValue";
-    public static final String TOPIC_URL = "test-topicUrl";
-    public static final LinkableItem TOPIC_LINKABLE_ITEM = new LinkableItem(TOPIC_NAME, TOPIC_VALUE, TOPIC_URL);
+    private static final String TOPIC_NAME = "test-topicName";
+    private static final String TOPIC_VALUE = "test-topicValue";
+    private static final String TOPIC_URL = "test-topicUrl";
+    private static final LinkableItem TOPIC_LINKABLE_ITEM = new LinkableItem(TOPIC_NAME, TOPIC_VALUE, TOPIC_URL);
 
-    public final ProviderMessageContent.Builder validBuilder = new ProviderMessageContent.Builder();
+    private final ProviderMessageContent.Builder validBuilder = new ProviderMessageContent.Builder();
 
     @BeforeEach
     public void init() {

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/MessageContentKeyTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/MessageContentKeyTest.java
@@ -10,10 +10,10 @@ import org.junit.jupiter.api.Test;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 
 public class MessageContentKeyTest {
-    public static final String TOPIC_NAME = "test-topicName";
-    public static final String TOPIC_VALUE = "test-topicValue";
-    public static final String SUB_TOPIC_NAME = "test-subTopicName";
-    public static final String SUB_TOPIC_VALUE = "test-subTopicValue";
+    private static final String TOPIC_NAME = "test-topicName";
+    private static final String TOPIC_VALUE = "test-topicValue";
+    private static final String SUB_TOPIC_NAME = "test-subTopicName";
+    private static final String SUB_TOPIC_VALUE = "test-subTopicValue";
 
     @Test
     public void getKeyNoSubTopicTest() {

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/MessageContentKeyTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/MessageContentKeyTest.java
@@ -3,56 +3,64 @@ package com.synopsys.integration.alert.channel.email.attachment.compatibility;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import java.util.LinkedHashSet;
+
 import org.junit.jupiter.api.Test;
 
+import com.synopsys.integration.alert.common.message.model.LinkableItem;
+
 public class MessageContentKeyTest {
+    public static final String TOPIC_NAME = "test-topicName";
+    public static final String TOPIC_VALUE = "test-topicValue";
+    public static final String SUB_TOPIC_NAME = "test-subTopicName";
+    public static final String SUB_TOPIC_VALUE = "test-subTopicValue";
+
     @Test
     public void getKeyNoSubTopicTest() {
-        final String topicName = "Topic";
-        final String topicValue = "My Topic";
-        MessageContentKey contentKey = MessageContentKey.from(topicName, topicValue);
-
-        assertEquals(String.format("%s_%s", topicName, topicValue), contentKey.getKey());
+        MessageContentKey contentKey = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE);
+        assertEquals(String.format("%s_%s", TOPIC_NAME, TOPIC_VALUE), contentKey.getKey());
     }
 
     @Test
     public void getKeyNullSubTopicTest() {
-        final String topicName = "Topic";
-        final String topicValue = "My Topic";
-        final String notNull = "not null";
+        MessageContentKey contentKey1 = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE, null, SUB_TOPIC_VALUE);
+        assertEquals(String.format("%s_%s", TOPIC_NAME, TOPIC_VALUE), contentKey1.getKey());
 
-        MessageContentKey contentKey1 = MessageContentKey.from(topicName, topicValue, null, notNull);
-        assertEquals(String.format("%s_%s", topicName, topicValue), contentKey1.getKey());
-
-        MessageContentKey contentKey2 = MessageContentKey.from(topicName, topicValue, notNull, null);
-        assertEquals(String.format("%s_%s", topicName, topicValue), contentKey2.getKey());
+        MessageContentKey contentKey2 = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE, SUB_TOPIC_NAME, null);
+        assertEquals(String.format("%s_%s", TOPIC_NAME, TOPIC_VALUE), contentKey2.getKey());
     }
 
     @Test
     public void getKeyWithSubTopicTest() {
-        final String topicName = "Topic";
-        final String topicValue = "My Topic";
-        final String subTopicName = "Sub Topic";
-        final String subTopicValue = "A Sub Topic";
-        MessageContentKey contentKey = MessageContentKey.from(topicName, topicValue, subTopicName, subTopicValue);
-
-        assertEquals(String.format("%s_%s_%s_%s", topicName, topicValue, subTopicName, subTopicValue), contentKey.getKey());
+        MessageContentKey contentKey = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE, SUB_TOPIC_NAME, SUB_TOPIC_VALUE);
+        assertEquals(String.format("%s_%s_%s_%s", TOPIC_NAME, TOPIC_VALUE, SUB_TOPIC_NAME, SUB_TOPIC_VALUE), contentKey.getKey());
     }
 
     @Test
     public void equalsTest() {
-        final String topicName = "Topic";
-        final String topicValue = "My Topic";
-        final String subTopicName = "Sub Topic";
-        final String subTopicValue = "A Sub Topic";
-        MessageContentKey contentKey1 = MessageContentKey.from(topicName, topicValue);
-        MessageContentKey contentKey2 = MessageContentKey.from(topicName, topicValue);
-        MessageContentKey contentKey3 = MessageContentKey.from(topicName, topicValue, subTopicName, subTopicValue);
-        MessageContentKey contentKey4 = MessageContentKey.from(topicName, topicValue, subTopicName, subTopicValue);
+        MessageContentKey contentKey1 = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE);
+        MessageContentKey contentKey2 = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE);
+        MessageContentKey contentKey3 = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE, SUB_TOPIC_NAME, SUB_TOPIC_VALUE);
+        MessageContentKey contentKey4 = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE, SUB_TOPIC_NAME, SUB_TOPIC_VALUE);
 
         assertEquals(contentKey1, contentKey2);
         assertNotEquals(contentKey1, contentKey3);
         assertEquals(contentKey3, contentKey4);
+    }
+
+    @Test
+    public void getKeyWithLinkableItemTest() {
+        MessageContentKey contentKey1 = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE, null);
+        assertEquals(String.format("%s_%s", TOPIC_NAME, TOPIC_VALUE), contentKey1.getKey());
+
+        LinkedHashSet<LinkableItem> subTopics = new LinkedHashSet<>();
+        MessageContentKey contentKey2 = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE, subTopics);
+        assertEquals(String.format("%s_%s", TOPIC_NAME, TOPIC_VALUE), contentKey2.getKey());
+
+        LinkableItem linkableItem = new LinkableItem(SUB_TOPIC_NAME, SUB_TOPIC_VALUE);
+        subTopics.add(linkableItem);
+        MessageContentKey contentKey3 = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE, subTopics);
+        assertEquals(String.format("%s_%s_%s_%s", TOPIC_NAME, TOPIC_VALUE, SUB_TOPIC_NAME, SUB_TOPIC_VALUE), contentKey3.getKey());
     }
 
 }

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/MessageContentKeyTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/MessageContentKeyTest.java
@@ -9,20 +9,20 @@ import org.junit.jupiter.api.Test;
 
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 
-public class MessageContentKeyTest {
+class MessageContentKeyTest {
     private static final String TOPIC_NAME = "test-topicName";
     private static final String TOPIC_VALUE = "test-topicValue";
     private static final String SUB_TOPIC_NAME = "test-subTopicName";
     private static final String SUB_TOPIC_VALUE = "test-subTopicValue";
 
     @Test
-    public void getKeyNoSubTopicTest() {
+    void getKeyNoSubTopicTest() {
         MessageContentKey contentKey = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE);
         assertEquals(String.format("%s_%s", TOPIC_NAME, TOPIC_VALUE), contentKey.getKey());
     }
 
     @Test
-    public void getKeyNullSubTopicTest() {
+    void getKeyNullSubTopicTest() {
         MessageContentKey contentKey1 = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE, null, SUB_TOPIC_VALUE);
         assertEquals(String.format("%s_%s", TOPIC_NAME, TOPIC_VALUE), contentKey1.getKey());
 
@@ -31,13 +31,13 @@ public class MessageContentKeyTest {
     }
 
     @Test
-    public void getKeyWithSubTopicTest() {
+    void getKeyWithSubTopicTest() {
         MessageContentKey contentKey = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE, SUB_TOPIC_NAME, SUB_TOPIC_VALUE);
         assertEquals(String.format("%s_%s_%s_%s", TOPIC_NAME, TOPIC_VALUE, SUB_TOPIC_NAME, SUB_TOPIC_VALUE), contentKey.getKey());
     }
 
     @Test
-    public void equalsTest() {
+    void equalsTest() {
         MessageContentKey contentKey1 = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE);
         MessageContentKey contentKey2 = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE);
         MessageContentKey contentKey3 = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE, SUB_TOPIC_NAME, SUB_TOPIC_VALUE);
@@ -49,7 +49,7 @@ public class MessageContentKeyTest {
     }
 
     @Test
-    public void getKeyWithLinkableItemTest() {
+    void getKeyWithLinkableItemTest() {
         MessageContentKey contentKey1 = MessageContentKey.from(TOPIC_NAME, TOPIC_VALUE, null);
         assertEquals(String.format("%s_%s", TOPIC_NAME, TOPIC_VALUE), contentKey1.getKey());
 

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ProviderMessageContentTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ProviderMessageContentTest.java
@@ -22,29 +22,28 @@ import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.datastructure.SetMap;
 
 public class ProviderMessageContentTest {
-    public static final String PROVIDER_NAME = "test-providerName";
-    public static final String PROVIDER_CONFIG_NAME = "test-providerConfigName";
-    public static final String PROVIDER_URL = "test-providerUrl";
-    public static final LinkableItem PROVIDER_LINKABLE_ITEM = new LinkableItem(PROVIDER_NAME, PROVIDER_CONFIG_NAME, PROVIDER_URL);
+    private static final String PROVIDER_NAME = "test-providerName";
+    private static final String PROVIDER_CONFIG_NAME = "test-providerConfigName";
+    private static final String PROVIDER_URL = "test-providerUrl";
+    private static final LinkableItem PROVIDER_LINKABLE_ITEM = new LinkableItem(PROVIDER_NAME, PROVIDER_CONFIG_NAME, PROVIDER_URL);
 
-    public static final String TOPIC_NAME = "test-topicName";
-    public static final String TOPIC_VALUE = "test-topicValue";
-    public static final String TOPIC_URL = "test-topicUrl";
-    public static final LinkableItem TOPIC_LINKABLE_ITEM = new LinkableItem(TOPIC_NAME, TOPIC_VALUE, TOPIC_URL);
+    private static final String TOPIC_NAME = "test-topicName";
+    private static final String TOPIC_VALUE = "test-topicValue";
+    private static final String TOPIC_URL = "test-topicUrl";
+    private static final LinkableItem TOPIC_LINKABLE_ITEM = new LinkableItem(TOPIC_NAME, TOPIC_VALUE, TOPIC_URL);
 
-    public static final String SUB_TOPIC_NAME = "test-subTopicName";
-    public static final String SUB_TOPIC_VALUE = "test-subTopicValue";
-    public static final String SUB_TOPIC_URL = "test-subTopicUrl";
-    public static final LinkableItem SUB_TOPIC_LINKABLE_ITEM = new LinkableItem(SUB_TOPIC_NAME, SUB_TOPIC_VALUE, SUB_TOPIC_URL);
+    private static final String SUB_TOPIC_NAME = "test-subTopicName";
+    private static final String SUB_TOPIC_VALUE = "test-subTopicValue";
+    private static final String SUB_TOPIC_URL = "test-subTopicUrl";
+    private static final LinkableItem SUB_TOPIC_LINKABLE_ITEM = new LinkableItem(SUB_TOPIC_NAME, SUB_TOPIC_VALUE, SUB_TOPIC_URL);
 
-    public static final Long PROVIDER_CONFIG_ID = 1234567890L;
-    public static final ItemOperation ITEM_OPERATION_1 = ItemOperation.ADD;
-    public static final ItemOperation ITEM_OPERATION_2 = ItemOperation.UPDATE;
-    public static final Long NOTIFICATION_ID = 9876543210L;
+    private static final Long PROVIDER_CONFIG_ID = 1234567890L;
+    private static final ItemOperation ITEM_OPERATION_1 = ItemOperation.ADD;
+    private static final Long NOTIFICATION_ID = 9876543210L;
 
-    public final ProviderMessageContent.Builder validBuilder = new ProviderMessageContent.Builder();
-    public final ComponentItem.Builder validComponentItemBuilder1 = new ComponentItem.Builder();
-    public final ComponentItem.Builder validComponentItemBuilder2 = new ComponentItem.Builder();
+    private final ProviderMessageContent.Builder validBuilder = new ProviderMessageContent.Builder();
+    private final ComponentItem.Builder validComponentItemBuilder1 = new ComponentItem.Builder();
+    private final ComponentItem.Builder validComponentItemBuilder2 = new ComponentItem.Builder();
 
     @BeforeEach
     public void init() {
@@ -57,7 +56,7 @@ public class ProviderMessageContentTest {
             .applyCategoryItem("label1", "value1");
 
         validComponentItemBuilder2.applyCategory("category2")
-            .applyOperation(ITEM_OPERATION_2)
+            .applyOperation(ItemOperation.UPDATE)
             .applyComponentData("label2", "value2")
             .applyCategoryItem("label2", "value2");
     }

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ProviderMessageContentTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ProviderMessageContentTest.java
@@ -1,0 +1,283 @@
+package com.synopsys.integration.alert.channel.email.attachment.compatibility;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.alert.api.common.model.exception.AlertException;
+import com.synopsys.integration.alert.common.enumeration.ItemOperation;
+import com.synopsys.integration.alert.common.message.model.LinkableItem;
+import com.synopsys.integration.datastructure.SetMap;
+
+public class ProviderMessageContentTest {
+    public static final String PROVIDER_NAME = "test-providerName";
+    public static final String PROVIDER_CONFIG_NAME = "test-providerConfigName";
+    public static final String PROVIDER_URL = "test-providerUrl";
+    public static final LinkableItem PROVIDER_LINKABLE_ITEM = new LinkableItem(PROVIDER_NAME, PROVIDER_CONFIG_NAME, PROVIDER_URL);
+
+    public static final String TOPIC_NAME = "test-topicName";
+    public static final String TOPIC_VALUE = "test-topicValue";
+    public static final String TOPIC_URL = "test-topicUrl";
+    public static final LinkableItem TOPIC_LINKABLE_ITEM = new LinkableItem(TOPIC_NAME, TOPIC_VALUE, TOPIC_URL);
+
+    public static final String SUB_TOPIC_NAME = "test-subTopicName";
+    public static final String SUB_TOPIC_VALUE = "test-subTopicValue";
+    public static final String SUB_TOPIC_URL = "test-subTopicUrl";
+    public static final LinkableItem SUB_TOPIC_LINKABLE_ITEM = new LinkableItem(SUB_TOPIC_NAME, SUB_TOPIC_VALUE, SUB_TOPIC_URL);
+
+    public static final Long PROVIDER_CONFIG_ID = 1234567890L;
+    public static final ItemOperation ITEM_OPERATION_1 = ItemOperation.ADD;
+    public static final ItemOperation ITEM_OPERATION_2 = ItemOperation.UPDATE;
+    public static final Long NOTIFICATION_ID = 9876543210L;
+
+    public final ProviderMessageContent.Builder validBuilder = new ProviderMessageContent.Builder();
+    public final ComponentItem.Builder validComponentItemBuilder1 = new ComponentItem.Builder();
+    public final ComponentItem.Builder validComponentItemBuilder2 = new ComponentItem.Builder();
+
+    @BeforeEach
+    public void init() {
+        validBuilder.applyProvider(PROVIDER_NAME, PROVIDER_CONFIG_ID, PROVIDER_CONFIG_NAME, PROVIDER_URL)
+            .applyTopic(TOPIC_NAME, TOPIC_VALUE, TOPIC_URL);
+
+        validComponentItemBuilder1.applyCategory("category1")
+            .applyOperation(ITEM_OPERATION_1)
+            .applyComponentData("label1", "value1")
+            .applyCategoryItem("label1", "value1");
+
+        validComponentItemBuilder2.applyCategory("category2")
+            .applyOperation(ITEM_OPERATION_2)
+            .applyComponentData("label2", "value2")
+            .applyCategoryItem("label2", "value2");
+    }
+
+    @Test
+    public void validateRequiredFieldsPresentTest() {
+        ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertEquals(PROVIDER_LINKABLE_ITEM, providerMessageContent.getProvider());
+        assertEquals(PROVIDER_CONFIG_ID, providerMessageContent.getProviderConfigId());
+        assertEquals(TOPIC_LINKABLE_ITEM, providerMessageContent.getTopic());
+
+        String contentKeyValue = providerMessageContent.getContentKey().getValue();
+        assertTrue(contentKeyValue.contains(PROVIDER_NAME));
+        assertTrue(contentKeyValue.contains(PROVIDER_CONFIG_ID.toString()));
+        assertTrue(contentKeyValue.contains(TOPIC_NAME));
+        assertTrue(contentKeyValue.contains(TOPIC_VALUE));
+    }
+
+    @Test
+    public void validateRequiredFieldsMissingTest() {
+        ProviderMessageContent.Builder builder = new ProviderMessageContent.Builder();
+        assertEquals("__", builder.getCurrentContentKey().getValue());
+
+        // Test providerName null
+        builder.applyProvider(null, null, null);
+        assertThrows(AlertException.class, builder::build);
+
+        // Test providerConfigId null
+        builder.applyProvider(PROVIDER_NAME, null, null);
+        assertThrows(AlertException.class, builder::build);
+
+        // Test providerConfigName null
+        builder.applyProvider(PROVIDER_NAME, PROVIDER_CONFIG_ID, null);
+        assertThrows(AlertException.class, builder::build);
+
+        // Test topicName null
+        builder.applyProvider(PROVIDER_NAME, PROVIDER_CONFIG_ID, PROVIDER_CONFIG_NAME);
+        assertThrows(AlertException.class, builder::build);
+
+        // Test topicValue null
+        builder.applyTopic(TOPIC_NAME, null);
+        AlertException alertException = assertThrows(AlertException.class, builder::build);
+        assertEquals("Missing required field(s)", alertException.getMessage());
+    }
+
+    @Test
+    public void validateSubTopicTest() {
+        ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertEquals(Optional.empty(), providerMessageContent.getSubTopic());
+
+        validBuilder.applySubTopic(SUB_TOPIC_NAME, null, null);
+        providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertEquals(Optional.empty(), providerMessageContent.getSubTopic());
+
+        validBuilder.applySubTopic(null, SUB_TOPIC_VALUE, null);
+        providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertEquals(Optional.empty(), providerMessageContent.getSubTopic());
+
+        validBuilder.applySubTopic(SUB_TOPIC_NAME, SUB_TOPIC_VALUE, null);
+        providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertEquals(SUB_TOPIC_NAME, providerMessageContent.getSubTopic().get().getLabel());
+        assertEquals(SUB_TOPIC_VALUE, providerMessageContent.getSubTopic().get().getValue());
+        assertEquals(Optional.empty(), providerMessageContent.getSubTopic().get().getUrl());
+
+        validBuilder.applySubTopic(SUB_TOPIC_NAME, SUB_TOPIC_VALUE, SUB_TOPIC_URL);
+        providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertEquals(Optional.of(SUB_TOPIC_LINKABLE_ITEM), providerMessageContent.getSubTopic());
+        String contentKeyValue = providerMessageContent.getContentKey().getValue();
+        assertEquals(validBuilder.getCurrentContentKey().getValue(), contentKeyValue);
+        assertTrue(contentKeyValue.contains(SUB_TOPIC_NAME));
+        assertTrue(contentKeyValue.contains(SUB_TOPIC_VALUE));
+    }
+
+    @Test
+    public void validateActionTest() {
+        ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertEquals(Optional.empty(), providerMessageContent.getAction());
+        assertFalse(providerMessageContent.getContentKey().getValue().contains(ITEM_OPERATION_1.toString()));
+        assertFalse(validBuilder.getCurrentContentKey().getValue().contains(ITEM_OPERATION_1.toString()));
+
+        validBuilder.applyAction(ITEM_OPERATION_1);
+        providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertEquals(Optional.of(ITEM_OPERATION_1), providerMessageContent.getAction());
+        assertTrue(providerMessageContent.getContentKey().getValue().contains(ITEM_OPERATION_1.toString()));
+        assertTrue(validBuilder.getCurrentContentKey().getValue().contains(ITEM_OPERATION_1.toString()));
+    }
+
+    @Test
+    public void validateNotificationIdTest() {
+        ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertEquals(Optional.empty(), providerMessageContent.getNotificationId());
+
+        validBuilder.applyNotificationId(NOTIFICATION_ID);
+        providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertEquals(Optional.of(NOTIFICATION_ID), providerMessageContent.getNotificationId());
+    }
+
+    @Test
+    public void validateComponentItemTest() {
+        ComponentItem componentItem1 = assertDoesNotThrow(validComponentItemBuilder1::build);
+        ComponentItem componentItem2 = assertDoesNotThrow(validComponentItemBuilder2::build);
+        Set<ComponentItem> componentItems = new LinkedHashSet<>();
+        componentItems.add(componentItem2);
+
+        ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertTrue(providerMessageContent.getComponentItems().isEmpty());
+
+        validBuilder.applyComponentItem(componentItem1);
+        providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertTrue(providerMessageContent.getComponentItems().contains(componentItem1));
+
+        validBuilder.applyAllComponentItems(componentItems);
+        providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertTrue(providerMessageContent.getComponentItems().contains(componentItem2));
+    }
+
+    @Test
+    public void validateProviderCreationTimeTest() {
+        ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertNull(providerMessageContent.getProviderCreationTime());
+
+        OffsetDateTime offsetDateTime = OffsetDateTime.now();
+        validBuilder.applyProviderCreationTime(offsetDateTime);
+        providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertEquals(offsetDateTime, providerMessageContent.getProviderCreationTime());
+    }
+
+    @Test
+    public void validateApplyEarliestProviderCreationTimeTest() {
+        OffsetDateTime currentOffsetDateTime = OffsetDateTime.now();
+        OffsetDateTime pastOffsetDateTime = OffsetDateTime.of(1966, 9, 8, 0, 0, 1, 1, ZoneOffset.of("-04:00"));
+        OffsetDateTime futureOffsetDateTime = OffsetDateTime.of(2233, 3, 22, 0, 0, 1, 1, ZoneOffset.of("-04:00"));
+
+        validBuilder.applyEarliestProviderCreationTime(currentOffsetDateTime);
+        ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertEquals(currentOffsetDateTime, providerMessageContent.getProviderCreationTime());
+
+        validBuilder.applyEarliestProviderCreationTime(pastOffsetDateTime);
+        providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertEquals(pastOffsetDateTime, providerMessageContent.getProviderCreationTime());
+
+        validBuilder.applyEarliestProviderCreationTime(futureOffsetDateTime);
+        providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertEquals(pastOffsetDateTime, providerMessageContent.getProviderCreationTime());
+    }
+
+    @Test
+    public void validateIsTopLevelActionOnlyTest() {
+        // Test action null
+        validBuilder.applyAction(null)
+            .applyNotificationId(null);
+        ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertFalse(providerMessageContent.isTopLevelActionOnly());
+
+        // Test notificationId null
+        validBuilder.applyAction(ITEM_OPERATION_1)
+            .applyNotificationId(null);
+        providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertFalse(providerMessageContent.isTopLevelActionOnly());
+
+        // Test componentItems empty
+        validBuilder.applyAction(ITEM_OPERATION_1)
+            .applyNotificationId(NOTIFICATION_ID);
+        providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertTrue(providerMessageContent.getComponentItems().isEmpty());
+        assertTrue(providerMessageContent.isTopLevelActionOnly());
+
+        // Test componentItems NOT empty
+        ComponentItem componentItem = assertDoesNotThrow(validComponentItemBuilder1::build);
+        validBuilder.applyAction(ITEM_OPERATION_1)
+            .applyNotificationId(NOTIFICATION_ID)
+            .applyComponentItem(componentItem);
+        providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertFalse(providerMessageContent.getComponentItems().isEmpty());
+        assertFalse(providerMessageContent.isTopLevelActionOnly());
+    }
+
+    @Test
+    public void validateGroupRelatedComponentItemsFalseTest() {
+        boolean includeOperation = false;
+        ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertTrue(providerMessageContent.groupRelatedComponentItems().isEmpty());
+        assertTrue(providerMessageContent.groupRelatedComponentItems(includeOperation).isEmpty());
+
+        ComponentItem componentItem1 = assertDoesNotThrow(validComponentItemBuilder1::build);
+        String componentItem1Key = componentItem1.createKey(includeOperation, false);
+        ComponentItem componentItem2 = assertDoesNotThrow(validComponentItemBuilder2::build);
+        String componentItem2Key = componentItem2.createKey(includeOperation, false);
+        validBuilder.applyComponentItem(componentItem1)
+            .applyComponentItem(componentItem2);
+
+        providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        SetMap<String, ComponentItem> relatedComponentItems = providerMessageContent.groupRelatedComponentItems(includeOperation);
+        assertFalse(relatedComponentItems.isEmpty());
+        assertTrue(relatedComponentItems.containsKey(componentItem1Key));
+        assertEquals(componentItem1, relatedComponentItems.getMap().get(componentItem1Key).toArray()[0]);
+        assertTrue(relatedComponentItems.containsKey(componentItem2Key));
+        assertEquals(componentItem2, relatedComponentItems.getMap().get(componentItem2Key).toArray()[0]);
+    }
+
+    @Test
+    public void validateGroupRelatedComponentItemsTrueTest() {
+        boolean includeOperation = true;
+        ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        assertTrue(providerMessageContent.groupRelatedComponentItems().isEmpty());
+        assertTrue(providerMessageContent.groupRelatedComponentItems(includeOperation).isEmpty());
+
+        ComponentItem componentItem1 = assertDoesNotThrow(validComponentItemBuilder1::build);
+        String componentItem1Key = componentItem1.createKey(includeOperation, false);
+        ComponentItem componentItem2 = assertDoesNotThrow(validComponentItemBuilder2::build);
+        String componentItem2Key = componentItem2.createKey(includeOperation, false);
+        validBuilder.applyComponentItem(componentItem1)
+            .applyComponentItem(componentItem2);
+
+        providerMessageContent = assertDoesNotThrow(validBuilder::build);
+        SetMap<String, ComponentItem> relatedComponentItems = providerMessageContent.groupRelatedComponentItems(includeOperation);
+        assertFalse(relatedComponentItems.isEmpty());
+        assertTrue(relatedComponentItems.containsKey(componentItem1Key));
+        assertEquals(componentItem1, relatedComponentItems.getMap().get(componentItem1Key).toArray()[0]);
+        assertTrue(relatedComponentItems.containsKey(componentItem2Key));
+        assertEquals(componentItem2, relatedComponentItems.getMap().get(componentItem2Key).toArray()[0]);
+    }
+}

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ProviderMessageContentTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility/ProviderMessageContentTest.java
@@ -21,7 +21,7 @@ import com.synopsys.integration.alert.common.enumeration.ItemOperation;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.datastructure.SetMap;
 
-public class ProviderMessageContentTest {
+class ProviderMessageContentTest {
     private static final String PROVIDER_NAME = "test-providerName";
     private static final String PROVIDER_CONFIG_NAME = "test-providerConfigName";
     private static final String PROVIDER_URL = "test-providerUrl";
@@ -46,7 +46,7 @@ public class ProviderMessageContentTest {
     private final ComponentItem.Builder validComponentItemBuilder2 = new ComponentItem.Builder();
 
     @BeforeEach
-    public void init() {
+    void init() {
         validBuilder.applyProvider(PROVIDER_NAME, PROVIDER_CONFIG_ID, PROVIDER_CONFIG_NAME, PROVIDER_URL)
             .applyTopic(TOPIC_NAME, TOPIC_VALUE, TOPIC_URL);
 
@@ -62,7 +62,7 @@ public class ProviderMessageContentTest {
     }
 
     @Test
-    public void validateRequiredFieldsPresentTest() {
+    void validateRequiredFieldsPresentTest() {
         ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
         assertEquals(PROVIDER_LINKABLE_ITEM, providerMessageContent.getProvider());
         assertEquals(PROVIDER_CONFIG_ID, providerMessageContent.getProviderConfigId());
@@ -76,7 +76,7 @@ public class ProviderMessageContentTest {
     }
 
     @Test
-    public void validateRequiredFieldsMissingTest() {
+    void validateRequiredFieldsMissingTest() {
         ProviderMessageContent.Builder builder = new ProviderMessageContent.Builder();
         assertEquals("__", builder.getCurrentContentKey().getValue());
 
@@ -103,7 +103,7 @@ public class ProviderMessageContentTest {
     }
 
     @Test
-    public void validateSubTopicTest() {
+    void validateSubTopicTest() {
         ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
         assertEquals(Optional.empty(), providerMessageContent.getSubTopic());
 
@@ -131,7 +131,7 @@ public class ProviderMessageContentTest {
     }
 
     @Test
-    public void validateActionTest() {
+    void validateActionTest() {
         ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
         assertEquals(Optional.empty(), providerMessageContent.getAction());
         assertFalse(providerMessageContent.getContentKey().getValue().contains(ITEM_OPERATION_1.toString()));
@@ -145,7 +145,7 @@ public class ProviderMessageContentTest {
     }
 
     @Test
-    public void validateNotificationIdTest() {
+    void validateNotificationIdTest() {
         ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
         assertEquals(Optional.empty(), providerMessageContent.getNotificationId());
 
@@ -155,7 +155,7 @@ public class ProviderMessageContentTest {
     }
 
     @Test
-    public void validateComponentItemTest() {
+    void validateComponentItemTest() {
         ComponentItem componentItem1 = assertDoesNotThrow(validComponentItemBuilder1::build);
         ComponentItem componentItem2 = assertDoesNotThrow(validComponentItemBuilder2::build);
         Set<ComponentItem> componentItems = new LinkedHashSet<>();
@@ -174,7 +174,7 @@ public class ProviderMessageContentTest {
     }
 
     @Test
-    public void validateProviderCreationTimeTest() {
+    void validateProviderCreationTimeTest() {
         ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
         assertNull(providerMessageContent.getProviderCreationTime());
 
@@ -185,7 +185,7 @@ public class ProviderMessageContentTest {
     }
 
     @Test
-    public void validateApplyEarliestProviderCreationTimeTest() {
+    void validateApplyEarliestProviderCreationTimeTest() {
         OffsetDateTime currentOffsetDateTime = OffsetDateTime.now();
         OffsetDateTime pastOffsetDateTime = OffsetDateTime.of(1966, 9, 8, 0, 0, 1, 1, ZoneOffset.of("-04:00"));
         OffsetDateTime futureOffsetDateTime = OffsetDateTime.of(2233, 3, 22, 0, 0, 1, 1, ZoneOffset.of("-04:00"));
@@ -204,7 +204,7 @@ public class ProviderMessageContentTest {
     }
 
     @Test
-    public void validateIsTopLevelActionOnlyTest() {
+    void validateIsTopLevelActionOnlyTest() {
         // Test action null
         validBuilder.applyAction(null)
             .applyNotificationId(null);
@@ -235,7 +235,7 @@ public class ProviderMessageContentTest {
     }
 
     @Test
-    public void validateGroupRelatedComponentItemsFalseTest() {
+    void validateGroupRelatedComponentItemsFalseTest() {
         boolean includeOperation = false;
         ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
         assertTrue(providerMessageContent.groupRelatedComponentItems().isEmpty());
@@ -258,7 +258,7 @@ public class ProviderMessageContentTest {
     }
 
     @Test
-    public void validateGroupRelatedComponentItemsTrueTest() {
+    void validateGroupRelatedComponentItemsTrueTest() {
         boolean includeOperation = true;
         ProviderMessageContent providerMessageContent = assertDoesNotThrow(validBuilder::build);
         assertTrue(providerMessageContent.groupRelatedComponentItems().isEmpty());


### PR DESCRIPTION
Update apply methods in ProviderMessageContent to perform assignment in fewer locations
Bring test coverage to 100% for channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/compatibility
Code coverage verified increase of 0.5% and no new code smells