### PR TITLE
distribution event test coverage

### DIFF
--- a/channel-jira-cloud/build.gradle
+++ b/channel-jira-cloud/build.gradle
@@ -9,9 +9,11 @@ dependencies {
     implementation project(':api-channel-jira')
     implementation project(':api-processor')
     implementation project(':api-descriptor')
+    implementation project(':alert-database')
 
     implementation 'com.synopsys.integration:integration-rest'
     implementation 'org.springframework:spring-web'
 
     testImplementation project(':test-common-channel')
+    testImplementation project(':alert-database-job')
 }

--- a/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/database/accessor/mock/MockJiraCloudJobCustomFieldRepository.java
+++ b/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/database/accessor/mock/MockJiraCloudJobCustomFieldRepository.java
@@ -1,0 +1,48 @@
+package com.synopsys.integration.alert.channel.jira.cloud.database.accessor.mock;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.synopsys.integration.alert.database.job.jira.cloud.custom_field.JiraCloudJobCustomFieldEntity;
+import com.synopsys.integration.alert.database.job.jira.cloud.custom_field.JiraCloudJobCustomFieldPK;
+import com.synopsys.integration.alert.database.job.jira.cloud.custom_field.JiraCloudJobCustomFieldRepository;
+import com.synopsys.integration.alert.test.common.database.MockRepositoryContainer;
+
+public class MockJiraCloudJobCustomFieldRepository extends MockRepositoryContainer<JiraCloudJobCustomFieldPK, JiraCloudJobCustomFieldEntity>
+    implements JiraCloudJobCustomFieldRepository {
+
+    private static Function<JiraCloudJobCustomFieldEntity, JiraCloudJobCustomFieldPK> createIDGenerator() {
+        return entity -> new JiraCloudJobCustomFieldPK(
+            entity.getJobId(),
+            entity.getFieldName()
+        );
+    }
+
+    public MockJiraCloudJobCustomFieldRepository() {
+        super(createIDGenerator());
+    }
+
+    @Override
+    public List<JiraCloudJobCustomFieldEntity> findByJobId(UUID jobId) {
+        Map<JiraCloudJobCustomFieldPK, JiraCloudJobCustomFieldEntity> dataMap = getDataMap();
+        return dataMap.entrySet()
+            .stream()
+            .filter(pk -> pk.getKey().getJobId().equals(jobId))
+            .map(Map.Entry::getValue)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public void bulkDeleteByJobId(UUID jobId) {
+        Map<JiraCloudJobCustomFieldPK, JiraCloudJobCustomFieldEntity> dataMap = getDataMap();
+        Set<JiraCloudJobCustomFieldPK> customFieldPrimaryKeys = dataMap.keySet()
+            .stream()
+            .filter(pk -> pk.getJobId().equals(jobId))
+            .collect(Collectors.toSet());
+        deleteAllById(customFieldPrimaryKeys);
+    }
+}

--- a/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/database/accessor/mock/MockJiraCloudJobDetailsRepository.java
+++ b/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/database/accessor/mock/MockJiraCloudJobDetailsRepository.java
@@ -1,0 +1,13 @@
+package com.synopsys.integration.alert.channel.jira.cloud.database.accessor.mock;
+
+import java.util.UUID;
+
+import com.synopsys.integration.alert.database.job.jira.cloud.JiraCloudJobDetailsEntity;
+import com.synopsys.integration.alert.database.job.jira.cloud.JiraCloudJobDetailsRepository;
+import com.synopsys.integration.alert.test.common.database.MockRepositoryContainer;
+
+public class MockJiraCloudJobDetailsRepository extends MockRepositoryContainer<UUID, JiraCloudJobDetailsEntity> implements JiraCloudJobDetailsRepository {
+    public MockJiraCloudJobDetailsRepository() {
+        super(JiraCloudJobDetailsEntity::getJobId);
+    }
+}

--- a/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventListenerTest.java
+++ b/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventListenerTest.java
@@ -1,0 +1,69 @@
+package com.synopsys.integration.alert.channel.jira.cloud.distribution.event;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.amqp.core.Message;
+import org.springframework.core.task.SyncTaskExecutor;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.channel.issue.model.IssueCommentModel;
+import com.synopsys.integration.alert.api.event.EventManager;
+import com.synopsys.integration.alert.channel.jira.cloud.distribution.event.mock.MockCorrelationToNotificationRelationRepository;
+import com.synopsys.integration.alert.channel.jira.cloud.distribution.event.mock.MockJobSubTaskStatusRepository;
+import com.synopsys.integration.alert.common.persistence.model.job.workflow.JobSubTaskStatusModel;
+import com.synopsys.integration.alert.database.api.workflow.DefaultJobSubTaskAccessor;
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
+
+class JiraCloudCommentEventListenerTest {
+    private final Gson gson = new Gson();
+
+    @Test
+    void onMessageTest() {
+        UUID parentEventId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L);
+        EventManager eventManager = Mockito.mock(EventManager.class);
+
+        IssueCommentModel<String> issueCommentModel = new IssueCommentModel<>(null, List.of("A comment"), null);
+        JiraCloudCommentEvent event = new JiraCloudCommentEvent(
+            "destination",
+            parentEventId,
+            jobId,
+            notificationIds,
+            issueCommentModel
+        );
+
+        MockJobSubTaskStatusRepository subTaskRepository = new MockJobSubTaskStatusRepository();
+        MockCorrelationToNotificationRelationRepository relationRepository = new MockCorrelationToNotificationRelationRepository();
+        DefaultJobSubTaskAccessor jobSubTaskAccessor = new DefaultJobSubTaskAccessor(subTaskRepository, relationRepository);
+        JiraCloudCommentEventHandler handler = Mockito.spy(new JiraCloudCommentEventHandler(
+            eventManager,
+            jobSubTaskAccessor,
+            gson,
+            null,
+            null,
+            null,
+            null
+        ));
+        Mockito.doNothing().when(handler).handle(event);
+
+        jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobId, 1L, notificationIds);
+        Optional<JobSubTaskStatusModel> optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        assertTrue(optionalJobSubTaskStatusModel.isPresent());
+
+        JiraCloudCommentEventListener listener = new JiraCloudCommentEventListener(gson, new SyncTaskExecutor(), ChannelKeys.JIRA_CLOUD, handler);
+        Message message = new Message(gson.toJson(event).getBytes());
+        listener.onMessage(message);
+
+        optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        assertFalse(optionalJobSubTaskStatusModel.isPresent());
+    }
+}

--- a/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventListenerTest.java
+++ b/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventListenerTest.java
@@ -1,0 +1,70 @@
+package com.synopsys.integration.alert.channel.jira.cloud.distribution.event;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.amqp.core.Message;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.channel.issue.model.IssueCreationModel;
+import com.synopsys.integration.alert.api.event.EventManager;
+import com.synopsys.integration.alert.channel.jira.cloud.distribution.event.mock.MockCorrelationToNotificationRelationRepository;
+import com.synopsys.integration.alert.channel.jira.cloud.distribution.event.mock.MockJobSubTaskStatusRepository;
+import com.synopsys.integration.alert.common.message.model.LinkableItem;
+import com.synopsys.integration.alert.common.persistence.model.job.workflow.JobSubTaskStatusModel;
+import com.synopsys.integration.alert.database.api.workflow.DefaultJobSubTaskAccessor;
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
+
+class JiraCloudCreateIssueEventListenerTest {
+    private final Gson gson = new Gson();
+
+    @Test
+    void onMessageTest() {
+        UUID parentEventId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L);
+        EventManager eventManager = Mockito.mock(EventManager.class);
+
+        LinkableItem provider = new LinkableItem("provider", "test-provider");
+        IssueCreationModel issueCreationModel = IssueCreationModel.simple("title", "description", List.of(), provider);
+        JiraCloudCreateIssueEvent event = new JiraCloudCreateIssueEvent(
+            "destination",
+            parentEventId,
+            jobId,
+            notificationIds,
+            issueCreationModel
+        );
+
+        MockJobSubTaskStatusRepository subTaskRepository = new MockJobSubTaskStatusRepository();
+        MockCorrelationToNotificationRelationRepository relationRepository = new MockCorrelationToNotificationRelationRepository();
+        DefaultJobSubTaskAccessor jobSubTaskAccessor = new DefaultJobSubTaskAccessor(subTaskRepository, relationRepository);
+        JiraCloudCreateIssueEventHandler handler = Mockito.spy(new JiraCloudCreateIssueEventHandler(
+            eventManager,
+            jobSubTaskAccessor,
+            gson,
+            null,
+            null,
+            null,
+            null
+        ));
+        Mockito.doNothing().when(handler).handle(event);
+
+        jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobId, 1L, notificationIds);
+        Optional<JobSubTaskStatusModel> optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        assertTrue(optionalJobSubTaskStatusModel.isPresent());
+
+        JiraCloudCreateIssueEventListener listener = new JiraCloudCreateIssueEventListener(gson, ChannelKeys.JIRA_CLOUD, handler);
+        Message message = new Message(gson.toJson(event).getBytes());
+        listener.onMessage(message);
+
+        optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        assertFalse(optionalJobSubTaskStatusModel.isPresent());
+    }
+}

--- a/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventListenerTest.java
+++ b/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventListenerTest.java
@@ -1,0 +1,70 @@
+package com.synopsys.integration.alert.channel.jira.cloud.distribution.event;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.amqp.core.Message;
+import org.springframework.core.task.SyncTaskExecutor;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.channel.issue.model.IssueTransitionModel;
+import com.synopsys.integration.alert.api.event.EventManager;
+import com.synopsys.integration.alert.channel.jira.cloud.distribution.event.mock.MockCorrelationToNotificationRelationRepository;
+import com.synopsys.integration.alert.channel.jira.cloud.distribution.event.mock.MockJobSubTaskStatusRepository;
+import com.synopsys.integration.alert.common.channel.issuetracker.enumeration.IssueOperation;
+import com.synopsys.integration.alert.common.persistence.model.job.workflow.JobSubTaskStatusModel;
+import com.synopsys.integration.alert.database.api.workflow.DefaultJobSubTaskAccessor;
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
+
+class JiraCloudTransitionEventListenerTest {
+    private final Gson gson = new Gson();
+
+    @Test
+    void onMessageTest() {
+        UUID parentEventId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L);
+        EventManager eventManager = Mockito.mock(EventManager.class);
+
+        IssueTransitionModel<String> issueTransitionModel = new IssueTransitionModel<>(null, IssueOperation.RESOLVE, List.of(), null);
+        JiraCloudTransitionEvent event = new JiraCloudTransitionEvent(
+            "destination",
+            parentEventId,
+            jobId,
+            notificationIds,
+            issueTransitionModel
+        );
+
+        MockJobSubTaskStatusRepository subTaskRepository = new MockJobSubTaskStatusRepository();
+        MockCorrelationToNotificationRelationRepository relationRepository = new MockCorrelationToNotificationRelationRepository();
+        DefaultJobSubTaskAccessor jobSubTaskAccessor = new DefaultJobSubTaskAccessor(subTaskRepository, relationRepository);
+        JiraCloudTransitionEventHandler handler = Mockito.spy(new JiraCloudTransitionEventHandler(
+            eventManager,
+            jobSubTaskAccessor,
+            gson,
+            null,
+            null,
+            null,
+            null
+        ));
+        Mockito.doNothing().when(handler).handle(event);
+
+        jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobId, 1L, notificationIds);
+        Optional<JobSubTaskStatusModel> optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        assertTrue(optionalJobSubTaskStatusModel.isPresent());
+
+        JiraCloudTransitionEventListener listener = new JiraCloudTransitionEventListener(gson, new SyncTaskExecutor(), ChannelKeys.JIRA_CLOUD, handler);
+        Message message = new Message(gson.toJson(event).getBytes());
+        listener.onMessage(message);
+
+        optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        assertFalse(optionalJobSubTaskStatusModel.isPresent());
+    }
+}

--- a/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/mock/MockCorrelationToNotificationRelationRepository.java
+++ b/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/mock/MockCorrelationToNotificationRelationRepository.java
@@ -1,0 +1,23 @@
+package com.synopsys.integration.alert.channel.jira.cloud.distribution.event.mock;
+
+import java.util.function.Function;
+
+import com.synopsys.integration.alert.database.distribution.workflow.NotificationCorrelationToNotificationRelation;
+import com.synopsys.integration.alert.database.distribution.workflow.NotificationCorrelationToNotificationRelationPK;
+import com.synopsys.integration.alert.database.distribution.workflow.NotificationCorrelationToNotificationRelationRepository;
+import com.synopsys.integration.alert.test.common.database.MockRepositoryContainer;
+
+public class MockCorrelationToNotificationRelationRepository
+    extends MockRepositoryContainer<NotificationCorrelationToNotificationRelationPK, NotificationCorrelationToNotificationRelation>
+    implements NotificationCorrelationToNotificationRelationRepository {
+    private static Function<NotificationCorrelationToNotificationRelation, NotificationCorrelationToNotificationRelationPK> createIDGenerator() {
+        return relation -> new NotificationCorrelationToNotificationRelationPK(
+            relation.getNotificationCorrelationId(),
+            relation.getNotificationId()
+        );
+    }
+
+    public MockCorrelationToNotificationRelationRepository() {
+        super(createIDGenerator());
+    }
+}

--- a/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/mock/MockJobSubTaskStatusRepository.java
+++ b/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/mock/MockJobSubTaskStatusRepository.java
@@ -1,0 +1,13 @@
+package com.synopsys.integration.alert.channel.jira.cloud.distribution.event.mock;
+
+import java.util.UUID;
+
+import com.synopsys.integration.alert.database.distribution.workflow.JobSubTaskRepository;
+import com.synopsys.integration.alert.database.distribution.workflow.JobSubTaskStatusEntity;
+import com.synopsys.integration.alert.test.common.database.MockRepositoryContainer;
+
+public class MockJobSubTaskStatusRepository extends MockRepositoryContainer<UUID, JobSubTaskStatusEntity> implements JobSubTaskRepository {
+    public MockJobSubTaskStatusRepository() {
+        super(JobSubTaskStatusEntity::getId);
+    }
+}

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandlerTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandlerTest.java
@@ -1,6 +1,8 @@
 package com.synopsys.integration.alert.channel.jira.server.distribution.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,6 +17,7 @@ import org.mockito.Mockito;
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.channel.issue.IssueTrackerResponsePostProcessor;
 import com.synopsys.integration.alert.api.channel.issue.callback.IssueTrackerCallbackInfoCreator;
+import com.synopsys.integration.alert.api.channel.issue.callback.ProviderCallbackIssueTrackerResponsePostProcessor;
 import com.synopsys.integration.alert.api.channel.issue.event.IssueTrackerCommentEvent;
 import com.synopsys.integration.alert.api.channel.issue.model.IssueCommentModel;
 import com.synopsys.integration.alert.api.channel.issue.search.ExistingIssueDetails;
@@ -24,10 +27,16 @@ import com.synopsys.integration.alert.api.channel.issue.search.enumeration.Issue
 import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.channel.jira.server.JiraServerProperties;
 import com.synopsys.integration.alert.channel.jira.server.JiraServerPropertiesFactory;
+import com.synopsys.integration.alert.channel.jira.server.database.accessor.DefaultJiraServerJobDetailsAccessor;
+import com.synopsys.integration.alert.channel.jira.server.database.accessor.mock.MockJiraServerJobCustomFieldRepository;
+import com.synopsys.integration.alert.channel.jira.server.database.accessor.mock.MockJiraServerJobDetailsRepository;
 import com.synopsys.integration.alert.channel.jira.server.distribution.JiraServerMessageSenderFactory;
-import com.synopsys.integration.alert.common.persistence.accessor.JobDetailsAccessor;
+import com.synopsys.integration.alert.channel.jira.server.distribution.event.mock.MockCorrelationToNotificationRelationRepository;
+import com.synopsys.integration.alert.channel.jira.server.distribution.event.mock.MockJobSubTaskStatusRepository;
 import com.synopsys.integration.alert.common.persistence.accessor.JobSubTaskAccessor;
 import com.synopsys.integration.alert.common.persistence.model.job.details.JiraServerJobDetailsModel;
+import com.synopsys.integration.alert.common.persistence.model.job.workflow.JobSubTaskStatusModel;
+import com.synopsys.integration.alert.database.api.workflow.DefaultJobSubTaskAccessor;
 import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.jira.common.model.request.IssueCommentRequestModel;
@@ -44,13 +53,25 @@ class JiraServerCommentEventHandlerTest {
     private EventManager eventManager;
     private JobSubTaskAccessor jobSubTaskAccessor;
     private IssueTrackerResponsePostProcessor responsePostProcessor;
+    private DefaultJiraServerJobDetailsAccessor jobDetailsAccessor;
 
     @BeforeEach
     public void init() {
         issueCounter = new AtomicInteger(0);
         eventManager = Mockito.mock(EventManager.class);
-        jobSubTaskAccessor = Mockito.mock(JobSubTaskAccessor.class);
-        responsePostProcessor = Mockito.mock(IssueTrackerResponsePostProcessor.class);
+        responsePostProcessor = new ProviderCallbackIssueTrackerResponsePostProcessor(eventManager);
+
+        MockJobSubTaskStatusRepository subTaskRepository = new MockJobSubTaskStatusRepository();
+        MockCorrelationToNotificationRelationRepository relationRepository = new MockCorrelationToNotificationRelationRepository();
+        jobSubTaskAccessor = new DefaultJobSubTaskAccessor(subTaskRepository, relationRepository);
+
+        MockJiraServerJobDetailsRepository jiraServerJobDetailsRepository = new MockJiraServerJobDetailsRepository();
+        MockJiraServerJobCustomFieldRepository jiraServerJobCustomFieldRepository = new MockJiraServerJobCustomFieldRepository();
+        jobDetailsAccessor = new DefaultJiraServerJobDetailsAccessor(
+            ChannelKeys.JIRA_SERVER,
+            jiraServerJobDetailsRepository,
+            jiraServerJobCustomFieldRepository
+        );
     }
 
     @Test
@@ -71,7 +92,9 @@ class JiraServerCommentEventHandlerTest {
             eventManager,
             jobSubTaskAccessor
         );
-        JobDetailsAccessor<JiraServerJobDetailsModel> jobDetailsAccessor = jobId1 -> Optional.empty();
+
+        JiraServerJobDetailsModel jobDetailsModel = createJobDetails(jobId);
+        jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobDetailsModel.getJobId(), 1L, notificationIds);
 
         JiraServerCommentEventHandler handler = new JiraServerCommentEventHandler(
             eventManager,
@@ -93,6 +116,8 @@ class JiraServerCommentEventHandlerTest {
         );
         handler.handle(event);
         assertEquals(0, issueCounter.get());
+        Optional<JobSubTaskStatusModel> jobSubTaskStatusModelOptional = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        assertTrue(jobSubTaskStatusModelOptional.isEmpty());
     }
 
     @Test
@@ -100,6 +125,9 @@ class JiraServerCommentEventHandlerTest {
         UUID parentEventId = UUID.randomUUID();
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
+
+        JiraServerJobDetailsModel jobDetailsModel = createJobDetails(jobId);
+        jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobDetailsModel.getJobId(), 1L, notificationIds);
 
         JiraServerPropertiesFactory propertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
         JiraServerProperties jiraProperties = Mockito.mock(JiraServerProperties.class);
@@ -132,8 +160,8 @@ class JiraServerCommentEventHandlerTest {
             eventManager,
             jobSubTaskAccessor
         );
-        JobDetailsAccessor<JiraServerJobDetailsModel> jobDetailsAccessor = jobId1 -> Optional.of(createJobDetails(jobId));
 
+        jobDetailsAccessor.saveConcreteJobDetails(jobId, jobDetailsModel);
         JiraServerCommentEventHandler handler = new JiraServerCommentEventHandler(
             eventManager,
             jobSubTaskAccessor,
@@ -154,6 +182,8 @@ class JiraServerCommentEventHandlerTest {
         );
         handler.handle(event);
         assertEquals(1, issueCounter.get());
+        Optional<JobSubTaskStatusModel> jobSubTaskStatusModelOptional = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        assertFalse(jobSubTaskStatusModelOptional.isPresent());
     }
 
     private JiraServerJobDetailsModel createJobDetails(UUID jobId) {

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventListenerTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventListenerTest.java
@@ -1,0 +1,69 @@
+package com.synopsys.integration.alert.channel.jira.server.distribution.event;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.amqp.core.Message;
+import org.springframework.core.task.SyncTaskExecutor;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.channel.issue.model.IssueCommentModel;
+import com.synopsys.integration.alert.api.event.EventManager;
+import com.synopsys.integration.alert.channel.jira.server.distribution.event.mock.MockCorrelationToNotificationRelationRepository;
+import com.synopsys.integration.alert.channel.jira.server.distribution.event.mock.MockJobSubTaskStatusRepository;
+import com.synopsys.integration.alert.common.persistence.model.job.workflow.JobSubTaskStatusModel;
+import com.synopsys.integration.alert.database.api.workflow.DefaultJobSubTaskAccessor;
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
+
+class JiraServerCommentEventListenerTest {
+    private final Gson gson = new Gson();
+
+    @Test
+    void onMessageTest() {
+        UUID parentEventId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L);
+        EventManager eventManager = Mockito.mock(EventManager.class);
+
+        IssueCommentModel<String> issueCommentModel = new IssueCommentModel<>(null, List.of("A comment"), null);
+        JiraServerCommentEvent event = new JiraServerCommentEvent(
+            "destination",
+            parentEventId,
+            jobId,
+            notificationIds,
+            issueCommentModel
+        );
+
+        MockJobSubTaskStatusRepository subTaskRepository = new MockJobSubTaskStatusRepository();
+        MockCorrelationToNotificationRelationRepository relationRepository = new MockCorrelationToNotificationRelationRepository();
+        DefaultJobSubTaskAccessor jobSubTaskAccessor = new DefaultJobSubTaskAccessor(subTaskRepository, relationRepository);
+        JiraServerCommentEventHandler handler = Mockito.spy(new JiraServerCommentEventHandler(
+            eventManager,
+            jobSubTaskAccessor,
+            gson,
+            null,
+            null,
+            null,
+            null
+        ));
+        Mockito.doNothing().when(handler).handle(event);
+
+        jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobId, 1L, notificationIds);
+        Optional<JobSubTaskStatusModel> optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        assertTrue(optionalJobSubTaskStatusModel.isPresent());
+
+        JiraServerCommentEventListener listener = new JiraServerCommentEventListener(gson, new SyncTaskExecutor(), ChannelKeys.JIRA_SERVER, handler);
+        Message message = new Message(gson.toJson(event).getBytes());
+        listener.onMessage(message);
+
+        optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        assertFalse(optionalJobSubTaskStatusModel.isPresent());
+    }
+}

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandlerTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandlerTest.java
@@ -34,7 +34,6 @@ import com.synopsys.integration.alert.channel.jira.server.distribution.JiraServe
 import com.synopsys.integration.alert.channel.jira.server.distribution.event.mock.MockCorrelationToNotificationRelationRepository;
 import com.synopsys.integration.alert.channel.jira.server.distribution.event.mock.MockJobSubTaskStatusRepository;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
-import com.synopsys.integration.alert.common.persistence.accessor.JobDetailsAccessor;
 import com.synopsys.integration.alert.common.persistence.model.job.details.JiraServerJobDetailsModel;
 import com.synopsys.integration.alert.common.persistence.model.job.workflow.JobSubTaskStatusModel;
 import com.synopsys.integration.alert.database.api.workflow.DefaultJobSubTaskAccessor;
@@ -128,10 +127,10 @@ class JiraServerCreateIssueEventHandlerTest {
             issueCreationModel
         );
 
-        handler.handleEvent(event);
+        handler.handle(event);
         assertEquals(0, issueCounter.get());
         Optional<JobSubTaskStatusModel> jobSubTaskStatusModelOptional = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
-        assertTrue(jobSubTaskStatusModelOptional.isPresent());
+        assertTrue(jobSubTaskStatusModelOptional.isEmpty());
     }
 
     @Test

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandlerTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandlerTest.java
@@ -139,6 +139,9 @@ class JiraServerCreateIssueEventHandlerTest {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
 
+        JiraServerJobDetailsModel jobDetailsModel = createJobDetails(jobId);
+        jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobDetailsModel.getJobId(), 1L, notificationIds);
+
         JiraServerPropertiesFactory propertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
         JiraServerProperties jiraProperties = Mockito.mock(JiraServerProperties.class);
         JiraServerServiceFactory jiraServiceFactory = Mockito.mock(JiraServerServiceFactory.class);
@@ -147,9 +150,6 @@ class JiraServerCreateIssueEventHandlerTest {
         FieldService fieldService = Mockito.mock(FieldService.class);
         ProjectService projectService = Mockito.mock(ProjectService.class);
         IssuePropertyService issuePropertyService = Mockito.mock(IssuePropertyService.class);
-
-        JiraServerJobDetailsModel jobDetailsModel = createJobDetails(jobId);
-        jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobDetailsModel.getJobId(), 1L, notificationIds);
 
         Mockito.doAnswer(invocation -> {
             issueCounter.incrementAndGet();
@@ -213,6 +213,9 @@ class JiraServerCreateIssueEventHandlerTest {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
 
+        JiraServerJobDetailsModel jobDetailsModel = createJobDetails(jobId);
+        jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobDetailsModel.getJobId(), 1L, notificationIds);
+
         JiraServerPropertiesFactory propertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
         JiraServerProperties jiraProperties = Mockito.mock(JiraServerProperties.class);
         JiraServerServiceFactory jiraServiceFactory = Mockito.mock(JiraServerServiceFactory.class);
@@ -221,9 +224,6 @@ class JiraServerCreateIssueEventHandlerTest {
         FieldService fieldService = Mockito.mock(FieldService.class);
         ProjectService projectService = Mockito.mock(ProjectService.class);
         IssuePropertyService issuePropertyService = Mockito.mock(IssuePropertyService.class);
-
-        JiraServerJobDetailsModel jobDetailsModel = createJobDetails(jobId);
-        jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobDetailsModel.getJobId(), 1L, notificationIds);
 
         Mockito.doAnswer(invocation -> {
             issueCounter.incrementAndGet();
@@ -294,6 +294,9 @@ class JiraServerCreateIssueEventHandlerTest {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
 
+        JiraServerJobDetailsModel jobDetailsModel = createJobDetails(jobId);
+        jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobDetailsModel.getJobId(), 1L, notificationIds);
+
         JiraServerPropertiesFactory propertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
         JiraServerProperties jiraProperties = Mockito.mock(JiraServerProperties.class);
         JiraServerServiceFactory jiraServiceFactory = Mockito.mock(JiraServerServiceFactory.class);
@@ -301,9 +304,6 @@ class JiraServerCreateIssueEventHandlerTest {
         IssueSearchService issueSearchService = Mockito.mock(IssueSearchService.class);
         FieldService fieldService = Mockito.mock(FieldService.class);
         ProjectService projectService = Mockito.mock(ProjectService.class);
-
-        JiraServerJobDetailsModel jobDetailsModel = createJobDetails(jobId);
-        jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobDetailsModel.getJobId(), 1L, notificationIds);
 
         Mockito.doAnswer(invocation -> {
             issueCounter.incrementAndGet();

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventListenerTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventListenerTest.java
@@ -1,0 +1,70 @@
+package com.synopsys.integration.alert.channel.jira.server.distribution.event;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.amqp.core.Message;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.channel.issue.model.IssueCreationModel;
+import com.synopsys.integration.alert.api.event.EventManager;
+import com.synopsys.integration.alert.channel.jira.server.distribution.event.mock.MockCorrelationToNotificationRelationRepository;
+import com.synopsys.integration.alert.channel.jira.server.distribution.event.mock.MockJobSubTaskStatusRepository;
+import com.synopsys.integration.alert.common.message.model.LinkableItem;
+import com.synopsys.integration.alert.common.persistence.model.job.workflow.JobSubTaskStatusModel;
+import com.synopsys.integration.alert.database.api.workflow.DefaultJobSubTaskAccessor;
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
+
+class JiraServerCreateIssueEventListenerTest {
+    private final Gson gson = new Gson();
+
+    @Test
+    void onMessageTest() {
+        UUID parentEventId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L);
+        EventManager eventManager = Mockito.mock(EventManager.class);
+
+        LinkableItem provider = new LinkableItem("provider", "test-provider");
+        IssueCreationModel issueCreationModel = IssueCreationModel.simple("title", "description", List.of(), provider);
+        JiraServerCreateIssueEvent event = new JiraServerCreateIssueEvent(
+            "destination",
+            parentEventId,
+            jobId,
+            notificationIds,
+            issueCreationModel
+        );
+
+        MockJobSubTaskStatusRepository subTaskRepository = new MockJobSubTaskStatusRepository();
+        MockCorrelationToNotificationRelationRepository relationRepository = new MockCorrelationToNotificationRelationRepository();
+        DefaultJobSubTaskAccessor jobSubTaskAccessor = new DefaultJobSubTaskAccessor(subTaskRepository, relationRepository);
+        JiraServerCreateIssueEventHandler handler = Mockito.spy(new JiraServerCreateIssueEventHandler(
+            eventManager,
+            jobSubTaskAccessor,
+            gson,
+            null,
+            null,
+            null,
+            null
+        ));
+        Mockito.doNothing().when(handler).handle(event);
+
+        jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobId, 1L, notificationIds);
+        Optional<JobSubTaskStatusModel> optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        assertTrue(optionalJobSubTaskStatusModel.isPresent());
+
+        JiraServerCreateIssueEventListener listener = new JiraServerCreateIssueEventListener(gson, ChannelKeys.JIRA_SERVER, handler);
+        Message message = new Message(gson.toJson(event).getBytes());
+        listener.onMessage(message);
+
+        optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        assertFalse(optionalJobSubTaskStatusModel.isPresent());
+    }
+}

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventListenerTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventListenerTest.java
@@ -1,0 +1,70 @@
+package com.synopsys.integration.alert.channel.jira.server.distribution.event;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.amqp.core.Message;
+import org.springframework.core.task.SyncTaskExecutor;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.channel.issue.model.IssueTransitionModel;
+import com.synopsys.integration.alert.api.event.EventManager;
+import com.synopsys.integration.alert.channel.jira.server.distribution.event.mock.MockCorrelationToNotificationRelationRepository;
+import com.synopsys.integration.alert.channel.jira.server.distribution.event.mock.MockJobSubTaskStatusRepository;
+import com.synopsys.integration.alert.common.channel.issuetracker.enumeration.IssueOperation;
+import com.synopsys.integration.alert.common.persistence.model.job.workflow.JobSubTaskStatusModel;
+import com.synopsys.integration.alert.database.api.workflow.DefaultJobSubTaskAccessor;
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
+
+class JiraServerTransitionEventListenerTest {
+    private final Gson gson = new Gson();
+
+    @Test
+    void onMessageTest() {
+        UUID parentEventId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L);
+        EventManager eventManager = Mockito.mock(EventManager.class);
+
+        IssueTransitionModel<String> issueTransitionModel = new IssueTransitionModel<>(null, IssueOperation.RESOLVE, List.of(), null);
+        JiraServerTransitionEvent event = new JiraServerTransitionEvent(
+            "destination",
+            parentEventId,
+            jobId,
+            notificationIds,
+            issueTransitionModel
+        );
+
+        MockJobSubTaskStatusRepository subTaskRepository = new MockJobSubTaskStatusRepository();
+        MockCorrelationToNotificationRelationRepository relationRepository = new MockCorrelationToNotificationRelationRepository();
+        DefaultJobSubTaskAccessor jobSubTaskAccessor = new DefaultJobSubTaskAccessor(subTaskRepository, relationRepository);
+        JiraServerTransitionEventHandler handler = Mockito.spy(new JiraServerTransitionEventHandler(
+            eventManager,
+            jobSubTaskAccessor,
+            gson,
+            null,
+            null,
+            null,
+            null
+        ));
+        Mockito.doNothing().when(handler).handle(event);
+
+        jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobId, 1L, notificationIds);
+        Optional<JobSubTaskStatusModel> optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        assertTrue(optionalJobSubTaskStatusModel.isPresent());
+
+        JiraServerTransitionEventListener listener = new JiraServerTransitionEventListener(gson, new SyncTaskExecutor(), ChannelKeys.JIRA_SERVER, handler);
+        Message message = new Message(gson.toJson(event).getBytes());
+        listener.onMessage(message);
+
+        optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        assertFalse(optionalJobSubTaskStatusModel.isPresent());
+    }
+}


### PR DESCRIPTION
Adding test coverage for the api-channel-issue-tracker  issue.event package. The handlers and listeners are abstract classes so the tests created were for their implementations in Jira Server and Jira Cloud. 

Azure implementations are blocked by a necessary refactor of the services factory and will therefore need to be revisited in the future.