### PR TITLE
test: Remove usage of Mockito.eq

### DIFF
--- a/alert-common/src/test/java/com/synopsys/integration/alert/common/descriptor/accessor/DefaultDescriptorGlobalConfigUtilityTest.java
+++ b/alert-common/src/test/java/com/synopsys/integration/alert/common/descriptor/accessor/DefaultDescriptorGlobalConfigUtilityTest.java
@@ -20,45 +20,47 @@ import com.synopsys.integration.alert.common.persistence.util.ConfigurationField
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
 
-public class DefaultDescriptorGlobalConfigUtilityTest {
+class DefaultDescriptorGlobalConfigUtilityTest {
 
     private DescriptorKey createDescriptorKey() {
         return new DescriptorKey("universal_key", "Universal Key") {};
     }
 
     @Test
-    public void testGetKey() {
+    void testGetKey() {
         DescriptorKey descriptorKey = createDescriptorKey();
         DefaultDescriptorGlobalConfigUtility configUtility = new DefaultDescriptorGlobalConfigUtility(descriptorKey, null, null, null);
         assertEquals(descriptorKey, configUtility.getKey());
     }
 
     @Test
-    public void testConfigurationExists() throws Exception {
+    void testConfigurationExists() {
         DescriptorKey descriptorKey = createDescriptorKey();
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
         DefaultDescriptorGlobalConfigUtility configUtility = new DefaultDescriptorGlobalConfigUtility(descriptorKey, configurationModelConfigurationAccessor, null, null);
         assertFalse(configUtility.doesConfigurationExist());
         ConfigurationModel configurationModel = Mockito.mock(ConfigurationModel.class);
-        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKeyAndContext(Mockito.any(DescriptorKey.class), Mockito.any(ConfigContextEnum.class))).thenReturn(List.of(configurationModel));
+        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKeyAndContext(Mockito.any(DescriptorKey.class), Mockito.any(ConfigContextEnum.class)))
+            .thenReturn(List.of(configurationModel));
 
         assertTrue(configUtility.doesConfigurationExist());
     }
- 
+
     @Test
-    public void testGetConfiguration() throws Exception {
+    void testGetConfiguration() {
         DescriptorKey descriptorKey = createDescriptorKey();
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
         DefaultDescriptorGlobalConfigUtility configUtility = new DefaultDescriptorGlobalConfigUtility(descriptorKey, configurationModelConfigurationAccessor, null, null);
         assertFalse(configUtility.getConfiguration().isPresent());
         ConfigurationModel configurationModel = Mockito.mock(ConfigurationModel.class);
-        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKeyAndContext(Mockito.any(DescriptorKey.class), Mockito.any(ConfigContextEnum.class))).thenReturn(List.of(configurationModel));
+        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKeyAndContext(Mockito.any(DescriptorKey.class), Mockito.any(ConfigContextEnum.class)))
+            .thenReturn(List.of(configurationModel));
 
         assertTrue(configUtility.getConfiguration().isPresent());
     }
 
     @Test
-    public void testGetFieldModelEmptyConfiguration() throws Exception {
+    void testGetFieldModelEmptyConfiguration() throws Exception {
         DescriptorKey descriptorKey = createDescriptorKey();
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
         ConfigurationFieldModelConverter converter = Mockito.mock(ConfigurationFieldModelConverter.class);
@@ -67,16 +69,17 @@ public class DefaultDescriptorGlobalConfigUtilityTest {
     }
 
     @Test
-    public void testGetFieldModel() throws Exception {
+    void testGetFieldModel() throws Exception {
         DescriptorKey descriptorKey = createDescriptorKey();
         FieldModel fieldModel = new FieldModel(descriptorKey.getUniversalKey(), ConfigContextEnum.GLOBAL.name(), Map.of());
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
         ConfigurationFieldModelConverter converter = Mockito.mock(ConfigurationFieldModelConverter.class);
         ConfigurationModel configurationModel = Mockito.mock(ConfigurationModel.class);
         ApiAction apiAction = Mockito.mock(ApiAction.class);
-        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKeyAndContext(Mockito.any(DescriptorKey.class), Mockito.any(ConfigContextEnum.class))).thenReturn(List.of(configurationModel));
+        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKeyAndContext(Mockito.any(DescriptorKey.class), Mockito.any(ConfigContextEnum.class)))
+            .thenReturn(List.of(configurationModel));
         Mockito.when(converter.convertToFieldModel(Mockito.any())).thenReturn(fieldModel);
-        Mockito.when(apiAction.afterGetAction(Mockito.eq(fieldModel))).thenReturn(fieldModel);
+        Mockito.when(apiAction.afterGetAction(fieldModel)).thenReturn(fieldModel);
 
         DefaultDescriptorGlobalConfigUtility configUtility = new DefaultDescriptorGlobalConfigUtility(descriptorKey, configurationModelConfigurationAccessor, apiAction, converter);
         FieldModel actualFieldModel = configUtility.getFieldModel().orElse(null);
@@ -84,16 +87,17 @@ public class DefaultDescriptorGlobalConfigUtilityTest {
     }
 
     @Test
-    public void testGetFieldModelActionNull() throws Exception {
+    void testGetFieldModelActionNull() throws Exception {
         DescriptorKey descriptorKey = createDescriptorKey();
         FieldModel fieldModel = new FieldModel(descriptorKey.getUniversalKey(), ConfigContextEnum.GLOBAL.name(), Map.of());
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
         ConfigurationFieldModelConverter converter = Mockito.mock(ConfigurationFieldModelConverter.class);
         ConfigurationModel configurationModel = Mockito.mock(ConfigurationModel.class);
         ApiAction apiAction = Mockito.mock(ApiAction.class);
-        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKeyAndContext(Mockito.any(DescriptorKey.class), Mockito.any(ConfigContextEnum.class))).thenReturn(List.of(configurationModel));
+        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKeyAndContext(Mockito.any(DescriptorKey.class), Mockito.any(ConfigContextEnum.class)))
+            .thenReturn(List.of(configurationModel));
         Mockito.when(converter.convertToFieldModel(Mockito.any())).thenReturn(fieldModel);
-        Mockito.when(apiAction.afterGetAction(Mockito.eq(fieldModel))).thenReturn(null);
+        Mockito.when(apiAction.afterGetAction(fieldModel)).thenReturn(null);
 
         DefaultDescriptorGlobalConfigUtility configUtility = new DefaultDescriptorGlobalConfigUtility(descriptorKey, configurationModelConfigurationAccessor, apiAction, converter);
         Optional<FieldModel> actualFieldModel = configUtility.getFieldModel();
@@ -101,7 +105,7 @@ public class DefaultDescriptorGlobalConfigUtilityTest {
     }
 
     @Test
-    public void testSave() throws Exception {
+    void testSave() throws Exception {
         DescriptorKey descriptorKey = createDescriptorKey();
         FieldModel fieldModel = new FieldModel(descriptorKey.getUniversalKey(), ConfigContextEnum.GLOBAL.name(), Map.of());
         Map<String, ConfigurationFieldModel> configurationFieldModelCollection = Map.of();
@@ -109,11 +113,12 @@ public class DefaultDescriptorGlobalConfigUtilityTest {
         ConfigurationFieldModelConverter converter = Mockito.mock(ConfigurationFieldModelConverter.class);
         ConfigurationModel configurationModel = Mockito.mock(ConfigurationModel.class);
         ApiAction apiAction = Mockito.mock(ApiAction.class);
-        Mockito.when(configurationModelConfigurationAccessor.createConfiguration(Mockito.eq(descriptorKey), Mockito.any(ConfigContextEnum.class), Mockito.anyCollection())).thenReturn(configurationModel);
-        Mockito.when(converter.convertToConfigurationFieldModelMap(Mockito.eq(fieldModel))).thenReturn(configurationFieldModelCollection);
+        Mockito.when(configurationModelConfigurationAccessor.createConfiguration(Mockito.eq(descriptorKey), Mockito.any(ConfigContextEnum.class), Mockito.anyCollection()))
+            .thenReturn(configurationModel);
+        Mockito.when(converter.convertToConfigurationFieldModelMap(fieldModel)).thenReturn(configurationFieldModelCollection);
         Mockito.when(converter.convertToFieldModel(Mockito.any())).thenReturn(fieldModel);
-        Mockito.when(apiAction.beforeSaveAction(Mockito.eq(fieldModel))).thenReturn(fieldModel);
-        Mockito.when(apiAction.afterSaveAction(Mockito.eq(fieldModel))).thenReturn(fieldModel);
+        Mockito.when(apiAction.beforeSaveAction(fieldModel)).thenReturn(fieldModel);
+        Mockito.when(apiAction.afterSaveAction(fieldModel)).thenReturn(fieldModel);
 
         DefaultDescriptorGlobalConfigUtility configUtility = new DefaultDescriptorGlobalConfigUtility(descriptorKey, configurationModelConfigurationAccessor, apiAction, converter);
         FieldModel savedModel = configUtility.save(fieldModel);
@@ -123,7 +128,7 @@ public class DefaultDescriptorGlobalConfigUtilityTest {
     }
 
     @Test
-    public void testUpdateNoExistingConfig() throws Exception {
+    void testUpdateNoExistingConfig() throws Exception {
         DescriptorKey descriptorKey = createDescriptorKey();
         FieldModel fieldModel = new FieldModel(descriptorKey.getUniversalKey(), ConfigContextEnum.GLOBAL.name(), Map.of());
         Map<String, ConfigurationFieldModel> configurationFieldModelCollection = Map.of();
@@ -131,11 +136,12 @@ public class DefaultDescriptorGlobalConfigUtilityTest {
         ConfigurationFieldModelConverter converter = Mockito.mock(ConfigurationFieldModelConverter.class);
         ConfigurationModel configurationModel = Mockito.mock(ConfigurationModel.class);
         ApiAction apiAction = Mockito.mock(ApiAction.class);
-        Mockito.when(configurationModelConfigurationAccessor.createConfiguration(Mockito.eq(descriptorKey), Mockito.any(ConfigContextEnum.class), Mockito.anyCollection())).thenReturn(configurationModel);
-        Mockito.when(converter.convertToConfigurationFieldModelMap(Mockito.eq(fieldModel))).thenReturn(configurationFieldModelCollection);
+        Mockito.when(configurationModelConfigurationAccessor.createConfiguration(Mockito.eq(descriptorKey), Mockito.any(ConfigContextEnum.class), Mockito.anyCollection()))
+            .thenReturn(configurationModel);
+        Mockito.when(converter.convertToConfigurationFieldModelMap(fieldModel)).thenReturn(configurationFieldModelCollection);
         Mockito.when(converter.convertToFieldModel(Mockito.any())).thenReturn(fieldModel);
-        Mockito.when(apiAction.beforeUpdateAction(Mockito.eq(fieldModel))).thenReturn(fieldModel);
-        Mockito.when(apiAction.afterUpdateAction(Mockito.eq(fieldModel), Mockito.eq(fieldModel))).thenReturn(fieldModel);
+        Mockito.when(apiAction.beforeUpdateAction(fieldModel)).thenReturn(fieldModel);
+        Mockito.when(apiAction.afterUpdateAction(fieldModel, fieldModel)).thenReturn(fieldModel);
 
         DefaultDescriptorGlobalConfigUtility configUtility = new DefaultDescriptorGlobalConfigUtility(descriptorKey, configurationModelConfigurationAccessor, apiAction, converter);
         FieldModel savedModel = configUtility.update(1L, fieldModel);
@@ -144,7 +150,7 @@ public class DefaultDescriptorGlobalConfigUtilityTest {
     }
 
     @Test
-    public void testUpdate() throws Exception {
+    void testUpdate() throws Exception {
         DescriptorKey descriptorKey = createDescriptorKey();
         FieldModel fieldModel = new FieldModel(descriptorKey.getUniversalKey(), ConfigContextEnum.GLOBAL.name(), Map.of());
         Map<String, ConfigurationFieldModel> configurationFieldModelCollection = Map.of();
@@ -153,11 +159,12 @@ public class DefaultDescriptorGlobalConfigUtilityTest {
         ConfigurationModel configurationModel = Mockito.mock(ConfigurationModel.class);
         ApiAction apiAction = Mockito.mock(ApiAction.class);
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.anyLong())).thenReturn(Optional.of(configurationModel));
-        Mockito.when(configurationModelConfigurationAccessor.createConfiguration(Mockito.eq(descriptorKey), Mockito.any(ConfigContextEnum.class), Mockito.anyCollection())).thenReturn(configurationModel);
-        Mockito.when(converter.convertToConfigurationFieldModelMap(Mockito.eq(fieldModel))).thenReturn(configurationFieldModelCollection);
+        Mockito.when(configurationModelConfigurationAccessor.createConfiguration(Mockito.eq(descriptorKey), Mockito.any(ConfigContextEnum.class), Mockito.anyCollection()))
+            .thenReturn(configurationModel);
+        Mockito.when(converter.convertToConfigurationFieldModelMap(fieldModel)).thenReturn(configurationFieldModelCollection);
         Mockito.when(converter.convertToFieldModel(Mockito.any())).thenReturn(fieldModel);
-        Mockito.when(apiAction.beforeUpdateAction(Mockito.eq(fieldModel))).thenReturn(fieldModel);
-        Mockito.when(apiAction.afterUpdateAction(Mockito.eq(fieldModel), Mockito.eq(fieldModel))).thenReturn(fieldModel);
+        Mockito.when(apiAction.beforeUpdateAction(fieldModel)).thenReturn(fieldModel);
+        Mockito.when(apiAction.afterUpdateAction(fieldModel, fieldModel)).thenReturn(fieldModel);
 
         DefaultDescriptorGlobalConfigUtility configUtility = new DefaultDescriptorGlobalConfigUtility(descriptorKey, configurationModelConfigurationAccessor, apiAction, converter);
         FieldModel savedModel = configUtility.update(1L, fieldModel);

--- a/alert-database-job/src/test/java/com/synopsys/integration/alert/database/api/StaticJobAccessorTest.java
+++ b/alert-database-job/src/test/java/com/synopsys/integration/alert/database/api/StaticJobAccessorTest.java
@@ -95,7 +95,7 @@ class StaticJobAccessorTest {
 
     @Test
     void countJobsByFrequencyTest() {
-        Mockito.when(distributionJobRepository.existsByDistributionFrequency(Mockito.eq(FrequencyType.DAILY.name()))).thenReturn(true);
+        Mockito.when(distributionJobRepository.existsByDistributionFrequency(FrequencyType.DAILY.name())).thenReturn(true);
         assertTrue(jobAccessor.hasJobsByFrequency(FrequencyType.DAILY.name()));
 
     }

--- a/alert-database/src/test/java/com/synopsys/integration/alert/database/api/DefaultConfigurationModelConfigurationAccessorTest.java
+++ b/alert-database/src/test/java/com/synopsys/integration/alert/database/api/DefaultConfigurationModelConfigurationAccessorTest.java
@@ -29,26 +29,21 @@ import com.synopsys.integration.alert.database.configuration.RegisteredDescripto
 import com.synopsys.integration.alert.database.configuration.repository.ConfigContextRepository;
 import com.synopsys.integration.alert.database.configuration.repository.DefinedFieldRepository;
 import com.synopsys.integration.alert.database.configuration.repository.DescriptorConfigRepository;
-import com.synopsys.integration.alert.database.configuration.repository.DescriptorTypeRepository;
 import com.synopsys.integration.alert.database.configuration.repository.FieldValueRepository;
 import com.synopsys.integration.alert.database.configuration.repository.RegisteredDescriptorRepository;
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
 
-public class DefaultConfigurationModelConfigurationAccessorTest {
+class DefaultConfigurationModelConfigurationAccessorTest {
     private static final String TEST_PASSWORD = "testPassword";
     private static final String TEST_SALT = "testSalt";
     private static final String TEST_DIRECTORY = "./testDB";
     private static final String TEST_SECRETS_DIRECTORY = "./testDB/run/secrets";
-
-    private AlertProperties alertProperties;
-    private FilePersistenceUtil filePersistenceUtil;
 
     private DescriptorConfigRepository descriptorConfigRepository;
     private ConfigContextRepository configContextRepository;
     private FieldValueRepository fieldValueRepository;
     private DefinedFieldRepository definedFieldRepository;
     private RegisteredDescriptorRepository registeredDescriptorRepository;
-    private DescriptorTypeRepository descriptorTypeRepository;
     private EncryptionUtility encryptionUtility;
 
     private final ConfigContextEnum configContextEnum = ConfigContextEnum.GLOBAL;
@@ -62,12 +57,11 @@ public class DefaultConfigurationModelConfigurationAccessorTest {
         fieldValueRepository = Mockito.mock(FieldValueRepository.class);
         definedFieldRepository = Mockito.mock(DefinedFieldRepository.class);
         registeredDescriptorRepository = Mockito.mock(RegisteredDescriptorRepository.class);
-        descriptorTypeRepository = Mockito.mock(DescriptorTypeRepository.class);
         encryptionUtility = createEncryptionUtility();
     }
 
     @Test
-    public void getProviderConfigurationByNameTest() {
+    void getProviderConfigurationByNameTest() {
         final String providerConfigName = "provider-config-name-test";
         final String emptyProviderConfigName = "bad-config-name";
         final Long fieldId = 1L;
@@ -77,7 +71,12 @@ public class DefaultConfigurationModelConfigurationAccessorTest {
         DefinedFieldEntity definedFieldEntity = new DefinedFieldEntity(fieldKey, false);
         definedFieldEntity.setId(fieldId);
         FieldValueEntity fieldValueEntity = new FieldValueEntity(2L, 3L, fieldValue);
-        DescriptorConfigEntity descriptorConfigEntity = new DescriptorConfigEntity(descriptorId, 5L, DateUtils.createCurrentDateTimestamp(), DateUtils.createCurrentDateTimestamp());
+        DescriptorConfigEntity descriptorConfigEntity = new DescriptorConfigEntity(
+            descriptorId,
+            5L,
+            DateUtils.createCurrentDateTimestamp(),
+            DateUtils.createCurrentDateTimestamp()
+        );
         descriptorConfigEntity.setId(configurationId);
         ConfigContextEntity configContextEntity = new ConfigContextEntity(configContextEnum.name());
 
@@ -86,7 +85,14 @@ public class DefaultConfigurationModelConfigurationAccessorTest {
         Mockito.when(fieldValueRepository.findAllByFieldIdAndValue(fieldId, emptyProviderConfigName)).thenReturn(List.of());
         setupGetJobMocks(descriptorConfigEntity, configContextEntity, fieldValueEntity, definedFieldEntity);
 
-        DefaultConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = new DefaultConfigurationModelConfigurationAccessor(null, definedFieldRepository, descriptorConfigRepository, configContextRepository, fieldValueRepository, encryptionUtility);
+        DefaultConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = new DefaultConfigurationModelConfigurationAccessor(
+            null,
+            definedFieldRepository,
+            descriptorConfigRepository,
+            configContextRepository,
+            fieldValueRepository,
+            encryptionUtility
+        );
         Optional<ConfigurationModel> configurationModelOptional = configurationModelConfigurationAccessor.getProviderConfigurationByName(providerConfigName);
         Optional<ConfigurationModel> configurationModelProviderConfigsEmpty = configurationModelConfigurationAccessor.getProviderConfigurationByName(emptyProviderConfigName);
 
@@ -98,17 +104,24 @@ public class DefaultConfigurationModelConfigurationAccessorTest {
     }
 
     @Test
-    public void getConfigurationByIdEmptyTest() {
+    void getConfigurationByIdEmptyTest() {
         Mockito.when(descriptorConfigRepository.findById(Mockito.any())).thenReturn(Optional.empty());
 
-        DefaultConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = new DefaultConfigurationModelConfigurationAccessor(null, null, descriptorConfigRepository, null, null, null);
+        DefaultConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = new DefaultConfigurationModelConfigurationAccessor(
+            null,
+            null,
+            descriptorConfigRepository,
+            null,
+            null,
+            null
+        );
         Optional<ConfigurationModel> configurationModelOptional = configurationModelConfigurationAccessor.getConfigurationById(1L);
 
         assertFalse(configurationModelOptional.isPresent());
     }
 
     @Test
-    public void getConfigurationsByDescriptorKeyTest() {
+    void getConfigurationsByDescriptorKeyTest() {
         final Long descriptorId = 3L;
         final Long configurationId = 5L;
 
@@ -116,7 +129,12 @@ public class DefaultConfigurationModelConfigurationAccessorTest {
         DescriptorKey badDescriptorKey = createDescriptorKey("bad-descriptorKey");
         RegisteredDescriptorEntity registeredDescriptorEntity = new RegisteredDescriptorEntity("name-test", 1L);
         registeredDescriptorEntity.setId(2L);
-        DescriptorConfigEntity descriptorConfigEntity = new DescriptorConfigEntity(descriptorId, 4L, DateUtils.createCurrentDateTimestamp(), DateUtils.createCurrentDateTimestamp());
+        DescriptorConfigEntity descriptorConfigEntity = new DescriptorConfigEntity(
+            descriptorId,
+            4L,
+            DateUtils.createCurrentDateTimestamp(),
+            DateUtils.createCurrentDateTimestamp()
+        );
         descriptorConfigEntity.setId(configurationId);
         ConfigContextEntity configContextEntity = new ConfigContextEntity(configContextEnum.name());
         FieldValueEntity fieldValueEntity = new FieldValueEntity(6L, 7L, fieldValue);
@@ -145,7 +163,7 @@ public class DefaultConfigurationModelConfigurationAccessorTest {
     }
 
     @Test
-    public void getConfigurationsByDescriptorTypeTest() {
+    void getConfigurationsByDescriptorTypeTest() {
         final Long descriptorId = 3L;
         final Long configurationId = 5L;
         DescriptorType descriptorType = DescriptorType.CHANNEL;
@@ -154,14 +172,19 @@ public class DefaultConfigurationModelConfigurationAccessorTest {
         descriptorTypeEntity.setId(1L);
         RegisteredDescriptorEntity registeredDescriptorEntity = new RegisteredDescriptorEntity("name-test", 1L);
         registeredDescriptorEntity.setId(2L);
-        DescriptorConfigEntity descriptorConfigEntity = new DescriptorConfigEntity(descriptorId, 4L, DateUtils.createCurrentDateTimestamp(), DateUtils.createCurrentDateTimestamp());
+        DescriptorConfigEntity descriptorConfigEntity = new DescriptorConfigEntity(
+            descriptorId,
+            4L,
+            DateUtils.createCurrentDateTimestamp(),
+            DateUtils.createCurrentDateTimestamp()
+        );
         descriptorConfigEntity.setId(configurationId);
         ConfigContextEntity configContextEntity = new ConfigContextEntity(configContextEnum.name());
         FieldValueEntity fieldValueEntity = new FieldValueEntity(6L, 7L, fieldValue);
         DefinedFieldEntity definedFieldEntity = new DefinedFieldEntity(fieldKey, false);
         definedFieldEntity.setId(8L);
 
-        Mockito.when(descriptorConfigRepository.findByDescriptorType(Mockito.eq(descriptorType.name()))).thenReturn(List.of(descriptorConfigEntity));
+        Mockito.when(descriptorConfigRepository.findByDescriptorType(descriptorType.name())).thenReturn(List.of(descriptorConfigEntity));
         setupCreatConfigMocks(descriptorConfigEntity, configContextEntity, fieldValueEntity, definedFieldEntity);
 
         DefaultConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = new DefaultConfigurationModelConfigurationAccessor(
@@ -180,12 +203,17 @@ public class DefaultConfigurationModelConfigurationAccessorTest {
     }
 
     @Test
-    public void getConfigurationsByDescriptorKeyAndContextTest() {
+    void getConfigurationsByDescriptorKeyAndContextTest() {
         final Long descriptorId = 3L;
         final Long configurationId = 5L;
 
         DescriptorKey descriptorKey = createDescriptorKey("descriptorKeyName");
-        DescriptorConfigEntity descriptorConfigEntity = new DescriptorConfigEntity(descriptorId, 4L, DateUtils.createCurrentDateTimestamp(), DateUtils.createCurrentDateTimestamp());
+        DescriptorConfigEntity descriptorConfigEntity = new DescriptorConfigEntity(
+            descriptorId,
+            4L,
+            DateUtils.createCurrentDateTimestamp(),
+            DateUtils.createCurrentDateTimestamp()
+        );
         descriptorConfigEntity.setId(configurationId);
         ConfigContextEntity configContextEntity = new ConfigContextEntity(configContextEnum.name());
         configContextEntity.setId(3L);
@@ -213,7 +241,7 @@ public class DefaultConfigurationModelConfigurationAccessorTest {
     }
 
     @Test
-    public void createConfigurationTest() {
+    void createConfigurationTest() {
         final Long descriptorId = 3L;
         final Long configurationId = 5L;
 
@@ -244,14 +272,19 @@ public class DefaultConfigurationModelConfigurationAccessorTest {
     }
 
     @Test
-    public void updateConfigurationTest() throws Exception {
+    void updateConfigurationTest() throws Exception {
         Long configurationId = 2L;
         Long descriptorId = 3L;
 
         ConfigurationFieldModel configurationFieldModel = ConfigurationFieldModel.create("channel.common.name");
         configurationFieldModel.setFieldValue(fieldValue);
         List<ConfigurationFieldModel> configuredFields = List.of(configurationFieldModel);
-        DescriptorConfigEntity descriptorConfigEntity = new DescriptorConfigEntity(descriptorId, 4L, DateUtils.createCurrentDateTimestamp(), DateUtils.createCurrentDateTimestamp());
+        DescriptorConfigEntity descriptorConfigEntity = new DescriptorConfigEntity(
+            descriptorId,
+            4L,
+            DateUtils.createCurrentDateTimestamp(),
+            DateUtils.createCurrentDateTimestamp()
+        );
         descriptorConfigEntity.setId(configurationId);
         FieldValueEntity fieldValueEntity = new FieldValueEntity(5L, 6L, fieldValue);
         ConfigContextEntity configContextEntity = new ConfigContextEntity(configContextEnum.name());
@@ -274,17 +307,24 @@ public class DefaultConfigurationModelConfigurationAccessorTest {
     }
 
     @Test
-    public void deleteConfigurationTest() {
+    void deleteConfigurationTest() {
         ConfigurationModel configurationModel = new ConfigurationModel(1L, 2L, "dateCreated", "lastUpdated", configContextEnum);
 
-        DefaultConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = new DefaultConfigurationModelConfigurationAccessor(null, null, descriptorConfigRepository, null, null, null);
+        DefaultConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = new DefaultConfigurationModelConfigurationAccessor(
+            null,
+            null,
+            descriptorConfigRepository,
+            null,
+            null,
+            null
+        );
         configurationModelConfigurationAccessor.deleteConfiguration(configurationModel);
 
         Mockito.verify(descriptorConfigRepository).deleteById(Mockito.any());
     }
 
     @Test
-    public void decryptTest() {
+    void decryptTest() {
         final String decryptedString = "decryptedString";
         final String providerConfigName = "provider-config-name-test";
         final String emptyProviderConfigName = "bad-config-name";
@@ -338,18 +378,17 @@ public class DefaultConfigurationModelConfigurationAccessorTest {
     }
 
     private EncryptionUtility createEncryptionUtility() {
-        alertProperties = Mockito.mock(AlertProperties.class);
+        AlertProperties alertProperties = Mockito.mock(AlertProperties.class);
         Mockito.when(alertProperties.getAlertEncryptionPassword()).thenReturn(Optional.of(TEST_PASSWORD));
         Mockito.when(alertProperties.getAlertEncryptionGlobalSalt()).thenReturn(Optional.of(TEST_SALT));
         Mockito.when(alertProperties.getAlertConfigHome()).thenReturn(TEST_DIRECTORY);
         Mockito.when(alertProperties.getAlertSecretsDir()).thenReturn(TEST_SECRETS_DIRECTORY);
-        filePersistenceUtil = new FilePersistenceUtil(alertProperties, new Gson());
+        FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, new Gson());
         return new EncryptionUtility(alertProperties, filePersistenceUtil);
     }
 
     private DescriptorKey createDescriptorKey(String key) {
-        DescriptorKey testDescriptorKey = new DescriptorKey(key, key) {};
-        return testDescriptorKey;
+        return new DescriptorKey(key, key) {};
     }
 
 }

--- a/alert-database/src/test/java/com/synopsys/integration/alert/database/api/DefaultProcessingAuditAccessorTest.java
+++ b/alert-database/src/test/java/com/synopsys/integration/alert/database/api/DefaultProcessingAuditAccessorTest.java
@@ -21,16 +21,16 @@ import com.synopsys.integration.alert.database.audit.AuditEntryNotificationView;
 import com.synopsys.integration.alert.database.audit.AuditEntryRepository;
 import com.synopsys.integration.alert.database.audit.AuditNotificationRepository;
 
-public class DefaultProcessingAuditAccessorTest {
+class DefaultProcessingAuditAccessorTest {
     private static final Random RANDOM = new Random();
 
     @Test
-    public void createOrUpdatePendingAuditEntryForJobTest() {
+    void createOrUpdatePendingAuditEntryForJobTest() {
         UUID testJobId = UUID.randomUUID();
         Set<Long> testNotificationIds = Set.of(1L, 2L, 10L);
 
         AuditEntryRepository auditEntryRepository = Mockito.mock(AuditEntryRepository.class);
-        Mockito.when(auditEntryRepository.findByJobIdAndNotificationIds(Mockito.eq(testJobId), Mockito.eq(testNotificationIds))).thenReturn(List.of());
+        Mockito.when(auditEntryRepository.findByJobIdAndNotificationIds(testJobId, testNotificationIds)).thenReturn(List.of());
         Mockito.when(auditEntryRepository.save(Mockito.any())).then(invocation -> {
             AuditEntryEntity auditEntry = invocation.getArgument(0);
             auditEntry.setId(RANDOM.nextLong());
@@ -47,7 +47,7 @@ public class DefaultProcessingAuditAccessorTest {
     }
 
     @Test
-    public void setAuditEntrySuccessTest() {
+    void setAuditEntrySuccessTest() {
         setAuditEntryStatusTest(
             AuditEntryStatus.SUCCESS,
             ProcessingAuditAccessor::setAuditEntrySuccess
@@ -55,7 +55,7 @@ public class DefaultProcessingAuditAccessorTest {
     }
 
     @Test
-    public void setAuditEntryFailureTest() {
+    void setAuditEntryFailureTest() {
         String testErrorMessage = "Uh oh, an error occurred!";
         String testExceptionMessage = "Something bad happened. Yikes...";
         Throwable testThrowable = new AlertException(testExceptionMessage);
@@ -65,7 +65,10 @@ public class DefaultProcessingAuditAccessorTest {
         );
         assertEquals(testErrorMessage, testResultEntry.getErrorMessage());
         assertNotNull(testResultEntry.getErrorStackTrace(), "Expected the audit entry to contain an error stack trace");
-        assertTrue(testResultEntry.getErrorStackTrace().contains(testExceptionMessage), "Expected the error stack trace to contain a specific message, but that message was missing");
+        assertTrue(
+            testResultEntry.getErrorStackTrace().contains(testExceptionMessage),
+            "Expected the error stack trace to contain a specific message, but that message was missing"
+        );
     }
 
     private AuditEntryEntity setAuditEntryStatusTest(AuditEntryStatus expectedStatus, AuditAccessorStatusSetter statusSetter) {

--- a/alert-database/src/test/java/com/synopsys/integration/alert/database/api/DefaultRoleAccessorTest.java
+++ b/alert-database/src/test/java/com/synopsys/integration/alert/database/api/DefaultRoleAccessorTest.java
@@ -32,7 +32,7 @@ import com.synopsys.integration.alert.database.user.RoleEntity;
 import com.synopsys.integration.alert.database.user.RoleRepository;
 import com.synopsys.integration.alert.database.user.UserRoleRepository;
 
-public class DefaultRoleAccessorTest {
+class DefaultRoleAccessorTest {
     private RoleRepository roleRepository;
     private UserRoleRepository userRoleRepository;
     private PermissionMatrixRepository permissionMatrixRepository;
@@ -49,13 +49,19 @@ public class DefaultRoleAccessorTest {
     }
 
     @Test
-    public void getRolesTest() {
+    void getRolesTest() {
         RoleEntity roleEntity = new RoleEntity(DefaultUserRole.ALERT_USER.name(), true);
         roleEntity.setId(1L);
 
         Mockito.when(roleRepository.findAll()).thenReturn(List.of(roleEntity));
 
-        DefaultRoleAccessor authorizationUtility = new DefaultRoleAccessor(roleRepository, userRoleRepository, permissionMatrixRepository, registeredDescriptorRepository, configContextRepository);
+        DefaultRoleAccessor authorizationUtility = new DefaultRoleAccessor(
+            roleRepository,
+            userRoleRepository,
+            permissionMatrixRepository,
+            registeredDescriptorRepository,
+            configContextRepository
+        );
         Set<UserRoleModel> userRoleModelsSet = authorizationUtility.getRoles();
 
         UserRoleModel expectedUserRoleModel = createUserRoleModel(1L, DefaultUserRole.ALERT_USER.name(), true);
@@ -65,13 +71,19 @@ public class DefaultRoleAccessorTest {
     }
 
     @Test
-    public void getRolesByRoleIdsTest() {
+    void getRolesByRoleIdsTest() {
         RoleEntity roleEntity = new RoleEntity(DefaultUserRole.ALERT_USER.name(), true);
         roleEntity.setId(1L);
 
         Mockito.when(roleRepository.findById(Mockito.any())).thenReturn(Optional.of(roleEntity));
 
-        DefaultRoleAccessor authorizationUtility = new DefaultRoleAccessor(roleRepository, userRoleRepository, permissionMatrixRepository, registeredDescriptorRepository, configContextRepository);
+        DefaultRoleAccessor authorizationUtility = new DefaultRoleAccessor(
+            roleRepository,
+            userRoleRepository,
+            permissionMatrixRepository,
+            registeredDescriptorRepository,
+            configContextRepository
+        );
         Set<UserRoleModel> userRoleModelsSet = authorizationUtility.getRoles(List.of(1L));
 
         UserRoleModel expectedUserRoleModel = createUserRoleModel(1L, DefaultUserRole.ALERT_USER.name(), true);
@@ -81,15 +93,21 @@ public class DefaultRoleAccessorTest {
     }
 
     @Test
-    public void doesRoleNameExistTest() {
+    void doesRoleNameExistTest() {
         Mockito.when(roleRepository.existsRoleEntityByRoleName(Mockito.any())).thenReturn(true);
-        DefaultRoleAccessor authorizationUtility = new DefaultRoleAccessor(roleRepository, userRoleRepository, permissionMatrixRepository, registeredDescriptorRepository, configContextRepository);
+        DefaultRoleAccessor authorizationUtility = new DefaultRoleAccessor(
+            roleRepository,
+            userRoleRepository,
+            permissionMatrixRepository,
+            registeredDescriptorRepository,
+            configContextRepository
+        );
 
         assertTrue(authorizationUtility.doesRoleNameExist("name"));
     }
 
     @Test
-    public void createRoleWithPermissions() {
+    void createRoleWithPermissions() {
         final String roleName = "roleName";
         final String contextString = "context-test";
         final String descriptorName = "descriptorName";
@@ -120,7 +138,7 @@ public class DefaultRoleAccessorTest {
     }
 
     @Test
-    public void updateRoleNameTest() throws Exception {
+    void updateRoleNameTest() throws Exception {
         final String roleName = "roleName";
         final Long roleId = 1L;
 
@@ -129,14 +147,20 @@ public class DefaultRoleAccessorTest {
 
         Mockito.when(roleRepository.findById(Mockito.any())).thenReturn(Optional.of(roleEntity));
 
-        DefaultRoleAccessor authorizationUtility = new DefaultRoleAccessor(roleRepository, userRoleRepository, permissionMatrixRepository, registeredDescriptorRepository, configContextRepository);
+        DefaultRoleAccessor authorizationUtility = new DefaultRoleAccessor(
+            roleRepository,
+            userRoleRepository,
+            permissionMatrixRepository,
+            registeredDescriptorRepository,
+            configContextRepository
+        );
         authorizationUtility.updateRoleName(roleId, roleName);
 
         Mockito.verify(roleRepository).save(Mockito.any());
     }
 
     @Test
-    public void updatePermissionsForRole() throws Exception {
+    void updatePermissionsForRole() throws Exception {
         final String roleName = "roleName";
         final String contextString = "context-test";
         final String descriptorName = "descriptorName";
@@ -166,7 +190,7 @@ public class DefaultRoleAccessorTest {
     }
 
     @Test
-    public void deleteRoleTest() throws Exception {
+    void deleteRoleTest() throws Exception {
         final String roleName = "roleName";
         final Long roleId = 1L;
 
@@ -175,15 +199,27 @@ public class DefaultRoleAccessorTest {
 
         Mockito.when(roleRepository.findById(Mockito.any())).thenReturn(Optional.of(roleEntity));
 
-        DefaultRoleAccessor authorizationUtility = new DefaultRoleAccessor(roleRepository, userRoleRepository, permissionMatrixRepository, registeredDescriptorRepository, configContextRepository);
+        DefaultRoleAccessor authorizationUtility = new DefaultRoleAccessor(
+            roleRepository,
+            userRoleRepository,
+            permissionMatrixRepository,
+            registeredDescriptorRepository,
+            configContextRepository
+        );
         authorizationUtility.deleteRole(roleId);
 
         Mockito.verify(roleRepository).deleteById(Mockito.any());
     }
 
     @Test
-    public void deleteRoleCustomFalseTest() {
-        DefaultRoleAccessor authorizationUtility = new DefaultRoleAccessor(roleRepository, userRoleRepository, permissionMatrixRepository, registeredDescriptorRepository, configContextRepository);
+    void deleteRoleCustomFalseTest() {
+        DefaultRoleAccessor authorizationUtility = new DefaultRoleAccessor(
+            roleRepository,
+            userRoleRepository,
+            permissionMatrixRepository,
+            registeredDescriptorRepository,
+            configContextRepository
+        );
 
         RoleEntity roleEntity = new RoleEntity("name", false);
         roleEntity.setId(1L);
@@ -198,7 +234,7 @@ public class DefaultRoleAccessorTest {
     }
 
     @Test
-    public void updateUserRolesTest() {
+    void updateUserRolesTest() {
         final Long userId = 1L;
         final String roleName = "roleName";
         final Long roleId = 1L;
@@ -218,7 +254,7 @@ public class DefaultRoleAccessorTest {
     }
 
     @Test
-    public void testSuperSetRoles() {
+    void testSuperSetRoles() {
         RoleRepository roleRepository = Mockito.mock(RoleRepository.class);
         UserRoleRepository userRoleRepository = Mockito.mock(UserRoleRepository.class);
         PermissionMatrixRepository permissionMatrixRepository = Mockito.mock(PermissionMatrixRepository.class);
@@ -236,7 +272,7 @@ public class DefaultRoleAccessorTest {
         String contextString = "PERMISSION";
         ConfigContextEntity contextEntity = new ConfigContextEntity(contextString);
         contextEntity.setId(contextId);
-        Mockito.when(configContextRepository.findById(Mockito.eq(contextEntity.getId()))).thenReturn(Optional.of(contextEntity));
+        Mockito.when(configContextRepository.findById(contextEntity.getId())).thenReturn(Optional.of(contextEntity));
 
         Long descriptorId_1 = 1L;
         String descriptorName_1 = "key.1";
@@ -247,28 +283,48 @@ public class DefaultRoleAccessorTest {
 
         RegisteredDescriptorEntity registeredDescriptorEntity_1 = new RegisteredDescriptorEntity(descriptorName_1, 1L);
         registeredDescriptorEntity_1.setId(descriptorId_1);
-        Mockito.when(registeredDescriptorRepository.findById(Mockito.eq(registeredDescriptorEntity_1.getId()))).thenReturn(Optional.of(registeredDescriptorEntity_1));
+        Mockito.when(registeredDescriptorRepository.findById(registeredDescriptorEntity_1.getId())).thenReturn(Optional.of(registeredDescriptorEntity_1));
 
         RegisteredDescriptorEntity registeredDescriptorEntity_2 = new RegisteredDescriptorEntity(descriptorName_2, 1L);
         registeredDescriptorEntity_2.setId(descriptorId_2);
-        Mockito.when(registeredDescriptorRepository.findById(Mockito.eq(registeredDescriptorEntity_2.getId()))).thenReturn(Optional.of(registeredDescriptorEntity_2));
+        Mockito.when(registeredDescriptorRepository.findById(registeredDescriptorEntity_2.getId())).thenReturn(Optional.of(registeredDescriptorEntity_2));
 
         RegisteredDescriptorEntity registeredDescriptorEntity_3 = new RegisteredDescriptorEntity(descriptorName_3, 1L);
         registeredDescriptorEntity_3.setId(descriptorId_3);
-        Mockito.when(registeredDescriptorRepository.findById(Mockito.eq(registeredDescriptorEntity_3.getId()))).thenReturn(Optional.of(registeredDescriptorEntity_3));
+        Mockito.when(registeredDescriptorRepository.findById(registeredDescriptorEntity_3.getId())).thenReturn(Optional.of(registeredDescriptorEntity_3));
 
         PermissionKey permission_1 = new PermissionKey(contextString, descriptorName_1);
         PermissionKey permission_2 = new PermissionKey(contextString, descriptorName_2);
         PermissionKey permission_3 = new PermissionKey(contextString, descriptorName_3);
 
-        PermissionMatrixRelation adminRelation_1 = new PermissionMatrixRelation(adminRole.getId(), contextEntity.getId(), registeredDescriptorEntity_1.getId(), AccessOperation.READ.getBit() + AccessOperation.WRITE.getBit());
-        PermissionMatrixRelation adminRelation_3 = new PermissionMatrixRelation(adminRole.getId(), contextEntity.getId(), registeredDescriptorEntity_3.getId(), AccessOperation.READ.getBit() + AccessOperation.WRITE.getBit());
-        PermissionMatrixRelation userRelation_1 = new PermissionMatrixRelation(userRole.getId(), contextEntity.getId(), registeredDescriptorEntity_1.getId(), AccessOperation.READ.getBit());
-        PermissionMatrixRelation userRelation_2 = new PermissionMatrixRelation(userRole.getId(), contextEntity.getId(), registeredDescriptorEntity_2.getId(), AccessOperation.READ.getBit() + AccessOperation.EXECUTE.getBit());
+        PermissionMatrixRelation adminRelation_1 = new PermissionMatrixRelation(
+            adminRole.getId(),
+            contextEntity.getId(),
+            registeredDescriptorEntity_1.getId(),
+            AccessOperation.READ.getBit() + AccessOperation.WRITE.getBit()
+        );
+        PermissionMatrixRelation adminRelation_3 = new PermissionMatrixRelation(
+            adminRole.getId(),
+            contextEntity.getId(),
+            registeredDescriptorEntity_3.getId(),
+            AccessOperation.READ.getBit() + AccessOperation.WRITE.getBit()
+        );
+        PermissionMatrixRelation userRelation_1 = new PermissionMatrixRelation(
+            userRole.getId(),
+            contextEntity.getId(),
+            registeredDescriptorEntity_1.getId(),
+            AccessOperation.READ.getBit()
+        );
+        PermissionMatrixRelation userRelation_2 = new PermissionMatrixRelation(
+            userRole.getId(),
+            contextEntity.getId(),
+            registeredDescriptorEntity_2.getId(),
+            AccessOperation.READ.getBit() + AccessOperation.EXECUTE.getBit()
+        );
         List<Long> roleIds = List.of(adminRole.getId(), userRole.getId());
-        Mockito.when(permissionMatrixRepository.findAllByRoleId(Mockito.eq(adminRole.getId()))).thenReturn(List.of(adminRelation_1, adminRelation_3));
-        Mockito.when(permissionMatrixRepository.findAllByRoleId(Mockito.eq(userRole.getId()))).thenReturn(List.of(userRelation_1, userRelation_2));
-        Mockito.when(permissionMatrixRepository.findAllByRoleIdIn(Mockito.eq(roleIds))).thenReturn(List.of(adminRelation_1, adminRelation_3, userRelation_1, userRelation_2));
+        Mockito.when(permissionMatrixRepository.findAllByRoleId(adminRole.getId())).thenReturn(List.of(adminRelation_1, adminRelation_3));
+        Mockito.when(permissionMatrixRepository.findAllByRoleId(userRole.getId())).thenReturn(List.of(userRelation_1, userRelation_2));
+        Mockito.when(permissionMatrixRepository.findAllByRoleIdIn(roleIds)).thenReturn(List.of(adminRelation_1, adminRelation_3, userRelation_1, userRelation_2));
 
         DefaultRoleAccessor authorizationUtility =
             new DefaultRoleAccessor(roleRepository, userRoleRepository, permissionMatrixRepository, registeredDescriptorRepository, configContextRepository);

--- a/alert-database/src/test/java/com/synopsys/integration/alert/database/api/DefaultUserAccessorTest.java
+++ b/alert-database/src/test/java/com/synopsys/integration/alert/database/api/DefaultUserAccessorTest.java
@@ -29,7 +29,7 @@ import com.synopsys.integration.alert.database.user.UserRepository;
 import com.synopsys.integration.alert.database.user.UserRoleRelation;
 import com.synopsys.integration.alert.database.user.UserRoleRepository;
 
-public class DefaultUserAccessorTest {
+class DefaultUserAccessorTest {
     private final String username = "username";
     private final String password = "password";
     private final String emailAddress = "noreply@blackducksoftware.com";
@@ -50,7 +50,7 @@ public class DefaultUserAccessorTest {
     }
 
     @Test
-    public void getUsersTest() {
+    void getUsersTest() {
         final Long authenticationTypeId = 1L;
         final String roleName = "userName";
 
@@ -71,7 +71,7 @@ public class DefaultUserAccessorTest {
     }
 
     @Test
-    public void getUserByUserIdTest() {
+    void getUserByUserIdTest() {
         final Long userId = 1L;
         final Long emptyUserId = 5L;
         final Long authenticationTypeId = 1L;
@@ -97,7 +97,7 @@ public class DefaultUserAccessorTest {
     }
 
     @Test
-    public void getUserByUsernameTest() {
+    void getUserByUsernameTest() {
         final String emptyUsername = "";
         final Long authenticationTypeId = 1L;
         final String roleName = "userName";
@@ -122,7 +122,7 @@ public class DefaultUserAccessorTest {
     }
 
     @Test
-    public void addUserTest() throws Exception {
+    void addUserTest() throws Exception {
         final String roleName = "userName";
 
         UserEntity userEntity = new UserEntity(username, password, emailAddress, 2L);
@@ -143,7 +143,7 @@ public class DefaultUserAccessorTest {
     }
 
     @Test
-    public void addUserExistsTest() throws Exception {
+    void addUserExistsTest() {
         UserEntity userEntity = new UserEntity(username, password, emailAddress, 2L);
         userEntity.setId(1L);
 
@@ -160,7 +160,7 @@ public class DefaultUserAccessorTest {
     }
 
     @Test
-    public void updateUserTest() throws Exception {
+    void updateUserTest() throws Exception {
         final String roleName = "userName";
         AuthenticationType authenticationType = AuthenticationType.DATABASE;
 
@@ -186,7 +186,7 @@ public class DefaultUserAccessorTest {
     }
 
     @Test
-    public void updateUserNonDatabaseAuthTest() throws Exception {
+    void updateUserNonDatabaseAuthTest() throws Exception {
         final String roleName = "roleName";
         AuthenticationType authenticationType = AuthenticationType.LDAP;
 
@@ -211,7 +211,7 @@ public class DefaultUserAccessorTest {
     }
 
     @Test
-    public void updateUserNonDatabaseAuthInvalidTest() throws Exception {
+    void updateUserNonDatabaseAuthInvalidTest() {
         final String roleName = "roleName";
         AuthenticationType authenticationType = AuthenticationType.LDAP;
 
@@ -242,15 +242,15 @@ public class DefaultUserAccessorTest {
     }
 
     @Test
-    public void assignRolesTest() {
+    void assignRolesTest() {
         final String badUsername = "badUsername";
         final Long roleId = 5L;
 
         UserEntity userEntity = new UserEntity(username, password, emailAddress, 2L);
         userEntity.setId(1L);
 
-        Mockito.when(userRepository.findByUserName(Mockito.eq(username))).thenReturn(Optional.of(userEntity));
-        Mockito.when(userRepository.findByUserName(Mockito.eq(badUsername))).thenReturn(Optional.empty());
+        Mockito.when(userRepository.findByUserName(username)).thenReturn(Optional.of(userEntity));
+        Mockito.when(userRepository.findByUserName(badUsername)).thenReturn(Optional.empty());
 
         DefaultUserAccessor defaultUserAccessor = new DefaultUserAccessor(userRepository, userRoleRepository, defaultPasswordEncoder, roleAccessor, authenticationTypeAccessor);
         boolean assignedRoles = defaultUserAccessor.assignRoles(username, Set.of(roleId));
@@ -264,7 +264,7 @@ public class DefaultUserAccessorTest {
     }
 
     @Test
-    public void changeUserPasswordTest() {
+    void changeUserPasswordTest() {
         final String badUsername = "badUsername";
         final String newPassword = "newPassword";
 
@@ -273,8 +273,8 @@ public class DefaultUserAccessorTest {
         UserEntity newUserEntity = new UserEntity(username, newPassword, emailAddress, 2L);
         userEntity.setId(1L);
 
-        Mockito.when(userRepository.findByUserName(Mockito.eq(username))).thenReturn(Optional.of(userEntity));
-        Mockito.when(userRepository.findByUserName(Mockito.eq(badUsername))).thenReturn(Optional.empty());
+        Mockito.when(userRepository.findByUserName(username)).thenReturn(Optional.of(userEntity));
+        Mockito.when(userRepository.findByUserName(badUsername)).thenReturn(Optional.empty());
         Mockito.when(defaultPasswordEncoder.encode(Mockito.any())).thenReturn(newPassword);
         Mockito.when(userRepository.save(Mockito.any())).thenReturn(newUserEntity);
 
@@ -285,7 +285,7 @@ public class DefaultUserAccessorTest {
     }
 
     @Test
-    public void changeUserEmailAddressTest() {
+    void changeUserEmailAddressTest() {
         final String badUsername = "badUsername";
         final String newEmailAddress = "newemail.noreplay@blackducksoftware.com";
 
@@ -294,8 +294,8 @@ public class DefaultUserAccessorTest {
         UserEntity newUserEntity = new UserEntity(username, password, newEmailAddress, 2L);
         userEntity.setId(1L);
 
-        Mockito.when(userRepository.findByUserName(Mockito.eq(username))).thenReturn(Optional.of(userEntity));
-        Mockito.when(userRepository.findByUserName(Mockito.eq(badUsername))).thenReturn(Optional.empty());
+        Mockito.when(userRepository.findByUserName(username)).thenReturn(Optional.of(userEntity));
+        Mockito.when(userRepository.findByUserName(badUsername)).thenReturn(Optional.empty());
         Mockito.when(userRepository.save(Mockito.any())).thenReturn(newUserEntity);
 
         DefaultUserAccessor defaultUserAccessor = new DefaultUserAccessor(userRepository, userRoleRepository, defaultPasswordEncoder, roleAccessor, authenticationTypeAccessor);
@@ -305,12 +305,12 @@ public class DefaultUserAccessorTest {
     }
 
     @Test
-    public void deleteUserByNameTest() throws Exception {
+    void deleteUserByNameTest() throws Exception {
         //userEntity Id's between 0 and 2 are reserved
         UserEntity userEntity = new UserEntity(username, password, emailAddress, 2L);
         userEntity.setId(5L);
 
-        Mockito.when(userRepository.findByUserName(Mockito.eq(username))).thenReturn(Optional.of(userEntity));
+        Mockito.when(userRepository.findByUserName(username)).thenReturn(Optional.of(userEntity));
 
         DefaultUserAccessor defaultUserAccessor = new DefaultUserAccessor(userRepository, userRoleRepository, defaultPasswordEncoder, roleAccessor, authenticationTypeAccessor);
         defaultUserAccessor.deleteUser(username);
@@ -320,11 +320,11 @@ public class DefaultUserAccessorTest {
     }
 
     @Test
-    public void deleteUserByIdTest() throws Exception {
+    void deleteUserByIdTest() throws Exception {
         UserEntity userEntity = new UserEntity(username, password, emailAddress, 2L);
         userEntity.setId(5L);
 
-        Mockito.when(userRepository.findById(Mockito.eq(userEntity.getId()))).thenReturn(Optional.of(userEntity));
+        Mockito.when(userRepository.findById(userEntity.getId())).thenReturn(Optional.of(userEntity));
 
         DefaultUserAccessor defaultUserAccessor = new DefaultUserAccessor(userRepository, userRoleRepository, defaultPasswordEncoder, roleAccessor, authenticationTypeAccessor);
         defaultUserAccessor.deleteUser(userEntity.getId());
@@ -334,11 +334,11 @@ public class DefaultUserAccessorTest {
     }
 
     @Test
-    public void deleteUserReservedIdTest() throws Exception {
+    void deleteUserReservedIdTest() {
         UserEntity userEntity = new UserEntity(username, password, emailAddress, 2L);
         userEntity.setId(1L);
 
-        Mockito.when(userRepository.findByUserName(Mockito.eq(username))).thenReturn(Optional.of(userEntity));
+        Mockito.when(userRepository.findByUserName(username)).thenReturn(Optional.of(userEntity));
         Mockito.when(userRepository.findById(Mockito.any())).thenReturn(Optional.of(userEntity));
 
         DefaultUserAccessor defaultUserAccessor = new DefaultUserAccessor(userRepository, userRoleRepository, defaultPasswordEncoder, roleAccessor, authenticationTypeAccessor);

--- a/alert-database/src/test/java/com/synopsys/integration/alert/database/job/blackduck/BlackDuckJobDetailsAccessorTest.java
+++ b/alert-database/src/test/java/com/synopsys/integration/alert/database/job/blackduck/BlackDuckJobDetailsAccessorTest.java
@@ -23,7 +23,7 @@ import com.synopsys.integration.alert.database.job.blackduck.projects.BlackDuckJ
 import com.synopsys.integration.alert.database.job.blackduck.vulnerability.BlackDuckJobVulnerabilitySeverityFilterEntity;
 import com.synopsys.integration.alert.database.job.blackduck.vulnerability.BlackDuckJobVulnerabilitySeverityFilterRepository;
 
-public class BlackDuckJobDetailsAccessorTest {
+class BlackDuckJobDetailsAccessorTest {
     private BlackDuckJobDetailsRepository blackDuckJobDetailsRepository;
     private BlackDuckJobNotificationTypeRepository blackDuckJobNotificationTypeRepository;
     private BlackDuckJobProjectRepository blackDuckJobProjectRepository;
@@ -32,29 +32,29 @@ public class BlackDuckJobDetailsAccessorTest {
 
     private BlackDuckJobDetailsAccessor blackDuckJobDetailsAccessor;
 
-    private final String jobName = "jobName";
-
     @BeforeEach
-    public void init() {
+    void init() {
         blackDuckJobDetailsRepository = Mockito.mock(BlackDuckJobDetailsRepository.class);
         blackDuckJobNotificationTypeRepository = Mockito.mock(BlackDuckJobNotificationTypeRepository.class);
         blackDuckJobProjectRepository = Mockito.mock(BlackDuckJobProjectRepository.class);
         blackDuckJobPolicyFilterRepository = Mockito.mock(BlackDuckJobPolicyFilterRepository.class);
         blackDuckJobVulnerabilitySeverityFilterRepository = Mockito.mock(BlackDuckJobVulnerabilitySeverityFilterRepository.class);
 
-        blackDuckJobDetailsAccessor = new BlackDuckJobDetailsAccessor(blackDuckJobDetailsRepository,
+        blackDuckJobDetailsAccessor = new BlackDuckJobDetailsAccessor(
+            blackDuckJobDetailsRepository,
             blackDuckJobNotificationTypeRepository,
             blackDuckJobProjectRepository,
             blackDuckJobPolicyFilterRepository,
-            blackDuckJobVulnerabilitySeverityFilterRepository);
+            blackDuckJobVulnerabilitySeverityFilterRepository
+        );
     }
 
     @Test
-    public void saveBlackDuckJobDetailsTest() {
+    void saveBlackDuckJobDetailsTest() {
         UUID jobId = UUID.randomUUID();
         DistributionJobRequestModel distributionJobRequestModel = new DistributionJobRequestModel(
             true,
-            jobName,
+            "jobName",
             FrequencyType.DAILY,
             ProcessingType.DEFAULT,
             null,
@@ -91,10 +91,10 @@ public class BlackDuckJobDetailsAccessorTest {
 
         BlackDuckJobDetailsEntity createdBlackDuckJobDetailsEntity = blackDuckJobDetailsAccessor.saveBlackDuckJobDetails(jobId, distributionJobRequestModel);
 
-        Mockito.verify(blackDuckJobNotificationTypeRepository).bulkDeleteAllByJobId(Mockito.eq(jobId));
-        Mockito.verify(blackDuckJobProjectRepository).bulkDeleteAllByJobId(Mockito.eq(jobId));
-        Mockito.verify(blackDuckJobPolicyFilterRepository).bulkDeleteAllByJobId(Mockito.eq(jobId));
-        Mockito.verify(blackDuckJobVulnerabilitySeverityFilterRepository).bulkDeleteAllByJobId(Mockito.eq(jobId));
+        Mockito.verify(blackDuckJobNotificationTypeRepository).bulkDeleteAllByJobId(jobId);
+        Mockito.verify(blackDuckJobProjectRepository).bulkDeleteAllByJobId(jobId);
+        Mockito.verify(blackDuckJobPolicyFilterRepository).bulkDeleteAllByJobId(jobId);
+        Mockito.verify(blackDuckJobVulnerabilitySeverityFilterRepository).bulkDeleteAllByJobId(jobId);
 
         assertEquals(jobId, createdBlackDuckJobDetailsEntity.getJobId());
         assertEquals(1, createdBlackDuckJobDetailsEntity.getBlackDuckJobNotificationTypes().size());
@@ -108,12 +108,12 @@ public class BlackDuckJobDetailsAccessorTest {
     }
 
     @Test
-    public void retrieveNotificationTypesForJobTest() {
+    void retrieveNotificationTypesForJobTest() {
         UUID jobId = UUID.randomUUID();
         String notificationType = "testNotificationType";
         BlackDuckJobNotificationTypeEntity blackDuckJobNotificationTypeEntity = new BlackDuckJobNotificationTypeEntity(jobId, notificationType);
 
-        Mockito.when(blackDuckJobNotificationTypeRepository.findByJobId(Mockito.eq(jobId))).thenReturn(List.of(blackDuckJobNotificationTypeEntity));
+        Mockito.when(blackDuckJobNotificationTypeRepository.findByJobId(jobId)).thenReturn(List.of(blackDuckJobNotificationTypeEntity));
 
         List<String> notificationTypes = blackDuckJobDetailsAccessor.retrieveNotificationTypesForJob(jobId);
 
@@ -122,13 +122,13 @@ public class BlackDuckJobDetailsAccessorTest {
     }
 
     @Test
-    public void retrieveProjectDetailsForJobTest() {
+    void retrieveProjectDetailsForJobTest() {
         UUID jobId = UUID.randomUUID();
         String projectName = "projectName";
         String href = "href";
         BlackDuckJobProjectEntity blackDuckJobProjectEntity = new BlackDuckJobProjectEntity(jobId, projectName, href);
 
-        Mockito.when(blackDuckJobProjectRepository.findByJobId(Mockito.eq(jobId))).thenReturn(List.of(blackDuckJobProjectEntity));
+        Mockito.when(blackDuckJobProjectRepository.findByJobId(jobId)).thenReturn(List.of(blackDuckJobProjectEntity));
 
         List<BlackDuckProjectDetailsModel> blackDuckProjectDetailsModels = blackDuckJobDetailsAccessor.retrieveProjectDetailsForJob(jobId);
 
@@ -139,12 +139,12 @@ public class BlackDuckJobDetailsAccessorTest {
     }
 
     @Test
-    public void retrievePolicyNamesForJobTest() {
+    void retrievePolicyNamesForJobTest() {
         UUID jobId = UUID.randomUUID();
         String policyName = "policyName";
         BlackDuckJobPolicyFilterEntity blackDuckJobPolicyFilterEntity = new BlackDuckJobPolicyFilterEntity(jobId, policyName);
 
-        Mockito.when(blackDuckJobPolicyFilterRepository.findByJobId(Mockito.eq(jobId))).thenReturn(List.of(blackDuckJobPolicyFilterEntity));
+        Mockito.when(blackDuckJobPolicyFilterRepository.findByJobId(jobId)).thenReturn(List.of(blackDuckJobPolicyFilterEntity));
 
         List<String> policyNamesList = blackDuckJobDetailsAccessor.retrievePolicyNamesForJob(jobId);
 
@@ -153,12 +153,12 @@ public class BlackDuckJobDetailsAccessorTest {
     }
 
     @Test
-    public void retrieveVulnerabilitySeverityNamesForJobTest() {
+    void retrieveVulnerabilitySeverityNamesForJobTest() {
         UUID jobId = UUID.randomUUID();
         String severityName = "severityName";
         BlackDuckJobVulnerabilitySeverityFilterEntity blackDuckJobVulnerabilitySeverityFilterEntity = new BlackDuckJobVulnerabilitySeverityFilterEntity(jobId, severityName);
 
-        Mockito.when(blackDuckJobVulnerabilitySeverityFilterRepository.findByJobId(Mockito.eq(jobId))).thenReturn(List.of(blackDuckJobVulnerabilitySeverityFilterEntity));
+        Mockito.when(blackDuckJobVulnerabilitySeverityFilterRepository.findByJobId(jobId)).thenReturn(List.of(blackDuckJobVulnerabilitySeverityFilterEntity));
 
         List<String> vulnerabilitySeverityNames = blackDuckJobDetailsAccessor.retrieveVulnerabilitySeverityNamesForJob(jobId);
 

--- a/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/IssueTrackerModelExtractorTest.java
+++ b/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/IssueTrackerModelExtractorTest.java
@@ -95,7 +95,7 @@ class IssueTrackerModelExtractorTest {
         MockIssueTrackerMessageFormatter formatter = MockIssueTrackerMessageFormatter.withIntegerMaxValueLength();
 
         IssueTrackerSearcher<String> searcher = Mockito.mock(IssueTrackerSearcher.class);
-        Mockito.when(searcher.findIssues(Mockito.eq(projectMessage))).thenReturn(List.of(searchResult));
+        Mockito.when(searcher.findIssues(projectMessage)).thenReturn(List.of(searchResult));
 
         IssueTrackerModelExtractor<String> extractor = new IssueTrackerModelExtractor<>(formatter, searcher);
 
@@ -127,7 +127,7 @@ class IssueTrackerModelExtractorTest {
         MockIssueTrackerMessageFormatter formatter = MockIssueTrackerMessageFormatter.withIntegerMaxValueLength();
 
         IssueTrackerSearcher<String> searcher = Mockito.mock(IssueTrackerSearcher.class);
-        Mockito.when(searcher.findIssues(Mockito.eq(projectMessage))).thenReturn(List.of(searchResult));
+        Mockito.when(searcher.findIssues(projectMessage)).thenReturn(List.of(searchResult));
 
         IssueTrackerModelExtractor<String> extractor = new IssueTrackerModelExtractor<>(formatter, searcher);
 
@@ -157,7 +157,7 @@ class IssueTrackerModelExtractorTest {
         MockIssueTrackerMessageFormatter formatter = MockIssueTrackerMessageFormatter.withIntegerMaxValueLength();
 
         IssueTrackerSearcher<String> searcher = Mockito.mock(IssueTrackerSearcher.class);
-        Mockito.when(searcher.findIssues(Mockito.eq(projectMessage))).thenReturn(List.of(searchResult));
+        Mockito.when(searcher.findIssues(projectMessage)).thenReturn(List.of(searchResult));
 
         IssueTrackerModelExtractor<String> extractor = new IssueTrackerModelExtractor<>(formatter, searcher);
 

--- a/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/send/IssueTrackerIssueCommenterTest.java
+++ b/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/send/IssueTrackerIssueCommenterTest.java
@@ -20,10 +20,17 @@ import com.synopsys.integration.alert.api.channel.issue.search.enumeration.Issue
 import com.synopsys.integration.alert.api.channel.issue.search.enumeration.IssueStatus;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 
-public class IssueTrackerIssueCommenterTest {
+class IssueTrackerIssueCommenterTest {
     private static final AlertException TEST_EXCEPTION = new AlertException("Test exception");
 
-    private static final ExistingIssueDetails<String> EXISTING_ISSUE_DETAILS = new ExistingIssueDetails<>("id", "key", "summary", "https://ui-link", IssueStatus.UNKNOWN, IssueCategory.BOM);
+    private static final ExistingIssueDetails<String> EXISTING_ISSUE_DETAILS = new ExistingIssueDetails<>(
+        "id",
+        "key",
+        "summary",
+        "https://ui-link",
+        IssueStatus.UNKNOWN,
+        IssueCategory.BOM
+    );
     private static final IssueCommentModel<String> COMMENT_MODEL = new IssueCommentModel<>(EXISTING_ISSUE_DETAILS, List.of("Comment 1", "Comment 2"), null);
     private static final IssueTrackerIssueResponseModel<String> ISSUE_RESPONSE_MODEL = new IssueTrackerIssueResponseModel<>(
         EXISTING_ISSUE_DETAILS.getIssueId(),
@@ -43,7 +50,7 @@ public class IssueTrackerIssueCommenterTest {
     }
 
     @Test
-    public void commentOnIssueTest() throws AlertException {
+    void commentOnIssueTest() throws AlertException {
         TestCommenter commenter = new TestCommenter(responseCreator, true, false);
         Optional<IssueTrackerIssueResponseModel<String>> optionalResponseModel = commenter.commentOnIssue(COMMENT_MODEL);
         assertTrue(optionalResponseModel.isPresent(), "Expected response model to be present");
@@ -56,14 +63,14 @@ public class IssueTrackerIssueCommenterTest {
     }
 
     @Test
-    public void commentOnIssueDisabledTest() throws AlertException {
+    void commentOnIssueDisabledTest() throws AlertException {
         TestCommenter commenter = new TestCommenter(responseCreator, false, false);
         Optional<IssueTrackerIssueResponseModel<String>> responseModel = commenter.commentOnIssue(COMMENT_MODEL);
         assertTrue(responseModel.isEmpty(), "Expected response model to be empty");
     }
 
     @Test
-    public void commentOnIssueThrowsExceptionTest() {
+    void commentOnIssueThrowsExceptionTest() {
         TestCommenter commenter = new TestCommenter(responseCreator, true, true);
         try {
             commenter.commentOnIssue(COMMENT_MODEL);

--- a/api-event/src/test/java/com/synopsys/integration/alert/api/event/EventManagerTest.java
+++ b/api-event/src/test/java/com/synopsys/integration/alert/api/event/EventManagerTest.java
@@ -23,7 +23,7 @@ class EventManagerTest {
         EventManager eventManager = new EventManager(gson, rabbitTemplate, new SyncTaskExecutor());
         eventManager.sendEvents(List.of(testEvent));
 
-        Mockito.verify(rabbitTemplate, Mockito.times(1)).convertAndSend(Mockito.eq(testDestination), Mockito.eq(testEventJson));
+        Mockito.verify(rabbitTemplate, Mockito.times(1)).convertAndSend(testDestination, testEventJson);
     }
 
 }

--- a/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/JobNotificationProcessorTest.java
+++ b/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/JobNotificationProcessorTest.java
@@ -50,7 +50,7 @@ import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.rest.HttpUrl;
 
-public class JobNotificationProcessorTest {
+class JobNotificationProcessorTest {
     private static final Gson GSON = new GsonBuilder().create();
     private static final BlackDuckResponseResolver RESPONSE_RESOLVER = new BlackDuckResponseResolver(GSON);
 
@@ -62,16 +62,23 @@ public class JobNotificationProcessorTest {
     private final Long notificationId = 123L;
 
     @Test
-    public void processNotificationForJobTest() throws IntegrationException {
+    void processNotificationForJobTest() throws IntegrationException {
         // Set up dependencies for JobNotificationProcessor
         RuleViolationNotificationDetailExtractor ruleViolationNotificationDetailExtractor = new RuleViolationNotificationDetailExtractor();
-        NotificationDetailExtractionDelegator notificationDetailExtractionDelegator = new NotificationDetailExtractionDelegator(RESPONSE_RESOLVER, List.of(ruleViolationNotificationDetailExtractor));
+        NotificationDetailExtractionDelegator notificationDetailExtractionDelegator = new NotificationDetailExtractionDelegator(
+            RESPONSE_RESOLVER,
+            List.of(ruleViolationNotificationDetailExtractor)
+        );
 
         RuleViolationNotificationMessageExtractor ruleViolationNotificationMessageExtractor = createRuleViolationNotificationMessageExtractor();
         ProviderMessageExtractionDelegator providerMessageExtractionDelegator = new ProviderMessageExtractionDelegator(List.of(ruleViolationNotificationMessageExtractor));
         ProjectMessageDigester projectMessageDigester = new ProjectMessageDigester();
         ProjectMessageSummarizer projectMessageSummarizer = new ProjectMessageSummarizer();
-        NotificationContentProcessor notificationContentProcessor = new NotificationContentProcessor(providerMessageExtractionDelegator, projectMessageDigester, projectMessageSummarizer);
+        NotificationContentProcessor notificationContentProcessor = new NotificationContentProcessor(
+            providerMessageExtractionDelegator,
+            projectMessageDigester,
+            projectMessageSummarizer
+        );
 
         MockProcessingAuditAccessor processingAuditAccessor = new MockProcessingAuditAccessor();
         EventManager eventManager = Mockito.mock(EventManager.class);

--- a/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/NotificationContentProcessorTest.java
+++ b/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/NotificationContentProcessorTest.java
@@ -44,7 +44,7 @@ import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.rest.HttpUrl;
 
-public class NotificationContentProcessorTest {
+class NotificationContentProcessorTest {
     private static final Gson GSON = new GsonBuilder().create();
 
     private static final ProviderDetails PROVIDER_DETAILS = new ProviderDetails(15L, new LinkableItem("Black Duck", "bd-server", "https://bd-server"));
@@ -66,43 +66,77 @@ public class NotificationContentProcessorTest {
     }
 
     @Test
-    public void processNotificationContentDefaultTest() {
+    void processNotificationContentDefaultTest() {
         //Create a NotificationContentWrapper
         AlertNotificationModel notificationModel = createNotification(NotificationType.RULE_VIOLATION.name());
 
-        RuleViolationUniquePolicyNotificationContent notificationContent = blackDuckResponseTestUtility.createRuleViolationUniquePolicyNotificationContent(projectName, projectVersionName);
+        RuleViolationUniquePolicyNotificationContent notificationContent = blackDuckResponseTestUtility.createRuleViolationUniquePolicyNotificationContent(
+            projectName,
+            projectVersionName
+        );
 
-        NotificationContentWrapper notificationContentWrapper = new NotificationContentWrapper(notificationModel, notificationContent, RuleViolationUniquePolicyNotificationContent.class);
+        NotificationContentWrapper notificationContentWrapper = new NotificationContentWrapper(
+            notificationModel,
+            notificationContent,
+            RuleViolationUniquePolicyNotificationContent.class
+        );
 
         //Run the test
-        ProcessedProviderMessageHolder processedProviderMessageHolder = notificationContentProcessor.processNotificationContent(ProcessingType.DEFAULT, List.of(notificationContentWrapper));
+        ProcessedProviderMessageHolder processedProviderMessageHolder = notificationContentProcessor.processNotificationContent(
+            ProcessingType.DEFAULT,
+            List.of(notificationContentWrapper)
+        );
         runProjectMessageAssertions(processedProviderMessageHolder, projectName, projectVersionName);
     }
 
     @Test
-    public void processNotificationContentDigestTest() {
+    void processNotificationContentDigestTest() {
         AlertNotificationModel notificationModel = createNotification(NotificationType.RULE_VIOLATION.name());
 
-        RuleViolationUniquePolicyNotificationContent notificationContent = blackDuckResponseTestUtility.createRuleViolationUniquePolicyNotificationContent(projectName, projectVersionName);
+        RuleViolationUniquePolicyNotificationContent notificationContent = blackDuckResponseTestUtility.createRuleViolationUniquePolicyNotificationContent(
+            projectName,
+            projectVersionName
+        );
 
-        NotificationContentWrapper notificationContentWrapper1 = new NotificationContentWrapper(notificationModel, notificationContent, RuleViolationUniquePolicyNotificationContent.class);
-        NotificationContentWrapper notificationContentWrapper2 = new NotificationContentWrapper(notificationModel, notificationContent, RuleViolationUniquePolicyNotificationContent.class);
+        NotificationContentWrapper notificationContentWrapper1 = new NotificationContentWrapper(
+            notificationModel,
+            notificationContent,
+            RuleViolationUniquePolicyNotificationContent.class
+        );
+        NotificationContentWrapper notificationContentWrapper2 = new NotificationContentWrapper(
+            notificationModel,
+            notificationContent,
+            RuleViolationUniquePolicyNotificationContent.class
+        );
 
-        //When set to digest, the NotificationContentProcessor will combine duplicate duplicate messages created from the two NotificationContentWrappers to a single message
-        ProcessedProviderMessageHolder processedProviderMessageHolder = notificationContentProcessor.processNotificationContent(ProcessingType.DIGEST, List.of(notificationContentWrapper1, notificationContentWrapper2));
+        //When set to digest, the NotificationContentProcessor will combine duplicate messages created from the two NotificationContentWrappers to a single message
+        ProcessedProviderMessageHolder processedProviderMessageHolder = notificationContentProcessor.processNotificationContent(
+            ProcessingType.DIGEST,
+            List.of(notificationContentWrapper1, notificationContentWrapper2)
+        );
         runProjectMessageAssertions(processedProviderMessageHolder, projectName, projectVersionName);
     }
 
     @Test
-    public void processNotificationContentSummaryTest() {
+    void processNotificationContentSummaryTest() {
         AlertNotificationModel notificationModel = createNotification(NotificationType.RULE_VIOLATION.name());
 
-        RuleViolationUniquePolicyNotificationContent notificationContent = blackDuckResponseTestUtility.createRuleViolationUniquePolicyNotificationContent(projectName, projectVersionName);
+        RuleViolationUniquePolicyNotificationContent notificationContent = blackDuckResponseTestUtility.createRuleViolationUniquePolicyNotificationContent(
+            projectName,
+            projectVersionName
+        );
 
-        NotificationContentWrapper notificationContentWrapper1 = new NotificationContentWrapper(notificationModel, notificationContent, RuleViolationUniquePolicyNotificationContent.class);
+        NotificationContentWrapper notificationContentWrapper1 = new NotificationContentWrapper(
+            notificationModel,
+            notificationContent,
+            RuleViolationUniquePolicyNotificationContent.class
+        );
 
         //When set to summary, project messages will be summarized into a SimpleMessage rather than ProjectMessage
-        ProcessedProviderMessageHolder processedProviderMessageHolder = notificationContentProcessor.processNotificationContent(ProcessingType.SUMMARY, List.of(notificationContentWrapper1));
+        ProcessedProviderMessageHolder processedProviderMessageHolder = notificationContentProcessor.processNotificationContent(
+            ProcessingType.SUMMARY,
+            List.of(notificationContentWrapper1)
+        );
         List<ProcessedProviderMessage<ProjectMessage>> processedProviderMessages = processedProviderMessageHolder.getProcessedProjectMessages();
         List<ProcessedProviderMessage<SimpleMessage>> processedSimpleMessages = processedProviderMessageHolder.getProcessedSimpleMessages();
 

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalConfigurationActionTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailGlobalConfigurationActionTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -63,7 +62,7 @@ class EmailGlobalConfigurationActionTest {
         model.setSmtpAuth(true);
         model.setSmtpUsername("user");
         model.setSmtpPassword("password");
-        Mockito.when(emailGlobalConfigAccessor.createConfiguration(Mockito.eq(model))).thenReturn(model);
+        Mockito.when(emailGlobalConfigAccessor.createConfiguration(model)).thenReturn(model);
 
         EmailGlobalCrudActions configActions = new EmailGlobalCrudActions(authorizationManager, emailGlobalConfigAccessor, validator);
         ActionResponse<EmailGlobalConfigModel> response = configActions.create(model);
@@ -87,7 +86,7 @@ class EmailGlobalConfigurationActionTest {
         model.setSmtpUsername("user");
         model.setSmtpPassword("password");
         Mockito.when(emailGlobalConfigAccessor.getConfiguration()).thenReturn(Optional.of(model));
-        Mockito.when(emailGlobalConfigAccessor.updateConfiguration(Mockito.eq(model))).thenReturn(model);
+        Mockito.when(emailGlobalConfigAccessor.updateConfiguration(model)).thenReturn(model);
         Mockito.when(emailGlobalConfigAccessor.doesConfigurationExist()).thenReturn(true);
 
         EmailGlobalCrudActions configActions = new EmailGlobalCrudActions(authorizationManager, emailGlobalConfigAccessor, validator);
@@ -163,7 +162,6 @@ class EmailGlobalConfigurationActionTest {
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.NO_PERMISSIONS);
         AuthorizationManager authorizationManager = authenticationTestUtils
             .createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
-        UUID configId = UUID.randomUUID();
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
         EmailGlobalConfigModel model = new EmailGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, "from", "host");
@@ -184,7 +182,6 @@ class EmailGlobalConfigurationActionTest {
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.FULL_PERMISSIONS);
         AuthorizationManager authorizationManager = authenticationTestUtils
             .createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
-        UUID configId = UUID.randomUUID();
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
         Mockito.when(emailGlobalConfigAccessor.getConfiguration()).thenReturn(Optional.empty());
@@ -207,7 +204,6 @@ class EmailGlobalConfigurationActionTest {
         Map<PermissionKey, Integer> permissions = Map.of(permissionKey, AuthenticationTestUtils.NO_PERMISSIONS);
         AuthorizationManager authorizationManager = authenticationTestUtils
             .createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
-        UUID configId = UUID.randomUUID();
         EmailGlobalConfigurationValidator validator = new EmailGlobalConfigurationValidator();
         EmailGlobalConfigAccessor emailGlobalConfigAccessor = Mockito.mock(EmailGlobalConfigAccessor.class);
 

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/database/accessor/EmailJobDetailsAccessorTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/database/accessor/EmailJobDetailsAccessorTest.java
@@ -83,7 +83,6 @@ class EmailJobDetailsAccessorTest {
         UUID jobId = UUID.randomUUID();
         String additionalEmailAddress = "fake@synopsys.com";
 
-        EmailJobDetailsEntity emailJobDetailsEntity = new EmailJobDetailsEntity(jobId, null, false, false, null);
         EmailJobAdditionalEmailAddressEntity emailJobAdditionalEmailAddressEntity = new EmailJobAdditionalEmailAddressEntity(jobId, additionalEmailAddress);
 
         Mockito.when(emailJobDetailsRepository.findById(Mockito.any())).thenReturn(Optional.empty());
@@ -99,7 +98,7 @@ class EmailJobDetailsAccessorTest {
 
         EmailJobAdditionalEmailAddressEntity emailJobAdditionalEmailAddressEntity = new EmailJobAdditionalEmailAddressEntity(jobId, additionalEmailAddress);
 
-        Mockito.when(additionalEmailAddressRepository.findByJobId(Mockito.eq(jobId))).thenReturn(List.of(emailJobAdditionalEmailAddressEntity));
+        Mockito.when(additionalEmailAddressRepository.findByJobId(jobId)).thenReturn(List.of(emailJobAdditionalEmailAddressEntity));
 
         List<String> newEmailAddresses = emailJobDetailsAccessor.retrieveAdditionalEmailAddressesForJob(jobId);
 

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/database/accessor/JiraServerGlobalConfigAccessorTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/database/accessor/JiraServerGlobalConfigAccessorTest.java
@@ -32,9 +32,9 @@ import com.synopsys.integration.alert.common.util.DateUtils;
 import com.synopsys.integration.alert.test.common.MockAlertProperties;
 
 class JiraServerGlobalConfigAccessorTest {
-    public static final String TEST_URL = "url";
-    public static final String TEST_USERNAME = "username";
-    public static final String TEST_PASSWORD = "password";
+    static final String TEST_URL = "url";
+    static final String TEST_USERNAME = "username";
+    static final String TEST_PASSWORD = "password";
     private final Gson gson = new Gson();
     private final AlertProperties alertProperties = new MockAlertProperties();
     private final FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, gson);
@@ -199,7 +199,6 @@ class JiraServerGlobalConfigAccessorTest {
 
     @Test
     void getPageEmptyTest() {
-        UUID id = UUID.randomUUID();
         Page<JiraServerConfigurationEntity> jiraConfigurations = new PageImpl<>(List.of());
         Mockito.when(jiraServerConfigurationRepository.findAll(Mockito.any(PageRequest.class))).thenReturn(jiraConfigurations);
         AlertPagedModel<JiraServerGlobalConfigModel> pagedModel = jiraServerGlobalConfigAccessor.getConfigurationPage(0, 10, null, null, null);
@@ -314,8 +313,6 @@ class JiraServerGlobalConfigAccessorTest {
     @Test
     void updateConfigurationNotFoundTest() {
         UUID id = UUID.randomUUID();
-        String updatedName = "updatedName";
-        String newUrl = "https://updated.example.com";
         JiraServerConfigurationEntity entity = createEntity(id, OffsetDateTime.now(), OffsetDateTime.now());
 
         JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(

--- a/component/src/test/java/com/synopsys/integration/alert/component/authentication/security/saml/SamlManagerTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/authentication/security/saml/SamlManagerTest.java
@@ -23,7 +23,7 @@ import com.synopsys.integration.alert.common.persistence.model.ConfigurationMode
 import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
 import com.synopsys.integration.alert.component.authentication.descriptor.AuthenticationDescriptor;
 
-public class SamlManagerTest {
+class SamlManagerTest {
     private Gson gson;
     private SAMLContext context;
     private ParserPool parserPool;
@@ -50,7 +50,7 @@ public class SamlManagerTest {
     }
 
     @Test
-    public void testInitializeEntityIDInvalid() throws Exception {
+    void testInitializeEntityIDInvalid() throws Exception {
         Mockito.when(context.getCurrentConfiguration()).thenReturn(currentConfiguration);
         Mockito.when(context.isSAMLEnabled(Mockito.any(ConfigurationModel.class))).thenReturn(Boolean.TRUE.booleanValue());
         Mockito.when(context.getFieldValueOrEmpty(Mockito.any(ConfigurationModel.class), Mockito.eq(AuthenticationDescriptor.KEY_SAML_METADATA_URL))).thenReturn("metadataURL");
@@ -64,7 +64,7 @@ public class SamlManagerTest {
     }
 
     @Test
-    public void testInitializeHttpProviderInvalid() throws Exception {
+    void testInitializeHttpProviderInvalid() throws Exception {
         Mockito.when(context.getCurrentConfiguration()).thenReturn(currentConfiguration);
         Mockito.when(context.isSAMLEnabled(Mockito.any(ConfigurationModel.class))).thenReturn(Boolean.TRUE.booleanValue());
         Mockito.when(context.getFieldValueOrEmpty(Mockito.any(ConfigurationModel.class), Mockito.eq(AuthenticationDescriptor.KEY_SAML_METADATA_URL))).thenReturn("metadataURL");
@@ -78,7 +78,7 @@ public class SamlManagerTest {
     }
 
     @Test
-    public void testInitializeFileProviderInvalid() throws Exception {
+    void testInitializeFileProviderInvalid() throws Exception {
         Mockito.when(context.getCurrentConfiguration()).thenReturn(currentConfiguration);
         Mockito.when(context.isSAMLEnabled(Mockito.any(ConfigurationModel.class))).thenReturn(Boolean.TRUE.booleanValue());
 
@@ -88,7 +88,7 @@ public class SamlManagerTest {
     }
 
     @Test
-    public void testInitializeNoProvidersDisable() throws Exception {
+    void testInitializeNoProvidersDisable() throws Exception {
         Mockito.when(context.getCurrentConfiguration()).thenReturn(currentConfiguration);
         Mockito.when(context.isSAMLEnabled(Mockito.any(ConfigurationModel.class))).thenReturn(Boolean.TRUE.booleanValue());
 
@@ -98,7 +98,7 @@ public class SamlManagerTest {
     }
 
     @Test
-    public void testUpdateSamlDisabled() throws Exception {
+    void testUpdateSamlDisabled() throws Exception {
         Mockito.when(context.getCurrentConfiguration()).thenReturn(currentConfiguration);
         Mockito.when(context.isSAMLEnabled(Mockito.any(ConfigurationModel.class))).thenReturn(Boolean.FALSE.booleanValue());
 
@@ -111,7 +111,7 @@ public class SamlManagerTest {
     }
 
     @Test
-    public void testUpdateSamlEnabled() throws Exception {
+    void testUpdateSamlEnabled() throws Exception {
         Mockito.when(context.getCurrentConfiguration()).thenReturn(currentConfiguration);
         Mockito.when(context.isSAMLEnabled(Mockito.any(ConfigurationModel.class))).thenReturn(Boolean.TRUE.booleanValue());
         Mockito.when(context.getFieldValueOrEmpty(Mockito.any(ConfigurationModel.class), Mockito.eq(AuthenticationDescriptor.KEY_SAML_METADATA_URL))).thenReturn("metadataURL");

--- a/component/src/test/java/com/synopsys/integration/alert/component/authentication/security/saml/UserDetailsServiceTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/authentication/security/saml/UserDetailsServiceTest.java
@@ -29,7 +29,7 @@ import com.synopsys.integration.alert.common.security.UserPrincipal;
 import com.synopsys.integration.alert.component.authentication.descriptor.AuthenticationDescriptorKey;
 import com.synopsys.integration.alert.component.authentication.security.UserManagementAuthoritiesPopulator;
 
-public class UserDetailsServiceTest {
+class UserDetailsServiceTest {
 
     private static final String USER_NAME = "user_name";
     private static final String EMAIL = "email_address";
@@ -48,13 +48,13 @@ public class UserDetailsServiceTest {
         ConfigurationModel configuration = Mockito.mock(ConfigurationModel.class);
         UserAccessor userAccessor = Mockito.mock(UserAccessor.class);
         Mockito.when(configuration.getField(Mockito.anyString())).thenReturn(Optional.empty());
-        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKey(Mockito.eq(key))).thenReturn(List.of(configuration));
+        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKey(key)).thenReturn(List.of(configuration));
         Mockito.when(userAccessor.getUser(Mockito.anyString())).thenReturn(Optional.of(userModel));
         authoritiesPopulator = new UserManagementAuthoritiesPopulator(key, configurationModelConfigurationAccessor, userAccessor);
     }
 
     @Test
-    public void testValidCredential() {
+    void testValidCredential() {
         SAMLCredential credential = Mockito.mock(SAMLCredential.class);
 
         NameID nameId = Mockito.mock(NameID.class);
@@ -80,7 +80,7 @@ public class UserDetailsServiceTest {
     }
 
     @Test
-    public void testNullRoleArray() {
+    void testNullRoleArray() {
         SAMLCredential credential = Mockito.mock(SAMLCredential.class);
 
         NameID nameId = Mockito.mock(NameID.class);
@@ -105,7 +105,7 @@ public class UserDetailsServiceTest {
     }
 
     @Test
-    public void testEmptyRoleArray() {
+    void testEmptyRoleArray() {
         SAMLCredential credential = Mockito.mock(SAMLCredential.class);
         String[] roles = new String[0];
         NameID nameId = Mockito.mock(NameID.class);

--- a/component/src/test/java/com/synopsys/integration/alert/component/settings/proxy/actions/SettingsProxyTestActionTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/settings/proxy/actions/SettingsProxyTestActionTest.java
@@ -157,7 +157,7 @@ class SettingsProxyTestActionTest {
     void passwordAlreadySavedTest() {
         ConfigurationTestResult configurationTestResult = ConfigurationTestResult.success();
         ProxyTestService proxyTestService = Mockito.mock(ProxyTestService.class);
-        Mockito.when(proxyTestService.pingHost(Mockito.eq(TEST_URL), Mockito.any())).thenReturn(configurationTestResult);
+        Mockito.when(proxyTestService.pingHost(Mockito.endsWith(TEST_URL), Mockito.any())).thenReturn(configurationTestResult);
 
         SettingsProxyModel settingsProxyModel = createDefaultSettingsProxyModel();
         settingsProxyModel.setProxyPassword(null);

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/action/BlackDuckGlobalApiActionTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/action/BlackDuckGlobalApiActionTest.java
@@ -29,14 +29,14 @@ import com.synopsys.integration.alert.provider.blackduck.task.BlackDuckDataSyncT
 import com.synopsys.integration.alert.provider.blackduck.task.accumulator.BlackDuckAccumulator;
 import com.synopsys.integration.function.ThrowingBiFunction;
 
-public class BlackDuckGlobalApiActionTest {
+class BlackDuckGlobalApiActionTest {
     @Test
-    public void afterSaveActionSuccessTest() throws AlertException {
+    void afterSaveActionSuccessTest() throws AlertException {
         runApiActionTest(BlackDuckGlobalApiAction::afterSaveAction);
     }
 
     @Test
-    public void afterUpdateActionSuccessTest() throws AlertException {
+    void afterUpdateActionSuccessTest() throws AlertException {
         runApiActionTest((blackDuckGlobalApiAction, fieldModel) -> blackDuckGlobalApiAction.afterUpdateAction(fieldModel, fieldModel));
     }
 
@@ -46,9 +46,9 @@ public class BlackDuckGlobalApiActionTest {
         Mockito.when(properties.isConfigEnabled()).thenReturn(true);
         FieldModel fieldModel = Mockito.mock(FieldModel.class);
         Mockito.when(fieldModel.getId()).thenReturn("1");
-        Mockito.when(fieldModel.getFieldValue(Mockito.eq(ProviderDescriptor.KEY_PROVIDER_CONFIG_ENABLED))).thenReturn(Optional.of("true"));
+        Mockito.when(fieldModel.getFieldValue(ProviderDescriptor.KEY_PROVIDER_CONFIG_ENABLED)).thenReturn(Optional.of("true"));
         String providerConfigName = "Test Provider Config";
-        Mockito.when(fieldModel.getFieldValue(Mockito.eq(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME))).thenReturn(Optional.of(providerConfigName));
+        Mockito.when(fieldModel.getFieldValue(ProviderDescriptor.KEY_PROVIDER_CONFIG_NAME)).thenReturn(Optional.of(providerConfigName));
 
         BlackDuckAccumulator blackDuckAccumulator = Mockito.mock(BlackDuckAccumulator.class);
         Mockito.when(blackDuckAccumulator.getTaskName()).thenReturn("accumulator-task");
@@ -68,7 +68,11 @@ public class BlackDuckGlobalApiActionTest {
 
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
         Mockito.when(configurationModelConfigurationAccessor.getProviderConfigurationByName(Mockito.anyString())).thenReturn(Optional.of(configurationModel));
-        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKeyAndContext(Mockito.any(BlackDuckProviderKey.class), Mockito.eq(ConfigContextEnum.DISTRIBUTION))).thenReturn(List.of());
+        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKeyAndContext(
+                Mockito.any(BlackDuckProviderKey.class),
+                Mockito.eq(ConfigContextEnum.DISTRIBUTION)
+            ))
+            .thenReturn(List.of());
 
         BlackDuckProviderKey blackDuckProviderKey = new BlackDuckProviderKey();
         StatefulProvider statefulProvider = Mockito.mock(StatefulProvider.class);

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/NotificationExtractorBlackDuckServicesFactoryCacheTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/NotificationExtractorBlackDuckServicesFactoryCacheTest.java
@@ -25,7 +25,7 @@ import com.synopsys.integration.alert.provider.blackduck.factory.BlackDuckProper
 import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
 import com.synopsys.integration.rest.proxy.ProxyInfo;
 
-public class NotificationExtractorBlackDuckServicesFactoryCacheTest {
+class NotificationExtractorBlackDuckServicesFactoryCacheTest {
     private final ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
     private final Gson gson = new Gson();
     private final AlertProperties properties = new AlertProperties();
@@ -42,9 +42,9 @@ public class NotificationExtractorBlackDuckServicesFactoryCacheTest {
     }
 
     @Test
-    public void retrieveBlackDuckServicesFactoryTest() throws AlertConfigurationException {
+    void retrieveBlackDuckServicesFactoryTest() throws AlertConfigurationException {
         ConfigurationModel configurationModel = createConfigurationModel();
-        Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.eq(blackDuckConfigId))).thenReturn(Optional.of(configurationModel));
+        Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(blackDuckConfigId)).thenReturn(Optional.of(configurationModel));
 
         ProxyInfo proxyInfo = ProxyInfo.NO_PROXY_INFO;
         Mockito.when(proxyManager.createProxyInfoForHost(Mockito.any())).thenReturn(proxyInfo);
@@ -57,9 +57,9 @@ public class NotificationExtractorBlackDuckServicesFactoryCacheTest {
     }
 
     @Test
-    public void cacheClearedTest() throws AlertConfigurationException {
+    void cacheClearedTest() throws AlertConfigurationException {
         ConfigurationModel configurationModel = createConfigurationModel();
-        Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.eq(blackDuckConfigId))).thenReturn(Optional.of(configurationModel));
+        Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(blackDuckConfigId)).thenReturn(Optional.of(configurationModel));
 
         ProxyInfo proxyInfo = ProxyInfo.NO_PROXY_INFO;
         Mockito.when(proxyManager.createProxyInfoForHost(Mockito.any())).thenReturn(proxyInfo);
@@ -72,7 +72,7 @@ public class NotificationExtractorBlackDuckServicesFactoryCacheTest {
     }
 
     @Test
-    public void missingConfigurationTest() {
+    void missingConfigurationTest() {
         try {
             cache.retrieveBlackDuckServicesFactory(blackDuckConfigId);
             fail("Expected AlertConfigurationException to be thrown due to missing optionalProperties.");
@@ -82,9 +82,9 @@ public class NotificationExtractorBlackDuckServicesFactoryCacheTest {
     }
 
     @Test
-    public void invalidConfigurationTest() {
+    void invalidConfigurationTest() {
         ConfigurationModel configurationModel = new ConfigurationModel(1L, 2L, "createdAt", "lastUpdated", ConfigContextEnum.GLOBAL, Map.of());
-        Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.eq(blackDuckConfigId))).thenReturn(Optional.of(configurationModel));
+        Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(blackDuckConfigId)).thenReturn(Optional.of(configurationModel));
 
         try {
             cache.retrieveBlackDuckServicesFactory(blackDuckConfigId);

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/BomEditNotificationDetailExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/detail/BomEditNotificationDetailExtractorTest.java
@@ -24,13 +24,13 @@ import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.rest.HttpUrl;
 
-public class BomEditNotificationDetailExtractorTest {
-    public static final String BOM_EDIT_JSON_PATH = "json/bomEditNotification.json";
+class BomEditNotificationDetailExtractorTest {
+    static final String BOM_EDIT_JSON_PATH = "json/bomEditNotification.json";
 
     private final Gson gson = new Gson();
 
     @Test
-    public void extractDetailedContentTest() throws IOException, IntegrationException {
+    void extractDetailedContentTest() throws IOException, IntegrationException {
         String projectName = "project-name";
         String projectVersionName = "project-version-name";
         Long blackDuckConfigId = 0L;
@@ -57,14 +57,15 @@ public class BomEditNotificationDetailExtractorTest {
     }
 
     @Test
-    public void extractDetailedContentErrorTest() throws IOException, IntegrationException {
+    void extractDetailedContentErrorTest() throws IOException, IntegrationException {
         Long blackDuckConfigId = 0L;
 
         String notificationString = TestResourceUtils.readFileToString(BOM_EDIT_JSON_PATH);
         BomEditNotificationView notificationView = gson.fromJson(notificationString, BomEditNotificationView.class);
 
         NotificationExtractorBlackDuckServicesFactoryCache cache = Mockito.mock(NotificationExtractorBlackDuckServicesFactoryCache.class);
-        Mockito.doThrow(new AlertConfigurationException("Expected Exception thrown creating BlackDuckServicesFactory")).when(cache).retrieveBlackDuckServicesFactory(Mockito.anyLong());
+        Mockito.doThrow(new AlertConfigurationException("Expected Exception thrown creating BlackDuckServicesFactory")).when(cache)
+            .retrieveBlackDuckServicesFactory(Mockito.anyLong());
 
         BomEditNotificationDetailExtractor extractor = new BomEditNotificationDetailExtractor(cache);
 
@@ -84,13 +85,13 @@ public class BomEditNotificationDetailExtractorTest {
 
         BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
         Mockito.when(blackDuckApiClient.getResponse(Mockito.any(HttpUrl.class), Mockito.eq(ProjectVersionView.class))).thenReturn(projectVersionView);
-        Mockito.when(blackDuckApiClient.getResponse(Mockito.eq(projectVersionView.metaProjectLink()))).thenReturn(projectView);
+        Mockito.when(blackDuckApiClient.getResponse(projectVersionView.metaProjectLink())).thenReturn(projectView);
 
         BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
         Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
 
         NotificationExtractorBlackDuckServicesFactoryCache cache = Mockito.mock(NotificationExtractorBlackDuckServicesFactoryCache.class);
-        Mockito.when(cache.retrieveBlackDuckServicesFactory(Mockito.eq(blackDuckConfigId))).thenReturn(blackDuckServicesFactory);
+        Mockito.when(cache.retrieveBlackDuckServicesFactory(blackDuckConfigId)).thenReturn(blackDuckServicesFactory);
 
         return cache;
     }

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/PolicyOverrideNotificationMessageExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/PolicyOverrideNotificationMessageExtractorTest.java
@@ -43,7 +43,7 @@ import com.synopsys.integration.rest.HttpMethod;
 import com.synopsys.integration.rest.HttpUrl;
 import com.synopsys.integration.rest.exception.IntegrationRestException;
 
-public class PolicyOverrideNotificationMessageExtractorTest {
+class PolicyOverrideNotificationMessageExtractorTest {
     private static final LinkableItem COMPONENT = new LinkableItem("Component", "A BOM component");
     private static final LinkableItem COMPONENT_VERSION = new LinkableItem("Component Version", "0.8.7");
     private static final String COMPONENT_VERSION_URL = "http://componentVersionUrl";
@@ -76,7 +76,7 @@ public class PolicyOverrideNotificationMessageExtractorTest {
     }
 
     @Test
-    public void createBomComponentDetailsTest() throws IntegrationException {
+    void createBomComponentDetailsTest() throws IntegrationException {
         BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
         BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
         Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
@@ -91,7 +91,7 @@ public class PolicyOverrideNotificationMessageExtractorTest {
         componentPolicyRulesView.setName(COMPONENT_POLICY.getPolicyName());
         componentPolicyRulesView.setSeverity(PolicyRuleSeverityType.BLOCKER);
         componentPolicyRulesView.setPolicyApprovalStatus(ProjectVersionComponentPolicyStatusType.IN_VIOLATION_OVERRIDDEN);
-        Mockito.when(blackDuckApiClient.getAllResponses(Mockito.eq(projectVersionComponentVersionView.metaPolicyRulesLink()))).thenReturn(List.of(componentPolicyRulesView));
+        Mockito.when(blackDuckApiClient.getAllResponses(projectVersionComponentVersionView.metaPolicyRulesLink())).thenReturn(List.of(componentPolicyRulesView));
 
         PolicyRuleView policyRuleView = new PolicyRuleView();
         policyRuleView.setCategory(PolicyRuleCategoryType.UNCATEGORIZED);
@@ -120,12 +120,19 @@ public class PolicyOverrideNotificationMessageExtractorTest {
     }
 
     @Test
-    public void createBomComponentDetailsMissingBomComponentTest() throws IntegrationException {
+    void createBomComponentDetailsMissingBomComponentTest() throws IntegrationException {
         BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
         BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
         Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
 
-        Mockito.doThrow(new IntegrationRestException(HttpMethod.GET, new HttpUrl("https://google.com"), HttpStatus.NOT_FOUND.value(), "httpStatusMessageTest", "httpResponseContentTest", "IntegrationRestExceptionForAlertTest"))
+        Mockito.doThrow(new IntegrationRestException(
+                HttpMethod.GET,
+                new HttpUrl("https://google.com"),
+                HttpStatus.NOT_FOUND.value(),
+                "httpStatusMessageTest",
+                "httpResponseContentTest",
+                "IntegrationRestExceptionForAlertTest"
+            ))
             .when(blackDuckApiClient).getResponse(Mockito.any(), Mockito.any());
 
         List<BomComponentDetails> bomComponentDetailsList = extractor.createBomComponentDetails(policyOverrideUniquePolicyNotificationContent, blackDuckServicesFactory);

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/RuleViolationClearedNotificationMessageExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/RuleViolationClearedNotificationMessageExtractorTest.java
@@ -45,7 +45,7 @@ import com.synopsys.integration.rest.HttpMethod;
 import com.synopsys.integration.rest.HttpUrl;
 import com.synopsys.integration.rest.exception.IntegrationRestException;
 
-public class RuleViolationClearedNotificationMessageExtractorTest {
+class RuleViolationClearedNotificationMessageExtractorTest {
     private static String PROJECT = "ProjectName";
     private static String PROJECT_VERSION = "ProjectVersionName";
     private static String PROJECT_VERSION_URL = "http://projectVersionUrl";
@@ -80,7 +80,7 @@ public class RuleViolationClearedNotificationMessageExtractorTest {
     }
 
     @Test
-    public void createBomComponentDetailsTest() throws IntegrationException {
+    void createBomComponentDetailsTest() throws IntegrationException {
         BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
         BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
         Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
@@ -95,7 +95,7 @@ public class RuleViolationClearedNotificationMessageExtractorTest {
         componentPolicyRulesView.setName(COMPONENT_POLICY.getPolicyName());
         componentPolicyRulesView.setSeverity(PolicyRuleSeverityType.BLOCKER);
         componentPolicyRulesView.setPolicyApprovalStatus(ProjectVersionComponentPolicyStatusType.IN_VIOLATION_OVERRIDDEN);
-        Mockito.when(blackDuckApiClient.getAllResponses(Mockito.eq(projectVersionComponentVersionView.metaPolicyRulesLink()))).thenReturn(List.of(componentPolicyRulesView));
+        Mockito.when(blackDuckApiClient.getAllResponses(projectVersionComponentVersionView.metaPolicyRulesLink())).thenReturn(List.of(componentPolicyRulesView));
 
         PolicyRuleView policyRuleView = new PolicyRuleView();
         policyRuleView.setCategory(PolicyRuleCategoryType.UNCATEGORIZED);
@@ -129,16 +129,28 @@ public class RuleViolationClearedNotificationMessageExtractorTest {
     }
 
     @Test
-    public void createBomComponentDetailsMissingBomComponentTest() throws IntegrationException {
+    void createBomComponentDetailsMissingBomComponentTest() throws IntegrationException {
         BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
         BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
         Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
 
-        Mockito.doThrow(new IntegrationRestException(HttpMethod.GET, new HttpUrl("https://google.com"), HttpStatus.NOT_FOUND.value(), "httpStatusMessageTest", "httpResponseContentTest", "IntegrationRestExceptionForAlertTest"))
+        Mockito.doThrow(new IntegrationRestException(
+                HttpMethod.GET,
+                new HttpUrl("https://google.com"),
+                HttpStatus.NOT_FOUND.value(),
+                "httpStatusMessageTest",
+                "httpResponseContentTest",
+                "IntegrationRestExceptionForAlertTest"
+            ))
             .when(blackDuckApiClient).getResponse(Mockito.any(), Mockito.any());
 
-        RuleViolationClearedUniquePolicyNotificationContent notificationContent = new RuleViolationClearedUniquePolicyNotificationContent(PROJECT, PROJECT_VERSION, PROJECT_VERSION_URL, COMPONENT_VERSIONS_CLEARED,
-            List.of(componentVersionStatus), policyInfo);
+        RuleViolationClearedUniquePolicyNotificationContent notificationContent = new RuleViolationClearedUniquePolicyNotificationContent(PROJECT,
+            PROJECT_VERSION,
+            PROJECT_VERSION_URL,
+            COMPONENT_VERSIONS_CLEARED,
+            List.of(componentVersionStatus),
+            policyInfo
+        );
 
         List<BomComponentDetails> bomComponentDetailsList = extractor.createBomComponentDetails(notificationContent, blackDuckServicesFactory);
 

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/RuleViolationNotificationMessageExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/RuleViolationNotificationMessageExtractorTest.java
@@ -45,7 +45,7 @@ import com.synopsys.integration.rest.HttpMethod;
 import com.synopsys.integration.rest.HttpUrl;
 import com.synopsys.integration.rest.exception.IntegrationRestException;
 
-public class RuleViolationNotificationMessageExtractorTest {
+class RuleViolationNotificationMessageExtractorTest {
     private static String PROJECT = "ProjectName";
     private static String PROJECT_VERSION = "ProjectVersionName";
     private static String PROJECT_VERSION_URL = "http://projectVersionUrl";
@@ -80,7 +80,7 @@ public class RuleViolationNotificationMessageExtractorTest {
     }
 
     @Test
-    public void createBomComponentDetailsTest() throws IntegrationException {
+    void createBomComponentDetailsTest() throws IntegrationException {
         BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
         BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
         Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
@@ -95,7 +95,7 @@ public class RuleViolationNotificationMessageExtractorTest {
         componentPolicyRulesView.setName(COMPONENT_POLICY.getPolicyName());
         componentPolicyRulesView.setSeverity(PolicyRuleSeverityType.BLOCKER);
         componentPolicyRulesView.setPolicyApprovalStatus(ProjectVersionComponentPolicyStatusType.IN_VIOLATION_OVERRIDDEN);
-        Mockito.when(blackDuckApiClient.getAllResponses(Mockito.eq(projectVersionComponentVersionView.metaPolicyRulesLink()))).thenReturn(List.of(componentPolicyRulesView));
+        Mockito.when(blackDuckApiClient.getAllResponses(projectVersionComponentVersionView.metaPolicyRulesLink())).thenReturn(List.of(componentPolicyRulesView));
 
         PolicyRuleView policyRuleView = new PolicyRuleView();
         policyRuleView.setCategory(PolicyRuleCategoryType.UNCATEGORIZED);
@@ -129,16 +129,28 @@ public class RuleViolationNotificationMessageExtractorTest {
     }
 
     @Test
-    public void createBomComponentDetailsMissingBomComponentTest() throws IntegrationException {
+    void createBomComponentDetailsMissingBomComponentTest() throws IntegrationException {
         BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
         BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
         Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
 
-        Mockito.doThrow(new IntegrationRestException(HttpMethod.GET, new HttpUrl("https://google.com"), HttpStatus.NOT_FOUND.value(), "httpStatusMessageTest", "httpResponseContentTest", "IntegrationRestExceptionForAlertTest"))
+        Mockito.doThrow(new IntegrationRestException(
+                HttpMethod.GET,
+                new HttpUrl("https://google.com"),
+                HttpStatus.NOT_FOUND.value(),
+                "httpStatusMessageTest",
+                "httpResponseContentTest",
+                "IntegrationRestExceptionForAlertTest"
+            ))
             .when(blackDuckApiClient).getResponse(Mockito.any(), Mockito.any());
 
-        RuleViolationUniquePolicyNotificationContent notificationContent = new RuleViolationUniquePolicyNotificationContent(PROJECT, PROJECT_VERSION, PROJECT_VERSION_URL, COMPONENT_VERSIONS_IN_VIOLATION,
-            List.of(componentVersionStatus), policyInfo);
+        RuleViolationUniquePolicyNotificationContent notificationContent = new RuleViolationUniquePolicyNotificationContent(PROJECT,
+            PROJECT_VERSION,
+            PROJECT_VERSION_URL,
+            COMPONENT_VERSIONS_IN_VIOLATION,
+            List.of(componentVersionStatus),
+            policyInfo
+        );
 
         List<BomComponentDetails> bomComponentDetailsList = extractor.createBomComponentDetails(notificationContent, blackDuckServicesFactory);
 

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/VulnerabilityNotificationMessageExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/VulnerabilityNotificationMessageExtractorTest.java
@@ -52,7 +52,7 @@ import com.synopsys.integration.rest.HttpMethod;
 import com.synopsys.integration.rest.HttpUrl;
 import com.synopsys.integration.rest.exception.IntegrationRestException;
 
-public class VulnerabilityNotificationMessageExtractorTest {
+class VulnerabilityNotificationMessageExtractorTest {
     private static String PROJECT = "ProjectName";
     private static String PROJECT_VERSION = "ProjectVersionName";
     private static String PROJECT_VERSION_URL = "http://projectVersionUrl";
@@ -82,7 +82,7 @@ public class VulnerabilityNotificationMessageExtractorTest {
     }
 
     @Test
-    public void createBomComponentDetailsTest() throws IntegrationException {
+    void createBomComponentDetailsTest() throws IntegrationException {
         BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
         BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
         Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
@@ -92,8 +92,11 @@ public class VulnerabilityNotificationMessageExtractorTest {
 
         ComponentVersionUpgradeGuidanceView componentVersionUpgradeGuidanceView = createComponentVersionUpgradeGuidanceView();
         // A UrlSingleResponse is needed to Mock the blackDuckApiClient in BlackDuckMessageComponentVersionUpgradeGuidanceService::requestUpgradeGuidanceItems
-        UrlSingleResponse<ComponentVersionUpgradeGuidanceView> urlSingleResponse = new UrlSingleResponse<>(new HttpUrl(UPGRADE_GUIDANCE_URL), ComponentVersionUpgradeGuidanceView.class);
-        Mockito.when(blackDuckApiClient.getResponse(Mockito.eq(urlSingleResponse))).thenReturn(componentVersionUpgradeGuidanceView);
+        UrlSingleResponse<ComponentVersionUpgradeGuidanceView> urlSingleResponse = new UrlSingleResponse<>(
+            new HttpUrl(UPGRADE_GUIDANCE_URL),
+            ComponentVersionUpgradeGuidanceView.class
+        );
+        Mockito.when(blackDuckApiClient.getResponse(urlSingleResponse)).thenReturn(componentVersionUpgradeGuidanceView);
 
         VulnerabilityUniqueProjectNotificationContent notificationContent = createVulnerabilityUniqueProjectNotificationContent();
         List<BomComponentDetails> bomComponentDetailsList = extractor.createBomComponentDetails(notificationContent, blackDuckServicesFactory);
@@ -117,7 +120,7 @@ public class VulnerabilityNotificationMessageExtractorTest {
     }
 
     @Test
-    public void createBomComponentDetailsMissingOriginTest() throws IntegrationException {
+    void createBomComponentDetailsMissingOriginTest() throws IntegrationException {
         BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
         BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
         Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
@@ -127,8 +130,11 @@ public class VulnerabilityNotificationMessageExtractorTest {
 
         ComponentVersionUpgradeGuidanceView componentVersionUpgradeGuidanceView = createComponentVersionUpgradeGuidanceView();
         // A UrlSingleResponse is needed to Mock the blackDuckApiClient in BlackDuckMessageComponentVersionUpgradeGuidanceService::requestUpgradeGuidanceItems
-        UrlSingleResponse<ComponentVersionUpgradeGuidanceView> urlSingleResponse = new UrlSingleResponse<>(new HttpUrl(UPGRADE_GUIDANCE_URL), ComponentVersionUpgradeGuidanceView.class);
-        Mockito.when(blackDuckApiClient.getResponse(Mockito.eq(urlSingleResponse))).thenReturn(componentVersionUpgradeGuidanceView);
+        UrlSingleResponse<ComponentVersionUpgradeGuidanceView> urlSingleResponse = new UrlSingleResponse<>(
+            new HttpUrl(UPGRADE_GUIDANCE_URL),
+            ComponentVersionUpgradeGuidanceView.class
+        );
+        Mockito.when(blackDuckApiClient.getResponse(urlSingleResponse)).thenReturn(componentVersionUpgradeGuidanceView);
 
         VulnerabilityUniqueProjectNotificationContent notificationContent = createVulnerabilityUniqueProjectNotificationContent();
         List<BomComponentDetails> bomComponentDetailsList = extractor.createBomComponentDetails(notificationContent, blackDuckServicesFactory);
@@ -151,19 +157,26 @@ public class VulnerabilityNotificationMessageExtractorTest {
     }
 
     @Test
-    public void createBomComponentDetailsMissingBomComponentTest() throws IntegrationException {
+    void createBomComponentDetailsMissingBomComponentTest() throws IntegrationException {
         BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
         BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
         Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
 
-        Mockito.doThrow(new IntegrationRestException(HttpMethod.GET, new HttpUrl("https://google.com"), HttpStatus.NOT_FOUND.value(), "httpStatusMessageTest", "httpResponseContentTest", "IntegrationRestExceptionForAlertTest"))
+        Mockito.doThrow(new IntegrationRestException(
+                HttpMethod.GET,
+                new HttpUrl("https://google.com"),
+                HttpStatus.NOT_FOUND.value(),
+                "httpStatusMessageTest",
+                "httpResponseContentTest",
+                "IntegrationRestExceptionForAlertTest"
+            ))
             .when(blackDuckApiClient).getResponse(Mockito.any(), Mockito.eq(ProjectVersionComponentVersionView.class));
 
         ComponentVersionView componentVersionView = createComponentVersionView();
         Mockito.when(blackDuckApiClient.getResponse(Mockito.any(), Mockito.eq(ComponentVersionView.class))).thenReturn(componentVersionView);
         ComponentVersionUpgradeGuidanceView componentVersionUpgradeGuidanceView = createComponentVersionUpgradeGuidanceView();
         UrlSingleResponse<ComponentVersionUpgradeGuidanceView> urlSingleResponse = new UrlSingleResponse<>(new HttpUrl(UPGRADE_GUIDANCE_URL), ComponentVersionUpgradeGuidanceView.class);
-        Mockito.when(blackDuckApiClient.getResponse(Mockito.eq(urlSingleResponse))).thenReturn(componentVersionUpgradeGuidanceView);
+        Mockito.when(blackDuckApiClient.getResponse(urlSingleResponse)).thenReturn(componentVersionUpgradeGuidanceView);
 
         VulnerabilityUniqueProjectNotificationContent notificationContent = createVulnerabilityUniqueProjectNotificationContent();
 
@@ -186,15 +199,29 @@ public class VulnerabilityNotificationMessageExtractorTest {
     }
 
     @Test
-    public void retrieveComponentVersionViewEmptyTest() throws IntegrationException {
+    void retrieveComponentVersionViewEmptyTest() throws IntegrationException {
         BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
         BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
         Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
 
-        Mockito.doThrow(new IntegrationRestException(HttpMethod.GET, new HttpUrl("https://google.com"), HttpStatus.NOT_FOUND.value(), "httpStatusMessageTest", "httpResponseContentTest", "IntegrationRestExceptionForAlertTest"))
+        Mockito.doThrow(new IntegrationRestException(
+                HttpMethod.GET,
+                new HttpUrl("https://google.com"),
+                HttpStatus.NOT_FOUND.value(),
+                "httpStatusMessageTest",
+                "httpResponseContentTest",
+                "IntegrationRestExceptionForAlertTest"
+            ))
             .when(blackDuckApiClient).getResponse(Mockito.any(), Mockito.eq(ProjectVersionComponentVersionView.class));
 
-        Mockito.doThrow(new IntegrationRestException(HttpMethod.GET, new HttpUrl("https://google.com"), HttpStatus.NOT_FOUND.value(), "httpStatusMessageTest", "httpResponseContentTest", "IntegrationRestExceptionForAlertTest"))
+        Mockito.doThrow(new IntegrationRestException(
+                HttpMethod.GET,
+                new HttpUrl("https://google.com"),
+                HttpStatus.NOT_FOUND.value(),
+                "httpStatusMessageTest",
+                "httpResponseContentTest",
+                "IntegrationRestExceptionForAlertTest"
+            ))
             .when(blackDuckApiClient).getResponse(Mockito.any(), Mockito.eq(ComponentVersionView.class));
 
         VulnerabilityUniqueProjectNotificationContent notificationContent = createVulnerabilityUniqueProjectNotificationContent();
@@ -209,20 +236,34 @@ public class VulnerabilityNotificationMessageExtractorTest {
     }
 
     @Test
-    public void safelyRetrieveItemsEmptyTest() throws IntegrationException {
+    void safelyRetrieveItemsEmptyTest() throws IntegrationException {
         BlackDuckServicesFactory blackDuckServicesFactory = Mockito.mock(BlackDuckServicesFactory.class);
         BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
         Mockito.when(blackDuckServicesFactory.getBlackDuckApiClient()).thenReturn(blackDuckApiClient);
 
-        Mockito.doThrow(new IntegrationRestException(HttpMethod.GET, new HttpUrl("https://google.com"), HttpStatus.NOT_FOUND.value(), "httpStatusMessageTest", "httpResponseContentTest", "IntegrationRestExceptionForAlertTest"))
+        Mockito.doThrow(new IntegrationRestException(
+                HttpMethod.GET,
+                new HttpUrl("https://google.com"),
+                HttpStatus.NOT_FOUND.value(),
+                "httpStatusMessageTest",
+                "httpResponseContentTest",
+                "IntegrationRestExceptionForAlertTest"
+            ))
             .when(blackDuckApiClient).getResponse(Mockito.any(), Mockito.eq(ProjectVersionComponentVersionView.class));
 
         ComponentVersionView componentVersionView = createComponentVersionView();
         Mockito.when(blackDuckApiClient.getResponse(Mockito.any(), Mockito.eq(ComponentVersionView.class))).thenReturn(componentVersionView);
 
         UrlSingleResponse<ComponentVersionUpgradeGuidanceView> urlSingleResponse = new UrlSingleResponse<>(new HttpUrl(UPGRADE_GUIDANCE_URL), ComponentVersionUpgradeGuidanceView.class);
-        Mockito.doThrow(new IntegrationRestException(HttpMethod.GET, new HttpUrl("https://google.com"), HttpStatus.NOT_FOUND.value(), "httpStatusMessageTest", "httpResponseContentTest", "IntegrationRestExceptionForAlertTest"))
-            .when(blackDuckApiClient).getResponse(Mockito.eq(urlSingleResponse));
+        Mockito.doThrow(new IntegrationRestException(
+                HttpMethod.GET,
+                new HttpUrl("https://google.com"),
+                HttpStatus.NOT_FOUND.value(),
+                "httpStatusMessageTest",
+                "httpResponseContentTest",
+                "IntegrationRestExceptionForAlertTest"
+            ))
+            .when(blackDuckApiClient).getResponse(urlSingleResponse);
 
         VulnerabilityUniqueProjectNotificationContent notificationContent = createVulnerabilityUniqueProjectNotificationContent();
 

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/BlackDuckMessageComponentVersionUpgradeGuidanceServiceTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/BlackDuckMessageComponentVersionUpgradeGuidanceServiceTest.java
@@ -23,9 +23,9 @@ import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.rest.HttpUrl;
 
-public class BlackDuckMessageComponentVersionUpgradeGuidanceServiceTest {
+class BlackDuckMessageComponentVersionUpgradeGuidanceServiceTest {
     @Test
-    public void requestUpgradeGuidanceItemsBomTest() throws IntegrationException {
+    void requestUpgradeGuidanceItemsBomTest() throws IntegrationException {
         HttpUrl httpUrl = new HttpUrl("https://fake-url");
         UrlSingleResponse<ComponentVersionUpgradeGuidanceView> expectedUrl = new UrlSingleResponse<>(httpUrl, ComponentVersionUpgradeGuidanceView.class);
         ComponentVersionUpgradeGuidanceView upgradeGuidanceView = createUpgradeGuidance(true);
@@ -41,7 +41,7 @@ public class BlackDuckMessageComponentVersionUpgradeGuidanceServiceTest {
     }
 
     @Test
-    public void requestUpgradeGuidanceItemsComponentTest() throws IntegrationException {
+    void requestUpgradeGuidanceItemsComponentTest() throws IntegrationException {
         HttpUrl httpUrl = new HttpUrl("https://fake-url");
         UrlSingleResponse<ComponentVersionUpgradeGuidanceView> expectedUrl = new UrlSingleResponse<>(httpUrl, ComponentVersionUpgradeGuidanceView.class);
         ComponentVersionUpgradeGuidanceView upgradeGuidanceView = createUpgradeGuidance(false);
@@ -57,7 +57,7 @@ public class BlackDuckMessageComponentVersionUpgradeGuidanceServiceTest {
 
     private ProjectVersionComponentVersionView createBomComponent(LinkSingleResponse<ComponentVersionUpgradeGuidanceView> upgradeGuidanceLink, UrlSingleResponse<ComponentVersionUpgradeGuidanceView> expectedUrl) {
         ProjectVersionComponentVersionView bomComponent = Mockito.mock(ProjectVersionComponentVersionView.class);
-        Mockito.when(bomComponent.metaSingleResponseSafely(Mockito.eq(upgradeGuidanceLink))).thenReturn(Optional.of(expectedUrl));
+        Mockito.when(bomComponent.metaSingleResponseSafely(upgradeGuidanceLink)).thenReturn(Optional.of(expectedUrl));
         return bomComponent;
     }
 
@@ -97,7 +97,7 @@ public class BlackDuckMessageComponentVersionUpgradeGuidanceServiceTest {
 
     private BlackDuckApiClient createBlackDuckApiClient(UrlSingleResponse<ComponentVersionUpgradeGuidanceView> expectedArg, ComponentVersionUpgradeGuidanceView expectedReturn) throws IntegrationException {
         BlackDuckApiClient blackDuckApiClient = Mockito.mock(BlackDuckApiClient.class);
-        Mockito.when(blackDuckApiClient.getResponse(Mockito.eq(expectedArg))).thenReturn(expectedReturn);
+        Mockito.when(blackDuckApiClient.getResponse(expectedArg)).thenReturn(expectedReturn);
         return blackDuckApiClient;
     }
 

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/task/BlackDuckProjectSyncTaskTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/task/BlackDuckProjectSyncTaskTest.java
@@ -26,9 +26,9 @@ import com.synopsys.integration.blackduck.service.request.BlackDuckRequest;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.rest.HttpUrl;
 
-public class BlackDuckProjectSyncTaskTest {
+class BlackDuckProjectSyncTaskTest {
     @Test
-    public void testRun() throws Exception {
+    void testRun() throws Exception {
         MockProviderDataAccessor providerDataAccessor = new MockProviderDataAccessor();
 
         ApiDiscovery apiDiscovery = new ApiDiscovery(new HttpUrl("https://someblackduckserver"));
@@ -50,7 +50,7 @@ public class BlackDuckProjectSyncTaskTest {
         ProjectView projectView2 = createProjectView("project2", "description2", "https://projectUrl2");
         ProjectView projectView3 = createProjectView("project3", "description3", "https://projectUrl3");
 
-        Mockito.when(blackDuckApiClient.getAllResponses(Mockito.eq(apiDiscovery.metaProjectsLink()))).thenReturn(List.of(projectView, projectView2, projectView3));
+        Mockito.when(blackDuckApiClient.getAllResponses(apiDiscovery.metaProjectsLink())).thenReturn(List.of(projectView, projectView2, projectView3));
         Mockito.doReturn(null).when(blackDuckApiClient).getResponse(Mockito.any(BlackDuckRequest.class));
 
         String email1 = "user1@email.com";
@@ -62,7 +62,7 @@ public class BlackDuckProjectSyncTaskTest {
         UserView user3 = createUserView(email3, true);
         UserView user4 = createUserView(email4, true);
 
-        Mockito.when(blackDuckApiClient.getAllResponses(Mockito.eq(apiDiscovery.metaUsersLink()))).thenReturn(List.of(user1, user2, user3, user4));
+        Mockito.when(blackDuckApiClient.getAllResponses(apiDiscovery.metaUsersLink())).thenReturn(List.of(user1, user2, user3, user4));
 
         Mockito.when(projectUsersService.getAllActiveUsersForProject(ArgumentMatchers.same(projectView))).thenReturn(new HashSet<>(List.of(user2, user4)));
         Mockito.when(projectUsersService.getAllActiveUsersForProject(ArgumentMatchers.same(projectView2))).thenReturn(new HashSet<>(List.of(user3)));
@@ -73,7 +73,7 @@ public class BlackDuckProjectSyncTaskTest {
         projectSyncTask.run();
 
         assertEquals(3, providerDataAccessor.getProjectsByProviderConfigId(providerConfigId).size());
-        Mockito.when(blackDuckApiClient.getAllResponses(Mockito.eq(apiDiscovery.metaProjectsLink()))).thenReturn(List.of(projectView, projectView2));
+        Mockito.when(blackDuckApiClient.getAllResponses(apiDiscovery.metaProjectsLink())).thenReturn(List.of(projectView, projectView2));
 
         Mockito.when(projectUsersService.getAllActiveUsersForProject(ArgumentMatchers.same(projectView))).thenReturn(new HashSet<>(List.of(user2, user4)));
         Mockito.when(projectUsersService.getAllActiveUsersForProject(ArgumentMatchers.same(projectView2))).thenReturn(new HashSet<>(List.of(user3)));

--- a/src/test/java/com/synopsys/integration/alert/channel/email/EmailMessagingServiceTest.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/email/EmailMessagingServiceTest.java
@@ -13,13 +13,12 @@ import org.mockito.Mockito;
 
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.service.email.EmailMessagingService;
-import com.synopsys.integration.alert.service.email.JavamailPropertiesFactory;
 import com.synopsys.integration.alert.service.email.template.FreemarkerTemplatingService;
 import com.synopsys.integration.alert.test.common.TestProperties;
 
-public class EmailMessagingServiceTest {
+class EmailMessagingServiceTest {
     @Test
-    public void sendAuthenticatedMessage() throws MessagingException, AlertException {
+    void sendAuthenticatedMessage() throws MessagingException, AlertException {
         TestProperties testProperties = new TestProperties();
 
         FreemarkerTemplatingService freemarkerTemplatingService = new FreemarkerTemplatingService();

--- a/src/test/java/com/synopsys/integration/alert/component/audit/web/AuditEntryHandlerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/audit/web/AuditEntryHandlerTestIT.java
@@ -74,7 +74,7 @@ import com.synopsys.integration.util.ResourceUtil;
 
 @Transactional
 @AlertIntegrationTest
-public class AuditEntryHandlerTestIT {
+class AuditEntryHandlerTestIT {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     @Autowired
     private AuditDescriptorKey auditDescriptorKey;
@@ -156,17 +156,32 @@ public class AuditEntryHandlerTestIT {
     }
 
     @Test
-    public void getTestIT() {
+    void getTestIT() {
         NotificationEntity savedNotificationEntity = notificationContentRepository.save(mockNotification.createEntity());
 
         notificationContentRepository
-            .save(new MockNotificationContent(DateUtils.createCurrentDateTimestamp(), "provider", DateUtils.createCurrentDateTimestamp(), "notificationType", "{}", 234L, providerConfigModel.getConfigurationId()).createEntity());
+            .save(new MockNotificationContent(
+                DateUtils.createCurrentDateTimestamp(),
+                "provider",
+                DateUtils.createCurrentDateTimestamp(),
+                "notificationType",
+                "{}",
+                234L,
+                providerConfigModel.getConfigurationId()
+            ).createEntity());
 
         DistributionJobRequestModel jobRequestModel = createJobRequestModel();
         DistributionJobModel jobModel = jobAccessor.createJob(jobRequestModel);
 
         AuditEntryEntity savedAuditEntryEntity = auditEntryRepository.save(
-            new AuditEntryEntity(jobModel.getJobId(), DateUtils.createCurrentDateTimestamp(), DateUtils.createCurrentDateTimestamp(), AuditEntryStatus.SUCCESS.toString(), null, null));
+            new AuditEntryEntity(
+                jobModel.getJobId(),
+                DateUtils.createCurrentDateTimestamp(),
+                DateUtils.createCurrentDateTimestamp(),
+                AuditEntryStatus.SUCCESS.toString(),
+                null,
+                null
+            ));
 
         auditNotificationRepository.save(new AuditNotificationRelation(savedAuditEntryEntity.getId(), savedNotificationEntity.getId()));
 
@@ -196,7 +211,7 @@ public class AuditEntryHandlerTestIT {
     }
 
     @Test
-    public void getGetAuditInfoForJobIT() {
+    void getGetAuditInfoForJobIT() {
         DistributionJobRequestModel jobRequestModel = createJobRequestModel();
         DistributionJobModel job = jobAccessor.createJob(jobRequestModel);
 
@@ -204,7 +219,7 @@ public class AuditEntryHandlerTestIT {
             new AuditEntryEntity(job.getJobId(), DateUtils.createCurrentDateTimestamp(), DateUtils.createCurrentDateTimestamp(), AuditEntryStatus.SUCCESS.toString(), null, null));
 
         AuthorizationManager authorizationManager = Mockito.mock(AuthorizationManager.class);
-        Mockito.when(authorizationManager.hasReadPermission(Mockito.eq(ConfigContextEnum.GLOBAL), Mockito.eq(auditDescriptorKey))).thenReturn(true);
+        Mockito.when(authorizationManager.hasReadPermission(ConfigContextEnum.GLOBAL, auditDescriptorKey)).thenReturn(true);
         AuditEntryActions auditEntryController = createAuditActions(authorizationManager);
 
         AuditJobStatusModel jobStatusModel = auditEntryController.getAuditInfoForJob(savedAuditEntryEntity.getCommonConfigId()).getContent().orElse(null);
@@ -212,11 +227,17 @@ public class AuditEntryHandlerTestIT {
     }
 
     @Test
-    public void resendNotificationTestIT() throws Exception {
+    void resendNotificationTestIT() throws Exception {
         String content = ResourceUtil.getResourceAsString(getClass(), "/json/policyOverrideNotification.json", StandardCharsets.UTF_8);
 
-        MockNotificationContent mockNotification = new MockNotificationContent(DateUtils.createCurrentDateTimestamp(), blackDuckProviderKey.getUniversalKey(), DateUtils.createCurrentDateTimestamp(), "POLICY_OVERRIDE", content, 1L,
-            providerConfigModel.getConfigurationId());
+        MockNotificationContent mockNotification = new MockNotificationContent(DateUtils.createCurrentDateTimestamp(),
+            blackDuckProviderKey.getUniversalKey(),
+            DateUtils.createCurrentDateTimestamp(),
+            "POLICY_OVERRIDE",
+            content,
+            1L,
+            providerConfigModel.getConfigurationId()
+        );
 
         ConfigurationFieldModel providerConfigId = ConfigurationFieldModel.create(ProviderDescriptor.KEY_PROVIDER_CONFIG_ID);
         providerConfigId.setFieldValue(String.valueOf(providerConfigModel.getConfigurationId()));
@@ -234,7 +255,7 @@ public class AuditEntryHandlerTestIT {
         auditNotificationRepository.save(new AuditNotificationRelation(savedAuditEntryEntity.getId(), savedNotificationEntity.getId()));
 
         AuthorizationManager authorizationManager = Mockito.mock(AuthorizationManager.class);
-        Mockito.when(authorizationManager.hasExecutePermission(Mockito.eq(ConfigContextEnum.GLOBAL.name()), Mockito.eq(AuditDescriptor.AUDIT_COMPONENT))).thenReturn(true);
+        Mockito.when(authorizationManager.hasExecutePermission(ConfigContextEnum.GLOBAL.name(), AuditDescriptor.AUDIT_COMPONENT)).thenReturn(true);
         AuditEntryActions auditEntryActions = createAuditActions(authorizationManager);
 
         try {

--- a/src/test/java/com/synopsys/integration/alert/component/authentication/security/UserManagementAuthoritiesPopulatorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/component/authentication/security/UserManagementAuthoritiesPopulatorTest.java
@@ -15,41 +15,39 @@ import com.synopsys.integration.alert.common.persistence.model.ConfigurationMode
 import com.synopsys.integration.alert.component.authentication.descriptor.AuthenticationDescriptor;
 import com.synopsys.integration.alert.component.authentication.descriptor.AuthenticationDescriptorKey;
 
-public class UserManagementAuthoritiesPopulatorTest {
-    private static final String TEST_USERNAME = "testUserName";
+class UserManagementAuthoritiesPopulatorTest {
     private final AuthenticationDescriptorKey descriptorKey = new AuthenticationDescriptorKey();
     private final ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
     private final ConfigurationModel configurationModel = Mockito.mock(ConfigurationModel.class);
-    private final ConfigurationFieldModel roleMappingField = Mockito.mock(ConfigurationFieldModel.class);
     private final ConfigurationFieldModel samlAttributeMappingField = Mockito.mock(ConfigurationFieldModel.class);
     private final UserAccessor userAccessor = Mockito.mock(UserAccessor.class);
 
     @Test
-    public void testSAMLAttributeName() {
+    void testSAMLAttributeName() {
         String attributeName = "SAML_ATTRIBUTE_NAME";
         Mockito.when(samlAttributeMappingField.getFieldValue()).thenReturn(Optional.of(attributeName));
-        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKey(Mockito.eq(descriptorKey))).thenReturn(List.of(configurationModel));
-        Mockito.when(configurationModel.getField(Mockito.eq(AuthenticationDescriptor.KEY_SAML_ROLE_ATTRIBUTE_MAPPING))).thenReturn(Optional.of(samlAttributeMappingField));
+        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKey(descriptorKey)).thenReturn(List.of(configurationModel));
+        Mockito.when(configurationModel.getField(AuthenticationDescriptor.KEY_SAML_ROLE_ATTRIBUTE_MAPPING)).thenReturn(Optional.of(samlAttributeMappingField));
         Mockito.when(userAccessor.getUser(Mockito.anyString())).thenReturn(Optional.empty());
         UserManagementAuthoritiesPopulator authoritiesPopulator = new UserManagementAuthoritiesPopulator(descriptorKey, configurationModelConfigurationAccessor, userAccessor);
         assertEquals(attributeName, authoritiesPopulator.getSAMLRoleAttributeName("DEFAULT_ATTRIBUTE"));
     }
 
     @Test
-    public void testSAMLAttributeNameNotFound() {
+    void testSAMLAttributeNameNotFound() {
         String attributeName = "DEFAULT_ATTRIBUTE";
         Mockito.when(samlAttributeMappingField.getFieldValue()).thenReturn(Optional.empty());
-        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKey(Mockito.eq(descriptorKey))).thenReturn(List.of(configurationModel));
-        Mockito.when(configurationModel.getField(Mockito.eq(AuthenticationDescriptor.KEY_SAML_ROLE_ATTRIBUTE_MAPPING))).thenReturn(Optional.of(samlAttributeMappingField));
+        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKey(descriptorKey)).thenReturn(List.of(configurationModel));
+        Mockito.when(configurationModel.getField(AuthenticationDescriptor.KEY_SAML_ROLE_ATTRIBUTE_MAPPING)).thenReturn(Optional.of(samlAttributeMappingField));
         Mockito.when(userAccessor.getUser(Mockito.anyString())).thenReturn(Optional.empty());
         UserManagementAuthoritiesPopulator authoritiesPopulator = new UserManagementAuthoritiesPopulator(descriptorKey, configurationModelConfigurationAccessor, userAccessor);
         assertEquals(attributeName, authoritiesPopulator.getSAMLRoleAttributeName(attributeName));
     }
 
     @Test
-    public void testSAMLAttributeConfigurationNotFound() {
+    void testSAMLAttributeConfigurationNotFound() {
         String attributeName = "DEFAULT_ATTRIBUTE";
-        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKey(Mockito.eq(descriptorKey))).thenReturn(List.of());
+        Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKey(descriptorKey)).thenReturn(List.of());
         Mockito.when(userAccessor.getUser(Mockito.anyString())).thenReturn(Optional.empty());
         UserManagementAuthoritiesPopulator authoritiesPopulator = new UserManagementAuthoritiesPopulator(descriptorKey, configurationModelConfigurationAccessor, userAccessor);
         assertEquals(attributeName, authoritiesPopulator.getSAMLRoleAttributeName(attributeName));

--- a/src/test/java/com/synopsys/integration/alert/component/authentication/web/AuthenticationActionsTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/authentication/web/AuthenticationActionsTestIT.java
@@ -60,7 +60,7 @@ import com.synopsys.integration.alert.util.AlertIntegrationTestConstants;
 @Tag(TestTags.CUSTOM_BLACKDUCK_CONNECTION)
 @Transactional
 @AlertIntegrationTest
-public class AuthenticationActionsTestIT {
+class AuthenticationActionsTestIT {
     private final MockLoginRestModel mockLoginRestModel = new MockLoginRestModel();
     private final TestProperties properties = new TestProperties();
     @Autowired
@@ -80,7 +80,7 @@ public class AuthenticationActionsTestIT {
     }
 
     @Test
-    public void testAuthenticateDBUserIT() {
+    void testAuthenticateDBUserIT() {
         HttpServletRequest servletRequest = new MockHttpServletRequest();
         HttpServletResponse servletResponse = new MockHttpServletResponse();
         AuthenticationActions authenticationActions = new AuthenticationActions(authenticationProvider, csrfTokenRepository);
@@ -91,7 +91,7 @@ public class AuthenticationActionsTestIT {
     }
 
     @Test
-    public void testAuthenticateDBUserFailIT() {
+    void testAuthenticateDBUserFailIT() {
         HttpServletRequest servletRequest = new MockHttpServletRequest();
         HttpServletResponse servletResponse = new MockHttpServletResponse();
         mockLoginRestModel.setAlertUsername(properties.getProperty(TestPropertyKey.TEST_BLACKDUCK_PROVIDER_ACTIVE_USER));
@@ -104,7 +104,7 @@ public class AuthenticationActionsTestIT {
     }
 
     @Test
-    public void testAuthenticateDBUserRoleFailIT() throws AlertForbiddenOperationException, AlertConfigurationException {
+    void testAuthenticateDBUserRoleFailIT() throws AlertForbiddenOperationException, AlertConfigurationException {
         HttpServletRequest servletRequest = new MockHttpServletRequest();
         HttpServletResponse servletResponse = new MockHttpServletResponse();
         // add a user test then delete a user.
@@ -125,7 +125,7 @@ public class AuthenticationActionsTestIT {
     }
 
     @Test
-    public void testAuthenticationLDAPUserIT() throws Exception {
+    void testAuthenticationLDAPUserIT() throws Exception {
         HttpServletRequest servletRequest = new MockHttpServletRequest();
         HttpServletResponse servletResponse = new MockHttpServletResponse();
         Authentication authentication = Mockito.mock(Authentication.class);
@@ -143,7 +143,7 @@ public class AuthenticationActionsTestIT {
     }
 
     @Test
-    public void testAuthenticationLDAPExceptionIT() throws Exception {
+    void testAuthenticationLDAPExceptionIT() throws Exception {
         HttpServletRequest servletRequest = new MockHttpServletRequest();
         HttpServletResponse servletResponse = new MockHttpServletResponse();
         Authentication authentication = Mockito.mock(Authentication.class);
@@ -170,7 +170,7 @@ public class AuthenticationActionsTestIT {
     }
 
     @Test
-    public void userLogoutWithValidSessionTest() {
+    void userLogoutWithValidSessionTest() {
         AuthenticationActions authenticationActions = new AuthenticationActions(authenticationProvider, csrfTokenRepository);
         MockHttpServletRequest servletRequest = new MockHttpServletRequest();
         MockHttpServletResponse servletResponse = new MockHttpServletResponse();
@@ -183,7 +183,7 @@ public class AuthenticationActionsTestIT {
     }
 
     @Test
-    public void userLogoutWithInvalidSessionTest() {
+    void userLogoutWithInvalidSessionTest() {
         AuthenticationActions authenticationActions = new AuthenticationActions(authenticationProvider, csrfTokenRepository);
         HttpServletRequest servletRequest = new MockHttpServletRequest();
         MockHttpServletResponse servletResponse = new MockHttpServletResponse();
@@ -192,7 +192,7 @@ public class AuthenticationActionsTestIT {
     }
 
     @Test
-    public void userLoginWithBadCredentialsTest() {
+    void userLoginWithBadCredentialsTest() {
         AlertAuthenticationProvider authenticationProvider = Mockito.mock(AlertAuthenticationProvider.class);
         Mockito.when(authenticationProvider.authenticate(Mockito.any())).thenThrow(new BadCredentialsException("Bad credentials test"));
         AuthenticationActions authenticationActions = new AuthenticationActions(authenticationProvider, csrfTokenRepository);

--- a/src/test/java/com/synopsys/integration/alert/component/tasks/web/TaskActionTest.java
+++ b/src/test/java/com/synopsys/integration/alert/component/tasks/web/TaskActionTest.java
@@ -21,15 +21,15 @@ import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
 import com.synopsys.integration.alert.component.tasks.TaskManagementDescriptorKey;
 
-public class TaskActionTest {
+class TaskActionTest {
 
     @Test
-    public void testReadTasks() {
+    void testReadTasks() {
         Long expectedDelay = 1000L;
         TaskScheduler scheduler = Mockito.mock(TaskScheduler.class);
         ScheduledFuture scheduledFuture = Mockito.mock(ScheduledFuture.class);
         Mockito.when(scheduledFuture.isDone()).thenReturn(Boolean.FALSE);
-        Mockito.when(scheduledFuture.getDelay(Mockito.eq(TimeUnit.MILLISECONDS))).thenReturn(expectedDelay);
+        Mockito.when(scheduledFuture.getDelay(TimeUnit.MILLISECONDS)).thenReturn(expectedDelay);
         Mockito.when(scheduler.scheduleAtFixedRate(Mockito.any(), Mockito.anyLong())).thenReturn(scheduledFuture);
         ScheduledTask task = new ScheduledTask(scheduler) {
             @Override
@@ -45,7 +45,7 @@ public class TaskActionTest {
 
         TaskManagementDescriptorKey descriptorKey = new TaskManagementDescriptorKey();
         AuthorizationManager authorizationManager = Mockito.mock(AuthorizationManager.class);
-        Mockito.when(authorizationManager.hasReadPermission(Mockito.eq(ConfigContextEnum.GLOBAL), Mockito.eq(descriptorKey)))
+        Mockito.when(authorizationManager.hasReadPermission(ConfigContextEnum.GLOBAL, descriptorKey))
             .thenReturn(Boolean.TRUE);
 
         TaskManager taskManager = new TaskManager();
@@ -65,10 +65,10 @@ public class TaskActionTest {
     }
 
     @Test
-    public void testReadForbiddenTasks() {
+    void testReadForbiddenTasks() {
         TaskManagementDescriptorKey descriptorKey = new TaskManagementDescriptorKey();
         AuthorizationManager authorizationManager = Mockito.mock(AuthorizationManager.class);
-        Mockito.when(authorizationManager.hasReadPermission(Mockito.eq(ConfigContextEnum.GLOBAL), Mockito.eq(descriptorKey)))
+        Mockito.when(authorizationManager.hasReadPermission(ConfigContextEnum.GLOBAL, descriptorKey))
             .thenReturn(Boolean.FALSE);
 
         TaskManager taskManager = new TaskManager();

--- a/src/test/java/com/synopsys/integration/alert/component/users/web/role/RoleActionsTest.java
+++ b/src/test/java/com/synopsys/integration/alert/component/users/web/role/RoleActionsTest.java
@@ -26,7 +26,7 @@ import com.synopsys.integration.alert.component.users.UserManagementDescriptorKe
 import com.synopsys.integration.alert.component.users.web.role.util.PermissionModelUtil;
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
 
-public class RoleActionsTest {
+class RoleActionsTest {
     private final String roleName = "roleName";
     private final String context = "GLOBAL";
 
@@ -59,7 +59,7 @@ public class RoleActionsTest {
     }
 
     @Test
-    public void createTest() throws Exception {
+    void createTest() {
         PermissionModel permissionModel = createPermissionModel();
         RolePermissionModel rolePermissionModel = new RolePermissionModel(null, roleName, Set.of(permissionModel));
         UserRoleModel userRoleModel = new UserRoleModel(1L, roleName, false, PermissionModelUtil.convertToPermissionMatrixModel(Set.of(permissionModel)));
@@ -76,7 +76,7 @@ public class RoleActionsTest {
     }
 
     @Test
-    public void deleteTest() throws Exception {
+    void deleteTest() throws Exception {
         PermissionModel permissionModel = createPermissionModel();
         UserRoleModel userRoleModel = new UserRoleModel(1L, roleName, false, PermissionModelUtil.convertToPermissionMatrixModel(Set.of(permissionModel)));
 
@@ -93,7 +93,7 @@ public class RoleActionsTest {
     }
 
     @Test
-    public void deleteErrorTest() throws Exception {
+    void deleteErrorTest() throws Exception {
         PermissionModel permissionModel = createPermissionModel();
         UserRoleModel userRoleModel = new UserRoleModel(1L, roleName, false, PermissionModelUtil.convertToPermissionMatrixModel(Set.of(permissionModel)));
 
@@ -109,7 +109,7 @@ public class RoleActionsTest {
     }
 
     @Test
-    public void deleteNotFoundTest() {
+    void deleteNotFoundTest() {
         Mockito.when(roleAccessor.getRoles(Mockito.anyCollection())).thenReturn(Set.of());
 
         RoleActions roleActions = new RoleActions(userManagementDescriptorKey, roleAccessor, authorizationManager, descriptorMap);
@@ -121,7 +121,7 @@ public class RoleActionsTest {
     }
 
     @Test
-    public void getAllTest() {
+    void getAllTest() {
         PermissionModel permissionModel = createPermissionModel();
         UserRoleModel userRoleModel = new UserRoleModel(1L, roleName, false, PermissionModelUtil.convertToPermissionMatrixModel(Set.of(permissionModel)));
 
@@ -136,7 +136,7 @@ public class RoleActionsTest {
     }
 
     @Test
-    public void getOneTest() {
+    void getOneTest() {
         PermissionModel permissionModel = createPermissionModel();
         UserRoleModel userRoleModel = new UserRoleModel(1L, roleName, false, PermissionModelUtil.convertToPermissionMatrixModel(Set.of(permissionModel)));
 
@@ -151,7 +151,7 @@ public class RoleActionsTest {
     }
 
     @Test
-    public void getOneNotFoundTest() {
+    void getOneNotFoundTest() {
         Mockito.when(roleAccessor.getRoles(Mockito.anyCollection())).thenReturn(Set.of());
 
         RoleActions roleActions = new RoleActions(userManagementDescriptorKey, roleAccessor, authorizationManager, descriptorMap);
@@ -163,11 +163,11 @@ public class RoleActionsTest {
     }
 
     @Test
-    public void testTest() {
+    void testTest() {
         PermissionModel permissionModel = createPermissionModel();
         RolePermissionModel rolePermissionModel = new RolePermissionModel(null, roleName, Set.of(permissionModel));
 
-        Mockito.when(roleAccessor.doesRoleNameExist(Mockito.eq(roleName))).thenReturn(false);
+        Mockito.when(roleAccessor.doesRoleNameExist(roleName)).thenReturn(false);
 
         RoleActions roleActions = new RoleActions(userManagementDescriptorKey, roleAccessor, authorizationManager, descriptorMap);
         ValidationActionResponse validationActionResponse = roleActions.test(rolePermissionModel);
@@ -178,11 +178,11 @@ public class RoleActionsTest {
     }
 
     @Test
-    public void validateTest() {
+    void validateTest() {
         PermissionModel permissionModel = createPermissionModel();
         RolePermissionModel rolePermissionModel = new RolePermissionModel(null, roleName, Set.of(permissionModel));
 
-        Mockito.when(roleAccessor.doesRoleNameExist(Mockito.eq(roleName))).thenReturn(false);
+        Mockito.when(roleAccessor.doesRoleNameExist(roleName)).thenReturn(false);
 
         RoleActions roleActions = new RoleActions(userManagementDescriptorKey, roleAccessor, authorizationManager, descriptorMap);
         ValidationActionResponse validationActionResponse = roleActions.validate(rolePermissionModel);
@@ -193,11 +193,11 @@ public class RoleActionsTest {
     }
 
     @Test
-    public void validateMissingRoleNameTest() {
+    void validateMissingRoleNameTest() {
         PermissionModel permissionModel = createPermissionModel();
         RolePermissionModel rolePermissionModel = new RolePermissionModel(null, "", Set.of(permissionModel));
 
-        Mockito.when(roleAccessor.doesRoleNameExist(Mockito.eq(roleName))).thenReturn(true);
+        Mockito.when(roleAccessor.doesRoleNameExist(roleName)).thenReturn(true);
 
         RoleActions roleActions = new RoleActions(userManagementDescriptorKey, roleAccessor, authorizationManager, descriptorMap);
         ValidationActionResponse validationActionResponse = roleActions.validate(rolePermissionModel);
@@ -211,11 +211,11 @@ public class RoleActionsTest {
     }
 
     @Test
-    public void validateBadRequestTest() {
+    void validateBadRequestTest() {
         PermissionModel permissionModel = createPermissionModel();
         RolePermissionModel rolePermissionModel = new RolePermissionModel(null, roleName, Set.of(permissionModel));
 
-        Mockito.when(roleAccessor.doesRoleNameExist(Mockito.eq(roleName))).thenReturn(true);
+        Mockito.when(roleAccessor.doesRoleNameExist(roleName)).thenReturn(true);
 
         RoleActions roleActions = new RoleActions(userManagementDescriptorKey, roleAccessor, authorizationManager, descriptorMap);
         ValidationActionResponse validationActionResponse = roleActions.validate(rolePermissionModel);
@@ -229,12 +229,12 @@ public class RoleActionsTest {
     }
 
     @Test
-    public void validateDuplicatePermissionsTest() {
+    void validateDuplicatePermissionsTest() {
         PermissionModel permissionModel = createPermissionModel();
         PermissionModel permissionModelDuplicate = new PermissionModel(descriptorKey.getUniversalKey(), context, false, true, true, true, true, true, true, true);
         RolePermissionModel rolePermissionModel = new RolePermissionModel(null, roleName, Set.of(permissionModel, permissionModelDuplicate));
 
-        Mockito.when(roleAccessor.doesRoleNameExist(Mockito.eq(roleName))).thenReturn(false);
+        Mockito.when(roleAccessor.doesRoleNameExist(roleName)).thenReturn(false);
 
         RoleActions roleActions = new RoleActions(userManagementDescriptorKey, roleAccessor, authorizationManager, descriptorMap);
         ValidationActionResponse validationActionResponse = roleActions.validate(rolePermissionModel);
@@ -248,7 +248,7 @@ public class RoleActionsTest {
     }
 
     @Test
-    public void updateTest() throws Exception {
+    void updateTest() throws Exception {
         String newRoleName = "newRoleName";
         Long longId = 1L;
         PermissionModel permissionModel = createPermissionModel();
@@ -261,7 +261,7 @@ public class RoleActionsTest {
         RoleActions roleActions = new RoleActions(userManagementDescriptorKey, roleAccessor, authorizationManager, descriptorMap);
         ActionResponse<RolePermissionModel> rolePermissionModelActionResponse = roleActions.update(1L, rolePermissionModel);
 
-        Mockito.verify(authorizationManager).updateRoleName(Mockito.eq(longId), Mockito.eq(newRoleName));
+        Mockito.verify(authorizationManager).updateRoleName(longId, newRoleName);
         Mockito.verify(authorizationManager).updatePermissionsForRole(Mockito.anyString(), Mockito.any());
 
         assertTrue(rolePermissionModelActionResponse.isSuccessful());
@@ -270,7 +270,7 @@ public class RoleActionsTest {
     }
 
     @Test
-    public void updateNoContentTest() {
+    void updateNoContentTest() {
         String newRoleName = "newRoleName";
         PermissionModel permissionModel = createPermissionModel();
         RolePermissionModel rolePermissionModel = new RolePermissionModel(null, newRoleName, Set.of(permissionModel));
@@ -286,7 +286,7 @@ public class RoleActionsTest {
     }
 
     @Test
-    public void updateErrorTest() throws Exception {
+    void updateErrorTest() throws Exception {
         String newRoleName = "newRoleName";
         Long longId = 1L;
         PermissionModel permissionModel = createPermissionModel();
@@ -300,7 +300,7 @@ public class RoleActionsTest {
         RoleActions roleActions = new RoleActions(userManagementDescriptorKey, roleAccessor, authorizationManager, descriptorMap);
         ActionResponse<RolePermissionModel> rolePermissionModelActionResponse = roleActions.update(1L, rolePermissionModel);
 
-        Mockito.verify(authorizationManager).updateRoleName(Mockito.eq(longId), Mockito.eq(newRoleName));
+        Mockito.verify(authorizationManager).updateRoleName(longId, newRoleName);
 
         assertTrue(rolePermissionModelActionResponse.isError());
         assertFalse(rolePermissionModelActionResponse.hasContent());
@@ -308,7 +308,7 @@ public class RoleActionsTest {
     }
 
     @Test
-    public void findExistingTest() {
+    void findExistingTest() {
         PermissionModel permissionModel = createPermissionModel();
         UserRoleModel userRoleModel = new UserRoleModel(1L, roleName, false, PermissionModelUtil.convertToPermissionMatrixModel(Set.of(permissionModel)));
 
@@ -325,8 +325,7 @@ public class RoleActionsTest {
     }
 
     private DescriptorKey createDescriptorKey(String key) {
-        DescriptorKey descriptorKey = new DescriptorKey(key, key) {};
-        return descriptorKey;
+        return new DescriptorKey(key, key) {};
     }
 
 }

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckAccumulatorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckAccumulatorTest.java
@@ -25,14 +25,14 @@ import com.synopsys.integration.blackduck.api.manual.enumeration.NotificationTyp
 import com.synopsys.integration.blackduck.api.manual.view.NotificationUserView;
 import com.synopsys.integration.exception.IntegrationException;
 
-public class BlackDuckAccumulatorTest {
+class BlackDuckAccumulatorTest {
     private static final BlackDuckProviderKey BLACK_DUCK_PROVIDER_KEY = new BlackDuckProviderKey();
 
     /**
      * This test should simulate a normal run of the accumulator with notifications present.
      */
     @Test
-    public void runValidAccumulatorTest() throws Exception {
+    void runValidAccumulatorTest() throws Exception {
         ProviderTaskPropertiesAccessor taskPropertiesAccessor = Mockito.mock(ProviderTaskPropertiesAccessor.class);
         BlackDuckProperties blackDuckProperties = createBlackDuckProperties();
         BlackDuckSystemValidator validator = createBlackDuckValidator(blackDuckProperties, true);
@@ -57,7 +57,7 @@ public class BlackDuckAccumulatorTest {
     }
 
     @Test
-    public void runValidateFalseTest() {
+    void runValidateFalseTest() {
         BlackDuckProperties invalidProperties = createBlackDuckProperties();
         BlackDuckSystemValidator validator = createBlackDuckValidator(invalidProperties, false);
         BlackDuckNotificationRetrieverFactory notificationRetrieverFactory = Mockito.mock(BlackDuckNotificationRetrieverFactory.class);
@@ -69,20 +69,29 @@ public class BlackDuckAccumulatorTest {
     }
 
     @Test
-    public void runCreateNotificationRetrieverEmptyTest() {
+    void runCreateNotificationRetrieverEmptyTest() {
         ProviderTaskPropertiesAccessor taskPropertiesAccessor = Mockito.mock(ProviderTaskPropertiesAccessor.class);
         BlackDuckProperties blackDuckProperties = createBlackDuckProperties();
         BlackDuckSystemValidator validator = createBlackDuckValidator(blackDuckProperties, true);
         BlackDuckNotificationRetrieverFactory notificationRetrieverFactory = createBlackDuckNotificationRetrieverFactory(blackDuckProperties, null);
 
-        BlackDuckAccumulator accumulator = new BlackDuckAccumulator(BLACK_DUCK_PROVIDER_KEY, null, null, taskPropertiesAccessor, blackDuckProperties, validator, null, notificationRetrieverFactory);
+        BlackDuckAccumulator accumulator = new BlackDuckAccumulator(
+            BLACK_DUCK_PROVIDER_KEY,
+            null,
+            null,
+            taskPropertiesAccessor,
+            blackDuckProperties,
+            validator,
+            null,
+            notificationRetrieverFactory
+        );
         accumulator.run();
 
         Mockito.verify(taskPropertiesAccessor, Mockito.times(0)).getTaskProperty(Mockito.anyString(), Mockito.anyString());
     }
 
     @Test
-    public void runNotificationRetrieverThrowsException() throws IntegrationException {
+    void runNotificationRetrieverThrowsException() throws IntegrationException {
         ProviderTaskPropertiesAccessor taskPropertiesAccessor = Mockito.mock(ProviderTaskPropertiesAccessor.class);
         BlackDuckProperties blackDuckProperties = createBlackDuckProperties();
         BlackDuckSystemValidator validator = createBlackDuckValidator(blackDuckProperties, true);
@@ -107,7 +116,7 @@ public class BlackDuckAccumulatorTest {
 
     private BlackDuckSystemValidator createBlackDuckValidator(BlackDuckProperties blackDuckProperties, boolean validationResult) {
         BlackDuckSystemValidator blackDuckSystemValidator = Mockito.mock(BlackDuckSystemValidator.class);
-        Mockito.when(blackDuckSystemValidator.validate(Mockito.eq(blackDuckProperties))).thenReturn(validationResult);
+        Mockito.when(blackDuckSystemValidator.validate(blackDuckProperties)).thenReturn(validationResult);
         BlackDuckSystemValidator spiedBlackDuckSystemValidator = spy(blackDuckSystemValidator);
         Mockito.doReturn(validationResult).when(spiedBlackDuckSystemValidator).canConnect(Mockito.eq(blackDuckProperties), Mockito.any(BlackDuckApiTokenValidator.class));
         return spiedBlackDuckSystemValidator;

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckNotificationRetrieverTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckNotificationRetrieverTest.java
@@ -22,11 +22,11 @@ import com.synopsys.integration.blackduck.service.request.BlackDuckMultipleReque
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.rest.HttpUrl;
 
-public class BlackDuckNotificationRetrieverTest {
+class BlackDuckNotificationRetrieverTest {
     private static final String THROWAWAY_SERVER = "https://someblackduckserver";
 
     @Test
-    public void retrievePageOfFilteredNotificationsTest() throws IntegrationException {
+    void retrievePageOfFilteredNotificationsTest() throws IntegrationException {
         ProjectNotificationUserView projectNotificationView = new ProjectNotificationUserView();
         BlackDuckPageResponse<NotificationUserView> pageResponse = new BlackDuckPageResponse<>(1, List.of(projectNotificationView));
 
@@ -48,7 +48,7 @@ public class BlackDuckNotificationRetrieverTest {
             .getPageResponse(Mockito.any(BlackDuckMultipleRequest.class));
         Mockito.doReturn(apiUser)
             .when(blackDuckApiClient)
-            .getResponse(Mockito.eq(currentUserUrl));
+            .getResponse(currentUserUrl);
 
         BlackDuckAccumulatorSearchDateManager dateRangeCreator = createDateRangeCreator();
 

--- a/src/test/java/com/synopsys/integration/alert/startup/component/SAMLStartupComponentTest.java
+++ b/src/test/java/com/synopsys/integration/alert/startup/component/SAMLStartupComponentTest.java
@@ -14,10 +14,10 @@ import com.synopsys.integration.alert.component.authentication.descriptor.Authen
 import com.synopsys.integration.alert.component.authentication.security.saml.SAMLContext;
 import com.synopsys.integration.alert.component.authentication.security.saml.SAMLManager;
 
-public class SAMLStartupComponentTest {
+class SAMLStartupComponentTest {
 
     @Test
-    public void testInitialize() throws Exception {
+    void testInitialize() throws Exception {
         SAMLContext context = Mockito.mock(SAMLContext.class);
         ParserPool parserPool = Mockito.mock(ParserPool.class);
         ExtendedMetadata extendedMetadata = Mockito.mock(ExtendedMetadata.class);
@@ -39,7 +39,7 @@ public class SAMLStartupComponentTest {
     }
 
     @Test
-    public void testInitializeException() throws Exception {
+    void testInitializeException() throws Exception {
         SAMLContext context = Mockito.mock(SAMLContext.class);
         ParserPool parserPool = Mockito.mock(ParserPool.class);
         ExtendedMetadata extendedMetadata = Mockito.mock(ExtendedMetadata.class);

--- a/src/test/java/com/synopsys/integration/alert/startup/component/SystemValidatorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/startup/component/SystemValidatorTest.java
@@ -36,7 +36,7 @@ import com.synopsys.integration.rest.proxy.ProxyInfo;
 import com.synopsys.integration.rest.proxy.ProxyInfoBuilder;
 import com.synopsys.integration.rest.response.Response;
 
-public class SystemValidatorTest {
+class SystemValidatorTest {
     private static final String DEFAULT_CONFIG_NAME = "Default";
     private static final String LOCALHOST = "https://localhost:443";
 
@@ -55,7 +55,7 @@ public class SystemValidatorTest {
     }
 
     @Test
-    public void testValidate() {
+    void testValidate() {
         BlackDuckProperties blackDuckProperties = Mockito.mock(BlackDuckProperties.class);
         Mockito.when(blackDuckProperties.getBlackDuckUrl()).thenReturn(Optional.of("Black Duck URL"));
         Mockito.when(blackDuckProperties.getApiToken()).thenReturn("Black Duck API Token");
@@ -65,12 +65,18 @@ public class SystemValidatorTest {
         UserSystemValidator userSystemValidator = Mockito.mock(UserSystemValidator.class);
         SystemMessageAccessor systemMessageAccessor = Mockito.mock(SystemMessageAccessor.class);
 
-        SystemMessageInitializer systemValidator = new SystemMessageInitializer(List.of(), settingsSystemValidator, configurationModelConfigurationAccessor, userSystemValidator, systemMessageAccessor);
+        SystemMessageInitializer systemValidator = new SystemMessageInitializer(
+            List.of(),
+            settingsSystemValidator,
+            configurationModelConfigurationAccessor,
+            userSystemValidator,
+            systemMessageAccessor
+        );
         systemValidator.validate();
     }
 
     @Test
-    public void testValidateProviders() throws IOException {
+    void testValidateProviders() throws IOException {
         BlackDuckProperties blackDuckProperties = Mockito.mock(BlackDuckProperties.class);
         Mockito.when(blackDuckProperties.getBlackDuckUrl()).thenReturn(Optional.of("Black Duck URL"));
         Mockito.when(blackDuckProperties.getApiToken()).thenReturn("Black Duck API Token");
@@ -80,13 +86,19 @@ public class SystemValidatorTest {
         UserSystemValidator userSystemValidator = Mockito.mock(UserSystemValidator.class);
         SystemMessageAccessor systemMessageAccessor = Mockito.mock(SystemMessageAccessor.class);
 
-        SystemMessageInitializer systemValidator = new SystemMessageInitializer(List.of(), settingsSystemValidator, configurationModelConfigurationAccessor, userSystemValidator, systemMessageAccessor);
+        SystemMessageInitializer systemValidator = new SystemMessageInitializer(
+            List.of(),
+            settingsSystemValidator,
+            configurationModelConfigurationAccessor,
+            userSystemValidator,
+            systemMessageAccessor
+        );
         systemValidator.validateProviders();
         assertTrue(outputLogger.isLineContainingText("Validating configured providers: "));
     }
 
     @Test
-    public void testValidateBlackDuckProviderNullURL() throws Exception {
+    void testValidateBlackDuckProviderNullURL() throws Exception {
         long configId = 1L;
         BlackDuckProperties blackDuckProperties = Mockito.mock(BlackDuckProperties.class);
         Mockito.when(blackDuckProperties.getBlackDuckUrl()).thenReturn(Optional.empty());
@@ -104,12 +116,15 @@ public class SystemValidatorTest {
         BlackDuckSystemValidator blackDuckSystemValidator = new BlackDuckSystemValidator(defaultSystemMessageUtility);
         blackDuckSystemValidator.validate(blackDuckProperties);
         Mockito.verify(defaultSystemMessageUtility)
-            .addSystemMessage(Mockito.eq(String.format(BlackDuckSystemValidator.MISSING_BLACKDUCK_URL_ERROR_W_CONFIG_FORMAT, DEFAULT_CONFIG_NAME)), Mockito.eq(SystemMessageSeverity.WARNING),
-                Mockito.eq(missingUrlMessageType));
+            .addSystemMessage(
+                String.format(BlackDuckSystemValidator.MISSING_BLACKDUCK_URL_ERROR_W_CONFIG_FORMAT, DEFAULT_CONFIG_NAME),
+                SystemMessageSeverity.WARNING,
+                missingUrlMessageType
+            );
     }
 
     @Test
-    public void testValidateBlackDuckProviderLocalhostURL() throws Exception {
+    void testValidateBlackDuckProviderLocalhostURL() throws Exception {
         long configId = 1L;
         ProxyManager proxyManager = Mockito.mock(ProxyManager.class);
         Mockito.when(proxyManager.createProxyInfoForHost(Mockito.anyString())).thenReturn(ProxyInfo.NO_PROXY_INFO);
@@ -135,11 +150,15 @@ public class SystemValidatorTest {
         spiedBlackDuckSystemValidator.validate(blackDuckProperties);
 
         Mockito.verify(defaultSystemMessageUtility)
-            .addSystemMessage(Mockito.eq(String.format(BlackDuckSystemValidator.BLACKDUCK_LOCALHOST_ERROR_FORMAT, DEFAULT_CONFIG_NAME)), Mockito.eq(SystemMessageSeverity.WARNING), Mockito.eq(localhostMessageType));
+            .addSystemMessage(
+                String.format(BlackDuckSystemValidator.BLACKDUCK_LOCALHOST_ERROR_FORMAT, DEFAULT_CONFIG_NAME),
+                SystemMessageSeverity.WARNING,
+                localhostMessageType
+            );
     }
 
     @Test
-    public void testValidateHubInvalidProvider() throws Exception {
+    void testValidateHubInvalidProvider() throws Exception {
         long configId = 1L;
         ProxyManager proxyManager = Mockito.mock(ProxyManager.class);
         Mockito.when(proxyManager.createProxyInfoForHost(Mockito.anyString())).thenReturn(ProxyInfo.NO_PROXY_INFO);
@@ -169,14 +188,21 @@ public class SystemValidatorTest {
         spiedBlackDuckSystemValidator.validate(blackDuckProperties);
 
         Mockito.verify(defaultSystemMessageUtility)
-            .addSystemMessage(Mockito.eq(String.format(BlackDuckSystemValidator.BLACKDUCK_LOCALHOST_ERROR_FORMAT, DEFAULT_CONFIG_NAME)), Mockito.eq(SystemMessageSeverity.WARNING), Mockito.eq(localhostMessageType));
+            .addSystemMessage(
+                String.format(BlackDuckSystemValidator.BLACKDUCK_LOCALHOST_ERROR_FORMAT, DEFAULT_CONFIG_NAME),
+                SystemMessageSeverity.WARNING,
+                localhostMessageType
+            );
         Mockito.verify(defaultSystemMessageUtility)
-            .addSystemMessage(Mockito.eq(String.format("Can not connect to the Black Duck server with the configuration '%s'.", DEFAULT_CONFIG_NAME)), Mockito.eq(SystemMessageSeverity.WARNING),
-                Mockito.eq(connectivityMessageType));
+            .addSystemMessage(
+                String.format("Can not connect to the Black Duck server with the configuration '%s'.", DEFAULT_CONFIG_NAME),
+                SystemMessageSeverity.WARNING,
+                connectivityMessageType
+            );
     }
 
     @Test
-    public void testValidateHubValidProvider() throws Exception {
+    void testValidateHubValidProvider() throws Exception {
         ProxyManager proxyManager = Mockito.mock(ProxyManager.class);
         Mockito.when(proxyManager.createProxyInfoForHost(Mockito.anyString())).thenReturn(ProxyInfo.NO_PROXY_INFO);
         BlackDuckProperties blackDuckProperties = Mockito.mock(BlackDuckProperties.class);
@@ -203,7 +229,7 @@ public class SystemValidatorTest {
     }
 
     @Test
-    public void testValidateHubValidProviderWithProxy() throws Exception {
+    void testValidateHubValidProviderWithProxy() throws Exception {
         ProxyManager proxyManager = Mockito.mock(ProxyManager.class);
 
         CredentialsBuilder builder = Credentials.newBuilder();
@@ -240,7 +266,7 @@ public class SystemValidatorTest {
     }
 
     @Test
-    public void testCanConnectTrue() throws IOException, IntegrationException {
+    void testCanConnectTrue() throws IOException, IntegrationException {
         BlackDuckProperties blackDuckProperties = createMockBlackDuckProperties(Optional.of(LOCALHOST));
 
         DefaultSystemMessageAccessor defaultSystemMessageUtility = Mockito.mock(DefaultSystemMessageAccessor.class);
@@ -260,7 +286,7 @@ public class SystemValidatorTest {
     }
 
     @Test
-    public void testCanConnectFalse() throws IOException, IntegrationException {
+    void testCanConnectFalse() throws IOException, IntegrationException {
         int httpResponseCode = 409;
         BlackDuckProperties blackDuckProperties = createMockBlackDuckProperties(Optional.of(LOCALHOST));
 
@@ -281,7 +307,7 @@ public class SystemValidatorTest {
     }
 
     @Test
-    public void testCanConnectThrowException() throws IOException, IntegrationException {
+    void testCanConnectThrowException() throws IOException, IntegrationException {
         BlackDuckProperties blackDuckProperties = createMockBlackDuckProperties(Optional.of(LOCALHOST));
 
         DefaultSystemMessageAccessor mockDefaultSystemMessageAccessor = Mockito.mock(DefaultSystemMessageAccessor.class);
@@ -297,7 +323,7 @@ public class SystemValidatorTest {
     }
 
     @Test
-    public void testCanConnectNullBDUrl() throws IOException, IntegrationException {
+    void testCanConnectNullBDUrl() throws IOException, IntegrationException {
         BlackDuckProperties blackDuckProperties = createMockBlackDuckProperties(Optional.empty());
 
         DefaultSystemMessageAccessor mockDefaultSystemMessageAccessor = Mockito.mock(DefaultSystemMessageAccessor.class);

--- a/web/src/test/java/com/synopsys/integration/alert/web/api/job/JobConfigActionsTest.java
+++ b/web/src/test/java/com/synopsys/integration/alert/web/api/job/JobConfigActionsTest.java
@@ -162,7 +162,7 @@ class JobConfigActionsTest {
     }
 
     @Test
-    void getPageTest() throws Exception {
+    void getPageTest() {
         int totalPages = 1;
         int pageNumber = 0;
         int pageSize = 10;
@@ -487,7 +487,7 @@ class JobConfigActionsTest {
         JobIdsRequestModel jobIdsRequestModel = new JobIdsRequestModel(List.of(jobId));
         Mockito.when(mockedAuthorizationManager.anyReadPermission(Mockito.any())).thenReturn(true);
         Mockito.when(mockedConfigurationFieldModelConverter.convertToFieldModel(Mockito.any())).thenReturn(fieldModel);
-        Mockito.when(mockedFieldModelProcessor.performAfterReadAction(Mockito.eq(fieldModel))).thenReturn(fieldModel);
+        Mockito.when(mockedFieldModelProcessor.performAfterReadAction(fieldModel)).thenReturn(fieldModel);
 
         ActionResponse<List<JobFieldStatuses>> actionResponse = defaultJobConfigActions.validateJobsById(jobIdsRequestModel);
 
@@ -599,7 +599,7 @@ class JobConfigActionsTest {
     private FieldModelTestAction createTestActionWithErrors() {
         FieldModelTestAction fieldModelTestAction = new FieldModelTestAction() {
             @Override
-            public MessageResult testConfig(String configId, FieldModel fieldModel, FieldUtility registeredFieldValues) throws IntegrationException {
+            public MessageResult testConfig(String configId, FieldModel fieldModel, FieldUtility registeredFieldValues) {
                 AlertFieldStatus alertFieldStatus = AlertFieldStatus.error("fieldNameTest", "Alert Error Message");
                 return new MessageResult("Test Status Message", List.of(alertFieldStatus));
             }


### PR DESCRIPTION
- Remove unused values
- Remove unused throws
- Remove public where not needed

The data below was copied before running the dev branch, and again after.
The only data point that should change and the only one that did change was the Code Smell count.
The specific rule that is being addressed is named "Call to Mockito method "verify", "when" or "given" should be simplified"

|  | master branch | DEV branch |
| ------------- | ------------- | ------------- |
| **Sonar** | ------------- | ------------- |
| Code Smells | 582 | 493 |
| Debt | 17D | 17D |
| # of Tests | 1,632 | 1,632 |
| Code Coverage | 73.4% | 73.4% |
| Lines of Code | 52,507 | 52,507 |
|  |  |  |
| **Jenkins Test Results** |  |  |
| Failures | 0 | 0 |
| Skipped | 45 | 45 |
| Success | 1,677 | 1,677 |
|  |  |  |
| **Jenkins Coverage Report** |  |  |
| instruction | 73% | 73% |
|  | M: 23580 C: 65122 | M: 23580 C: 65122 |
| branch | 64% | 64% |
|  | M: 1268 C: 2248 | M: 1268 C: 2248 |
| complexity | 68% | 68% |
|  | M: 2527 C: 5263 | M: 2527 C: 5263 |
| line | 75% | 75% |
|  | M: 5430 C: 15875 | M: 5430 C: 15875 |
| method | 73% | 73% |
|  | M: 1608 C: 4414 | M: 1608 C: 4414 |
| class | 88% | 88% |
|  | M: 123 C: 906 | M: 123 C: 906 |