### PR TITLE
IALERT-3149 - Update build pieces for going to Postgres 13

### DIFF
--- a/alert-platform/build.gradle
+++ b/alert-platform/build.gradle
@@ -5,10 +5,10 @@ plugins {
 dependencies {
     constraints {
         api 'com.github.springtestdbunit:spring-test-dbunit:1.3.0'
-        api 'org.testcontainers:postgresql:1.17.4'
-        api 'com.playtika.testcontainers:embedded-postgresql:2.2.9'
-        api 'org.testcontainers:rabbitmq:1.17.4'
-        api 'com.playtika.testcontainers:embedded-rabbitmq:2.2.9'
+        api 'org.testcontainers:postgresql:1.17.3'
+        api 'com.playtika.testcontainers:embedded-postgresql:2.2.8'
+        api 'org.testcontainers:rabbitmq:1.17.3'
+        api 'com.playtika.testcontainers:embedded-rabbitmq:2.2.8'
         api 'org.springframework.cloud:spring-cloud-starter-bootstrap:3.0.1'
         api 'org.springframework.boot:spring-boot-starter-amqp:2.5.12'
 

--- a/alert-platform/build.gradle
+++ b/alert-platform/build.gradle
@@ -5,10 +5,10 @@ plugins {
 dependencies {
     constraints {
         api 'com.github.springtestdbunit:spring-test-dbunit:1.3.0'
-        api 'org.testcontainers:postgresql:1.16.3'
-        api 'com.playtika.testcontainers:embedded-postgresql:2.1.5'
-        api 'org.testcontainers:rabbitmq:1.16.3'
-        api 'com.playtika.testcontainers:embedded-rabbitmq:2.1.5'
+        api 'org.testcontainers:postgresql:1.17.4'
+        api 'com.playtika.testcontainers:embedded-postgresql:2.2.9'
+        api 'org.testcontainers:rabbitmq:1.17.4'
+        api 'com.playtika.testcontainers:embedded-rabbitmq:2.2.9'
         api 'org.springframework.cloud:spring-cloud-starter-bootstrap:3.0.1'
         api 'org.springframework.boot:spring-boot-starter-amqp:2.5.12'
 
@@ -36,7 +36,7 @@ dependencies {
         api 'org.javassist:javassist:3.24.0-GA'
         api 'io.springfox:springfox-boot-starter:3.0.0'
 
-        runtime 'org.postgresql:postgresql:42.3.3'
+        runtime 'org.postgresql:postgresql:42.3.7'
         runtime 'org.liquibase:liquibase-core:3.8.9'
         runtime 'io.springfox:springfox-swagger-ui:2.8.0'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ ext {
         exclude group: 'com.blackducksoftware.bdio', module: 'bdio2'
     }
 
+    // This version is also in src/test/resources/spring-test.properties for the test jdbc connection
     postgresContainerVersion = '13.8'
 
     // Docker Variables

--- a/build.gradle
+++ b/build.gradle
@@ -26,11 +26,11 @@ ext {
 
     moduleName = 'com.synopsys.integration.alert.main'
 
-    postgresContainerVersion = '12.2'
-
     blackduckCommonExcludes = {
         exclude group: 'com.blackducksoftware.bdio', module: 'bdio2'
     }
+
+    postgresContainerVersion = '13.8'
 
     // Docker Variables
     dockerStagingDirectory = project.buildDir.toString() + '/docker-staging'
@@ -53,7 +53,7 @@ apply plugin: 'com.synopsys.integration.solution'
 apply from: 'buildSrc/buildTasks.gradle'
 apply from: 'buildSrc/runTasks.gradle'
 apply from: 'buildSrc/deploymentTasks.gradle'
-apply from: 'buildSrc/docker-v2.gradle'
+apply from: 'buildSrc/docker.gradle'
 
 allprojects {
     // disable the test task when running the alert server to speed up startup time.

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ ext {
     postgresContainerVersion = '13.8'
 
     // Docker Variables
+    dockerBuildParam_POSTGRESIMAGEVERSION = 'postgres:' + postgresContainerVersion + '-alpine'
     dockerStagingDirectory = project.buildDir.toString() + '/docker-staging'
     baseDockerDirectory = project.projectDir.toString() + '/docker'
     dockerCleanStagingAreaDirectoryStageName = 'dockerCleanStagingAreaDirectory'
@@ -53,7 +54,7 @@ apply plugin: 'com.synopsys.integration.solution'
 apply from: 'buildSrc/buildTasks.gradle'
 apply from: 'buildSrc/runTasks.gradle'
 apply from: 'buildSrc/deploymentTasks.gradle'
-apply from: 'buildSrc/docker.gradle'
+apply from: 'buildSrc/docker-v2.gradle'
 
 allprojects {
     // disable the test task when running the alert server to speed up startup time.

--- a/buildSrc/docker-v2.gradle
+++ b/buildSrc/docker-v2.gradle
@@ -111,7 +111,15 @@ dockerImagesToBuild.each { imageName ->
     project.tasks.create(name: dockerImageBuildTaskName, type: Exec, group: 'Docker', description: "Build ${imageName} docker image") {
         dockerTasksCreated.add(dockerImageBuildTaskName)
         dependsOn project.tasks.findByName(dockerSetupStagingAreaDirectory)
-        def buildCommand = ['docker', 'build', '.', '-t', fullDockerImageName, '--build-arg', "VERSION=${project.version}", '--pull', '--force-rm']
+        def buildCommand = ['docker', 'build', '.', '-t', fullDockerImageName, '--pull', '--force-rm', '--build-arg', "VERSION=${project.version}"]
+
+        rootProject.ext.properties.each { key, value ->
+            if (key.startsWith('dockerBuildParam_')) {
+                String adjKey = key.substring(key.indexOf('_') + 1)
+                buildCommand.add('--build-arg')
+                buildCommand.add("${adjKey}=${value}")
+            }
+        }
 
         doFirst {
             logger.lifecycle("Building docker image:: ${fullDockerImageName}")

--- a/deployment/helm/synopsys-alert/README.md
+++ b/deployment/helm/synopsys-alert/README.md
@@ -562,7 +562,7 @@ For the on-premise database deployment a second Persistent Volume must be create
 ### External Postgres Database
 
 #### External Postgres Database Requirements
-- Postgres Version: 12
+- Postgres Version: 13
 - Extension: uuid-ossp (Note: this should be installed prior to creating the database)
 - Schemas: public, alert
 - Roles/Privileges: Alert requires two sets of Postgres Privileges. One set of privileges is necessary for initializing and upgrading the database. The other set (which is a subset of the first) is for reading and writing data when the

--- a/deployment/helm/synopsys-alert/templates/postgres.yaml
+++ b/deployment/helm/synopsys-alert/templates/postgres.yaml
@@ -138,9 +138,9 @@ spec:
               name: {{ .Release.Name }}-db-creds
         {{- end }}
         {{- if .Values.postgres.registry }}
-        image: {{ .Values.postgres.registry }}/postgresql-12-centos7:1
+        image: {{ .Values.postgres.registry }}/postgresql-13-centos7:1
         {{- else }}
-        image: {{ .Values.registry }}/postgresql-12-centos7:1
+        image: {{ .Values.registry }}/postgresql-13-centos7:1
         {{- end}}
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -149,7 +149,7 @@ spec:
               command:
                 - sh
                 - -c
-                - LD_LIBRARY_PATH=/opt/rh/rh-postgresql12/root/usr/lib64 /opt/rh/rh-postgresql12/root/usr/bin/pg_ctl -D /var/lib/pgsql/data/userdata -l logfile stop
+                - LD_LIBRARY_PATH=/opt/rh/rh-postgresql13/root/usr/lib64 /opt/rh/rh-postgresql13/root/usr/bin/pg_ctl -D /var/lib/pgsql/data/userdata -l logfile stop
         name: {{ .Release.Name }}-postgres
         ports:
         - containerPort: {{ .Values.postgres.port }}
@@ -159,7 +159,7 @@ spec:
             command:
               - /bin/bash
               - -c
-              - /opt/rh/rh-postgresql12/root/usr/bin/pg_isready -h localhost
+              - /opt/rh/rh-postgresql13/root/usr/bin/pg_isready -h localhost
           failureThreshold: 10
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/docker/blackduck-alert-db/Dockerfile
+++ b/docker/blackduck-alert-db/Dockerfile
@@ -1,4 +1,7 @@
-FROM postgres:12.11-alpine
+# The ARG for the FROM image comes from Gradle. It is based off of postgresContainerVersion,
+# and used in buildSrc/docker.gradle
+ARG POSTGRESIMAGEVERSION=""
+FROM ${POSTGRESIMAGEVERSION}
 
 ARG VERSION
 

--- a/src/test/resources/spring-test.properties
+++ b/src/test/resources/spring-test.properties
@@ -1,6 +1,6 @@
 server.ssl.enabled=false
-spring.datasource.url=jdbc:tc:postgresql:12.2:///alertdb?TC_INITSCRIPT=file:buildSrc/src/main/resources/init_test_db.sql&TC_TMPFS=/testtmpfs:rw
-spring.datasource.hikari.jdbc-url=spring.datasource.url=jdbc:tc:postgresql:12.2:///alertdb?TC_INITSCRIPT=file:buildSrc/src/main/resources/init_test_db.sql&TC_TMPFS=/testtmpfs:rw
+spring.datasource.url=jdbc:tc:postgresql:13.8:///alertdb?TC_INITSCRIPT=file:buildSrc/src/main/resources/init_test_db.sql&TC_TMPFS=/testtmpfs:rw
+spring.datasource.hikari.jdbc-url=spring.datasource.url=jdbc:tc:postgresql:13.8:///alertdb?TC_INITSCRIPT=file:buildSrc/src/main/resources/init_test_db.sql&TC_TMPFS=/testtmpfs:rw
 spring.datasource.username=sa
 spring.datasource.password=blackduck
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver


### PR DESCRIPTION
Update the build pieces needed to go to Postgres 13. This PR does **NOT** handle upgrades, that will be in a later PR.

* Update testcontainers version to latest version (that does not have breaking issues)
* Add logic to Docker gradle build to automate adding build arguments to the docker build step(s)
* Update helm to use Postgres 13 supported image
* Update alert-db image to leverage base image coming from gradle
* Update spring resources to use Postgres 13

A full comprehensive build was run with these changes