### PR TITLE
Rename azure properties file to legacy 

### DIFF
--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsPropertiesFactory.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsPropertiesFactory.java
@@ -25,20 +25,22 @@ public class AzureBoardsPropertiesFactory {
     private final ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor;
 
     @Autowired
-    public AzureBoardsPropertiesFactory(AzureBoardsChannelKey channelKey, AzureBoardsCredentialDataStoreFactory credentialDataStoreFactory,
-        AzureRedirectUrlCreator azureRedirectUrlCreator, ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor) {
+    public AzureBoardsPropertiesFactory(
+        AzureBoardsChannelKey channelKey, AzureBoardsCredentialDataStoreFactory credentialDataStoreFactory,
+        AzureRedirectUrlCreator azureRedirectUrlCreator, ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor
+    ) {
         this.channelKey = channelKey;
         this.credentialDataStoreFactory = credentialDataStoreFactory;
         this.azureRedirectUrlCreator = azureRedirectUrlCreator;
         this.configurationModelConfigurationAccessor = configurationModelConfigurationAccessor;
     }
 
-    public AzureBoardsProperties createAzureBoardsProperties() throws AlertConfigurationException {
+    public AzureBoardsPropertiesLegacy createAzureBoardsProperties() throws AlertConfigurationException {
         ConfigurationModel azureBoardsGlobalConfiguration = configurationModelConfigurationAccessor.getConfigurationsByDescriptorKeyAndContext(channelKey, ConfigContextEnum.GLOBAL)
-                                                                .stream()
-                                                                .findAny()
-                                                                .orElseThrow(() -> new AlertConfigurationException("Missing Azure Boards global configuration"));
-        return AzureBoardsProperties.fromGlobalConfig(credentialDataStoreFactory, azureRedirectUrlCreator.createOAuthRedirectUri(), azureBoardsGlobalConfiguration);
+            .stream()
+            .findAny()
+            .orElseThrow(() -> new AlertConfigurationException("Missing Azure Boards global configuration"));
+        return AzureBoardsPropertiesLegacy.fromGlobalConfig(credentialDataStoreFactory, azureRedirectUrlCreator.createOAuthRedirectUri(), azureBoardsGlobalConfiguration);
     }
 
 }

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsPropertiesLegacy.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsPropertiesLegacy.java
@@ -52,7 +52,7 @@ import com.synopsys.integration.azure.boards.common.oauth.AzureAuthorizationCode
 import com.synopsys.integration.azure.boards.common.oauth.AzureOAuthScopes;
 import com.synopsys.integration.rest.proxy.ProxyInfo;
 
-public class AzureBoardsProperties {
+public class AzureBoardsPropertiesLegacy {
     private static final String DEFAULT_AZURE_OAUTH_USER_ID = "azure_default_user";
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -65,21 +65,33 @@ public class AzureBoardsProperties {
     private final List<String> scopes;
     private final String redirectUri;
 
-    public static AzureBoardsProperties fromFieldAccessor(AzureBoardsCredentialDataStoreFactory credentialDataStoreFactory, String redirectUri, FieldUtility fieldUtility) {
+    public static AzureBoardsPropertiesLegacy fromFieldAccessor(AzureBoardsCredentialDataStoreFactory credentialDataStoreFactory, String redirectUri, FieldUtility fieldUtility) {
         String organizationName = fieldUtility.getStringOrNull(AzureBoardsDescriptor.KEY_ORGANIZATION_NAME);
         String clientId = fieldUtility.getStringOrNull(AzureBoardsDescriptor.KEY_CLIENT_ID);
         String clientSecret = fieldUtility.getStringOrNull(AzureBoardsDescriptor.KEY_CLIENT_SECRET);
         String oAuthUserEmail = fieldUtility.getString(AzureBoardsDescriptor.KEY_OAUTH_USER_EMAIL).orElse(DEFAULT_AZURE_OAUTH_USER_ID);
         List<String> defaultScopes = List.of(AzureOAuthScopes.PROJECTS_READ.getScope(), AzureOAuthScopes.WORK_FULL.getScope());
-        return new AzureBoardsProperties(credentialDataStoreFactory, organizationName, clientId, clientSecret, oAuthUserEmail, defaultScopes, redirectUri);
+        return new AzureBoardsPropertiesLegacy(credentialDataStoreFactory, organizationName, clientId, clientSecret, oAuthUserEmail, defaultScopes, redirectUri);
     }
 
-    public static AzureBoardsProperties fromGlobalConfig(AzureBoardsCredentialDataStoreFactory credentialDataStoreFactory, String redirectUri, ConfigurationModel globalConfiguration) {
+    public static AzureBoardsPropertiesLegacy fromGlobalConfig(
+        AzureBoardsCredentialDataStoreFactory credentialDataStoreFactory,
+        String redirectUri,
+        ConfigurationModel globalConfiguration
+    ) {
         FieldUtility globalFieldUtility = new FieldUtility(globalConfiguration.getCopyOfKeyToFieldMap());
         return fromFieldAccessor(credentialDataStoreFactory, redirectUri, globalFieldUtility);
     }
 
-    public AzureBoardsProperties(AzureBoardsCredentialDataStoreFactory credentialDataStoreFactory, String organizationName, String clientId, String clientSecret, String oauthUserId, List<String> scopes, String redirectUri) {
+    public AzureBoardsPropertiesLegacy(
+        AzureBoardsCredentialDataStoreFactory credentialDataStoreFactory,
+        String organizationName,
+        String clientId,
+        String clientSecret,
+        String oauthUserId,
+        List<String> scopes,
+        String redirectUri
+    ) {
         this.credentialDataStoreFactory = credentialDataStoreFactory;
         this.organizationName = organizationName;
         this.clientId = clientId;
@@ -88,7 +100,13 @@ public class AzureBoardsProperties {
         this.scopes = scopes;
         this.redirectUri = redirectUri;
 
-        logger.debug("Initializing Azure Boards Properties with values: organizationName=[{}], oAuthUserId=[{}], scopes=[{}], redirectUri=[{}]", organizationName, oauthUserId, StringUtils.join(scopes, ","), redirectUri);
+        logger.debug(
+            "Initializing Azure Boards Properties with values: organizationName=[{}], oAuthUserId=[{}], scopes=[{}], redirectUri=[{}]",
+            organizationName,
+            oauthUserId,
+            StringUtils.join(scopes, ","),
+            redirectUri
+        );
     }
 
     public String getOrganizationName() {

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalFieldModelTestAction.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalFieldModelTestAction.java
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.google.gson.Gson;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
 import com.synopsys.integration.alert.channel.azure.boards.descriptor.AzureBoardsDescriptor;
 import com.synopsys.integration.alert.channel.azure.boards.oauth.storage.AzureBoardsCredentialDataStoreFactory;
@@ -43,7 +43,12 @@ public class AzureBoardsGlobalFieldModelTestAction extends FieldModelTestAction 
     private final ProxyManager proxyManager;
 
     @Autowired
-    public AzureBoardsGlobalFieldModelTestAction(Gson gson, AzureBoardsCredentialDataStoreFactory azureBoardsCredentialDataStoreFactory, AzureRedirectUrlCreator azureRedirectUrlCreator, ProxyManager proxyManager) {
+    public AzureBoardsGlobalFieldModelTestAction(
+        Gson gson,
+        AzureBoardsCredentialDataStoreFactory azureBoardsCredentialDataStoreFactory,
+        AzureRedirectUrlCreator azureRedirectUrlCreator,
+        ProxyManager proxyManager
+    ) {
         this.gson = gson;
         this.azureBoardsCredentialDataStoreFactory = azureBoardsCredentialDataStoreFactory;
         this.azureRedirectUrlCreator = azureRedirectUrlCreator;
@@ -56,7 +61,11 @@ public class AzureBoardsGlobalFieldModelTestAction extends FieldModelTestAction 
             Optional<ConfigurationFieldModel> configurationFieldModel = registeredFieldValues.getField(AzureBoardsDescriptor.KEY_ORGANIZATION_NAME);
             String organizationName = configurationFieldModel.flatMap(ConfigurationFieldModel::getFieldValue).orElse(null);
 
-            AzureBoardsProperties azureBoardsProperties = AzureBoardsProperties.fromFieldAccessor(azureBoardsCredentialDataStoreFactory, azureRedirectUrlCreator.createOAuthRedirectUri(), registeredFieldValues);
+            AzureBoardsPropertiesLegacy azureBoardsProperties = AzureBoardsPropertiesLegacy.fromFieldAccessor(
+                azureBoardsCredentialDataStoreFactory,
+                azureRedirectUrlCreator.createOAuthRedirectUri(),
+                registeredFieldValues
+            );
             AzureHttpService azureHttpService = createAzureHttpService(azureBoardsProperties);
             AzureProjectService azureProjectService = new AzureProjectService(azureHttpService, new AzureApiVersionAppender());
             azureProjectService.getProjects(organizationName);
@@ -67,7 +76,7 @@ public class AzureBoardsGlobalFieldModelTestAction extends FieldModelTestAction 
         }
     }
 
-    private AzureHttpService createAzureHttpService(AzureBoardsProperties azureBoardsProperties) throws IntegrationException {
+    private AzureHttpService createAzureHttpService(AzureBoardsPropertiesLegacy azureBoardsProperties) throws IntegrationException {
         ProxyInfo proxy = proxyManager.createProxyInfoForHost(AzureHttpRequestCreatorFactory.DEFAULT_BASE_URL);
         return azureBoardsProperties.createAzureHttpService(proxy, gson);
     }

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/AzureBoardsMessageSenderFactory.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/AzureBoardsMessageSenderFactory.java
@@ -26,8 +26,8 @@ import com.synopsys.integration.alert.api.channel.issue.send.IssueTrackerTransit
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsHttpExceptionMessageImprover;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesFactory;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.delegate.AzureBoardsCommentGenerator;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.delegate.AzureBoardsCreateEventGenerator;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.delegate.AzureBoardsIssueCommenter;
@@ -86,7 +86,7 @@ public class AzureBoardsMessageSenderFactory implements IssueTrackerMessageSende
 
     @Override
     public IssueTrackerMessageSender<Integer> createMessageSender(AzureBoardsJobDetailsModel distributionDetails, UUID globalId) throws AlertException {
-        AzureBoardsProperties azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
+        AzureBoardsPropertiesLegacy azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
         azureBoardsProperties.validateProperties();
 
         // Initialize Http Service

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/AzureBoardsProcessorFactory.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/AzureBoardsProcessorFactory.java
@@ -26,8 +26,8 @@ import com.synopsys.integration.alert.api.channel.issue.search.IssueCategoryRetr
 import com.synopsys.integration.alert.api.channel.issue.search.IssueTrackerSearcher;
 import com.synopsys.integration.alert.api.channel.issue.send.IssueTrackerAsyncMessageSender;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesFactory;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.search.AzureBoardsComponentIssueFinder;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.search.AzureBoardsExistingIssueDetailsCreator;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.search.AzureBoardsIssueStatusResolver;
@@ -81,7 +81,7 @@ public class AzureBoardsProcessorFactory implements IssueTrackerProcessorFactory
 
     @Override
     public IssueTrackerProcessor<Integer> createProcessor(AzureBoardsJobDetailsModel distributionDetails, UUID eventId, Set<Long> notificationIds) throws AlertException {
-        AzureBoardsProperties azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
+        AzureBoardsPropertiesLegacy azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
         String organizationName = azureBoardsProperties.getOrganizationName();
         azureBoardsProperties.validateProperties();
 
@@ -143,7 +143,13 @@ public class AzureBoardsProcessorFactory implements IssueTrackerProcessorFactory
         return new IssueTrackerProcessor<>(extractor, messageSender);
     }
 
-    private void installCustomFieldsIfNecessary(String organizationName, String projectName, String issueType, AzureProjectService projectService, AzureProcessService processService) throws AlertException {
+    private void installCustomFieldsIfNecessary(
+        String organizationName,
+        String projectName,
+        String issueType,
+        AzureProjectService projectService,
+        AzureProcessService processService
+    ) throws AlertException {
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         AzureCustomFieldManager azureCustomFieldInstaller = new AzureCustomFieldManager(organizationName, projectService, processService, executorService);
         try {

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCommentEventHandler.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCommentEventHandler.java
@@ -25,8 +25,8 @@ import com.synopsys.integration.alert.api.channel.issue.model.IssueTrackerRespon
 import com.synopsys.integration.alert.api.channel.issue.send.IssueTrackerMessageSender;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.api.event.EventManager;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesFactory;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.AzureBoardsMessageSenderFactory;
 import com.synopsys.integration.alert.common.persistence.accessor.JobDetailsAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.JobSubTaskAccessor;
@@ -76,22 +76,22 @@ public class AzureBoardsCommentEventHandler extends IssueTrackerCommentEventHand
         Optional<AzureBoardsJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(event.getJobId());
         if (details.isPresent()) {
             AzureBoardsJobDetailsModel distributionDetails = details.get();
-            AzureBoardsProperties azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
+            AzureBoardsPropertiesLegacy azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
             String organizationName = azureBoardsProperties.getOrganizationName();
             azureBoardsProperties.validateProperties();
 
             // Initialize Http Service
             ProxyInfo proxy = proxyManager.createProxyInfoForHost(AzureHttpRequestCreatorFactory.DEFAULT_BASE_URL);
-                AzureHttpRequestCreator azureHttpRequestCreator = azureBoardsProperties.createAzureHttpRequestCreator(proxy, gson);
-                AzureHttpService azureHttpService = new AzureHttpService(gson, azureHttpRequestCreator);
+            AzureHttpRequestCreator azureHttpRequestCreator = azureBoardsProperties.createAzureHttpRequestCreator(proxy, gson);
+            AzureHttpService azureHttpService = new AzureHttpService(gson, azureHttpRequestCreator);
 
-                // Common Azure Boards Services
-                AzureApiVersionAppender apiVersionAppender = new AzureApiVersionAppender();
-                AzureWorkItemService workItemService = new AzureWorkItemService(azureHttpService, azureHttpRequestCreator);
-                AzureWorkItemQueryService workItemQueryService = new AzureWorkItemQueryService(azureHttpService, apiVersionAppender);
-                // Message Sender Requirements
-                AzureWorkItemTypeStateService workItemTypeStateService = new AzureWorkItemTypeStateService(azureHttpService, apiVersionAppender);
-                AzureWorkItemCommentService workItemCommentService = new AzureWorkItemCommentService(azureHttpService, apiVersionAppender);
+            // Common Azure Boards Services
+            AzureApiVersionAppender apiVersionAppender = new AzureApiVersionAppender();
+            AzureWorkItemService workItemService = new AzureWorkItemService(azureHttpService, azureHttpRequestCreator);
+            AzureWorkItemQueryService workItemQueryService = new AzureWorkItemQueryService(azureHttpService, apiVersionAppender);
+            // Message Sender Requirements
+            AzureWorkItemTypeStateService workItemTypeStateService = new AzureWorkItemTypeStateService(azureHttpService, apiVersionAppender);
+            AzureWorkItemCommentService workItemCommentService = new AzureWorkItemCommentService(azureHttpService, apiVersionAppender);
 
             IssueTrackerMessageSender<Integer> messageSender = azureBoardsMessageSenderFactory.createMessageSender(
                 workItemService,

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCreateIssueEventHandler.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCreateIssueEventHandler.java
@@ -28,8 +28,8 @@ import com.synopsys.integration.alert.api.channel.issue.model.IssueTrackerRespon
 import com.synopsys.integration.alert.api.channel.issue.send.IssueTrackerMessageSender;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.api.event.EventManager;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesFactory;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.AzureBoardsMessageSenderFactory;
 import com.synopsys.integration.alert.common.persistence.accessor.JobDetailsAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.JobSubTaskAccessor;
@@ -81,7 +81,7 @@ public class AzureBoardsCreateIssueEventHandler extends IssueTrackerCreateIssueE
         if (details.isPresent()) {
             try {
                 AzureBoardsJobDetailsModel distributionDetails = details.get();
-                AzureBoardsProperties azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
+                AzureBoardsPropertiesLegacy azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
                 String organizationName = azureBoardsProperties.getOrganizationName();
                 azureBoardsProperties.validateProperties();
 

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsTransitionEventHandler.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsTransitionEventHandler.java
@@ -25,8 +25,8 @@ import com.synopsys.integration.alert.api.channel.issue.model.IssueTransitionMod
 import com.synopsys.integration.alert.api.channel.issue.send.IssueTrackerMessageSender;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.api.event.EventManager;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesFactory;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.AzureBoardsMessageSenderFactory;
 import com.synopsys.integration.alert.common.persistence.accessor.JobDetailsAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.JobSubTaskAccessor;
@@ -76,7 +76,7 @@ public class AzureBoardsTransitionEventHandler extends IssueTrackerTransitionEve
         Optional<AzureBoardsJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(event.getJobId());
         if (details.isPresent()) {
             AzureBoardsJobDetailsModel distributionDetails = details.get();
-            AzureBoardsProperties azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
+            AzureBoardsPropertiesLegacy azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
             String organizationName = azureBoardsProperties.getOrganizationName();
             azureBoardsProperties.validateProperties();
 
@@ -92,7 +92,7 @@ public class AzureBoardsTransitionEventHandler extends IssueTrackerTransitionEve
 
             // Message Sender Requirements
             AzureWorkItemTypeStateService workItemTypeStateService = new AzureWorkItemTypeStateService(azureHttpService, apiVersionAppender);
-                AzureWorkItemCommentService workItemCommentService = new AzureWorkItemCommentService(azureHttpService, apiVersionAppender);
+            AzureWorkItemCommentService workItemCommentService = new AzureWorkItemCommentService(azureHttpService, apiVersionAppender);
 
             IssueTrackerMessageSender<Integer> messageSender = azureBoardsMessageSenderFactory.createMessageSender(
                 workItemService,

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/web/AzureBoardsCustomFunctionAction.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/web/AzureBoardsCustomFunctionAction.java
@@ -23,7 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatus;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
 import com.synopsys.integration.alert.channel.azure.boards.descriptor.AzureBoardsDescriptor;
 import com.synopsys.integration.alert.channel.azure.boards.oauth.OAuthRequestValidator;
@@ -159,7 +159,11 @@ public class AzureBoardsCustomFunctionAction extends CustomFunctionAction<OAuthE
     }
 
     private boolean isAuthenticated(FieldUtility fieldUtility) {
-        AzureBoardsProperties properties = AzureBoardsProperties.fromFieldAccessor(azureBoardsCredentialDataStoreFactory, azureRedirectUrlCreator.createOAuthRedirectUri(), fieldUtility);
+        AzureBoardsPropertiesLegacy properties = AzureBoardsPropertiesLegacy.fromFieldAccessor(
+            azureBoardsCredentialDataStoreFactory,
+            azureRedirectUrlCreator.createOAuthRedirectUri(),
+            fieldUtility
+        );
         ProxyInfo proxy = proxyManager.createProxyInfoForHost(AzureHttpRequestCreatorFactory.DEFAULT_BASE_URL);
         return properties.hasOAuthCredentials(proxy);
     }

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/web/AzureOAuthCallbackController.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/web/AzureOAuthCallbackController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
 import com.synopsys.integration.alert.channel.azure.boards.oauth.OAuthRequestValidator;
 import com.synopsys.integration.alert.channel.azure.boards.oauth.storage.AzureBoardsCredentialDataStoreFactory;
@@ -63,8 +63,16 @@ public class AzureOAuthCallbackController {
     private final AuthorizationManager authorizationManager;
 
     @Autowired
-    public AzureOAuthCallbackController(ResponseFactory responseFactory, Gson gson, AzureBoardsCredentialDataStoreFactory azureBoardsCredentialDataStoreFactory, ProxyManager proxyManager, ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor,
-        AzureRedirectUrlCreator azureRedirectUrlCreator, OAuthRequestValidator oAuthRequestValidator, AuthorizationManager authorizationManager) {
+    public AzureOAuthCallbackController(
+        ResponseFactory responseFactory,
+        Gson gson,
+        AzureBoardsCredentialDataStoreFactory azureBoardsCredentialDataStoreFactory,
+        ProxyManager proxyManager,
+        ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor,
+        AzureRedirectUrlCreator azureRedirectUrlCreator,
+        OAuthRequestValidator oAuthRequestValidator,
+        AuthorizationManager authorizationManager
+    ) {
         this.responseFactory = responseFactory;
         this.gson = gson;
         this.azureBoardsCredentialDataStoreFactory = azureBoardsCredentialDataStoreFactory;
@@ -103,7 +111,11 @@ public class AzureOAuthCallbackController {
                         logger.error("OAuth request with id {}: Azure oauth callback: Authorization code isn't valid. Stop processing", oAuthRequestId);
                     } else {
                         String oAuthRedirectUri = azureRedirectUrlCreator.createOAuthRedirectUri();
-                        AzureBoardsProperties properties = AzureBoardsProperties.fromFieldAccessor(azureBoardsCredentialDataStoreFactory, oAuthRedirectUri, fieldUtility);
+                        AzureBoardsPropertiesLegacy properties = AzureBoardsPropertiesLegacy.fromFieldAccessor(
+                            azureBoardsCredentialDataStoreFactory,
+                            oAuthRedirectUri,
+                            fieldUtility
+                        );
                         testOAuthConnection(properties, authorizationCode, oAuthRequestId);
                     }
                 }
@@ -116,7 +128,7 @@ public class AzureOAuthCallbackController {
         return responseFactory.createFoundRedirectResponse(azureRedirectUrlCreator.createUIRedirectLocation());
     }
 
-    private void testOAuthConnection(AzureBoardsProperties azureBoardsProperties, String authorizationCode, String oAuthRequestId) {
+    private void testOAuthConnection(AzureBoardsPropertiesLegacy azureBoardsProperties, String authorizationCode, String oAuthRequestId) {
         try {
             ProxyInfo proxyInfo = proxyManager.createProxyInfoForHost(AzureHttpRequestCreatorFactory.DEFAULT_BASE_URL);
             String organizationName = azureBoardsProperties.getOrganizationName();
@@ -146,7 +158,10 @@ public class AzureOAuthCallbackController {
 
     private FieldUtility createFieldAccessor() {
         Map<String, ConfigurationFieldModel> fields = new HashMap<>();
-        List<ConfigurationModel> azureChannelConfigs = configurationModelConfigurationAccessor.getConfigurationsByDescriptorKeyAndContext(ChannelKeys.AZURE_BOARDS, ConfigContextEnum.GLOBAL);
+        List<ConfigurationModel> azureChannelConfigs = configurationModelConfigurationAccessor.getConfigurationsByDescriptorKeyAndContext(
+            ChannelKeys.AZURE_BOARDS,
+            ConfigContextEnum.GLOBAL
+        );
         azureChannelConfigs.stream()
             .findFirst()
             .map(ConfigurationModel::getCopyOfKeyToFieldMap)

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCreateIssueEventHandlerTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCreateIssueEventHandlerTest.java
@@ -24,8 +24,8 @@ import com.synopsys.integration.alert.api.channel.issue.model.IssueCreationModel
 import com.synopsys.integration.alert.api.channel.issue.search.IssueCategoryRetriever;
 import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsHttpExceptionMessageImprover;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesFactory;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.AzureBoardsMessageSenderFactory;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.event.mock.MockAzureBoardsJobDetailsRepository;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.event.mock.MockCorrelationToNotificationRelationRepository;
@@ -128,7 +128,7 @@ class AzureBoardsCreateIssueEventHandlerTest {
         Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
 
         AzureBoardsPropertiesFactory propertiesFactory = Mockito.mock(AzureBoardsPropertiesFactory.class);
-        AzureBoardsProperties azureBoardsProperties = Mockito.mock(AzureBoardsProperties.class);
+        AzureBoardsPropertiesLegacy azureBoardsProperties = Mockito.mock(AzureBoardsPropertiesLegacy.class);
         AzureHttpRequestCreator azureHttpRequestCreator = Mockito.mock(AzureHttpRequestCreator.class);
 
         AzureBoardsJobDetailsModel jobDetailsModel = createJobDetails(jobId);


### PR DESCRIPTION
Renaming AzureBoardsProperties to AzureBoardsPropertiesLegacy for IALERT-3183 refactor of the Azure OAuth actions for replacement