### PR TITLE
IALERT-3151: Upgrade spring boot to latest

### DIFF
--- a/alert-platform/build.gradle
+++ b/alert-platform/build.gradle
@@ -36,7 +36,6 @@ dependencies {
         api 'org.javassist:javassist:3.24.0-GA'
         api 'io.springfox:springfox-boot-starter:3.0.0'
 
-        runtime 'org.postgresql:postgresql:42.3.7'
         runtime 'org.liquibase:liquibase-core:3.8.9'
         runtime 'io.springfox:springfox-swagger-ui:2.8.0'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.7.1'
+        springBootVersion = '2.7.4'
     }
 
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-repositories.gradle', to: buildscript


### PR DESCRIPTION
This addresses vulnerabilities for 

(High) Apache Tomcat 9.0.64
(Medium) PostgreSQL JDBC Driver (pgjdbc)42.3.6
