### PR TITLE
FEAT: IALERT-2952 Azure Boards Test action

### DIFF
--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsPropertiesLegacy.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsPropertiesLegacy.java
@@ -42,6 +42,7 @@ import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.channel.azure.boards.descriptor.AzureBoardsDescriptor;
+import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
 import com.synopsys.integration.alert.channel.azure.boards.oauth.storage.AzureBoardsCredentialDataStoreFactory;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldUtility;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
@@ -81,6 +82,25 @@ public class AzureBoardsPropertiesLegacy {
     ) {
         FieldUtility globalFieldUtility = new FieldUtility(globalConfiguration.getCopyOfKeyToFieldMap());
         return fromFieldAccessor(credentialDataStoreFactory, redirectUri, globalFieldUtility);
+    }
+
+    public static AzureBoardsPropertiesLegacy fromGlobalConfigurationModel(
+        AzureBoardsCredentialDataStoreFactory credentialDataStoreFactory,
+        String redirectUri,
+        AzureBoardsGlobalConfigModel azureBoardsGlobalConfigModel
+    ) {
+        //TODO: Determine if we need the KEY_OAUTH_USER_EMAIL here or can we use the default
+        String oAuthUserEmail = DEFAULT_AZURE_OAUTH_USER_ID;
+        List<String> defaultScopes = List.of(AzureOAuthScopes.PROJECTS_READ.getScope(), AzureOAuthScopes.WORK_FULL.getScope());
+        return new AzureBoardsPropertiesLegacy(
+            credentialDataStoreFactory,
+            azureBoardsGlobalConfigModel.getOrganizationName(),
+            azureBoardsGlobalConfigModel.getAppId().orElse(null),
+            azureBoardsGlobalConfigModel.getClientSecret().orElse(null),
+            oAuthUserEmail,
+            defaultScopes,
+            redirectUri
+        );
     }
 
     public AzureBoardsPropertiesLegacy(

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestAction.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestAction.java
@@ -1,0 +1,105 @@
+package com.synopsys.integration.alert.channel.azure.boards.action;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
+import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
+import com.synopsys.integration.alert.channel.azure.boards.database.accessor.AzureBoardsGlobalConfigAccessor;
+import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
+import com.synopsys.integration.alert.channel.azure.boards.oauth.storage.AzureBoardsCredentialDataStoreFactory;
+import com.synopsys.integration.alert.channel.azure.boards.validator.AzureBoardsGlobalConfigurationValidator;
+import com.synopsys.integration.alert.common.action.ActionResponse;
+import com.synopsys.integration.alert.common.action.ValidationActionResponse;
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.message.model.ConfigurationTestResult;
+import com.synopsys.integration.alert.common.rest.api.ConfigurationTestHelper;
+import com.synopsys.integration.alert.common.rest.api.ConfigurationValidationHelper;
+import com.synopsys.integration.alert.common.rest.proxy.ProxyManager;
+import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
+import com.synopsys.integration.azure.boards.common.http.AzureApiVersionAppender;
+import com.synopsys.integration.azure.boards.common.http.AzureHttpRequestCreatorFactory;
+import com.synopsys.integration.azure.boards.common.http.AzureHttpService;
+import com.synopsys.integration.azure.boards.common.service.project.AzureProjectService;
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.rest.proxy.ProxyInfo;
+import org.apache.commons.lang3.BooleanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+@Component
+public class AzureBoardsGlobalTestAction {
+    private final AzureBoardsGlobalConfigurationValidator validator;
+    private final AzureBoardsGlobalConfigAccessor configurationAccessor;
+    private final AzureBoardsCredentialDataStoreFactory azureBoardsCredentialDataStoreFactory;
+    private final AzureRedirectUrlCreator azureRedirectUrlCreator;
+
+    private final ConfigurationValidationHelper validationHelper;
+    private final ConfigurationTestHelper testHelper;
+    private final Gson gson;
+    private final ProxyManager proxyManager;
+
+    @Autowired
+    public AzureBoardsGlobalTestAction(
+        AuthorizationManager authorizationManager,
+        AzureBoardsGlobalConfigurationValidator validator,
+        AzureBoardsGlobalConfigAccessor configurationAccessor,
+        AzureBoardsCredentialDataStoreFactory azureBoardsCredentialDataStoreFactory,
+        AzureRedirectUrlCreator azureRedirectUrlCreator,
+        Gson gson,
+        ProxyManager proxyManager
+    ) {
+        this.testHelper = new ConfigurationTestHelper(authorizationManager, ConfigContextEnum.GLOBAL, ChannelKeys.JIRA_SERVER);
+        this.validationHelper = new ConfigurationValidationHelper(authorizationManager, ConfigContextEnum.GLOBAL, ChannelKeys.JIRA_SERVER);
+        this.proxyManager = proxyManager;
+        this.gson = gson;
+
+        this.azureBoardsCredentialDataStoreFactory = azureBoardsCredentialDataStoreFactory;
+        this.azureRedirectUrlCreator = azureRedirectUrlCreator;
+        this.validator = validator;
+        this.configurationAccessor = configurationAccessor;
+    }
+
+    public ActionResponse<ValidationResponseModel> testWithPermissionCheck(AzureBoardsGlobalConfigModel requestResource) {
+        Supplier<ValidationActionResponse> validationSupplier = () -> validationHelper.validate(() -> validator.validate(requestResource, requestResource.getId()));
+        return testHelper.test(validationSupplier, () -> testConfigModelContent(requestResource));
+    }
+
+    public ConfigurationTestResult testConfigModelContent(AzureBoardsGlobalConfigModel azureBoardsGlobalConfigModel) {
+        try {
+            boolean isAppIdSet = BooleanUtils.toBoolean(azureBoardsGlobalConfigModel.getIsAppIdSet().orElse(Boolean.FALSE));
+            boolean isClientSecretSet = BooleanUtils.toBoolean(azureBoardsGlobalConfigModel.getIsClientSecretSet().orElse(Boolean.FALSE));
+            if (isAppIdSet || isClientSecretSet) {
+                Optional<AzureBoardsGlobalConfigModel> accessorModel = configurationAccessor.getConfiguration(UUID.fromString(azureBoardsGlobalConfigModel.getId()));
+
+                if (isAppIdSet) {
+                    accessorModel.flatMap(AzureBoardsGlobalConfigModel::getAppId).ifPresent(azureBoardsGlobalConfigModel::setAppId);
+                }
+                if (isClientSecretSet) {
+                    accessorModel.flatMap(AzureBoardsGlobalConfigModel::getClientSecret).ifPresent(azureBoardsGlobalConfigModel::setClientSecret);
+                }
+            }
+
+            AzureBoardsPropertiesLegacy azureBoardsProperties = AzureBoardsPropertiesLegacy.fromGlobalConfigurationModel(
+                azureBoardsCredentialDataStoreFactory,
+                azureRedirectUrlCreator.createOAuthRedirectUri(),
+                azureBoardsGlobalConfigModel
+            );
+            AzureHttpService azureHttpService = createAzureHttpService(azureBoardsProperties);
+            AzureProjectService azureProjectService = new AzureProjectService(azureHttpService, new AzureApiVersionAppender());
+            azureProjectService.getProjects(azureBoardsGlobalConfigModel.getOrganizationName());
+        } catch (IntegrationException ex) {
+            return ConfigurationTestResult.failure("Global Test Action failed testing Azure Boards connection." + ex.getMessage());
+        }
+        return ConfigurationTestResult.success("Successfully connected to Azure instance.");
+    }
+
+    private AzureHttpService createAzureHttpService(AzureBoardsPropertiesLegacy azureBoardsProperties) throws IntegrationException {
+        ProxyInfo proxy = proxyManager.createProxyInfoForHost(AzureHttpRequestCreatorFactory.DEFAULT_BASE_URL);
+        return azureBoardsProperties.createAzureHttpService(proxy, gson);
+    }
+}

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestAction.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestAction.java
@@ -53,8 +53,8 @@ public class AzureBoardsGlobalTestAction {
         Gson gson,
         ProxyManager proxyManager
     ) {
-        this.testHelper = new ConfigurationTestHelper(authorizationManager, ConfigContextEnum.GLOBAL, ChannelKeys.JIRA_SERVER);
-        this.validationHelper = new ConfigurationValidationHelper(authorizationManager, ConfigContextEnum.GLOBAL, ChannelKeys.JIRA_SERVER);
+        this.testHelper = new ConfigurationTestHelper(authorizationManager, ConfigContextEnum.GLOBAL, ChannelKeys.AZURE_BOARDS);
+        this.validationHelper = new ConfigurationValidationHelper(authorizationManager, ConfigContextEnum.GLOBAL, ChannelKeys.AZURE_BOARDS);
         this.proxyManager = proxyManager;
         this.gson = gson;
 
@@ -69,7 +69,7 @@ public class AzureBoardsGlobalTestAction {
         return testHelper.test(validationSupplier, () -> testConfigModelContent(requestResource));
     }
 
-    public ConfigurationTestResult testConfigModelContent(AzureBoardsGlobalConfigModel azureBoardsGlobalConfigModel) {
+    protected ConfigurationTestResult testConfigModelContent(AzureBoardsGlobalConfigModel azureBoardsGlobalConfigModel) {
         try {
             boolean isAppIdSet = BooleanUtils.toBoolean(azureBoardsGlobalConfigModel.getIsAppIdSet().orElse(Boolean.FALSE));
             boolean isClientSecretSet = BooleanUtils.toBoolean(azureBoardsGlobalConfigModel.getIsClientSecretSet().orElse(Boolean.FALSE));
@@ -89,8 +89,8 @@ public class AzureBoardsGlobalTestAction {
                 azureRedirectUrlCreator.createOAuthRedirectUri(),
                 azureBoardsGlobalConfigModel
             );
-            AzureHttpService azureHttpService = createAzureHttpService(azureBoardsProperties);
-            AzureProjectService azureProjectService = new AzureProjectService(azureHttpService, new AzureApiVersionAppender());
+            // Just make sure service creations and getting project succeeds
+            AzureProjectService azureProjectService = createAzureProjectService(azureBoardsProperties);
             azureProjectService.getProjects(azureBoardsGlobalConfigModel.getOrganizationName());
         } catch (IntegrationException ex) {
             return ConfigurationTestResult.failure("Global Test Action failed testing Azure Boards connection." + ex.getMessage());
@@ -98,8 +98,9 @@ public class AzureBoardsGlobalTestAction {
         return ConfigurationTestResult.success("Successfully connected to Azure instance.");
     }
 
-    private AzureHttpService createAzureHttpService(AzureBoardsPropertiesLegacy azureBoardsProperties) throws IntegrationException {
+    protected AzureProjectService createAzureProjectService(AzureBoardsPropertiesLegacy azureBoardsProperties) throws IntegrationException {
         ProxyInfo proxy = proxyManager.createProxyInfoForHost(AzureHttpRequestCreatorFactory.DEFAULT_BASE_URL);
-        return azureBoardsProperties.createAzureHttpService(proxy, gson);
+        AzureHttpService azureHttpService = azureBoardsProperties.createAzureHttpService(proxy, gson);
+        return new AzureProjectService(azureHttpService, new AzureApiVersionAppender());
     }
 }

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/web/AzureBoardsGlobalConfigController.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/web/AzureBoardsGlobalConfigController.java
@@ -2,8 +2,11 @@ package com.synopsys.integration.alert.channel.azure.boards.web;
 
 import java.util.UUID;
 
+import com.synopsys.integration.alert.channel.azure.boards.action.AzureBoardsGlobalTestAction;
+import com.synopsys.integration.alert.channel.azure.boards.action.AzureBoardsGlobalValidationAction;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,13 +23,16 @@ import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 
 @RestController
 @RequestMapping(AlertRestConstants.AZURE_BOARDS_CONFIGURATION_PATH)
-public class AzureBoardsGlobalConfigController implements StaticConfigResourceController<AzureBoardsGlobalConfigModel>, ValidateController<AzureBoardsGlobalConfigModel>,
-    ReadPageController<AlertPagedModel<AzureBoardsGlobalConfigModel>> {
+public class AzureBoardsGlobalConfigController implements StaticConfigResourceController<AzureBoardsGlobalConfigModel>, ValidateController<AzureBoardsGlobalConfigModel>, ReadPageController<AlertPagedModel<AzureBoardsGlobalConfigModel>> {
     private final AzureBoardsGlobalCrudActions configActions;
+    private final AzureBoardsGlobalTestAction azureBoardsGlobalTestAction;
+    private final AzureBoardsGlobalValidationAction azureBoardsGlobalValidationAction;
 
     @Autowired
-    public AzureBoardsGlobalConfigController(AzureBoardsGlobalCrudActions configActions) {
+    public AzureBoardsGlobalConfigController(AzureBoardsGlobalCrudActions configActions, AzureBoardsGlobalTestAction azureBoardsGlobalTestAction, AzureBoardsGlobalValidationAction azureBoardsGlobalValidationAction) {
         this.configActions = configActions;
+        this.azureBoardsGlobalTestAction = azureBoardsGlobalTestAction;
+        this.azureBoardsGlobalValidationAction = azureBoardsGlobalValidationAction;
     }
 
     @Override
@@ -56,7 +62,12 @@ public class AzureBoardsGlobalConfigController implements StaticConfigResourceCo
 
     @Override
     public ValidationResponseModel validate(AzureBoardsGlobalConfigModel requestBody) {
-        return ValidationResponseModel.success(); // TODO: AzureBoardsGlobalValidationAction
+        return ResponseFactory.createContentResponseFromAction(azureBoardsGlobalValidationAction.validate(requestBody));
+    }
+
+    @PostMapping("/test")
+    public ValidationResponseModel test(@RequestBody AzureBoardsGlobalConfigModel resource) {
+        return ResponseFactory.createContentResponseFromAction(azureBoardsGlobalTestAction.testWithPermissionCheck(resource));
     }
 
     @PostMapping("/oauth/authenticate")

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestActionTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestActionTest.java
@@ -1,0 +1,188 @@
+package com.synopsys.integration.alert.channel.azure.boards.action;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
+import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
+import com.synopsys.integration.alert.channel.azure.boards.database.accessor.AzureBoardsGlobalConfigAccessor;
+import com.synopsys.integration.alert.channel.azure.boards.database.configuration.AzureBoardsConfigurationEntity;
+import com.synopsys.integration.alert.channel.azure.boards.database.mock.MockAzureBoardsConfigurationRepository;
+import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
+import com.synopsys.integration.alert.channel.azure.boards.oauth.storage.AzureBoardsCredentialDataStoreFactory;
+import com.synopsys.integration.alert.channel.azure.boards.validator.AzureBoardsGlobalConfigurationValidator;
+import com.synopsys.integration.alert.common.AlertProperties;
+import com.synopsys.integration.alert.common.action.ActionResponse;
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.message.model.ConfigurationTestResult;
+import com.synopsys.integration.alert.common.persistence.model.PermissionKey;
+import com.synopsys.integration.alert.common.persistence.model.PermissionMatrixModel;
+import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
+import com.synopsys.integration.alert.common.rest.proxy.ProxyManager;
+import com.synopsys.integration.alert.common.security.EncryptionUtility;
+import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
+import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
+import com.synopsys.integration.alert.test.common.AuthenticationTestUtils;
+import com.synopsys.integration.alert.test.common.MockAlertProperties;
+import com.synopsys.integration.alert.test.common.database.MockRepositorySorter;
+import com.synopsys.integration.azure.boards.common.service.project.AzureProjectService;
+import com.synopsys.integration.exception.IntegrationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(SpringExtension.class)
+public class AzureBoardsGlobalTestActionTest {
+    private final Gson gson = new Gson();
+    private final AlertProperties alertProperties = new MockAlertProperties();
+    private final FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, gson);
+    private final EncryptionUtility encryptionUtility = new EncryptionUtility(alertProperties, filePersistenceUtil);
+
+    AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor;
+    AzureBoardsGlobalConfigurationValidator azureBoardsGlobalConfigurationValidator;
+
+    @Mock AzureBoardsCredentialDataStoreFactory mockAzureBoardsCredentialDataStoreFactory;
+    @Mock AzureProjectService mockedAzureProjectService;
+    @Mock AzureRedirectUrlCreator mockAzureRedirectUrlCreator;
+    @Mock ProxyManager mockProxyManager;
+
+    @BeforeEach
+    void initEach() {
+        MockRepositorySorter<AzureBoardsConfigurationEntity> sorter = new MockRepositorySorter<>();
+        MockAzureBoardsConfigurationRepository mockAzureBoardsConfigurationRepository = new MockAzureBoardsConfigurationRepository(sorter);
+        azureBoardsGlobalConfigAccessor = new AzureBoardsGlobalConfigAccessor(encryptionUtility, mockAzureBoardsConfigurationRepository);
+        azureBoardsGlobalConfigurationValidator = new AzureBoardsGlobalConfigurationValidator(azureBoardsGlobalConfigAccessor);
+
+        Mockito.when(mockAzureRedirectUrlCreator.createOAuthRedirectUri()).thenReturn("https://www.redirect.com");
+    }
+
+    @Test
+    void testWithPermissionCheckReturnsHttpForbidden() {
+        AuthorizationManager authorizationManager = createAuthorizationManager(AuthenticationTestUtils.NO_PERMISSIONS);
+        AzureBoardsGlobalConfigModel requestModel = new AzureBoardsGlobalConfigModel(
+            String.valueOf(UUID.randomUUID()),
+            AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
+            "",
+            "",
+            "Organization name",
+            String.valueOf(UUID.randomUUID()),
+            Boolean.TRUE,
+            "A secret",
+            Boolean.TRUE
+        );
+
+        AzureBoardsGlobalTestAction azureBoardsGlobalTestAction = new AzureBoardsGlobalTestAction(
+            authorizationManager,
+            azureBoardsGlobalConfigurationValidator,
+            azureBoardsGlobalConfigAccessor,
+            mockAzureBoardsCredentialDataStoreFactory,
+            mockAzureRedirectUrlCreator,
+            gson,
+            mockProxyManager
+        );
+
+        ActionResponse<ValidationResponseModel> actionResponse = azureBoardsGlobalTestAction.testWithPermissionCheck(requestModel);
+        assertTrue(actionResponse.isError());
+        assertEquals(HttpStatus.FORBIDDEN, actionResponse.getHttpStatus());
+    }
+
+    @Test
+    void testWithPermissionCheckReturnsHttpOk() throws IntegrationException {
+        AuthorizationManager authorizationManager = createAuthorizationManager(AuthenticationTestUtils.FULL_PERMISSIONS);
+        AzureBoardsGlobalConfigModel requestModel = Mockito.mock(AzureBoardsGlobalConfigModel.class);
+
+        AzureBoardsGlobalTestAction spiedAzureBoardsGlobalTestAction = Mockito.spy(
+            new AzureBoardsGlobalTestAction(
+                authorizationManager,
+                azureBoardsGlobalConfigurationValidator,
+                azureBoardsGlobalConfigAccessor,
+                mockAzureBoardsCredentialDataStoreFactory,
+                mockAzureRedirectUrlCreator,
+                gson,
+                mockProxyManager
+            )
+        );
+        Mockito.doReturn(mockedAzureProjectService).when(spiedAzureBoardsGlobalTestAction).createAzureProjectService(any());
+
+        ActionResponse<ValidationResponseModel> actionResponse = spiedAzureBoardsGlobalTestAction.testWithPermissionCheck(requestModel);
+        assertTrue(actionResponse.isSuccessful());
+        assertEquals(HttpStatus.OK, actionResponse.getHttpStatus());
+    }
+
+    @Test
+    void testConfigModelContentSetsObfuscatedFields() throws IntegrationException {
+        AuthorizationManager authorizationManager = createAuthorizationManager(AuthenticationTestUtils.FULL_PERMISSIONS);
+        String name = AlertRestConstants.DEFAULT_CONFIGURATION_NAME;
+        String organizationName = "Organization name";
+        String appId  = "obfuscated-app-id";
+        String clientSecret  = "obfuscatedClientSecret";
+        AzureBoardsGlobalConfigModel createdModel = azureBoardsGlobalConfigAccessor.createConfiguration(
+            new AzureBoardsGlobalConfigModel(
+                "",
+                name,
+                "",
+                "",
+                organizationName,
+                appId,
+                Boolean.TRUE,
+                clientSecret,
+                Boolean.TRUE
+            )
+        );
+        String modelId = createdModel.getId();
+
+        AzureBoardsGlobalTestAction spiedAzureBoardsGlobalTestAction = Mockito.spy(
+            new AzureBoardsGlobalTestAction(
+                authorizationManager,
+                azureBoardsGlobalConfigurationValidator,
+                azureBoardsGlobalConfigAccessor,
+                mockAzureBoardsCredentialDataStoreFactory,
+                mockAzureRedirectUrlCreator,
+                gson,
+                mockProxyManager
+            )
+        );
+        Mockito.doReturn(mockedAzureProjectService).when(spiedAzureBoardsGlobalTestAction).createAzureProjectService(any());
+
+        AzureBoardsGlobalConfigModel requestModel = new AzureBoardsGlobalConfigModel(
+            modelId,
+            name,
+            "",
+            "",
+            organizationName,
+            "", // appId is hidden
+            Boolean.TRUE,
+            "", // clientSecret is hidden
+            Boolean.TRUE
+        );
+        assertEquals("", requestModel.getAppId().orElse("Not empty app id"));
+        assertEquals("", requestModel.getAppId().orElse("Not empty client secret"));
+
+        ConfigurationTestResult configurationTestResult = spiedAzureBoardsGlobalTestAction.testConfigModelContent(requestModel);
+
+        assertTrue(configurationTestResult.isSuccess());
+
+        assertEquals(appId, requestModel.getAppId().orElse("Not the saved app id"));
+        assertEquals(clientSecret, requestModel.getClientSecret().orElse("Not the saved client secret"));
+    }
+
+    private AuthorizationManager createAuthorizationManager(int assignedPermissions) {
+        AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
+        DescriptorKey descriptorKey = ChannelKeys.AZURE_BOARDS;
+        PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
+        Map<PermissionKey, Integer> permissions = Map.of(permissionKey, assignedPermissions);
+
+        return authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
+    }
+}

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestActionTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestActionTest.java
@@ -70,17 +70,7 @@ public class AzureBoardsGlobalTestActionTest {
     @Test
     void testWithPermissionCheckReturnsHttpForbidden() {
         AuthorizationManager authorizationManager = createAuthorizationManager(AuthenticationTestUtils.NO_PERMISSIONS);
-        AzureBoardsGlobalConfigModel requestModel = new AzureBoardsGlobalConfigModel(
-            String.valueOf(UUID.randomUUID()),
-            AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
-            "",
-            "",
-            "Organization name",
-            String.valueOf(UUID.randomUUID()),
-            Boolean.TRUE,
-            "A secret",
-            Boolean.TRUE
-        );
+        AzureBoardsGlobalConfigModel requestModel = Mockito.mock(AzureBoardsGlobalConfigModel.class);
 
         AzureBoardsGlobalTestAction azureBoardsGlobalTestAction = new AzureBoardsGlobalTestAction(
             authorizationManager,

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/validator/AzureBoardsGlobalConfigurationValidatorTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/validator/AzureBoardsGlobalConfigurationValidatorTest.java
@@ -79,7 +79,7 @@ public class AzureBoardsGlobalConfigurationValidatorTest {
 
         ValidationResponseModel responseModel = azureBoardsGlobalConfigurationValidator.validate(missingFieldsModel, modelId);
 
-        assertFalse(responseModel.getErrors().values().size() == 0);
+        assertNotEquals(0, responseModel.getErrors().values().size());
         responseModel.getErrors().values()
             .forEach((alertFieldStatus) -> assertEquals(AlertFieldStatusMessages.REQUIRED_FIELD_MISSING, alertFieldStatus.getFieldMessage()));
     }


### PR DESCRIPTION
- Add AzureBoardsGlobalTestAction
- Checkout AzureBoardsPropertiesLegacy.fromGlobalConfigurationModel from mc_IALERT-3183_Azure_OAuth_actions
- Hook validation and test actions to Azure Boards controller