### PR TITLE
build: Update to latest libraries to address CVE-2022-42889

### DIFF
--- a/alert-platform/build.gradle
+++ b/alert-platform/build.gradle
@@ -16,11 +16,11 @@ dependencies {
         api 'com.sun.mail:javax.mail:1.6.2'
         api 'javax.mail:javax.mail-api:1.6.2'
 
-        api 'com.synopsys.integration:integration-rest:10.3.4'
-        api 'com.synopsys.integration:integration-common:26.0.2'
-        api 'com.synopsys.integration:blackduck-common:64.3.2'
-        api 'com.synopsys.integration:int-jira-common:3.0.6'
-        api 'com.synopsys.integration:phone-home-client:5.1.5'
+        api 'com.synopsys.integration:integration-rest:10.3.6'
+        api 'com.synopsys.integration:integration-common:26.0.4'
+        api 'com.synopsys.integration:blackduck-common:66.0.2'
+        api 'com.synopsys.integration:int-jira-common:3.0.7'
+        api 'com.synopsys.integration:phone-home-client:5.1.7'
 
         api 'org.springframework.security.extensions:spring-security-saml2-core:1.0.10.RELEASE'
         api('org.apache.velocity:velocity-engine-core:2.3') {

--- a/src/test/java/com/synopsys/integration/alert/performance/NotificationRemovalTest.java
+++ b/src/test/java/com/synopsys/integration/alert/performance/NotificationRemovalTest.java
@@ -59,6 +59,8 @@ import com.synopsys.integration.log.Slf4jIntLogger;
 import com.synopsys.integration.wait.ResilientJobConfig;
 import com.synopsys.integration.wait.WaitJob;
 import com.synopsys.integration.wait.WaitJobCondition;
+import com.synopsys.integration.wait.tracker.WaitIntervalTracker;
+import com.synopsys.integration.wait.tracker.WaitIntervalTrackerFactory;
 
 @Tag(TestTags.DEFAULT_PERFORMANCE)
 @AlertIntegrationTest
@@ -129,7 +131,8 @@ class NotificationRemovalTest {
             return notificationsInDatabase.size() == BATCH_SIZE && notificationsInDatabase.stream()
                 .allMatch(AlertNotificationModel::getProcessed);
         };
-        ResilientJobConfig resilientJobConfig = new ResilientJobConfig(LOGGER, 600, startTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 1);
+        WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createConstant(600, 1);
+        ResilientJobConfig resilientJobConfig = new ResilientJobConfig(LOGGER, startTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), waitIntervalTracker);
         boolean isComplete = WaitJob.waitFor(resilientJobConfig, waitJobCondition, "int performance test runner notification wait");
 
         logTimeElapsedWithMessage("Purge of notifications duration: %s", startTime, LocalDateTime.now());

--- a/src/test/java/com/synopsys/integration/alert/performance/ScalingPerformanceTest.java
+++ b/src/test/java/com/synopsys/integration/alert/performance/ScalingPerformanceTest.java
@@ -39,6 +39,8 @@ import com.synopsys.integration.rest.client.IntHttpClient;
 import com.synopsys.integration.rest.proxy.ProxyInfo;
 import com.synopsys.integration.wait.ResilientJobConfig;
 import com.synopsys.integration.wait.WaitJob;
+import com.synopsys.integration.wait.tracker.WaitIntervalTracker;
+import com.synopsys.integration.wait.tracker.WaitIntervalTrackerFactory;
 
 @Tag(TestTags.DEFAULT_PERFORMANCE)
 public class ScalingPerformanceTest {
@@ -130,11 +132,11 @@ public class ScalingPerformanceTest {
         LocalDateTime startingNotificationWaitForTenJobs = LocalDateTime.now();
 
         // check that all jobs have processed the notification successfully, log how long it took
+        WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createConstant(900, 30);
         ResilientJobConfig resilientJobConfig = new ResilientJobConfig(
             intLogger,
-            900,
             startingNotificationSearchDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-            30
+            waitIntervalTracker
         );
         NotificationWaitJobTask notificationWaitJobTask = new NotificationWaitJobTask(
             intLogger,

--- a/src/test/java/com/synopsys/integration/alert/performance/serialization/ComponentUnknownVersionNotificationSerializationTest.java
+++ b/src/test/java/com/synopsys/integration/alert/performance/serialization/ComponentUnknownVersionNotificationSerializationTest.java
@@ -56,6 +56,8 @@ import com.synopsys.integration.log.Slf4jIntLogger;
 import com.synopsys.integration.rest.HttpUrl;
 import com.synopsys.integration.wait.ResilientJobConfig;
 import com.synopsys.integration.wait.WaitJob;
+import com.synopsys.integration.wait.tracker.WaitIntervalTracker;
+import com.synopsys.integration.wait.tracker.WaitIntervalTrackerFactory;
 
 @Tag(TestTags.DEFAULT_INTEGRATION)
 @SpringBootTest
@@ -87,7 +89,7 @@ public class ComponentUnknownVersionNotificationSerializationTest {
     @Test
     @Ignore // performance test
     @Disabled
-    void testNotificationSerialization() throws IntegrationException, InterruptedException {
+    void testNotificationSerialization() throws IntegrationException {
         LocalDateTime searchStartTime = LocalDateTime.now().minusMinutes(1);
         AlertRequestUtility alertRequestUtility = IntegrationPerformanceTestRunnerLegacy.createAlertRequestUtility(webApplicationContext);
         BlackDuckProviderService blackDuckProviderService = new BlackDuckProviderService(alertRequestUtility, gson);
@@ -100,7 +102,12 @@ public class ComponentUnknownVersionNotificationSerializationTest {
         blackDuckProviderService.triggerBlackDuckNotification(() -> externalId, componentFilter);
 
         try {
-            ResilientJobConfig resilientJobConfig = new ResilientJobConfig(intLogger, 300, searchStartTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 20);
+            WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createConstant(300, 20);
+            ResilientJobConfig resilientJobConfig = new ResilientJobConfig(
+                intLogger,
+                searchStartTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                waitIntervalTracker
+            );
             NotificationReceivedWaitJobTask notificationWaitJobTask = new NotificationReceivedWaitJobTask(
                 notificationAccessor,
                 searchStartTime,

--- a/src/test/java/com/synopsys/integration/alert/performance/utility/IntegrationPerformanceTestRunner.java
+++ b/src/test/java/com/synopsys/integration/alert/performance/utility/IntegrationPerformanceTestRunner.java
@@ -28,6 +28,8 @@ import com.synopsys.integration.log.Slf4jIntLogger;
 import com.synopsys.integration.wait.ResilientJobConfig;
 import com.synopsys.integration.wait.WaitJob;
 import com.synopsys.integration.wait.WaitJobCondition;
+import com.synopsys.integration.wait.tracker.WaitIntervalTracker;
+import com.synopsys.integration.wait.tracker.WaitIntervalTrackerFactory;
 
 public class IntegrationPerformanceTestRunner {
     private static final IntLogger intLogger = new Slf4jIntLogger(LoggerFactory.getLogger(IntegrationPerformanceTestRunner.class));
@@ -85,11 +87,11 @@ public class IntegrationPerformanceTestRunner {
         blackDuckProviderService.triggerBlackDuckNotification();
         intLogger.info("Triggered the Black Duck notification.");
 
+        WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createConstant(waitTimeoutInSeconds, 20);
         ResilientJobConfig resilientJobConfig = new ResilientJobConfig(
             intLogger,
-            waitTimeoutInSeconds,
             startingSearchDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-            20
+            waitIntervalTracker
         );
         NotificationWaitJobTask notificationWaitJobTask = new NotificationWaitJobTask(intLogger, dateTimeFormatter, gson, alertRequestUtility, startingSearchDateTime, jobId);
         boolean isComplete = WaitJob.waitFor(resilientJobConfig, notificationWaitJobTask, "int performance test runner notification wait");
@@ -221,11 +223,11 @@ public class IntegrationPerformanceTestRunner {
     }
 
     private PerformanceExecutionStatusModel waitForJobToFinish(LocalDateTime startingNotificationTime, WaitJobCondition waitJobCondition) {
+        WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createConstant(waitTimeoutInSeconds, 2);
         ResilientJobConfig resilientJobConfig = new ResilientJobConfig(
             intLogger,
-            waitTimeoutInSeconds,
             startingNotificationTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-            2
+            waitIntervalTracker
         );
         try {
             boolean isComplete = WaitJob.waitFor(resilientJobConfig, waitJobCondition, "int performance test runner notification wait");

--- a/src/test/java/com/synopsys/integration/alert/performance/utility/IntegrationPerformanceTestRunnerLegacy.java
+++ b/src/test/java/com/synopsys/integration/alert/performance/utility/IntegrationPerformanceTestRunnerLegacy.java
@@ -23,8 +23,10 @@ import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.log.Slf4jIntLogger;
 import com.synopsys.integration.wait.ResilientJobConfig;
 import com.synopsys.integration.wait.WaitJob;
+import com.synopsys.integration.wait.tracker.WaitIntervalTracker;
+import com.synopsys.integration.wait.tracker.WaitIntervalTrackerFactory;
 
-//TODO: Implementaions of this class should be replaced with IntegrationPerformanceTestRunner
+//TODO: Implementations of this class should be replaced with IntegrationPerformanceTestRunner
 @Deprecated(forRemoval = true)
 public class IntegrationPerformanceTestRunnerLegacy {
     private static final IntLogger intLogger = new Slf4jIntLogger(LoggerFactory.getLogger(IntegrationPerformanceTestRunnerLegacy.class));
@@ -85,7 +87,12 @@ public class IntegrationPerformanceTestRunnerLegacy {
         // trigger BD notification
         blackDuckProviderService.triggerBlackDuckNotification();
         intLogger.info("Triggered the Black Duck notification.");
-        ResilientJobConfig resilientJobConfig = new ResilientJobConfig(intLogger, 600, startingSearchDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(), 20);
+        WaitIntervalTracker waitIntervalTracker = WaitIntervalTrackerFactory.createConstant(600, 20);
+        ResilientJobConfig resilientJobConfig = new ResilientJobConfig(
+            intLogger,
+            startingSearchDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+            waitIntervalTracker
+        );
         NotificationWaitJobTask notificationWaitJobTask = new NotificationWaitJobTask(intLogger, dateTimeFormatter, gson, alertRequestUtility, startingSearchDateTime, jobId);
         boolean isComplete = WaitJob.waitFor(resilientJobConfig, notificationWaitJobTask, "int performance test runner notification wait");
         intLogger.info("Finished waiting for the notification to be processed: " + isComplete);


### PR DESCRIPTION
This is for 6.11.1

* Update to latest libraries which handles upgrading org.apache.commons:commons-text to address https://github.com/advisories/GHSA-599f-7c49-w659
* Updates for changes from integration-common for ResilientJobConfig