### PR TITLE
feat: Implement the channel wiring for GitHub.

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/GitHubJobDetailAccessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/GitHubJobDetailAccessor.java
@@ -1,0 +1,6 @@
+package com.synopsys.integration.alert.common.persistence.accessor;
+
+import com.synopsys.integration.alert.common.persistence.model.job.details.GitHubJobDetailsModel;
+
+public interface GitHubJobDetailAccessor extends JobDetailsAccessor<GitHubJobDetailsModel> {
+}

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/details/DistributionJobDetailsModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/details/DistributionJobDetailsModel.java
@@ -21,6 +21,7 @@ public abstract class DistributionJobDetailsModel extends AlertSerializableModel
     private static final long serialVersionUID = -9210491364879513303L;
     public static final Class<AzureBoardsJobDetailsModel> AZURE = AzureBoardsJobDetailsModel.class;
     public static final Class<EmailJobDetailsModel> EMAIL = EmailJobDetailsModel.class;
+    public static final Class<GitHubJobDetailsModel> GITHUB = GitHubJobDetailsModel.class;
     public static final Class<JiraCloudJobDetailsModel> JIRA_CLOUD = JiraCloudJobDetailsModel.class;
     public static final Class<JiraServerJobDetailsModel> JIRA_SERVER = JiraServerJobDetailsModel.class;
     public static final Class<MSTeamsJobDetailsModel> MS_TEAMS = MSTeamsJobDetailsModel.class;
@@ -31,6 +32,7 @@ public abstract class DistributionJobDetailsModel extends AlertSerializableModel
     static {
         detailsModels.put(ChannelKeys.AZURE_BOARDS, AZURE);
         detailsModels.put(ChannelKeys.EMAIL, EMAIL);
+        detailsModels.put(ChannelKeys.GITHUB, GITHUB);
         detailsModels.put(ChannelKeys.JIRA_CLOUD, JIRA_CLOUD);
         detailsModels.put(ChannelKeys.JIRA_SERVER, JIRA_SERVER);
         detailsModels.put(ChannelKeys.MS_TEAMS, MS_TEAMS);

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/details/GitHubJobDetailsModel.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/model/job/details/GitHubJobDetailsModel.java
@@ -1,0 +1,12 @@
+package com.synopsys.integration.alert.common.persistence.model.job.details;
+
+import java.util.UUID;
+
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
+
+public class GitHubJobDetailsModel extends DistributionJobDetailsModel {
+    
+    public GitHubJobDetailsModel(final UUID jobId) {
+        super(ChannelKeys.GITHUB, jobId);
+    }
+}

--- a/channel-github/build.gradle
+++ b/channel-github/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 
     implementation project(':alert-common')
     implementation project(':api-common-model')
+    implementation project(':api-channel')
     implementation project(':api-channel-github')
     implementation project(':api-processor')
     implementation project(':api-descriptor')

--- a/channel-github/src/main/java/com/synopsys/integration/alert/channel/github/database/accessor/DefaultGitHubJobDetailAccessor.java
+++ b/channel-github/src/main/java/com/synopsys/integration/alert/channel/github/database/accessor/DefaultGitHubJobDetailAccessor.java
@@ -1,0 +1,18 @@
+package com.synopsys.integration.alert.channel.github.database.accessor;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.common.persistence.accessor.GitHubJobDetailAccessor;
+import com.synopsys.integration.alert.common.persistence.model.job.details.GitHubJobDetailsModel;
+
+@Component
+public class DefaultGitHubJobDetailAccessor implements GitHubJobDetailAccessor {
+
+    @Override
+    public Optional<GitHubJobDetailsModel> retrieveDetails(final UUID jobId) {
+        return Optional.empty();
+    }
+}

--- a/channel-github/src/main/java/com/synopsys/integration/alert/channel/github/distribution/GitHubChannel.java
+++ b/channel-github/src/main/java/com/synopsys/integration/alert/channel/github/distribution/GitHubChannel.java
@@ -1,0 +1,28 @@
+package com.synopsys.integration.alert.channel.github.distribution;
+
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.api.channel.DistributionChannel;
+import com.synopsys.integration.alert.api.common.model.exception.AlertException;
+import com.synopsys.integration.alert.common.message.model.MessageResult;
+import com.synopsys.integration.alert.common.persistence.model.job.details.GitHubJobDetailsModel;
+import com.synopsys.integration.alert.processor.api.extract.model.ProviderMessageHolder;
+
+@Component
+public class GitHubChannel implements DistributionChannel<GitHubJobDetailsModel> {
+
+    @Override
+    public MessageResult distributeMessages(
+        final GitHubJobDetailsModel distributionDetails,
+        final ProviderMessageHolder messages,
+        final String jobName,
+        final UUID eventId,
+        final Set<Long> notificationIds
+    )
+        throws AlertException {
+        return MessageResult.success();
+    }
+}

--- a/channel-github/src/main/java/com/synopsys/integration/alert/channel/github/distribution/GitHubEventHandler.java
+++ b/channel-github/src/main/java/com/synopsys/integration/alert/channel/github/distribution/GitHubEventHandler.java
@@ -1,0 +1,20 @@
+package com.synopsys.integration.alert.channel.github.distribution;
+
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.api.channel.DistributionChannel;
+import com.synopsys.integration.alert.api.channel.DistributionEventHandler;
+import com.synopsys.integration.alert.common.persistence.accessor.GitHubJobDetailAccessor;
+import com.synopsys.integration.alert.common.persistence.accessor.ProcessingAuditAccessor;
+import com.synopsys.integration.alert.common.persistence.model.job.details.GitHubJobDetailsModel;
+
+@Component
+public class GitHubEventHandler extends DistributionEventHandler<GitHubJobDetailsModel> {
+    public GitHubEventHandler(
+        final DistributionChannel<GitHubJobDetailsModel> channel,
+        final GitHubJobDetailAccessor jobDetailsAccessor,
+        final ProcessingAuditAccessor auditAccessor
+    ) {
+        super(channel, jobDetailsAccessor, auditAccessor);
+    }
+}

--- a/channel-github/src/main/java/com/synopsys/integration/alert/channel/github/distribution/GitHubEventReceiver.java
+++ b/channel-github/src/main/java/com/synopsys/integration/alert/channel/github/distribution/GitHubEventReceiver.java
@@ -1,0 +1,20 @@
+package com.synopsys.integration.alert.channel.github.distribution;
+
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.stereotype.Component;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.channel.DistributionEventReceiver;
+import com.synopsys.integration.alert.common.persistence.model.job.details.GitHubJobDetailsModel;
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
+
+@Component
+public class GitHubEventReceiver extends DistributionEventReceiver<GitHubJobDetailsModel> {
+    public GitHubEventReceiver(
+        final Gson gson,
+        final TaskExecutor taskExecutor,
+        final GitHubEventHandler distributionEventHandler
+    ) {
+        super(gson, taskExecutor, ChannelKeys.GITHUB, distributionEventHandler);
+    }
+}


### PR DESCRIPTION
- create job details accessor interface
- Create default job details accessor
- Create the Job Details model
- Create the event receiver
- Create the event handler

The implementation of the event handler needs to be done.  The implementation of the Job Details and the accessor needs to be done.