### PR TITLE
Azure OAuth Implementation - global configuration

### DIFF
--- a/alert-database/src/main/resources/liquibase/6.12.0/oauth-credential-store.xml
+++ b/alert-database/src/main/resources/liquibase/6.12.0/oauth-credential-store.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
-    <changeSet author="martinch" id="create-azure-boards-configuration-table">
+    <changeSet author="martinch" id="create-azure-boards-oauth-credentials">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists schemaName="alert" tableName="oauth_credentials"/>
@@ -11,9 +11,9 @@
             <column name="configuration_id" type="UUID" defaultValueComputed="uuid_generate_v4()">
                 <constraints primaryKey="true"/>
             </column>
-            <column name="access_token" type="UUID"/>
-            <column name="refresh_token" type="UUID"/>
-            <column name="exipiration_time_ms" type="BIGINT" defaultValue="0"/>
+            <column name="access_token" type="VARCHAR"/>
+            <column name="refresh_token" type="VARCHAR"/>
+            <column name="expiration_time_ms" type="BIGINT" defaultValue="0"/>
         </createTable>
     </changeSet>
 </databaseChangeLog>

--- a/api-oauth/src/main/java/com/synopsys/integration/alert/api/oauth/AlertOAuthCredentialDataStore.java
+++ b/api-oauth/src/main/java/com/synopsys/integration/alert/api/oauth/AlertOAuthCredentialDataStore.java
@@ -8,14 +8,11 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
-import org.springframework.stereotype.Component;
-
 import com.google.api.client.auth.oauth2.StoredCredential;
 import com.google.api.client.util.store.AbstractDataStore;
 import com.synopsys.integration.alert.api.oauth.database.AlertOAuthModel;
 import com.synopsys.integration.alert.api.oauth.database.accessor.AlertOAuthConfigurationAccessor;
 
-@Component
 public class AlertOAuthCredentialDataStore extends AbstractDataStore<StoredCredential> {
     private final Lock lock = new ReentrantLock();
     private final AlertOAuthConfigurationAccessor accessor;
@@ -92,7 +89,7 @@ public class AlertOAuthCredentialDataStore extends AbstractDataStore<StoredCrede
                 if (model.getExirationTimeMilliseconds().isPresent()) {
                     expirationInMillseconds = model.getExirationTimeMilliseconds().get();
                 }
-                
+
                 AlertOAuthModel updateModel = new AlertOAuthModel(configurationId, accessToken, refreshToken, expirationInMillseconds);
                 accessor.updateConfiguration(model.getId(), updateModel);
             }

--- a/api-oauth/src/main/java/com/synopsys/integration/alert/api/oauth/database/accessor/AlertOAuthConfigurationAccessor.java
+++ b/api-oauth/src/main/java/com/synopsys/integration/alert/api/oauth/database/accessor/AlertOAuthConfigurationAccessor.java
@@ -62,7 +62,7 @@ public class AlertOAuthConfigurationAccessor {
     }
 
     private AlertOAuthModel convertToModel(AlertOAuthConfigurationEntity entity) {
-        return new AlertOAuthModel(entity.getId(), entity.getAccessToken(), entity.getRefreshToken(), entity.getExirationTimeMilliseconds());
+        return new AlertOAuthModel(entity.getId(), entity.getAccessToken(), entity.getRefreshToken(), entity.getExpirationTimeMilliseconds());
     }
 
     private AlertOAuthConfigurationEntity convertToEntity(AlertOAuthModel model) {

--- a/api-oauth/src/main/java/com/synopsys/integration/alert/api/oauth/database/configuration/AlertOAuthConfigurationEntity.java
+++ b/api-oauth/src/main/java/com/synopsys/integration/alert/api/oauth/database/configuration/AlertOAuthConfigurationEntity.java
@@ -46,7 +46,7 @@ public class AlertOAuthConfigurationEntity extends BaseEntity {
         return refreshToken;
     }
 
-    public Long getExpirationTimeMillisecondsTimeMilliseconds() {
+    public Long getExpirationTimeMilliseconds() {
         return expirationTimeMilliseconds;
     }
 }

--- a/api-oauth/src/main/java/com/synopsys/integration/alert/api/oauth/database/configuration/AlertOAuthConfigurationEntity.java
+++ b/api-oauth/src/main/java/com/synopsys/integration/alert/api/oauth/database/configuration/AlertOAuthConfigurationEntity.java
@@ -20,18 +20,18 @@ public class AlertOAuthConfigurationEntity extends BaseEntity {
     private String accessToken;
     @Column(name = "refresh_token")
     private String refreshToken;
-    @Column(name = "exipiration_time_ms")
-    private Long exirationTimeMilliseconds;
+    @Column(name = "expiration_time_ms")
+    private Long expirationTimeMilliseconds;
 
     public AlertOAuthConfigurationEntity() {
         //default constructor for JPA
     }
 
-    public AlertOAuthConfigurationEntity(final UUID id, final String accessToken, final String refreshToken, final Long exirationTimeMilliseconds) {
+    public AlertOAuthConfigurationEntity(UUID id, String accessToken, String refreshToken, Long expirationTimeMilliseconds) {
         this.id = id;
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
-        this.exirationTimeMilliseconds = exirationTimeMilliseconds;
+        this.expirationTimeMilliseconds = expirationTimeMilliseconds;
     }
 
     public UUID getId() {
@@ -46,7 +46,7 @@ public class AlertOAuthConfigurationEntity extends BaseEntity {
         return refreshToken;
     }
 
-    public Long getExirationTimeMilliseconds() {
-        return exirationTimeMilliseconds;
+    public Long getExpirationTimeMillisecondsTimeMilliseconds() {
+        return expirationTimeMilliseconds;
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ dependencies {
     implementation project(':api-distribution')
     implementation project(':api-environment')
     implementation project(':api-event')
+    implementation project(':api-oauth')
     implementation project(':api-processor')
     implementation project(':api-provider')
     implementation project(':api-task')

--- a/channel-azure-boards/build.gradle
+++ b/channel-azure-boards/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation project(':api-processor')
     implementation project(':api-descriptor')
     implementation project(':alert-database')
+    implementation project(':api-oauth')
 
     api 'org.springframework.data:spring-data-jpa'
     implementation 'jakarta.persistence:jakarta.persistence-api'

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsProperties.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsProperties.java
@@ -68,15 +68,13 @@ public class AzureBoardsProperties {
         String redirectUri,
         AzureBoardsGlobalConfigModel azureBoardsGlobalConfigModel
     ) {
-        //TODO: Determine if we need the KEY_OAUTH_USER_EMAIL here or can we use the default
-        String oAuthUserEmail = DEFAULT_AZURE_OAUTH_USER_ID;
         List<String> defaultScopes = List.of(AzureOAuthScopes.PROJECTS_READ.getScope(), AzureOAuthScopes.WORK_FULL.getScope());
         return new AzureBoardsProperties(
             alertOAuthCredentialDataStoreFactory,
             azureBoardsGlobalConfigModel.getOrganizationName(),
             azureBoardsGlobalConfigModel.getAppId().orElse(null),
             azureBoardsGlobalConfigModel.getClientSecret().orElse(null),
-            oAuthUserEmail,
+            azureBoardsGlobalConfigModel.getId(),
             defaultScopes,
             redirectUri
         );

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsPropertiesFactory.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsPropertiesFactory.java
@@ -35,12 +35,12 @@ public class AzureBoardsPropertiesFactory {
         this.configurationModelConfigurationAccessor = configurationModelConfigurationAccessor;
     }
 
-    public AzureBoardsProperties createAzureBoardsProperties() throws AlertConfigurationException {
+    public AzureBoardsPropertiesLegacy createAzureBoardsProperties() throws AlertConfigurationException {
         ConfigurationModel azureBoardsGlobalConfiguration = configurationModelConfigurationAccessor.getConfigurationsByDescriptorKeyAndContext(channelKey, ConfigContextEnum.GLOBAL)
             .stream()
             .findAny()
             .orElseThrow(() -> new AlertConfigurationException("Missing Azure Boards global configuration"));
-        return AzureBoardsProperties.fromGlobalConfig(credentialDataStoreFactory, azureRedirectUrlCreator.createOAuthRedirectUri(), azureBoardsGlobalConfiguration);
+        return AzureBoardsPropertiesLegacy.fromGlobalConfig(credentialDataStoreFactory, azureRedirectUrlCreator.createOAuthRedirectUri(), azureBoardsGlobalConfiguration);
     }
 
 }

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsPropertiesLegacy.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsPropertiesLegacy.java
@@ -42,7 +42,6 @@ import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.channel.azure.boards.descriptor.AzureBoardsDescriptor;
-import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
 import com.synopsys.integration.alert.channel.azure.boards.oauth.storage.AzureBoardsCredentialDataStoreFactory;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldUtility;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
@@ -90,25 +89,6 @@ public class AzureBoardsPropertiesLegacy {
     ) {
         FieldUtility globalFieldUtility = new FieldUtility(globalConfiguration.getCopyOfKeyToFieldMap());
         return fromFieldAccessor(credentialDataStoreFactory, redirectUri, globalFieldUtility);
-    }
-
-    public static AzureBoardsPropertiesLegacy fromGlobalConfigurationModel(
-        AzureBoardsCredentialDataStoreFactory credentialDataStoreFactory,
-        String redirectUri,
-        AzureBoardsGlobalConfigModel azureBoardsGlobalConfigModel
-    ) {
-        //TODO: Determine if we need the KEY_OAUTH_USER_EMAIL here or can we use the default
-        String oAuthUserEmail = DEFAULT_AZURE_OAUTH_USER_ID;
-        List<String> defaultScopes = List.of(AzureOAuthScopes.PROJECTS_READ.getScope(), AzureOAuthScopes.WORK_FULL.getScope());
-        return new AzureBoardsPropertiesLegacy(
-            credentialDataStoreFactory,
-            azureBoardsGlobalConfigModel.getOrganizationName(),
-            azureBoardsGlobalConfigModel.getAppId().orElse(null),
-            azureBoardsGlobalConfigModel.getClientSecret().orElse(null),
-            oAuthUserEmail,
-            defaultScopes,
-            redirectUri
-        );
     }
 
     public AzureBoardsPropertiesLegacy(

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalFieldModelTestAction.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalFieldModelTestAction.java
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.google.gson.Gson;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
 import com.synopsys.integration.alert.channel.azure.boards.descriptor.AzureBoardsDescriptor;
 import com.synopsys.integration.alert.channel.azure.boards.oauth.storage.AzureBoardsCredentialDataStoreFactory;
@@ -61,7 +61,7 @@ public class AzureBoardsGlobalFieldModelTestAction extends FieldModelTestAction 
             Optional<ConfigurationFieldModel> configurationFieldModel = registeredFieldValues.getField(AzureBoardsDescriptor.KEY_ORGANIZATION_NAME);
             String organizationName = configurationFieldModel.flatMap(ConfigurationFieldModel::getFieldValue).orElse(null);
 
-            AzureBoardsProperties azureBoardsProperties = AzureBoardsProperties.fromFieldAccessor(
+            AzureBoardsPropertiesLegacy azureBoardsProperties = AzureBoardsPropertiesLegacy.fromFieldAccessor(
                 azureBoardsCredentialDataStoreFactory,
                 azureRedirectUrlCreator.createOAuthRedirectUri(),
                 registeredFieldValues
@@ -76,7 +76,7 @@ public class AzureBoardsGlobalFieldModelTestAction extends FieldModelTestAction 
         }
     }
 
-    private AzureHttpService createAzureHttpService(AzureBoardsProperties azureBoardsProperties) throws IntegrationException {
+    private AzureHttpService createAzureHttpService(AzureBoardsPropertiesLegacy azureBoardsProperties) throws IntegrationException {
         ProxyInfo proxy = proxyManager.createProxyInfoForHost(AzureHttpRequestCreatorFactory.DEFAULT_BASE_URL);
         return azureBoardsProperties.createAzureHttpService(proxy, gson);
     }

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestAction.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestAction.java
@@ -10,11 +10,11 @@ import org.springframework.stereotype.Component;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
+import com.synopsys.integration.alert.api.oauth.AlertOAuthCredentialDataStoreFactory;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
 import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
 import com.synopsys.integration.alert.channel.azure.boards.database.accessor.AzureBoardsGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
-import com.synopsys.integration.alert.channel.azure.boards.oauth.storage.AzureBoardsCredentialDataStoreFactory;
 import com.synopsys.integration.alert.channel.azure.boards.validator.AzureBoardsGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.action.ValidationActionResponse;
@@ -36,7 +36,7 @@ import com.synopsys.integration.rest.proxy.ProxyInfo;
 public class AzureBoardsGlobalTestAction {
     private final AzureBoardsGlobalConfigurationValidator validator;
     private final AzureBoardsGlobalConfigAccessor configurationAccessor;
-    private final AzureBoardsCredentialDataStoreFactory azureBoardsCredentialDataStoreFactory;
+    private final AlertOAuthCredentialDataStoreFactory alertOAuthCredentialDataStoreFactory;
     private final AzureRedirectUrlCreator azureRedirectUrlCreator;
 
     private final ConfigurationValidationHelper validationHelper;
@@ -49,7 +49,7 @@ public class AzureBoardsGlobalTestAction {
         AuthorizationManager authorizationManager,
         AzureBoardsGlobalConfigurationValidator validator,
         AzureBoardsGlobalConfigAccessor configurationAccessor,
-        AzureBoardsCredentialDataStoreFactory azureBoardsCredentialDataStoreFactory,
+        AlertOAuthCredentialDataStoreFactory alertOAuthCredentialDataStoreFactory,
         AzureRedirectUrlCreator azureRedirectUrlCreator,
         Gson gson,
         ProxyManager proxyManager
@@ -58,8 +58,7 @@ public class AzureBoardsGlobalTestAction {
         this.validationHelper = new ConfigurationValidationHelper(authorizationManager, ConfigContextEnum.GLOBAL, ChannelKeys.AZURE_BOARDS);
         this.proxyManager = proxyManager;
         this.gson = gson;
-
-        this.azureBoardsCredentialDataStoreFactory = azureBoardsCredentialDataStoreFactory;
+        this.alertOAuthCredentialDataStoreFactory = alertOAuthCredentialDataStoreFactory;
         this.azureRedirectUrlCreator = azureRedirectUrlCreator;
         this.validator = validator;
         this.configurationAccessor = configurationAccessor;
@@ -85,8 +84,8 @@ public class AzureBoardsGlobalTestAction {
                 }
             }
 
-            AzureBoardsPropertiesLegacy azureBoardsProperties = AzureBoardsPropertiesLegacy.fromGlobalConfigurationModel(
-                azureBoardsCredentialDataStoreFactory,
+            AzureBoardsProperties azureBoardsProperties = AzureBoardsProperties.fromGlobalConfigurationModel(
+                alertOAuthCredentialDataStoreFactory,
                 azureRedirectUrlCreator.createOAuthRedirectUri(),
                 azureBoardsGlobalConfigModel
             );
@@ -99,7 +98,7 @@ public class AzureBoardsGlobalTestAction {
         return ConfigurationTestResult.success("Successfully connected to Azure instance.");
     }
 
-    protected AzureProjectService createAzureProjectService(AzureBoardsPropertiesLegacy azureBoardsProperties) throws IntegrationException {
+    protected AzureProjectService createAzureProjectService(AzureBoardsProperties azureBoardsProperties) throws IntegrationException {
         ProxyInfo proxy = proxyManager.createProxyInfoForHost(AzureHttpRequestCreatorFactory.DEFAULT_BASE_URL);
         AzureHttpService azureHttpService = azureBoardsProperties.createAzureHttpService(proxy, gson);
         return new AzureProjectService(azureHttpService, new AzureApiVersionAppender());

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestAction.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestAction.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
 import com.synopsys.integration.alert.channel.azure.boards.database.accessor.AzureBoardsGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
@@ -85,7 +85,7 @@ public class AzureBoardsGlobalTestAction {
                 }
             }
 
-            AzureBoardsProperties azureBoardsProperties = AzureBoardsProperties.fromGlobalConfigurationModel(
+            AzureBoardsPropertiesLegacy azureBoardsProperties = AzureBoardsPropertiesLegacy.fromGlobalConfigurationModel(
                 azureBoardsCredentialDataStoreFactory,
                 azureRedirectUrlCreator.createOAuthRedirectUri(),
                 azureBoardsGlobalConfigModel
@@ -99,7 +99,7 @@ public class AzureBoardsGlobalTestAction {
         return ConfigurationTestResult.success("Successfully connected to Azure instance.");
     }
 
-    protected AzureProjectService createAzureProjectService(AzureBoardsProperties azureBoardsProperties) throws IntegrationException {
+    protected AzureProjectService createAzureProjectService(AzureBoardsPropertiesLegacy azureBoardsProperties) throws IntegrationException {
         ProxyInfo proxy = proxyManager.createProxyInfoForHost(AzureHttpRequestCreatorFactory.DEFAULT_BASE_URL);
         AzureHttpService azureHttpService = azureBoardsProperties.createAzureHttpService(proxy, gson);
         return new AzureProjectService(azureHttpService, new AzureApiVersionAppender());

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsOAuthAuthenticateAction.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsOAuthAuthenticateAction.java
@@ -9,16 +9,17 @@ import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
+import com.synopsys.integration.alert.api.oauth.AlertOAuthCredentialDataStoreFactory;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
 import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
 import com.synopsys.integration.alert.channel.azure.boards.database.accessor.AzureBoardsGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
 import com.synopsys.integration.alert.channel.azure.boards.oauth.OAuthRequestValidator;
-import com.synopsys.integration.alert.channel.azure.boards.oauth.storage.AzureBoardsCredentialDataStoreFactory;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.oauth.OAuthEndpointResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
@@ -37,18 +38,19 @@ public class AzureBoardsOAuthAuthenticateAction {
     private final AuthorizationManager authorizationManager;
     private final AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor;
     private final AzureBoardsGlobalCrudActions azureBoardsGlobalCrudActions;
-    private final AzureBoardsCredentialDataStoreFactory azureBoardsCredentialDataStoreFactory;
+    private final AlertOAuthCredentialDataStoreFactory alertOAuthCredentialDataStoreFactory;
     private final AzureBoardsGlobalValidationAction azureBoardsGlobalValidationAction;
     private final AzureRedirectUrlCreator azureRedirectUrlCreator;
     private final OAuthRequestValidator oAuthRequestValidator;
     private final AlertWebServerUrlManager alertWebServerUrlManager;
     private final ProxyManager proxyManager;
 
+    @Autowired
     public AzureBoardsOAuthAuthenticateAction(
         AuthorizationManager authorizationManager,
         AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor,
         AzureBoardsGlobalCrudActions azureBoardsGlobalCrudActions,
-        AzureBoardsCredentialDataStoreFactory azureBoardsCredentialDataStoreFactory,
+        AlertOAuthCredentialDataStoreFactory alertOAuthCredentialDataStoreFactory,
         AzureBoardsGlobalValidationAction azureBoardsGlobalValidationAction,
         AzureRedirectUrlCreator azureRedirectUrlCreator,
         OAuthRequestValidator oAuthRequestValidator,
@@ -58,7 +60,7 @@ public class AzureBoardsOAuthAuthenticateAction {
         this.authorizationManager = authorizationManager;
         this.azureBoardsGlobalConfigAccessor = azureBoardsGlobalConfigAccessor;
         this.azureBoardsGlobalCrudActions = azureBoardsGlobalCrudActions;
-        this.azureBoardsCredentialDataStoreFactory = azureBoardsCredentialDataStoreFactory;
+        this.alertOAuthCredentialDataStoreFactory = alertOAuthCredentialDataStoreFactory;
         this.azureRedirectUrlCreator = azureRedirectUrlCreator;
         this.azureBoardsGlobalValidationAction = azureBoardsGlobalValidationAction;
         this.oAuthRequestValidator = oAuthRequestValidator;
@@ -148,7 +150,7 @@ public class AzureBoardsOAuthAuthenticateAction {
 
     private boolean isAuthenticated(AzureBoardsGlobalConfigModel azureBoardsGlobalConfigModel) {
         AzureBoardsProperties properties = AzureBoardsProperties.fromGlobalConfigurationModel(
-            azureBoardsCredentialDataStoreFactory,
+            alertOAuthCredentialDataStoreFactory,
             azureRedirectUrlCreator.createOAuthRedirectUri(),
             azureBoardsGlobalConfigModel
         );

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsOAuthCallbackAction.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsOAuthCallbackAction.java
@@ -14,12 +14,12 @@ import org.springframework.stereotype.Component;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
+import com.synopsys.integration.alert.api.oauth.AlertOAuthCredentialDataStoreFactory;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
 import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
 import com.synopsys.integration.alert.channel.azure.boards.database.accessor.AzureBoardsGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
 import com.synopsys.integration.alert.channel.azure.boards.oauth.OAuthRequestValidator;
-import com.synopsys.integration.alert.channel.azure.boards.oauth.storage.AzureBoardsCredentialDataStoreFactory;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.rest.proxy.ProxyManager;
@@ -37,7 +37,7 @@ import com.synopsys.integration.rest.proxy.ProxyInfo;
 @Component
 public class AzureBoardsOAuthCallbackAction {
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final AzureBoardsCredentialDataStoreFactory azureBoardsCredentialDataStoreFactory;
+    private final AlertOAuthCredentialDataStoreFactory alertOAuthCredentialDataStoreFactory;
     private final AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor;
     private final Gson gson;
     private final AuthorizationManager authorizationManager;
@@ -47,7 +47,7 @@ public class AzureBoardsOAuthCallbackAction {
 
     @Autowired
     public AzureBoardsOAuthCallbackAction(
-        AzureBoardsCredentialDataStoreFactory azureBoardsCredentialDataStoreFactory,
+        AlertOAuthCredentialDataStoreFactory alertOAuthCredentialDataStoreFactory,
         AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor,
         Gson gson,
         AuthorizationManager authorizationManager,
@@ -55,7 +55,7 @@ public class AzureBoardsOAuthCallbackAction {
         OAuthRequestValidator oAuthRequestValidator,
         AzureRedirectUrlCreator azureRedirectUrlCreator
     ) {
-        this.azureBoardsCredentialDataStoreFactory = azureBoardsCredentialDataStoreFactory;
+        this.alertOAuthCredentialDataStoreFactory = alertOAuthCredentialDataStoreFactory;
         this.azureBoardsGlobalConfigAccessor = azureBoardsGlobalConfigAccessor;
         this.gson = gson;
         this.authorizationManager = authorizationManager;
@@ -100,7 +100,7 @@ public class AzureBoardsOAuthCallbackAction {
                     } else {
                         String oAuthRedirectUri = azureRedirectUrlCreator.createOAuthRedirectUri();
                         AzureBoardsProperties properties = AzureBoardsProperties.fromGlobalConfigurationModel(
-                            azureBoardsCredentialDataStoreFactory,
+                            alertOAuthCredentialDataStoreFactory,
                             oAuthRedirectUri,
                             savedConfigModel
                         );

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/AzureBoardsMessageSenderFactory.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/AzureBoardsMessageSenderFactory.java
@@ -26,8 +26,8 @@ import com.synopsys.integration.alert.api.channel.issue.send.IssueTrackerTransit
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsHttpExceptionMessageImprover;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesFactory;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.delegate.AzureBoardsCommentGenerator;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.delegate.AzureBoardsCreateEventGenerator;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.delegate.AzureBoardsIssueCommenter;
@@ -86,7 +86,7 @@ public class AzureBoardsMessageSenderFactory implements IssueTrackerMessageSende
 
     @Override
     public IssueTrackerMessageSender<Integer> createMessageSender(AzureBoardsJobDetailsModel distributionDetails, UUID globalId) throws AlertException {
-        AzureBoardsProperties azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
+        AzureBoardsPropertiesLegacy azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
         azureBoardsProperties.validateProperties();
 
         // Initialize Http Service

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/AzureBoardsProcessorFactory.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/AzureBoardsProcessorFactory.java
@@ -26,8 +26,8 @@ import com.synopsys.integration.alert.api.channel.issue.search.IssueCategoryRetr
 import com.synopsys.integration.alert.api.channel.issue.search.IssueTrackerSearcher;
 import com.synopsys.integration.alert.api.channel.issue.send.IssueTrackerAsyncMessageSender;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesFactory;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.search.AzureBoardsComponentIssueFinder;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.search.AzureBoardsExistingIssueDetailsCreator;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.search.AzureBoardsIssueStatusResolver;
@@ -81,7 +81,7 @@ public class AzureBoardsProcessorFactory implements IssueTrackerProcessorFactory
 
     @Override
     public IssueTrackerProcessor<Integer> createProcessor(AzureBoardsJobDetailsModel distributionDetails, UUID eventId, Set<Long> notificationIds) throws AlertException {
-        AzureBoardsProperties azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
+        AzureBoardsPropertiesLegacy azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
         String organizationName = azureBoardsProperties.getOrganizationName();
         azureBoardsProperties.validateProperties();
 

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCommentEventHandler.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCommentEventHandler.java
@@ -25,8 +25,8 @@ import com.synopsys.integration.alert.api.channel.issue.model.IssueTrackerRespon
 import com.synopsys.integration.alert.api.channel.issue.send.IssueTrackerMessageSender;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.api.event.EventManager;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesFactory;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.AzureBoardsMessageSenderFactory;
 import com.synopsys.integration.alert.common.persistence.accessor.JobDetailsAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.JobSubTaskAccessor;
@@ -76,7 +76,7 @@ public class AzureBoardsCommentEventHandler extends IssueTrackerCommentEventHand
         Optional<AzureBoardsJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(event.getJobId());
         if (details.isPresent()) {
             AzureBoardsJobDetailsModel distributionDetails = details.get();
-            AzureBoardsProperties azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
+            AzureBoardsPropertiesLegacy azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
             String organizationName = azureBoardsProperties.getOrganizationName();
             azureBoardsProperties.validateProperties();
 

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCreateIssueEventHandler.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCreateIssueEventHandler.java
@@ -28,8 +28,8 @@ import com.synopsys.integration.alert.api.channel.issue.model.IssueTrackerRespon
 import com.synopsys.integration.alert.api.channel.issue.send.IssueTrackerMessageSender;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.api.event.EventManager;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesFactory;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.AzureBoardsMessageSenderFactory;
 import com.synopsys.integration.alert.common.persistence.accessor.JobDetailsAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.JobSubTaskAccessor;
@@ -81,7 +81,7 @@ public class AzureBoardsCreateIssueEventHandler extends IssueTrackerCreateIssueE
         if (details.isPresent()) {
             try {
                 AzureBoardsJobDetailsModel distributionDetails = details.get();
-                AzureBoardsProperties azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
+                AzureBoardsPropertiesLegacy azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
                 String organizationName = azureBoardsProperties.getOrganizationName();
                 azureBoardsProperties.validateProperties();
 

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsTransitionEventHandler.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsTransitionEventHandler.java
@@ -25,8 +25,8 @@ import com.synopsys.integration.alert.api.channel.issue.model.IssueTransitionMod
 import com.synopsys.integration.alert.api.channel.issue.send.IssueTrackerMessageSender;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.api.event.EventManager;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesFactory;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.AzureBoardsMessageSenderFactory;
 import com.synopsys.integration.alert.common.persistence.accessor.JobDetailsAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.JobSubTaskAccessor;
@@ -76,7 +76,7 @@ public class AzureBoardsTransitionEventHandler extends IssueTrackerTransitionEve
         Optional<AzureBoardsJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(event.getJobId());
         if (details.isPresent()) {
             AzureBoardsJobDetailsModel distributionDetails = details.get();
-            AzureBoardsProperties azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
+            AzureBoardsPropertiesLegacy azureBoardsProperties = azureBoardsPropertiesFactory.createAzureBoardsProperties();
             String organizationName = azureBoardsProperties.getOrganizationName();
             azureBoardsProperties.validateProperties();
 

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidator.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidator.java
@@ -66,7 +66,6 @@ public class OAuthRequestValidator {
             .filter(entry -> entry.getValue().getRequestTimestamp().isBefore(instant))
             .map(Map.Entry::getKey)
             .forEach(this::removeAuthorizationRequest);
-
     }
 
     public void removeRequestsOlderThan5MinutesAgo() {

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/storage/AzureBoardsCredentialDataStoreFactory.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/storage/AzureBoardsCredentialDataStoreFactory.java
@@ -18,6 +18,7 @@ import com.google.api.client.util.store.DataStore;
 import com.synopsys.integration.alert.api.common.model.exception.AlertRuntimeException;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationModelConfigurationAccessor;
 
+@Deprecated(forRemoval = true)
 @Component
 public class AzureBoardsCredentialDataStoreFactory extends AbstractDataStoreFactory {
     private final ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor;

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/web/AzureBoardsCustomFunctionAction.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/web/AzureBoardsCustomFunctionAction.java
@@ -23,7 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatus;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
 import com.synopsys.integration.alert.channel.azure.boards.descriptor.AzureBoardsDescriptor;
 import com.synopsys.integration.alert.channel.azure.boards.oauth.OAuthRequestValidatorLegacy;
@@ -163,7 +163,7 @@ public class AzureBoardsCustomFunctionAction extends CustomFunctionAction<OAuthE
     }
 
     private boolean isAuthenticated(FieldUtility fieldUtility) {
-        AzureBoardsProperties properties = AzureBoardsProperties.fromFieldAccessor(
+        AzureBoardsPropertiesLegacy properties = AzureBoardsPropertiesLegacy.fromFieldAccessor(
             azureBoardsCredentialDataStoreFactory,
             azureRedirectUrlCreator.createOAuthRedirectUri(),
             fieldUtility

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestActionTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestActionTest.java
@@ -1,13 +1,27 @@
 package com.synopsys.integration.alert.channel.azure.boards.action;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
+import com.synopsys.integration.alert.api.oauth.AlertOAuthCredentialDataStoreFactory;
 import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
 import com.synopsys.integration.alert.channel.azure.boards.database.accessor.AzureBoardsGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.azure.boards.database.configuration.AzureBoardsConfigurationEntity;
 import com.synopsys.integration.alert.channel.azure.boards.database.mock.MockAzureBoardsConfigurationRepository;
 import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
-import com.synopsys.integration.alert.channel.azure.boards.oauth.storage.AzureBoardsCredentialDataStoreFactory;
 import com.synopsys.integration.alert.channel.azure.boards.validator.AzureBoardsGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.action.ActionResponse;
@@ -27,23 +41,9 @@ import com.synopsys.integration.alert.test.common.MockAlertProperties;
 import com.synopsys.integration.alert.test.common.database.MockRepositorySorter;
 import com.synopsys.integration.azure.boards.common.service.project.AzureProjectService;
 import com.synopsys.integration.exception.IntegrationException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.springframework.http.HttpStatus;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-import java.util.Map;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(SpringExtension.class)
-public class AzureBoardsGlobalTestActionTest {
+class AzureBoardsGlobalTestActionTest {
     private final Gson gson = new Gson();
     private final AlertProperties alertProperties = new MockAlertProperties();
     private final FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, gson);
@@ -52,10 +52,14 @@ public class AzureBoardsGlobalTestActionTest {
     AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor;
     AzureBoardsGlobalConfigurationValidator azureBoardsGlobalConfigurationValidator;
 
-    @Mock AzureBoardsCredentialDataStoreFactory mockAzureBoardsCredentialDataStoreFactory;
-    @Mock AzureProjectService mockedAzureProjectService;
-    @Mock AzureRedirectUrlCreator mockAzureRedirectUrlCreator;
-    @Mock ProxyManager mockProxyManager;
+    @Mock
+    AlertOAuthCredentialDataStoreFactory mockAlertOAuthCredentialDataStoreFactory;
+    @Mock
+    AzureProjectService mockedAzureProjectService;
+    @Mock
+    AzureRedirectUrlCreator mockAzureRedirectUrlCreator;
+    @Mock
+    ProxyManager mockProxyManager;
 
     @BeforeEach
     void initEach() {
@@ -76,7 +80,7 @@ public class AzureBoardsGlobalTestActionTest {
             authorizationManager,
             azureBoardsGlobalConfigurationValidator,
             azureBoardsGlobalConfigAccessor,
-            mockAzureBoardsCredentialDataStoreFactory,
+            mockAlertOAuthCredentialDataStoreFactory,
             mockAzureRedirectUrlCreator,
             gson,
             mockProxyManager
@@ -97,7 +101,7 @@ public class AzureBoardsGlobalTestActionTest {
                 authorizationManager,
                 azureBoardsGlobalConfigurationValidator,
                 azureBoardsGlobalConfigAccessor,
-                mockAzureBoardsCredentialDataStoreFactory,
+                mockAlertOAuthCredentialDataStoreFactory,
                 mockAzureRedirectUrlCreator,
                 gson,
                 mockProxyManager
@@ -115,8 +119,8 @@ public class AzureBoardsGlobalTestActionTest {
         AuthorizationManager authorizationManager = createAuthorizationManager(AuthenticationTestUtils.FULL_PERMISSIONS);
         String name = AlertRestConstants.DEFAULT_CONFIGURATION_NAME;
         String organizationName = "Organization name";
-        String appId  = "obfuscated-app-id";
-        String clientSecret  = "obfuscatedClientSecret";
+        String appId = "obfuscated-app-id";
+        String clientSecret = "obfuscatedClientSecret";
         AzureBoardsGlobalConfigModel createdModel = azureBoardsGlobalConfigAccessor.createConfiguration(
             new AzureBoardsGlobalConfigModel(
                 "",
@@ -137,7 +141,7 @@ public class AzureBoardsGlobalTestActionTest {
                 authorizationManager,
                 azureBoardsGlobalConfigurationValidator,
                 azureBoardsGlobalConfigAccessor,
-                mockAzureBoardsCredentialDataStoreFactory,
+                mockAlertOAuthCredentialDataStoreFactory,
                 mockAzureRedirectUrlCreator,
                 gson,
                 mockProxyManager

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCreateIssueEventHandlerTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCreateIssueEventHandlerTest.java
@@ -24,8 +24,8 @@ import com.synopsys.integration.alert.api.channel.issue.model.IssueCreationModel
 import com.synopsys.integration.alert.api.channel.issue.search.IssueCategoryRetriever;
 import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsHttpExceptionMessageImprover;
-import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesFactory;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesLegacy;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.AzureBoardsMessageSenderFactory;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.event.mock.MockAzureBoardsJobDetailsRepository;
 import com.synopsys.integration.alert.channel.azure.boards.distribution.event.mock.MockCorrelationToNotificationRelationRepository;
@@ -128,7 +128,7 @@ class AzureBoardsCreateIssueEventHandlerTest {
         Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
 
         AzureBoardsPropertiesFactory propertiesFactory = Mockito.mock(AzureBoardsPropertiesFactory.class);
-        AzureBoardsProperties azureBoardsProperties = Mockito.mock(AzureBoardsProperties.class);
+        AzureBoardsPropertiesLegacy azureBoardsProperties = Mockito.mock(AzureBoardsPropertiesLegacy.class);
         AzureHttpRequestCreator azureHttpRequestCreator = Mockito.mock(AzureHttpRequestCreator.class);
 
         AzureBoardsJobDetailsModel jobDetailsModel = createJobDetails(jobId);

--- a/src/main/java/com/synopsys/integration/alert/Application.java
+++ b/src/main/java/com/synopsys/integration/alert/Application.java
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 import com.synopsys.integration.alert.component.authentication.security.database.UserDatabaseService;
 
-@EnableJpaRepositories(basePackages = { "com.synopsys.integration.alert.database", "com.synopsys.integration.alert.channel" })
+@EnableJpaRepositories(basePackages = { "com.synopsys.integration.alert.database", "com.synopsys.integration.alert.channel", "com.synopsys.integration.alert.api.oauth" })
 @EnableTransactionManagement
 @EnableBatchProcessing
 @EnableScheduling


### PR DESCRIPTION
This PR is set up to accomplish the following:

- Moved existing  AzureBoardsProperties into AzureBoardsPropertiesLegacy to be slowly deprecated and removed
- Fixed several issues in AlertOAuthCredentialDataStore that were causing new issues to  be updated rather than created, causing the oauth credential save to fail silently. 
- Fixed typos and incorrect objects types in the database
- Implemented AlertOAuthCredentialDataStore in existing OAuth authorization and callback for the global configuration

What is currently not supported:

- Distribution configurations for Azure will fail as a result of invalid Azure configurations still using the old legacy  AzureBoardsProperties. This fix will need to be made in a followup PR.