### PR TITLE
IALERT-3195 old rest endpoint update fix

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/action/api/GlobalConfigurationModelToConcreteConverter.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/action/api/GlobalConfigurationModelToConcreteConverter.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
 
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatus;
@@ -25,14 +26,13 @@ import com.synopsys.integration.alert.common.rest.model.ConfigWithMetadata;
 public abstract class GlobalConfigurationModelToConcreteConverter<T extends ConfigWithMetadata> {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    public Optional<T> convertAndValidate(ConfigurationModel globalConfigurationModel) {
+    public Optional<T> convertAndValidate(ConfigurationModel globalConfigurationModel, @Nullable String existingConfigurationId) {
         Optional<T> configModel = convert(globalConfigurationModel);
 
         if (configModel.isEmpty()) {
             return Optional.empty();
         }
-
-        ValidationResponseModel validationResponseModel = validate(configModel.get());
+        ValidationResponseModel validationResponseModel = validate(configModel.get(), existingConfigurationId);
         if (validationResponseModel.hasErrors()) {
             logger.error("Converted field model validation failed: {}", validationResponseModel.getMessage());
             for (AlertFieldStatus errorStatus : validationResponseModel.getErrors().values()) {
@@ -45,5 +45,5 @@ public abstract class GlobalConfigurationModelToConcreteConverter<T extends Conf
 
     protected abstract Optional<T> convert(ConfigurationModel globalConfigurationModel);
 
-    protected abstract ValidationResponseModel validate(T configModel);
+    protected abstract ValidationResponseModel validate(T configModel, @Nullable String existingConfigurationId);
 }

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/convert/AzureBoardsGlobalConfigurationModelConverter.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/convert/AzureBoardsGlobalConfigurationModelConverter.java
@@ -54,7 +54,7 @@ public class AzureBoardsGlobalConfigurationModelConverter extends GlobalConfigur
     }
 
     @Override
-    protected ValidationResponseModel validate(AzureBoardsGlobalConfigModel configModel) {
-        return validator.validate(configModel, null);
+    protected ValidationResponseModel validate(AzureBoardsGlobalConfigModel configModel, String existingConfigurationId) {
+        return validator.validate(configModel, existingConfigurationId);
     }
 }

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/convert/AzureBoardsGlobalConfigurationModelSaveActions.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/convert/AzureBoardsGlobalConfigurationModelSaveActions.java
@@ -47,7 +47,10 @@ public class AzureBoardsGlobalConfigurationModelSaveActions implements GlobalCon
         Optional<UUID> defaultConfigurationId = configurationAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
             .map(AzureBoardsGlobalConfigModel::getId)
             .map(UUID::fromString);
-        Optional<AzureBoardsGlobalConfigModel> azureBoardsGlobalConfigModel = azureBoardsModelConverter.convertAndValidate(configurationModel);
+        Optional<AzureBoardsGlobalConfigModel> azureBoardsGlobalConfigModel = azureBoardsModelConverter.convertAndValidate(
+            configurationModel,
+            defaultConfigurationId.map(UUID::toString).orElse(null)
+        );
         if (azureBoardsGlobalConfigModel.isPresent()) {
             AzureBoardsGlobalConfigModel model = azureBoardsGlobalConfigModel.get();
             model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
@@ -61,7 +64,7 @@ public class AzureBoardsGlobalConfigurationModelSaveActions implements GlobalCon
 
     @Override
     public void createConcreteModel(ConfigurationModel configurationModel) {
-        Optional<AzureBoardsGlobalConfigModel> azureBoardsGlobalConfigModel = azureBoardsModelConverter.convertAndValidate(configurationModel);
+        Optional<AzureBoardsGlobalConfigModel> azureBoardsGlobalConfigModel = azureBoardsModelConverter.convertAndValidate(configurationModel, null);
         if (azureBoardsGlobalConfigModel.isPresent()) {
             AzureBoardsGlobalConfigModel model = azureBoardsGlobalConfigModel.get();
             model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/convert/AzureBoardsGlobalConfigurationModelConverterTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/convert/AzureBoardsGlobalConfigurationModelConverterTest.java
@@ -42,7 +42,7 @@ class AzureBoardsGlobalConfigurationModelConverterTest {
     void validConversionTest() {
         ConfigurationModel configurationModel = createDefaultConfigurationModel();
         AzureBoardsGlobalConfigurationModelConverter converter = new AzureBoardsGlobalConfigurationModelConverter(validator);
-        Optional<AzureBoardsGlobalConfigModel> model = converter.convertAndValidate(configurationModel);
+        Optional<AzureBoardsGlobalConfigModel> model = converter.convertAndValidate(configurationModel, null);
         assertTrue(model.isPresent());
         AzureBoardsGlobalConfigModel azureBoardsGlobalConfigModel = model.get();
 
@@ -56,7 +56,7 @@ class AzureBoardsGlobalConfigurationModelConverterTest {
     void emptyFieldsTest() {
         ConfigurationModel emptyModel = new ConfigurationModel(1L, 1L, "", "", ConfigContextEnum.GLOBAL, Map.of());
         AzureBoardsGlobalConfigurationModelConverter converter = new AzureBoardsGlobalConfigurationModelConverter(validator);
-        Optional<AzureBoardsGlobalConfigModel> model = converter.convertAndValidate(emptyModel);
+        Optional<AzureBoardsGlobalConfigModel> model = converter.convertAndValidate(emptyModel, null);
         assertTrue(model.isEmpty());
     }
 
@@ -67,7 +67,7 @@ class AzureBoardsGlobalConfigurationModelConverterTest {
         Map<String, ConfigurationFieldModel> fieldValues = Map.of(invalidFieldKey, invalidField);
         ConfigurationModel configurationModel = new ConfigurationModel(1L, 1L, "", "", ConfigContextEnum.GLOBAL, fieldValues);
         AzureBoardsGlobalConfigurationModelConverter converter = new AzureBoardsGlobalConfigurationModelConverter(validator);
-        Optional<AzureBoardsGlobalConfigModel> model = converter.convertAndValidate(configurationModel);
+        Optional<AzureBoardsGlobalConfigModel> model = converter.convertAndValidate(configurationModel, null);
         assertTrue(model.isEmpty());
     }
 

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelConverter.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelConverter.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
@@ -95,7 +96,8 @@ public class EmailGlobalConfigurationModelConverter extends GlobalConfigurationM
     }
 
     @Override
-    protected ValidationResponseModel validate(EmailGlobalConfigModel configModel) {
+    protected ValidationResponseModel validate(EmailGlobalConfigModel configModel, @Nullable String existingConfigurationId) {
+        //Since there is only a single email global configuration, existingConfigurationId is ignored.
         return validator.validate(configModel);
     }
 

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelSaveActions.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelSaveActions.java
@@ -52,7 +52,10 @@ public class EmailGlobalConfigurationModelSaveActions implements GlobalConfigura
         Optional<UUID> defaultConfigurationId = configurationAccessor.getConfiguration()
             .map(EmailGlobalConfigModel::getId)
             .map(UUID::fromString);
-        Optional<EmailGlobalConfigModel> emailGlobalConfigModel = emailFieldModelConverter.convertAndValidate(configurationModel);
+        Optional<EmailGlobalConfigModel> emailGlobalConfigModel = emailFieldModelConverter.convertAndValidate(
+            configurationModel,
+            defaultConfigurationId.map(UUID::toString).orElse(null)
+        );
         if (defaultConfigurationId.isPresent()) {
             emailGlobalConfigModel.ifPresent(configurationActions::update);
         }
@@ -60,7 +63,7 @@ public class EmailGlobalConfigurationModelSaveActions implements GlobalConfigura
 
     @Override
     public void createConcreteModel(ConfigurationModel configurationModel) {
-        Optional<EmailGlobalConfigModel> emailGlobalConfigModel = emailFieldModelConverter.convertAndValidate(configurationModel);
+        Optional<EmailGlobalConfigModel> emailGlobalConfigModel = emailFieldModelConverter.convertAndValidate(configurationModel, null);
         emailGlobalConfigModel.ifPresent(configurationActions::create);
     }
 

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelConverterTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/convert/EmailGlobalConfigurationModelConverterTest.java
@@ -30,7 +30,7 @@ class EmailGlobalConfigurationModelConverterTest {
     void validConversionTest() {
         ConfigurationModel configurationModel = createDefaultConfigurationModel();
         EmailGlobalConfigurationModelConverter converter = new EmailGlobalConfigurationModelConverter(validator);
-        Optional<EmailGlobalConfigModel> model = converter.convertAndValidate(configurationModel);
+        Optional<EmailGlobalConfigModel> model = converter.convertAndValidate(configurationModel, null);
         assertTrue(model.isPresent());
         EmailGlobalConfigModel emailModel = model.get();
         assertEquals(Boolean.TRUE, emailModel.getSmtpAuth().orElse(Boolean.FALSE));
@@ -52,7 +52,7 @@ class EmailGlobalConfigurationModelConverterTest {
         configurationModel.getField(EmailPropertyKeys.JAVAMAIL_PORT_KEY.getPropertyKey())
             .ifPresent(field -> field.setFieldValue("twenty-five"));
         EmailGlobalConfigurationModelConverter converter = new EmailGlobalConfigurationModelConverter(validator);
-        Optional<EmailGlobalConfigModel> model = converter.convertAndValidate(configurationModel);
+        Optional<EmailGlobalConfigModel> model = converter.convertAndValidate(configurationModel, null);
         assertTrue(model.isEmpty());
     }
 
@@ -60,7 +60,7 @@ class EmailGlobalConfigurationModelConverterTest {
     void emptyFieldsTest() {
         ConfigurationModel emptyModel = new ConfigurationModel(1L, 1L, "", "", ConfigContextEnum.GLOBAL, Map.of());
         EmailGlobalConfigurationModelConverter converter = new EmailGlobalConfigurationModelConverter(validator);
-        Optional<EmailGlobalConfigModel> model = converter.convertAndValidate(emptyModel);
+        Optional<EmailGlobalConfigModel> model = converter.convertAndValidate(emptyModel, null);
         assertTrue(model.isEmpty());
     }
 
@@ -71,7 +71,7 @@ class EmailGlobalConfigurationModelConverterTest {
         Map<String, ConfigurationFieldModel> fieldValues = Map.of(invalidFieldKey, invalidField);
         ConfigurationModel configurationModel = new ConfigurationModel(1L, 1L, "", "", ConfigContextEnum.GLOBAL, fieldValues);
         EmailGlobalConfigurationModelConverter converter = new EmailGlobalConfigurationModelConverter(validator);
-        Optional<EmailGlobalConfigModel> model = converter.convertAndValidate(configurationModel);
+        Optional<EmailGlobalConfigModel> model = converter.convertAndValidate(configurationModel, null);
         assertTrue(model.isEmpty());
     }
 

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/convert/JiraServerGlobalConfigurationModelConverter.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/convert/JiraServerGlobalConfigurationModelConverter.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
@@ -69,7 +70,7 @@ public class JiraServerGlobalConfigurationModelConverter extends GlobalConfigura
     }
 
     @Override
-    protected ValidationResponseModel validate(JiraServerGlobalConfigModel configModel) {
-        return validator.validate(configModel, null);
+    protected ValidationResponseModel validate(JiraServerGlobalConfigModel configModel, @Nullable String existingConfigurationId) {
+        return validator.validate(configModel, existingConfigurationId);
     }
 }

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/convert/JiraServerGlobalConfigurationModelSaveActions.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/convert/JiraServerGlobalConfigurationModelSaveActions.java
@@ -51,7 +51,10 @@ public class JiraServerGlobalConfigurationModelSaveActions implements GlobalConf
         Optional<UUID> defaultConfigurationId = configurationAccessor.getConfigurationByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
             .map(JiraServerGlobalConfigModel::getId)
             .map(UUID::fromString);
-        Optional<JiraServerGlobalConfigModel> jiraGlobalConfigModel = jiraFieldModelConverter.convertAndValidate(configurationModel);
+        Optional<JiraServerGlobalConfigModel> jiraGlobalConfigModel = jiraFieldModelConverter.convertAndValidate(
+            configurationModel,
+            defaultConfigurationId.map(UUID::toString).orElse(null)
+        );
         if (jiraGlobalConfigModel.isPresent()) {
             JiraServerGlobalConfigModel model = jiraGlobalConfigModel.get();
             model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);
@@ -65,7 +68,7 @@ public class JiraServerGlobalConfigurationModelSaveActions implements GlobalConf
 
     @Override
     public void createConcreteModel(ConfigurationModel configurationModel) {
-        Optional<JiraServerGlobalConfigModel> jiraGlobalConfigModel = jiraFieldModelConverter.convertAndValidate(configurationModel);
+        Optional<JiraServerGlobalConfigModel> jiraGlobalConfigModel = jiraFieldModelConverter.convertAndValidate(configurationModel, null);
         if (jiraGlobalConfigModel.isPresent()) {
             JiraServerGlobalConfigModel model = jiraGlobalConfigModel.get();
             model.setName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME);

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/validator/JiraServerGlobalConfigurationValidator.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/validator/JiraServerGlobalConfigurationValidator.java
@@ -69,7 +69,7 @@ public class JiraServerGlobalConfigurationValidator {
     private boolean doesNameExist(String name, @Nullable String currentConfigId) {
         return jiraServerGlobalConfigAccessor.getConfigurationByName(name)
             .map(JiraServerGlobalConfigModel::getId)
-            .filter(id -> (currentConfigId != null) ? !currentConfigId.equals(id) : true)
+            .filter(id -> currentConfigId == null || !currentConfigId.equals(id))
             .isPresent();
     }
 }

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/convert/JiraServerGlobalConfigurationModelConverterTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/convert/JiraServerGlobalConfigurationModelConverterTest.java
@@ -38,7 +38,7 @@ class JiraServerGlobalConfigurationModelConverterTest {
     void validConversionTest() {
         ConfigurationModel configurationModel = createDefaultConfigurationModel();
         JiraServerGlobalConfigurationModelConverter converter = new JiraServerGlobalConfigurationModelConverter(validator);
-        Optional<JiraServerGlobalConfigModel> model = converter.convertAndValidate(configurationModel);
+        Optional<JiraServerGlobalConfigModel> model = converter.convertAndValidate(configurationModel, null);
         assertTrue(model.isPresent());
         JiraServerGlobalConfigModel jiraModel = model.get();
 
@@ -57,7 +57,7 @@ class JiraServerGlobalConfigurationModelConverterTest {
         fields.remove(JiraServerGlobalConfigurationModelConverter.DISABLE_PLUGIN_CHECK_KEY);
         configurationModel = new ConfigurationModel(1L, 1L, "", "", ConfigContextEnum.GLOBAL, fields);
         JiraServerGlobalConfigurationModelConverter converter = new JiraServerGlobalConfigurationModelConverter(validator);
-        Optional<JiraServerGlobalConfigModel> model = converter.convertAndValidate(configurationModel);
+        Optional<JiraServerGlobalConfigModel> model = converter.convertAndValidate(configurationModel, null);
         assertTrue(model.isPresent());
         JiraServerGlobalConfigModel jiraModel = model.get();
 
@@ -73,7 +73,7 @@ class JiraServerGlobalConfigurationModelConverterTest {
     void emptyFieldsTest() {
         ConfigurationModel emptyModel = new ConfigurationModel(1L, 1L, "", "", ConfigContextEnum.GLOBAL, Map.of());
         JiraServerGlobalConfigurationModelConverter converter = new JiraServerGlobalConfigurationModelConverter(validator);
-        Optional<JiraServerGlobalConfigModel> model = converter.convertAndValidate(emptyModel);
+        Optional<JiraServerGlobalConfigModel> model = converter.convertAndValidate(emptyModel, null);
         assertTrue(model.isEmpty());
     }
 
@@ -84,7 +84,7 @@ class JiraServerGlobalConfigurationModelConverterTest {
         Map<String, ConfigurationFieldModel> fieldValues = Map.of(invalidFieldKey, invalidField);
         ConfigurationModel configurationModel = new ConfigurationModel(1L, 1L, "", "", ConfigContextEnum.GLOBAL, fieldValues);
         JiraServerGlobalConfigurationModelConverter converter = new JiraServerGlobalConfigurationModelConverter(validator);
-        Optional<JiraServerGlobalConfigModel> model = converter.convertAndValidate(configurationModel);
+        Optional<JiraServerGlobalConfigModel> model = converter.convertAndValidate(configurationModel, null);
         assertTrue(model.isEmpty());
     }
 

--- a/component/src/main/java/com/synopsys/integration/alert/component/settings/convert/ProxyConfigurationModelConverter.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/settings/convert/ProxyConfigurationModelConverter.java
@@ -74,7 +74,8 @@ public class ProxyConfigurationModelConverter extends GlobalConfigurationModelTo
     }
 
     @Override
-    protected ValidationResponseModel validate(SettingsProxyModel configModel) {
+    protected ValidationResponseModel validate(SettingsProxyModel configModel, String existingConfigurationId) {
+        //Since there is only a single email global configuration, existingConfigurationId is ignored.
         return validator.validate(configModel);
     }
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/settings/convert/ProxyConfigurationModelSaveActions.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/settings/convert/ProxyConfigurationModelSaveActions.java
@@ -56,7 +56,7 @@ public class ProxyConfigurationModelSaveActions implements GlobalConfigurationMo
     }
 
     private void convertModelAndPerformAction(ConfigurationModel configurationModel, Function<SettingsProxyModel, ActionResponse<SettingsProxyModel>> configAction) {
-        Optional<SettingsProxyModel> settingsProxyModel = proxyFieldModelConverter.convertAndValidate(configurationModel);
+        Optional<SettingsProxyModel> settingsProxyModel = proxyFieldModelConverter.convertAndValidate(configurationModel, null);
         settingsProxyModel.ifPresent(configAction::apply);
     }
 }

--- a/component/src/test/java/com/synopsys/integration/alert/component/settings/convert/ProxyConfigurationModelConverterTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/settings/convert/ProxyConfigurationModelConverterTest.java
@@ -29,7 +29,7 @@ class ProxyConfigurationModelConverterTest {
     void validConversionTest() {
         ConfigurationModel configurationModel = createDefaultConfigurationModel();
         ProxyConfigurationModelConverter converter = new ProxyConfigurationModelConverter(validator);
-        Optional<SettingsProxyModel> model = converter.convertAndValidate(configurationModel);
+        Optional<SettingsProxyModel> model = converter.convertAndValidate(configurationModel, null);
         assertTrue(model.isPresent());
         SettingsProxyModel proxyModel = model.get();
         assertEquals(TEST_AUTH_USER, proxyModel.getProxyUsername().orElse(null));
@@ -46,7 +46,7 @@ class ProxyConfigurationModelConverterTest {
         configurationModel.getField(ProxyConfigurationModelConverter.FIELD_KEY_PORT)
             .ifPresent(field -> field.setFieldValue("twenty-five"));
         ProxyConfigurationModelConverter converter = new ProxyConfigurationModelConverter(validator);
-        Optional<SettingsProxyModel> model = converter.convertAndValidate(configurationModel);
+        Optional<SettingsProxyModel> model = converter.convertAndValidate(configurationModel, null);
         assertTrue(model.isEmpty());
     }
 
@@ -54,7 +54,7 @@ class ProxyConfigurationModelConverterTest {
     void emptyFieldsTest() {
         ConfigurationModel emptyModel = new ConfigurationModel(1L, 1L, "", "", ConfigContextEnum.GLOBAL, Map.of());
         ProxyConfigurationModelConverter converter = new ProxyConfigurationModelConverter(validator);
-        Optional<SettingsProxyModel> model = converter.convertAndValidate(emptyModel);
+        Optional<SettingsProxyModel> model = converter.convertAndValidate(emptyModel, null);
         assertTrue(model.isEmpty());
     }
 


### PR DESCRIPTION
Pushing changes to support update requests by the old field model converters. The change here is that we will now pass in an @Nullable existingGlobalConfig Id that whenever an update is passed in we can pass in a UUID. This is required by the validator to ignore duplicate names when the ID is the same, indicating that an update is being performed.

Test improvements will follow in a future PR.