### PR TITLE
IALERT-2752 - Fix Test configuration emailing users it shouldn't

### DIFF
--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailDistributionTestAction.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailDistributionTestAction.java
@@ -7,6 +7,7 @@
  */
 package com.synopsys.integration.alert.channel.email.action;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,7 +33,7 @@ public class EmailDistributionTestAction extends DistributionChannelMessageTestA
 
     @Override
     protected EmailJobDetailsModel resolveTestDistributionDetails(DistributionJobModel testJobModel) throws AlertException {
-        List<String> updateEmailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(testJobModel);
+        List<String> updateEmailAddresses = new ArrayList<>(emailTestActionHelper.createUpdatedEmailAddresses(testJobModel));
         EmailJobDetailsModel originalEmailJobDetails = testJobModel.getDistributionJobDetails().getAs(DistributionJobDetailsModel.EMAIL);
 
         return new EmailJobDetailsModel(

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailDistributionTestAction.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailDistributionTestAction.java
@@ -7,9 +7,7 @@
  */
 package com.synopsys.integration.alert.channel.email.action;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -34,14 +32,8 @@ public class EmailDistributionTestAction extends DistributionChannelMessageTestA
 
     @Override
     protected EmailJobDetailsModel resolveTestDistributionDetails(DistributionJobModel testJobModel) throws AlertException {
-        Set<String> updateEmailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(testJobModel);
+        List<String> updateEmailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(testJobModel);
         EmailJobDetailsModel originalEmailJobDetails = testJobModel.getDistributionJobDetails().getAs(DistributionJobDetailsModel.EMAIL);
-
-        // For testing configuration, just use additional email addresses field
-        List<String> originalAdditionalEmailAddresses = originalEmailJobDetails.getAdditionalEmailAddresses();
-        List<String> additionalEmailAddressesToUse = new ArrayList<>(updateEmailAddresses.size() + originalAdditionalEmailAddresses.size());
-        additionalEmailAddressesToUse.addAll(originalAdditionalEmailAddresses);
-        additionalEmailAddressesToUse.addAll(updateEmailAddresses);
 
         return new EmailJobDetailsModel(
             testJobModel.getJobId(),
@@ -49,7 +41,7 @@ public class EmailDistributionTestAction extends DistributionChannelMessageTestA
             false,
             true,
             originalEmailJobDetails.getAttachmentFileType(),
-            additionalEmailAddressesToUse
+            updateEmailAddresses
         );
     }
 

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailTestActionHelper.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailTestActionHelper.java
@@ -46,17 +46,11 @@ public class EmailTestActionHelper {
         DistributionJobDetailsModel distributionJobDetails = distributionJobModel.getDistributionJobDetails();
         EmailJobDetailsModel emailJobDetails = distributionJobDetails.getAs(DistributionJobDetailsModel.EMAIL);
 
-        Long providerConfigId = distributionJobModel.getBlackDuckGlobalConfigId();
-        // Won't this be caught as part of validation. Do we need this check?
-        if (null == providerConfigId) {
-            return Collections.emptyList();
-        }
-
         if (emailJobDetails.isAdditionalEmailAddressesOnly()) {
             return emailJobDetails.getAdditionalEmailAddresses();
         }
 
-        List<String> emailAddresses = getProviderEmailAddresses(emailJobDetails, distributionJobModel, providerConfigId);
+        List<String> emailAddresses = getProviderEmailAddresses(emailJobDetails, distributionJobModel);
 
         if (!emailJobDetails.isProjectOwnerOnly()) {
             emailAddresses.addAll(emailJobDetails.getAdditionalEmailAddresses());
@@ -65,8 +59,9 @@ public class EmailTestActionHelper {
         return emailAddresses;
     }
 
-    private List<String> getProviderEmailAddresses(EmailJobDetailsModel emailJobDetails, DistributionJobModel distributionJobModel, Long providerConfigId)
+    private List<String> getProviderEmailAddresses(EmailJobDetailsModel emailJobDetails, DistributionJobModel distributionJobModel)
         throws AlertFieldException {
+        Long providerConfigId = distributionJobModel.getBlackDuckGlobalConfigId();
         Set<ProviderProject> providerProjects = retrieveProviderProjects(distributionJobModel, providerConfigId);
         if (CollectionUtils.isNotEmpty(providerProjects)) {
             return new ArrayList<>(addEmailAddresses(providerConfigId, providerProjects, distributionJobModel, emailJobDetails));

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailTestActionHelper.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/action/EmailTestActionHelper.java
@@ -42,15 +42,15 @@ public class EmailTestActionHelper {
         this.providerDataAccessor = providerDataAccessor;
     }
 
-    public List<String> createUpdatedEmailAddresses(DistributionJobModel distributionJobModel) throws AlertException {
+    public Set<String> createUpdatedEmailAddresses(DistributionJobModel distributionJobModel) throws AlertException {
         DistributionJobDetailsModel distributionJobDetails = distributionJobModel.getDistributionJobDetails();
         EmailJobDetailsModel emailJobDetails = distributionJobDetails.getAs(DistributionJobDetailsModel.EMAIL);
 
         if (emailJobDetails.isAdditionalEmailAddressesOnly()) {
-            return emailJobDetails.getAdditionalEmailAddresses();
+            return new HashSet<>(emailJobDetails.getAdditionalEmailAddresses());
         }
 
-        List<String> emailAddresses = getProviderEmailAddresses(emailJobDetails, distributionJobModel);
+        Set<String> emailAddresses = new HashSet<>(getProviderEmailAddresses(emailJobDetails, distributionJobModel));
 
         if (!emailJobDetails.isProjectOwnerOnly()) {
             emailAddresses.addAll(emailJobDetails.getAdditionalEmailAddresses());

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailTestActionHelperTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailTestActionHelperTest.java
@@ -1,14 +1,22 @@
 package com.synopsys.integration.alert.channel.email.action;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
 
 import java.time.OffsetDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.common.enumeration.FrequencyType;
@@ -22,27 +30,135 @@ import com.synopsys.integration.alert.common.persistence.model.job.details.Email
 import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 import com.synopsys.integration.alert.descriptor.api.EmailChannelKey;
 
+@ExtendWith(SpringExtension.class)
 public class EmailTestActionHelperTest {
+    private final List<ProviderProject> providerProjects = createProviderProjects();
+    private final String projectOwnerEmailAddress = "project-owner@synopsys.com";
+    private final String additionalEmailAddress = "additional-email@synopsy.com";
+
+    @Mock
+    private ProviderDataAccessor providerDataAccessor;
 
     @Test
-    public void verifyAllProjectsProperlyRetrieved() throws AlertException {
-        ProviderDataAccessor providerDataAccessor = Mockito.mock(ProviderDataAccessor.class);
-        List<ProviderProject> providerProjects = createProviderProjects();
+    void verifyEmailProjectOwnerOnly() throws AlertException {
+        List<ProviderProject> singleProject = List.of(new ProviderProject("name", "description", "href", projectOwnerEmailAddress));
+        Mockito.when(providerDataAccessor.getProjectsByProviderConfigId(Mockito.anyLong())).thenReturn(singleProject);
+
+        DistributionJobModel distributionJobModel = createDistributionJobModelBuilder(createDefaultEmailJobDetails(
+            true,
+            false,
+            List.of(additionalEmailAddress)
+        ))
+            .projectNamePattern("name")
+            .filterByProject(true)
+            .build();
+
+        EmailTestActionHelper emailTestActionHelper = new EmailTestActionHelper(providerDataAccessor);
+        List<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
+
+        assertEquals(1, emailAddresses.size());
+        assertEquals(emailAddresses.get(0), projectOwnerEmailAddress);
+    }
+
+    @Test
+    void verifyAdditionalEmailAddressesOnly() throws AlertException {
+        List<ProviderProject> singleProject = List.of(new ProviderProject("name", "description", "href", projectOwnerEmailAddress));
+        Mockito.when(providerDataAccessor.getProjectsByProviderConfigId(Mockito.anyLong())).thenReturn(singleProject);
+
+        DistributionJobModel distributionJobModel = createDistributionJobModelBuilder(createDefaultEmailJobDetails(false, true, List.of(additionalEmailAddress))).build();
+
+        EmailTestActionHelper emailTestActionHelper = new EmailTestActionHelper(providerDataAccessor);
+        List<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
+
+        assertEquals(1, emailAddresses.size());
+        assertEquals(emailAddresses.get(0), additionalEmailAddress);
+    }
+
+    @Test
+    void verifyEmailOwnerAndAdditional() throws AlertException {
+        Long blackduckGlobalConfigId = new Random().nextLong();
+        List<ProviderProject> singleProject = List.of(new ProviderProject("name", "description", "href", projectOwnerEmailAddress));
+        Mockito.when(providerDataAccessor.getProjectsByProviderConfigId(Mockito.anyLong())).thenReturn(singleProject);
+        Mockito.when(providerDataAccessor.getEmailAddressesForProjectHref(Mockito.eq(blackduckGlobalConfigId), Mockito.anyString()))
+            .thenAnswer(i -> Set.of(projectOwnerEmailAddress));
+
+        DistributionJobModel distributionJobModel = createDistributionJobModelBuilder(createDefaultEmailJobDetails(
+            false,
+            false,
+            List.of(additionalEmailAddress)
+        )).blackDuckGlobalConfigId(blackduckGlobalConfigId).build();
+
+        EmailTestActionHelper emailTestActionHelper = new EmailTestActionHelper(providerDataAccessor);
+        List<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
+
+        assertEquals(2, emailAddresses.size());
+        assertTrue(emailAddresses.contains(projectOwnerEmailAddress));
+        assertTrue(emailAddresses.contains(additionalEmailAddress));
+    }
+
+    @Test
+    void verifyEmptyProjectEmailThrowsException() {
+        List<ProviderProject> singleProject = List.of(new ProviderProject("name", "description", "href", ""));
+        Mockito.when(providerDataAccessor.getProjectsByProviderConfigId(Mockito.anyLong())).thenReturn(singleProject);
+
+        DistributionJobModel distributionJobModel = createDistributionJobModelBuilder(createDefaultEmailJobDetails(true, false, List.of(additionalEmailAddress)))
+            .projectNamePattern("na.*")
+            .filterByProject(true)
+            .build();
+
+        EmailTestActionHelper emailTestActionHelper = new EmailTestActionHelper(providerDataAccessor);
+
+        assertThrows(AlertException.class, () -> emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel));
+    }
+
+    @Test
+    void verifyNullProviderConfigId() throws AlertException {
+        DistributionJobModel distributionJobModel = createDefaultDistributionJobModel();
+
+        DistributionJobModel spiedDistributionJobModel = spy(distributionJobModel);
+        Mockito.doReturn(distributionJobModel.getDistributionJobDetails()).when(spiedDistributionJobModel).getDistributionJobDetails();
+        Mockito.doReturn(null).when(spiedDistributionJobModel).getBlackDuckGlobalConfigId();
+
+        EmailTestActionHelper emailTestActionHelper = new EmailTestActionHelper(providerDataAccessor);
+        List<String> updatedEmailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(spiedDistributionJobModel);
+        assertEquals(updatedEmailAddresses, Collections.emptyList());
+    }
+
+    @Test
+    void verifyNoMatchingPattern() throws AlertException {
+        List<ProviderProject> singleProject = List.of(new ProviderProject("name", "description", "href", projectOwnerEmailAddress));
+        Mockito.when(providerDataAccessor.getProjectsByProviderConfigId(Mockito.anyLong())).thenReturn(singleProject);
+
+        DistributionJobModel distributionJobModel = createDistributionJobModelBuilder(createDefaultEmailJobDetails(
+            true,
+            false,
+            List.of(additionalEmailAddress)
+        ))
+            .projectNamePattern("pattern")
+            .filterByProject(true)
+            .build();
+
+        EmailTestActionHelper emailTestActionHelper = new EmailTestActionHelper(providerDataAccessor);
+        List<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
+
+        assertEquals(Collections.emptyList(), emailAddresses);
+    }
+
+    @Test
+    void verifyAllProjectsProperlyRetrieved() throws AlertException {
         Mockito.when(providerDataAccessor.getProjectsByProviderConfigId(Mockito.anyLong())).thenReturn(providerProjects);
         Mockito.when(providerDataAccessor.getEmailAddressesForProjectHref(Mockito.anyLong(), Mockito.anyString())).thenAnswer(i -> Set.of(UUID.randomUUID().toString()));
 
         EmailTestActionHelper emailTestActionHelper = new EmailTestActionHelper(providerDataAccessor);
 
         DistributionJobModel distributionJobModel = createDefaultDistributionJobModel();
-        Set<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
+        List<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
 
         assertEquals(providerProjects.size(), emailAddresses.size());
     }
 
     @Test
-    public void verifyProjectsRetrievedWithOnlyVersionPattern() throws AlertException {
-        ProviderDataAccessor providerDataAccessor = Mockito.mock(ProviderDataAccessor.class);
-        List<ProviderProject> providerProjects = createProviderProjects();
+    void verifyProjectsRetrievedWithOnlyVersionPattern() throws AlertException {
         Mockito.when(providerDataAccessor.getProjectsByProviderConfigId(Mockito.anyLong())).thenReturn(providerProjects);
         Mockito.when(providerDataAccessor.getEmailAddressesForProjectHref(Mockito.anyLong(), Mockito.anyString())).thenAnswer(i -> Set.of(UUID.randomUUID().toString()));
         Mockito.when(providerDataAccessor.getProjectVersionNamesByHref(Mockito.anyLong(), Mockito.anyString(), Mockito.anyInt())).thenReturn(getProjectVersions());
@@ -50,12 +166,12 @@ public class EmailTestActionHelperTest {
         EmailTestActionHelper emailTestActionHelper = new EmailTestActionHelper(providerDataAccessor);
 
         DistributionJobModel distributionJobModel = createDistributionJobModel(
-            createDefaultEmailJobDetails(),
+            createDefaultEmailJobDetails(false, false, List.of()),
             null,
             "1.0.*",
             List.of()
         );
-        Set<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
+        List<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
 
         assertEquals(providerProjects.size(), emailAddresses.size());
     }
@@ -81,17 +197,18 @@ public class EmailTestActionHelperTest {
     }
 
     private DistributionJobModel createDefaultDistributionJobModel() {
-        return createDistributionJobModelBuilder(createDefaultEmailJobDetails()).build();
+        return createDistributionJobModelBuilder(createDefaultEmailJobDetails(false, false, List.of())).build();
     }
 
-    private EmailJobDetailsModel createDefaultEmailJobDetails() {
+    private EmailJobDetailsModel createDefaultEmailJobDetails(boolean projectOwnerOnly, boolean additionalEmailAddressesOnly, List<String> additionalEmailAddresses) {
         return new EmailJobDetailsModel(
             UUID.randomUUID(),
             null,
-            false,
-            false,
+            projectOwnerOnly,
+            additionalEmailAddressesOnly,
             "none",
-            List.of());
+            additionalEmailAddresses
+        );
     }
 
     private DistributionJobModelBuilder createDistributionJobModelBuilder(EmailJobDetailsModel emailJobDetailsModel) {

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailTestActionHelperTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailTestActionHelperTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
@@ -53,10 +52,10 @@ public class EmailTestActionHelperTest {
             .build();
 
         EmailTestActionHelper emailTestActionHelper = new EmailTestActionHelper(providerDataAccessor);
-        List<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
+        Set<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
 
         assertEquals(1, emailAddresses.size());
-        assertEquals(emailAddresses.get(0), projectOwnerEmailAddress);
+        assertTrue(emailAddresses.contains(projectOwnerEmailAddress));
     }
 
     @Test
@@ -64,13 +63,17 @@ public class EmailTestActionHelperTest {
         List<ProviderProject> singleProject = List.of(new ProviderProject("name", "description", "href", projectOwnerEmailAddress));
         Mockito.when(providerDataAccessor.getProjectsByProviderConfigId(Mockito.anyLong())).thenReturn(singleProject);
 
-        DistributionJobModel distributionJobModel = createDistributionJobModelBuilder(createDefaultEmailJobDetails(false, true, List.of(additionalEmailAddress))).build();
+        DistributionJobModel distributionJobModel = createDistributionJobModelBuilder(createDefaultEmailJobDetails(
+            false,
+            true,
+            List.of(additionalEmailAddress, additionalEmailAddress)
+        )).build();
 
         EmailTestActionHelper emailTestActionHelper = new EmailTestActionHelper(providerDataAccessor);
-        List<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
+        Set<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
 
         assertEquals(1, emailAddresses.size());
-        assertEquals(emailAddresses.get(0), additionalEmailAddress);
+        assertTrue(emailAddresses.contains(additionalEmailAddress));
     }
 
     @Test
@@ -84,11 +87,11 @@ public class EmailTestActionHelperTest {
         DistributionJobModel distributionJobModel = createDistributionJobModelBuilder(createDefaultEmailJobDetails(
             false,
             false,
-            List.of(additionalEmailAddress)
+            List.of(additionalEmailAddress, additionalEmailAddress)
         )).blackDuckGlobalConfigId(blackduckGlobalConfigId).build();
 
         EmailTestActionHelper emailTestActionHelper = new EmailTestActionHelper(providerDataAccessor);
-        List<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
+        Set<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
 
         assertEquals(2, emailAddresses.size());
         assertTrue(emailAddresses.contains(projectOwnerEmailAddress));
@@ -125,9 +128,9 @@ public class EmailTestActionHelperTest {
             .build();
 
         EmailTestActionHelper emailTestActionHelper = new EmailTestActionHelper(providerDataAccessor);
-        List<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
+        Set<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
 
-        assertEquals(Collections.emptyList(), emailAddresses);
+        assertTrue(emailAddresses.isEmpty());
     }
 
     @Test
@@ -138,7 +141,7 @@ public class EmailTestActionHelperTest {
         EmailTestActionHelper emailTestActionHelper = new EmailTestActionHelper(providerDataAccessor);
 
         DistributionJobModel distributionJobModel = createDefaultDistributionJobModel();
-        List<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
+        Set<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
 
         assertEquals(providerProjects.size(), emailAddresses.size());
     }
@@ -157,7 +160,7 @@ public class EmailTestActionHelperTest {
             "1.0.*",
             List.of()
         );
-        List<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
+        Set<String> emailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel);
 
         assertEquals(providerProjects.size(), emailAddresses.size());
     }

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailTestActionHelperTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailTestActionHelperTest.java
@@ -121,7 +121,7 @@ public class EmailTestActionHelperTest {
 
         EmailTestActionHelper emailTestActionHelper = new EmailTestActionHelper(providerDataAccessor);
         List<String> updatedEmailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(spiedDistributionJobModel);
-        assertEquals(updatedEmailAddresses, Collections.emptyList());
+        assertEquals(Collections.emptyList(), updatedEmailAddresses);
     }
 
     @Test

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailTestActionHelperTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/action/EmailTestActionHelperTest.java
@@ -3,7 +3,6 @@ package com.synopsys.integration.alert.channel.email.action;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.spy;
 
 import java.time.OffsetDateTime;
 import java.util.Collections;
@@ -109,19 +108,6 @@ public class EmailTestActionHelperTest {
         EmailTestActionHelper emailTestActionHelper = new EmailTestActionHelper(providerDataAccessor);
 
         assertThrows(AlertException.class, () -> emailTestActionHelper.createUpdatedEmailAddresses(distributionJobModel));
-    }
-
-    @Test
-    void verifyNullProviderConfigId() throws AlertException {
-        DistributionJobModel distributionJobModel = createDefaultDistributionJobModel();
-
-        DistributionJobModel spiedDistributionJobModel = spy(distributionJobModel);
-        Mockito.doReturn(distributionJobModel.getDistributionJobDetails()).when(spiedDistributionJobModel).getDistributionJobDetails();
-        Mockito.doReturn(null).when(spiedDistributionJobModel).getBlackDuckGlobalConfigId();
-
-        EmailTestActionHelper emailTestActionHelper = new EmailTestActionHelper(providerDataAccessor);
-        List<String> updatedEmailAddresses = emailTestActionHelper.createUpdatedEmailAddresses(spiedDistributionJobModel);
-        assertEquals(Collections.emptyList(), updatedEmailAddresses);
     }
 
     @Test


### PR DESCRIPTION
If users were added to the additional email addresses AND ProjectOwnerOnly was checked, the test configuration should have only sent a test email to the ProjectOwner(s), but it was also sending to the list of additional email addresses.

* Move logic for calculating who to email into EmailTestActionHelper to have one location which is performing the necessary logic to get the email addresses to send a test message.
* Remove logic to validate BDconfig ID as this is done as part of UI validation
* Add test logic to cover 8 different combinations of options (see below) for Additional Email Addresses, Additional Email Addresses Only, Project Owner Only.

| Additional Email Addresses  | Additional Email Addresses Only | Project Owner Only | Who is emailed |
| ------------- | ------------- | ------------- | ------------- |
| No | Not Checked | Not Checked | Project Owner Only |
| No | Not Checked | Checked | Project Owner Only |
| Yes | Not Checked | Not Checked | Both Owner and Additional |
| Yes | Checked | Not Checked | Additional Email Only |
| Yes | Not Checked | Checked | Project Owner Only |
| No | Checked | Not Checked | Expected configuration failure, no email sent |
| Yes | Checked | Checked | Expected configuration failure, no email sent |
| No | Checked | Checked | Expected configuration failure, no email sent |