### PR TITLE
IALERT-3230: Move AzureBoardsProperties creation into factory class & test updates

### DIFF
--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsProperties.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsProperties.java
@@ -42,12 +42,10 @@ import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.api.oauth.AlertOAuthCredentialDataStoreFactory;
-import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
 import com.synopsys.integration.azure.boards.common.http.AzureHttpRequestCreator;
 import com.synopsys.integration.azure.boards.common.http.AzureHttpRequestCreatorFactory;
 import com.synopsys.integration.azure.boards.common.http.AzureHttpService;
 import com.synopsys.integration.azure.boards.common.oauth.AzureAuthorizationCodeFlow;
-import com.synopsys.integration.azure.boards.common.oauth.AzureOAuthScopes;
 import com.synopsys.integration.rest.proxy.ProxyInfo;
 
 public class AzureBoardsProperties {
@@ -60,23 +58,6 @@ public class AzureBoardsProperties {
     private final List<String> scopes;
     private final String redirectUri;
     private final String configurationId;
-
-    public static AzureBoardsProperties fromGlobalConfigurationModel(
-        AlertOAuthCredentialDataStoreFactory alertOAuthCredentialDataStoreFactory,
-        String redirectUri,
-        AzureBoardsGlobalConfigModel azureBoardsGlobalConfigModel
-    ) {
-        List<String> defaultScopes = List.of(AzureOAuthScopes.PROJECTS_READ.getScope(), AzureOAuthScopes.WORK_FULL.getScope());
-        return new AzureBoardsProperties(
-            alertOAuthCredentialDataStoreFactory,
-            azureBoardsGlobalConfigModel.getOrganizationName(),
-            azureBoardsGlobalConfigModel.getAppId().orElse(null),
-            azureBoardsGlobalConfigModel.getClientSecret().orElse(null),
-            defaultScopes,
-            redirectUri,
-            azureBoardsGlobalConfigModel.getId()
-        );
-    }
 
     public AzureBoardsProperties(
         AlertOAuthCredentialDataStoreFactory alertOAuthCredentialDataStoreFactory,

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsPropertiesFactory.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/AzureBoardsPropertiesFactory.java
@@ -1,5 +1,6 @@
 package com.synopsys.integration.alert.channel.azure.boards;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
@@ -13,6 +14,7 @@ import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlob
 import com.synopsys.integration.alert.common.persistence.accessor.JobAccessor;
 import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobModel;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
+import com.synopsys.integration.azure.boards.common.oauth.AzureOAuthScopes;
 
 @Component
 public class AzureBoardsPropertiesFactory {
@@ -34,10 +36,27 @@ public class AzureBoardsPropertiesFactory {
         this.jobAccessor = jobAccessor;
     }
 
+    public AzureBoardsProperties fromGlobalConfigurationModel(
+        AlertOAuthCredentialDataStoreFactory alertOAuthCredentialDataStoreFactory,
+        String redirectUri,
+        AzureBoardsGlobalConfigModel azureBoardsGlobalConfigModel
+    ) {
+        List<String> defaultScopes = List.of(AzureOAuthScopes.PROJECTS_READ.getScope(), AzureOAuthScopes.WORK_FULL.getScope());
+        return new AzureBoardsProperties(
+            alertOAuthCredentialDataStoreFactory,
+            azureBoardsGlobalConfigModel.getOrganizationName(),
+            azureBoardsGlobalConfigModel.getAppId().orElse(null),
+            azureBoardsGlobalConfigModel.getClientSecret().orElse(null),
+            defaultScopes,
+            redirectUri,
+            azureBoardsGlobalConfigModel.getId()
+        );
+    }
+
     public AzureBoardsProperties createAzureBoardsProperties(UUID configurationId) throws AlertConfigurationException {
         AzureBoardsGlobalConfigModel azureBoardsGlobalConfigModel = azureBoardsGlobalConfigAccessor.getConfiguration(configurationId)
             .orElseThrow(() -> new AlertConfigurationException("Missing Azure Boards global configuration"));
-        return AzureBoardsProperties.fromGlobalConfigurationModel(
+        return fromGlobalConfigurationModel(
             alertOAuthCredentialDataStoreFactory,
             azureRedirectUrlCreator.createOAuthRedirectUri(),
             azureBoardsGlobalConfigModel
@@ -74,7 +93,7 @@ public class AzureBoardsPropertiesFactory {
             appId,
             secret
         );
-        return AzureBoardsProperties.fromGlobalConfigurationModel(
+        return fromGlobalConfigurationModel(
             alertOAuthCredentialDataStoreFactory,
             azureRedirectUrlCreator.createOAuthRedirectUri(),
             azureBoardsGlobalConfigModel

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestAction.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestAction.java
@@ -12,6 +12,7 @@ import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.api.oauth.AlertOAuthCredentialDataStoreFactory;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesFactory;
 import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
 import com.synopsys.integration.alert.channel.azure.boards.database.accessor.AzureBoardsGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
@@ -37,8 +38,8 @@ public class AzureBoardsGlobalTestAction {
     private final AzureBoardsGlobalConfigurationValidator validator;
     private final AzureBoardsGlobalConfigAccessor configurationAccessor;
     private final AlertOAuthCredentialDataStoreFactory alertOAuthCredentialDataStoreFactory;
+    private final AzureBoardsPropertiesFactory azureBoardsPropertiesFactory;
     private final AzureRedirectUrlCreator azureRedirectUrlCreator;
-
     private final ConfigurationValidationHelper validationHelper;
     private final ConfigurationTestHelper testHelper;
     private final Gson gson;
@@ -50,6 +51,7 @@ public class AzureBoardsGlobalTestAction {
         AzureBoardsGlobalConfigurationValidator validator,
         AzureBoardsGlobalConfigAccessor configurationAccessor,
         AlertOAuthCredentialDataStoreFactory alertOAuthCredentialDataStoreFactory,
+        AzureBoardsPropertiesFactory azureBoardsPropertiesFactory,
         AzureRedirectUrlCreator azureRedirectUrlCreator,
         Gson gson,
         ProxyManager proxyManager
@@ -59,6 +61,7 @@ public class AzureBoardsGlobalTestAction {
         this.proxyManager = proxyManager;
         this.gson = gson;
         this.alertOAuthCredentialDataStoreFactory = alertOAuthCredentialDataStoreFactory;
+        this.azureBoardsPropertiesFactory = azureBoardsPropertiesFactory;
         this.azureRedirectUrlCreator = azureRedirectUrlCreator;
         this.validator = validator;
         this.configurationAccessor = configurationAccessor;
@@ -84,7 +87,7 @@ public class AzureBoardsGlobalTestAction {
                 }
             }
 
-            AzureBoardsProperties azureBoardsProperties = AzureBoardsProperties.fromGlobalConfigurationModel(
+            AzureBoardsProperties azureBoardsProperties = azureBoardsPropertiesFactory.fromGlobalConfigurationModel(
                 alertOAuthCredentialDataStoreFactory,
                 azureRedirectUrlCreator.createOAuthRedirectUri(),
                 azureBoardsGlobalConfigModel

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsOAuthAuthenticateAction.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsOAuthAuthenticateAction.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.api.oauth.AlertOAuthCredentialDataStoreFactory;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesFactory;
 import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
 import com.synopsys.integration.alert.channel.azure.boards.database.accessor.AzureBoardsGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
@@ -39,6 +40,7 @@ public class AzureBoardsOAuthAuthenticateAction {
     private final AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor;
     private final AzureBoardsGlobalCrudActions azureBoardsGlobalCrudActions;
     private final AlertOAuthCredentialDataStoreFactory alertOAuthCredentialDataStoreFactory;
+    private final AzureBoardsPropertiesFactory azureBoardsPropertiesFactory;
     private final AzureBoardsGlobalValidationAction azureBoardsGlobalValidationAction;
     private final AzureRedirectUrlCreator azureRedirectUrlCreator;
     private final OAuthRequestValidator oAuthRequestValidator;
@@ -51,6 +53,7 @@ public class AzureBoardsOAuthAuthenticateAction {
         AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor,
         AzureBoardsGlobalCrudActions azureBoardsGlobalCrudActions,
         AlertOAuthCredentialDataStoreFactory alertOAuthCredentialDataStoreFactory,
+        AzureBoardsPropertiesFactory azureBoardsPropertiesFactory,
         AzureBoardsGlobalValidationAction azureBoardsGlobalValidationAction,
         AzureRedirectUrlCreator azureRedirectUrlCreator,
         OAuthRequestValidator oAuthRequestValidator,
@@ -61,6 +64,7 @@ public class AzureBoardsOAuthAuthenticateAction {
         this.azureBoardsGlobalConfigAccessor = azureBoardsGlobalConfigAccessor;
         this.azureBoardsGlobalCrudActions = azureBoardsGlobalCrudActions;
         this.alertOAuthCredentialDataStoreFactory = alertOAuthCredentialDataStoreFactory;
+        this.azureBoardsPropertiesFactory = azureBoardsPropertiesFactory;
         this.azureRedirectUrlCreator = azureRedirectUrlCreator;
         this.azureBoardsGlobalValidationAction = azureBoardsGlobalValidationAction;
         this.oAuthRequestValidator = oAuthRequestValidator;
@@ -144,7 +148,7 @@ public class AzureBoardsOAuthAuthenticateAction {
     }
 
     private boolean isAuthenticated(AzureBoardsGlobalConfigModel azureBoardsGlobalConfigModel) {
-        AzureBoardsProperties properties = AzureBoardsProperties.fromGlobalConfigurationModel(
+        AzureBoardsProperties properties = azureBoardsPropertiesFactory.fromGlobalConfigurationModel(
             alertOAuthCredentialDataStoreFactory,
             azureRedirectUrlCreator.createOAuthRedirectUri(),
             azureBoardsGlobalConfigModel

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsOAuthCallbackAction.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsOAuthCallbackAction.java
@@ -16,6 +16,7 @@ import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.api.oauth.AlertOAuthCredentialDataStoreFactory;
 import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesFactory;
 import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
 import com.synopsys.integration.alert.channel.azure.boards.database.accessor.AzureBoardsGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
@@ -38,6 +39,7 @@ import com.synopsys.integration.rest.proxy.ProxyInfo;
 public class AzureBoardsOAuthCallbackAction {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final AlertOAuthCredentialDataStoreFactory alertOAuthCredentialDataStoreFactory;
+    private final AzureBoardsPropertiesFactory azureBoardsPropertiesFactory;
     private final AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor;
     private final Gson gson;
     private final AuthorizationManager authorizationManager;
@@ -48,6 +50,7 @@ public class AzureBoardsOAuthCallbackAction {
     @Autowired
     public AzureBoardsOAuthCallbackAction(
         AlertOAuthCredentialDataStoreFactory alertOAuthCredentialDataStoreFactory,
+        AzureBoardsPropertiesFactory azureBoardsPropertiesFactory,
         AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor,
         Gson gson,
         AuthorizationManager authorizationManager,
@@ -56,6 +59,7 @@ public class AzureBoardsOAuthCallbackAction {
         AzureRedirectUrlCreator azureRedirectUrlCreator
     ) {
         this.alertOAuthCredentialDataStoreFactory = alertOAuthCredentialDataStoreFactory;
+        this.azureBoardsPropertiesFactory = azureBoardsPropertiesFactory;
         this.azureBoardsGlobalConfigAccessor = azureBoardsGlobalConfigAccessor;
         this.gson = gson;
         this.authorizationManager = authorizationManager;
@@ -99,7 +103,7 @@ public class AzureBoardsOAuthCallbackAction {
                         logger.error("OAuth request with id {}: Azure oauth callback: Authorization code isn't valid. Stop processing", oAuthRequestId);
                     } else {
                         String oAuthRedirectUri = azureRedirectUrlCreator.createOAuthRedirectUri();
-                        AzureBoardsProperties properties = AzureBoardsProperties.fromGlobalConfigurationModel(
+                        AzureBoardsProperties properties = azureBoardsPropertiesFactory.fromGlobalConfigurationModel(
                             alertOAuthCredentialDataStoreFactory,
                             oAuthRedirectUri,
                             savedConfigModel

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestActionTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestActionTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.api.oauth.AlertOAuthCredentialDataStoreFactory;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesFactory;
 import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
 import com.synopsys.integration.alert.channel.azure.boards.database.accessor.AzureBoardsGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.azure.boards.database.configuration.AzureBoardsConfigurationEntity;
@@ -56,6 +57,8 @@ class AzureBoardsGlobalTestActionTest {
     @Mock
     AlertOAuthCredentialDataStoreFactory mockAlertOAuthCredentialDataStoreFactory;
     @Mock
+    AzureBoardsPropertiesFactory mockAzureBoardsPropertiesFactory;
+    @Mock
     AzureProjectService mockedAzureProjectService;
     @Mock
     AzureRedirectUrlCreator mockAzureRedirectUrlCreator;
@@ -82,6 +85,7 @@ class AzureBoardsGlobalTestActionTest {
             azureBoardsGlobalConfigurationValidator,
             azureBoardsGlobalConfigAccessor,
             mockAlertOAuthCredentialDataStoreFactory,
+            mockAzureBoardsPropertiesFactory,
             mockAzureRedirectUrlCreator,
             gson,
             mockProxyManager
@@ -103,6 +107,7 @@ class AzureBoardsGlobalTestActionTest {
                 azureBoardsGlobalConfigurationValidator,
                 azureBoardsGlobalConfigAccessor,
                 mockAlertOAuthCredentialDataStoreFactory,
+                mockAzureBoardsPropertiesFactory,
                 mockAzureRedirectUrlCreator,
                 gson,
                 mockProxyManager
@@ -143,6 +148,7 @@ class AzureBoardsGlobalTestActionTest {
                 azureBoardsGlobalConfigurationValidator,
                 azureBoardsGlobalConfigAccessor,
                 mockAlertOAuthCredentialDataStoreFactory,
+                mockAzureBoardsPropertiesFactory,
                 mockAzureRedirectUrlCreator,
                 gson,
                 mockProxyManager

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsOAuthAuthenticateActionTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsOAuthAuthenticateActionTest.java
@@ -1,0 +1,272 @@
+package com.synopsys.integration.alert.channel.azure.boards.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
+import com.synopsys.integration.alert.api.oauth.AlertOAuthCredentialDataStoreFactory;
+import com.synopsys.integration.alert.api.oauth.database.accessor.AlertOAuthConfigurationAccessor;
+import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
+import com.synopsys.integration.alert.channel.azure.boards.database.accessor.AzureBoardsGlobalConfigAccessor;
+import com.synopsys.integration.alert.channel.azure.boards.database.configuration.AzureBoardsConfigurationEntity;
+import com.synopsys.integration.alert.channel.azure.boards.database.mock.MockAlertOAuthConfigurationRepository;
+import com.synopsys.integration.alert.channel.azure.boards.database.mock.MockAzureBoardsConfigurationRepository;
+import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
+import com.synopsys.integration.alert.channel.azure.boards.oauth.OAuthRequestValidator;
+import com.synopsys.integration.alert.channel.azure.boards.validator.AzureBoardsGlobalConfigurationValidator;
+import com.synopsys.integration.alert.common.AlertProperties;
+import com.synopsys.integration.alert.common.action.ActionResponse;
+import com.synopsys.integration.alert.common.descriptor.accessor.SettingsUtility;
+import com.synopsys.integration.alert.common.descriptor.config.field.endpoint.oauth.OAuthEndpointResponse;
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.persistence.model.PermissionKey;
+import com.synopsys.integration.alert.common.persistence.model.PermissionMatrixModel;
+import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
+import com.synopsys.integration.alert.common.rest.AlertWebServerUrlManager;
+import com.synopsys.integration.alert.common.rest.model.SettingsProxyModel;
+import com.synopsys.integration.alert.common.rest.proxy.ProxyManager;
+import com.synopsys.integration.alert.common.security.EncryptionUtility;
+import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
+import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
+import com.synopsys.integration.alert.test.common.AuthenticationTestUtils;
+import com.synopsys.integration.alert.test.common.MockAlertProperties;
+import com.synopsys.integration.alert.test.common.database.MockRepositorySorter;
+
+class AzureBoardsOAuthAuthenticateActionTest {
+    private static final String SERVER_URL = "https://localhost:8443/alert";
+    private static final String ORG_NAME = "alert_test_org_name";
+    private static final String CLIENT_ID = "alert_test_client_id";
+    private static final String CLIENT_SECRET = "alert_test_client_secret";
+    private final Gson gson = new Gson();
+    private final AlertProperties alertProperties = new MockAlertProperties();
+    private final FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, gson);
+    private final EncryptionUtility encryptionUtility = new EncryptionUtility(alertProperties, filePersistenceUtil);
+    private AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor;
+    private final OAuthRequestValidator oAuthRequestValidator = new OAuthRequestValidator();
+    private AlertOAuthCredentialDataStoreFactory alertOAuthCredentialDataStoreFactory;
+    private AzureBoardsGlobalConfigurationValidator azureBoardsGlobalConfigurationValidator;
+    private AlertOAuthConfigurationAccessor alertOAuthConfigurationAccessor;
+    private AlertWebServerUrlManager alertWebServerUrlManager;
+    private AzureRedirectUrlCreator azureRedirectUrlCreator;
+    private ProxyManager proxyManager = new ProxyManager(new MockSettingsUtility());
+    private final AuthorizationManager authorizationManager = createAuthorizationManager(AuthenticationTestUtils.FULL_PERMISSIONS);
+    private AzureBoardsGlobalCrudActions azureBoardsGlobalCrudActions;
+    private AzureBoardsGlobalValidationAction validationAction;
+
+    @BeforeEach
+    void initEach() {
+        //Set up global config accessor
+        MockRepositorySorter<AzureBoardsConfigurationEntity> sorter = new MockRepositorySorter<>();
+        MockAzureBoardsConfigurationRepository mockAzureBoardsConfigurationRepository = new MockAzureBoardsConfigurationRepository(sorter);
+        azureBoardsGlobalConfigAccessor = new AzureBoardsGlobalConfigAccessor(encryptionUtility, mockAzureBoardsConfigurationRepository);
+
+        //Set up OAuth accessor
+        MockAlertOAuthConfigurationRepository mockAlertOAuthConfigurationRepository = new MockAlertOAuthConfigurationRepository();
+        alertOAuthConfigurationAccessor = new AlertOAuthConfigurationAccessor(mockAlertOAuthConfigurationRepository);
+        alertOAuthCredentialDataStoreFactory = new AlertOAuthCredentialDataStoreFactory(alertOAuthConfigurationAccessor);
+
+        //Set up azure global validation
+        azureBoardsGlobalConfigurationValidator = new AzureBoardsGlobalConfigurationValidator(azureBoardsGlobalConfigAccessor, oAuthRequestValidator);
+        validationAction = new AzureBoardsGlobalValidationAction(azureBoardsGlobalConfigurationValidator, authorizationManager);
+
+        //Set up AzureRedirectUrl and AlertWebServerManager
+        alertWebServerUrlManager = new TestAlertWebServerUrlManager();
+        azureRedirectUrlCreator = new AzureRedirectUrlCreator(alertWebServerUrlManager);
+
+        // Set up CRUD actions
+        azureBoardsGlobalCrudActions = new AzureBoardsGlobalCrudActions(
+            authorizationManager,
+            azureBoardsGlobalConfigAccessor,
+            azureBoardsGlobalConfigurationValidator
+        );
+    }
+
+    /**
+     * Test authenticate with:
+     * full permissions, performing a create action on a model
+     */
+    @Test
+    void authenticateTest() {
+        AzureBoardsOAuthAuthenticateAction authenticateAction = new AzureBoardsOAuthAuthenticateAction(
+            authorizationManager,
+            azureBoardsGlobalConfigAccessor,
+            azureBoardsGlobalCrudActions,
+            alertOAuthCredentialDataStoreFactory,
+            validationAction,
+            azureRedirectUrlCreator,
+            oAuthRequestValidator,
+            alertWebServerUrlManager,
+            proxyManager
+        );
+        AzureBoardsGlobalConfigModel azureBoardsGlobalConfigModel = new AzureBoardsGlobalConfigModel(
+            null,
+            "testConfigName",
+            ORG_NAME,
+            CLIENT_ID,
+            CLIENT_SECRET
+        );
+        ActionResponse<OAuthEndpointResponse> oAuthEndpointResponseActionResponse = authenticateAction.authenticate(azureBoardsGlobalConfigModel);
+
+        assertFalse(oAuthEndpointResponseActionResponse.isError());
+        OAuthEndpointResponse oAuthEndpointResponse = oAuthEndpointResponseActionResponse.getContent().orElseThrow(() -> new AssertionError("oAuthEndpointResponse should exist."));
+        String authorizationUrl = oAuthEndpointResponse.getAuthorizationUrl();
+        assertFalse(authorizationUrl.contains(ORG_NAME), "Organization Name should not be included in the URL");
+        assertTrue(authorizationUrl.contains(CLIENT_ID), "Missing Client ID");
+        assertFalse(authorizationUrl.contains(CLIENT_SECRET), "Client secret should not be exposed in the authUrl");
+        assertTrue(oAuthRequestValidator.hasRequests());
+
+        //No configurations present:
+        /*
+        assertEquals(1, alertOAuthConfigurationAccessor.getConfigurations().size());
+        AlertOAuthModel oAuthModel = alertOAuthConfigurationAccessor.getConfigurations().stream().findFirst()
+            .orElseThrow(() -> new AssertionError("an OAuth configuration should exist."));
+        String accessToken = oAuthModel.getAccessToken().orElse("Missing access token");
+        assertTrue(authorizationUrl.contains(accessToken));
+         */
+    }
+
+    /**
+     * Test authenticate with:
+     * full permissions, config model  with missing fields causing a validation failures
+     */
+    @Test
+    void testValidationErrors() {
+        AzureBoardsOAuthAuthenticateAction authenticateAction = new AzureBoardsOAuthAuthenticateAction(
+            authorizationManager,
+            azureBoardsGlobalConfigAccessor,
+            azureBoardsGlobalCrudActions,
+            alertOAuthCredentialDataStoreFactory,
+            validationAction,
+            azureRedirectUrlCreator,
+            oAuthRequestValidator,
+            alertWebServerUrlManager,
+            proxyManager
+        );
+        AzureBoardsGlobalConfigModel azureBoardsGlobalConfigModel = new AzureBoardsGlobalConfigModel(
+            null,
+            "testConfigName",
+            null,
+            null,
+            null
+        );
+        ActionResponse<OAuthEndpointResponse> oAuthEndpointResponseActionResponse = authenticateAction.authenticate(azureBoardsGlobalConfigModel);
+        assertTrue(oAuthEndpointResponseActionResponse.isError());
+        assertEquals(HttpStatus.BAD_REQUEST, oAuthEndpointResponseActionResponse.getHttpStatus());
+    }
+
+    /**
+     * Test authenticate with:
+     * full permissions, update performed on config model that has ID provided.
+     */
+    @Test
+    void testAuthenticateWithUpdateAction() throws AlertConfigurationException {
+        AzureBoardsOAuthAuthenticateAction authenticateAction = new AzureBoardsOAuthAuthenticateAction(
+            authorizationManager,
+            azureBoardsGlobalConfigAccessor,
+            azureBoardsGlobalCrudActions,
+            alertOAuthCredentialDataStoreFactory,
+            validationAction,
+            azureRedirectUrlCreator,
+            oAuthRequestValidator,
+            alertWebServerUrlManager,
+            proxyManager
+        );
+        AzureBoardsGlobalConfigModel azureBoardsGlobalConfigModel = new AzureBoardsGlobalConfigModel(
+            null,
+            "testConfigName",
+            "foo",
+            "bar",
+            "biz"
+        );
+        azureBoardsGlobalConfigAccessor.createConfiguration(azureBoardsGlobalConfigModel);
+        AzureBoardsGlobalConfigModel azureBoardsGlobalConfigModelUpdated = new AzureBoardsGlobalConfigModel(
+            azureBoardsGlobalConfigModel.getId(),
+            "testConfigName",
+            ORG_NAME,
+            CLIENT_ID,
+            CLIENT_SECRET
+        );
+        ActionResponse<OAuthEndpointResponse> oAuthEndpointResponseActionResponse = authenticateAction.authenticate(azureBoardsGlobalConfigModelUpdated);
+        assertFalse(oAuthEndpointResponseActionResponse.isError());
+        OAuthEndpointResponse oAuthEndpointResponse = oAuthEndpointResponseActionResponse.getContent().orElseThrow(() -> new AssertionError("oAuthEndpointResponse should exist."));
+        String authorizationUrl = oAuthEndpointResponse.getAuthorizationUrl();
+        assertFalse(authorizationUrl.contains(ORG_NAME), "Organization Name should not be included in the URL");
+        assertTrue(authorizationUrl.contains(CLIENT_ID), "Missing Client ID");
+        assertFalse(authorizationUrl.contains(CLIENT_SECRET), "Client secret should not be exposed in the authUrl");
+        assertTrue(oAuthRequestValidator.hasRequests());
+    }
+
+    /**
+     * Test authenticate with:
+     * full permissions, update performed on config model that has ID provided but no config is found in database
+     */
+    @Test
+    void testUpdateFailure() {
+        AzureBoardsOAuthAuthenticateAction authenticateAction = new AzureBoardsOAuthAuthenticateAction(
+            authorizationManager,
+            azureBoardsGlobalConfigAccessor,
+            azureBoardsGlobalCrudActions,
+            alertOAuthCredentialDataStoreFactory,
+            validationAction,
+            azureRedirectUrlCreator,
+            oAuthRequestValidator,
+            alertWebServerUrlManager,
+            proxyManager
+        );
+        AzureBoardsGlobalConfigModel azureBoardsGlobalConfigModel = new AzureBoardsGlobalConfigModel(
+            UUID.randomUUID().toString(),
+            "testConfigName",
+            ORG_NAME,
+            CLIENT_ID,
+            CLIENT_SECRET
+        );
+        ActionResponse<OAuthEndpointResponse> oAuthEndpointResponseActionResponse = authenticateAction.authenticate(azureBoardsGlobalConfigModel);
+        assertTrue(oAuthEndpointResponseActionResponse.isError());
+    }
+
+    private AuthorizationManager createAuthorizationManager(int assignedPermissions) {
+        AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
+        DescriptorKey descriptorKey = ChannelKeys.AZURE_BOARDS;
+        PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
+        Map<PermissionKey, Integer> permissions = Map.of(permissionKey, assignedPermissions);
+
+        return authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
+    }
+
+    private static class TestAlertWebServerUrlManager implements AlertWebServerUrlManager {
+        @Override
+        public UriComponentsBuilder getServerComponentsBuilder() {
+            return null;
+        }
+
+        @Override
+        public Optional<String> getServerUrl(String... pathSegments) {
+            return Optional.of(SERVER_URL);
+        }
+    }
+
+    private static class MockSettingsUtility implements SettingsUtility {
+
+        @Override
+        public DescriptorKey getKey() {
+            return null;
+        }
+
+        @Override
+        public Optional<SettingsProxyModel> getConfiguration() {
+            return Optional.empty();
+        }
+    }
+}

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsOAuthCallbackActionTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsOAuthCallbackActionTest.java
@@ -1,0 +1,2 @@
+package com.synopsys.integration.alert.channel.azure.boards.action;public class AzureBoardsOAuthCallbackActionTest {
+}

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsOAuthCallbackActionTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsOAuthCallbackActionTest.java
@@ -1,2 +1,317 @@
-package com.synopsys.integration.alert.channel.azure.boards.action;public class AzureBoardsOAuthCallbackActionTest {
+package com.synopsys.integration.alert.channel.azure.boards.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.oauth.AlertOAuthCredentialDataStoreFactory;
+import com.synopsys.integration.alert.api.oauth.database.accessor.AlertOAuthConfigurationAccessor;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsProperties;
+import com.synopsys.integration.alert.channel.azure.boards.AzureBoardsPropertiesFactory;
+import com.synopsys.integration.alert.channel.azure.boards.AzureRedirectUrlCreator;
+import com.synopsys.integration.alert.channel.azure.boards.database.accessor.AzureBoardsGlobalConfigAccessor;
+import com.synopsys.integration.alert.channel.azure.boards.database.configuration.AzureBoardsConfigurationEntity;
+import com.synopsys.integration.alert.channel.azure.boards.database.mock.MockAlertOAuthConfigurationRepository;
+import com.synopsys.integration.alert.channel.azure.boards.database.mock.MockAzureBoardsConfigurationRepository;
+import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
+import com.synopsys.integration.alert.channel.azure.boards.oauth.OAuthRequestValidator;
+import com.synopsys.integration.alert.common.AlertProperties;
+import com.synopsys.integration.alert.common.action.ActionResponse;
+import com.synopsys.integration.alert.common.descriptor.accessor.SettingsUtility;
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.persistence.model.PermissionKey;
+import com.synopsys.integration.alert.common.persistence.model.PermissionMatrixModel;
+import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
+import com.synopsys.integration.alert.common.rest.AlertWebServerUrlManager;
+import com.synopsys.integration.alert.common.rest.model.SettingsProxyModel;
+import com.synopsys.integration.alert.common.rest.proxy.ProxyManager;
+import com.synopsys.integration.alert.common.security.EncryptionUtility;
+import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
+import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
+import com.synopsys.integration.alert.test.common.AuthenticationTestUtils;
+import com.synopsys.integration.alert.test.common.MockAlertProperties;
+import com.synopsys.integration.alert.test.common.database.MockRepositorySorter;
+import com.synopsys.integration.azure.boards.common.http.AzureHttpService;
+import com.synopsys.integration.azure.boards.common.model.AzureArrayResponseModel;
+import com.synopsys.integration.azure.boards.common.service.project.TeamProjectReferenceResponseModel;
+
+@ExtendWith(SpringExtension.class)
+class AzureBoardsOAuthCallbackActionTest {
+    private static final String SERVER_URL = "https://localhost:8443/alert";
+    private static final String ORG_NAME = "alert_test_org_name";
+    private static final String CLIENT_ID = "alert_test_client_id";
+    private static final String CLIENT_SECRET = "alert_test_client_secret";
+    private final Gson gson = new Gson();
+    private final AlertProperties alertProperties = new MockAlertProperties();
+    private final FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, gson);
+    private final EncryptionUtility encryptionUtility = new EncryptionUtility(alertProperties, filePersistenceUtil);
+    private final OAuthRequestValidator oAuthRequestValidator = new OAuthRequestValidator();
+
+    private AlertOAuthCredentialDataStoreFactory alertOAuthCredentialDataStoreFactory;
+    private AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor;
+    private AlertOAuthConfigurationAccessor alertOAuthConfigurationAccessor;
+    private AzureRedirectUrlCreator azureRedirectUrlCreator;
+    private AlertWebServerUrlManager alertWebServerUrlManager;
+    private final AuthorizationManager authorizationManager = createAuthorizationManager(AuthenticationTestUtils.FULL_PERMISSIONS);
+    private ProxyManager proxyManager = new ProxyManager(new MockSettingsUtility());
+    private AzureBoardsOAuthCallbackAction callbackAction;
+
+    @Mock
+    private AzureBoardsPropertiesFactory azureBoardsPropertiesFactory;
+
+    @BeforeEach
+    void init() {
+        //Set up global config accessor
+        MockRepositorySorter<AzureBoardsConfigurationEntity> sorter = new MockRepositorySorter<>();
+        MockAzureBoardsConfigurationRepository mockAzureBoardsConfigurationRepository = new MockAzureBoardsConfigurationRepository(sorter);
+        azureBoardsGlobalConfigAccessor = new AzureBoardsGlobalConfigAccessor(encryptionUtility, mockAzureBoardsConfigurationRepository);
+
+        //Set up OAuth accessor
+        MockAlertOAuthConfigurationRepository mockAlertOAuthConfigurationRepository = new MockAlertOAuthConfigurationRepository();
+        alertOAuthConfigurationAccessor = new AlertOAuthConfigurationAccessor(mockAlertOAuthConfigurationRepository);
+        alertOAuthCredentialDataStoreFactory = new AlertOAuthCredentialDataStoreFactory(alertOAuthConfigurationAccessor);
+
+        //Set up AzureRedirectUrl and AlertWebServerManager
+        alertWebServerUrlManager = new TestAlertWebServerUrlManager();
+        azureRedirectUrlCreator = new AzureRedirectUrlCreator(alertWebServerUrlManager);
+
+        // Set up Azure Properties Factory
+        //azureBoardsPropertiesFactory = new AzureBoardsPropertiesFactory(alertOAuthCredentialDataStoreFactory, azureRedirectUrlCreator, azureBoardsGlobalConfigAccessor, null);
+
+        callbackAction = new AzureBoardsOAuthCallbackAction(
+            alertOAuthCredentialDataStoreFactory,
+            azureBoardsPropertiesFactory,
+            azureBoardsGlobalConfigAccessor,
+            gson,
+            authorizationManager,
+            proxyManager,
+            oAuthRequestValidator,
+            azureRedirectUrlCreator
+        );
+    }
+
+    /**
+     * Test with full permissions, ensure properties are created, and a successful redirect is created.
+     * Note: This class cannot fully validate the oAuth connection to Azure. Azure services are mocked and the responses are tailored to this test to return a successful output.
+     * @throws Exception
+     */
+    @Test
+    void handleCallbackTest() throws Exception {
+        UUID requestId = UUID.randomUUID();
+        AzureBoardsGlobalConfigModel createModel = new AzureBoardsGlobalConfigModel(
+            null,
+            "testConfigName",
+            ORG_NAME,
+            CLIENT_ID,
+            CLIENT_SECRET
+        );
+        AzureBoardsGlobalConfigModel savedModel = azureBoardsGlobalConfigAccessor.createConfiguration(createModel);
+        String configId = savedModel.getId();
+
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getParameter("state")).thenReturn(requestId.toString());
+        Mockito.when(request.getRequestURI()).thenReturn("/alert/api/callbacks/oauth/azure");
+        Mockito.when(request.getQueryString()).thenReturn("code/state");
+        Mockito.when(request.getParameter("code")).thenReturn("authorizationCode");
+
+        AzureBoardsProperties azureBoardsProperties = Mockito.mock(AzureBoardsProperties.class);
+        Mockito.when(azureBoardsPropertiesFactory.fromGlobalConfigurationModel(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(azureBoardsProperties);
+
+        AzureHttpService azureHttpService = Mockito.mock(AzureHttpService.class);
+        Mockito.when(azureBoardsProperties.getOrganizationName()).thenReturn(ORG_NAME);
+        Mockito.when(azureBoardsProperties.createAzureHttpService(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(azureHttpService);
+        Mockito.when(azureBoardsProperties.createAzureHttpService(Mockito.any(), Mockito.any())).thenReturn(azureHttpService);
+        AzureArrayResponseModel<TeamProjectReferenceResponseModel> azureArrayResponseModel = new AzureArrayResponseModel<>(0, List.of());
+        Mockito.when(azureHttpService.get(Mockito.any(), Mockito.any())).thenReturn(azureArrayResponseModel);
+
+        oAuthRequestValidator.addAuthorizationRequest(requestId, UUID.fromString(configId));
+
+        ActionResponse<String> callbackURLResponse = callbackAction.handleCallback(request);
+
+        assertFalse(callbackURLResponse.isError());
+        assertEquals(SERVER_URL, callbackURLResponse.getContent().orElseThrow(() -> new AssertionError("Callback content missing.")));
+        assertFalse(oAuthRequestValidator.hasRequests());
+        Mockito.verify(azureBoardsPropertiesFactory).fromGlobalConfigurationModel(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    void executePermissionFailure() {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        AuthorizationManager authorizationManagerNoPermissions = createAuthorizationManager(AuthenticationTestUtils.NO_PERMISSIONS);
+        callbackAction = new AzureBoardsOAuthCallbackAction(
+            alertOAuthCredentialDataStoreFactory,
+            azureBoardsPropertiesFactory,
+            azureBoardsGlobalConfigAccessor,
+            gson,
+            authorizationManagerNoPermissions,
+            proxyManager,
+            oAuthRequestValidator,
+            azureRedirectUrlCreator
+        );
+        ActionResponse<String> callbackURLResponse = callbackAction.handleCallback(request);
+
+        assertTrue(callbackURLResponse.isError());
+        assertEquals(HttpStatus.FORBIDDEN, callbackURLResponse.getHttpStatus());
+    }
+
+    /**
+     * In the event that the state azure returns is invalid, it indicates that the response state was not returned as the generated UUID.
+     * @throws Exception
+     */
+    @Test
+    void invalidStateTest() throws Exception {
+        UUID requestId = UUID.randomUUID();
+        AzureBoardsGlobalConfigModel createModel = new AzureBoardsGlobalConfigModel(
+            null,
+            "testConfigName",
+            ORG_NAME,
+            CLIENT_ID,
+            CLIENT_SECRET
+        );
+        AzureBoardsGlobalConfigModel savedModel = azureBoardsGlobalConfigAccessor.createConfiguration(createModel);
+        String configId = savedModel.getId();
+
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getParameter("state")).thenReturn("Invalid-Response-Without-UUID-RequestID");
+
+        oAuthRequestValidator.addAuthorizationRequest(requestId, UUID.fromString(configId));
+
+        ActionResponse<String> callbackURLResponse = callbackAction.handleCallback(request);
+
+        assertTrue(callbackURLResponse.isError());
+        assertEquals(HttpStatus.BAD_REQUEST, callbackURLResponse.getHttpStatus());
+    }
+
+    /**
+     * If the callback is performed but reaches the timeout, a message is logged and the user is redirected to the configuration.
+     * @throws Exception
+     */
+    @Test
+    void validatorTimeoutNotFoundTest() throws Exception {
+        UUID requestId = UUID.randomUUID();
+
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getParameter("state")).thenReturn(requestId.toString());
+        Mockito.when(request.getRequestURI()).thenReturn("/alert/api/callbacks/oauth/azure");
+        Mockito.when(request.getQueryString()).thenReturn("code/state");
+        Mockito.when(request.getParameter("code")).thenReturn("authorizationCode");
+
+        ActionResponse<String> callbackURLResponse = callbackAction.handleCallback(request);
+
+        assertFalse(callbackURLResponse.isError());
+        assertEquals(SERVER_URL, callbackURLResponse.getContent().orElseThrow(() -> new AssertionError("Callback content missing.")));
+        assertFalse(oAuthRequestValidator.hasRequests());
+        Mockito.verify(azureBoardsPropertiesFactory, Mockito.times(0)).fromGlobalConfigurationModel(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    /**
+     * If a configuration is missing after performing a callback (perhaps while waiting for the callback, the configuration was deleted) the request ID is still present but the
+     * configuration no longer exists. In this case we should return to the default redirect.
+     * @throws Exception
+     */
+    @Test
+    void globalConfigurationMissingAfterCallback() throws Exception {
+        UUID requestId = UUID.randomUUID();
+
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getParameter("state")).thenReturn(requestId.toString());
+        Mockito.when(request.getRequestURI()).thenReturn("/alert/api/callbacks/oauth/azure");
+        Mockito.when(request.getQueryString()).thenReturn("code/state");
+        Mockito.when(request.getParameter("code")).thenReturn("authorizationCode");
+
+        oAuthRequestValidator.addAuthorizationRequest(requestId, UUID.randomUUID());
+
+        ActionResponse<String> callbackURLResponse = callbackAction.handleCallback(request);
+
+        assertFalse(callbackURLResponse.isError());
+        assertEquals(SERVER_URL, callbackURLResponse.getContent().orElseThrow(() -> new AssertionError("Callback content missing.")));
+        assertFalse(oAuthRequestValidator.hasRequests());
+        Mockito.verify(azureBoardsPropertiesFactory, Mockito.times(0)).fromGlobalConfigurationModel(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    /**
+     * If a response is returned, but the authorizationn code is invalid or missing, we should return a failure for the oauth callback. To simulate this, the mocked server request
+     * returns an empty code. Expect to return a redirect to the default location
+     * @throws Exception
+     */
+    @Test
+    void noAuthorizationCodeTest() throws Exception {
+        UUID requestId = UUID.randomUUID();
+        AzureBoardsGlobalConfigModel createModel = new AzureBoardsGlobalConfigModel(
+            null,
+            "testConfigName",
+            ORG_NAME,
+            CLIENT_ID,
+            CLIENT_SECRET
+        );
+        AzureBoardsGlobalConfigModel savedModel = azureBoardsGlobalConfigAccessor.createConfiguration(createModel);
+        String configId = savedModel.getId();
+
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getParameter("state")).thenReturn(requestId.toString());
+        Mockito.when(request.getRequestURI()).thenReturn("/alert/api/callbacks/oauth/azure");
+        Mockito.when(request.getQueryString()).thenReturn("code/state");
+        Mockito.when(request.getParameter("code")).thenReturn("");
+
+        oAuthRequestValidator.addAuthorizationRequest(requestId, UUID.fromString(configId));
+
+        ActionResponse<String> callbackURLResponse = callbackAction.handleCallback(request);
+
+        assertFalse(callbackURLResponse.isError());
+        assertEquals(SERVER_URL, callbackURLResponse.getContent().orElseThrow(() -> new AssertionError("Callback content missing.")));
+        assertFalse(oAuthRequestValidator.hasRequests());
+        Mockito.verify(azureBoardsPropertiesFactory, Mockito.times(0)).fromGlobalConfigurationModel(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    private AuthorizationManager createAuthorizationManager(int assignedPermissions) {
+        AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
+        DescriptorKey descriptorKey = ChannelKeys.AZURE_BOARDS;
+        PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
+        Map<PermissionKey, Integer> permissions = Map.of(permissionKey, assignedPermissions);
+
+        return authenticationTestUtils.createAuthorizationManagerWithCurrentUserSet("admin", "admin", () -> new PermissionMatrixModel(permissions));
+    }
+
+    private static class TestAlertWebServerUrlManager implements AlertWebServerUrlManager {
+        @Override
+        public UriComponentsBuilder getServerComponentsBuilder() {
+            return null;
+        }
+
+        @Override
+        public Optional<String> getServerUrl(String... pathSegments) {
+            return Optional.of(SERVER_URL);
+        }
+    }
+
+    private static class MockSettingsUtility implements SettingsUtility {
+
+        @Override
+        public DescriptorKey getKey() {
+            return null;
+        }
+
+        @Override
+        public Optional<SettingsProxyModel> getConfiguration() {
+            return Optional.empty();
+        }
+    }
 }

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/database/mock/MockAlertOAuthConfigurationRepository.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/database/mock/MockAlertOAuthConfigurationRepository.java
@@ -1,0 +1,13 @@
+package com.synopsys.integration.alert.channel.azure.boards.database.mock;
+
+import java.util.UUID;
+
+import com.synopsys.integration.alert.api.oauth.database.configuration.AlertOAuthConfigurationEntity;
+import com.synopsys.integration.alert.api.oauth.database.configuration.AlertOAuthConfigurationRepository;
+import com.synopsys.integration.alert.test.common.database.MockRepositoryContainer;
+
+public class MockAlertOAuthConfigurationRepository extends MockRepositoryContainer<UUID, AlertOAuthConfigurationEntity> implements AlertOAuthConfigurationRepository {
+    public MockAlertOAuthConfigurationRepository() {
+        super(AlertOAuthConfigurationEntity::getId);
+    }
+}


### PR DESCRIPTION
Previously AzureBoardsProperties had a static  method in order to create the object which was used by the AzureBoardsPropertiesFactory in order to create an instance of the former. This is somewhat backwards as traditionally if we're following a factory workflow, the factory class creates an instance of the object using its constructor rather than it's static methods.

This accomplishes a few things:
It's easier for testing and mocking since we can mock out the properties class.
It lets us be consistent with other  issue trackers such as Jira Server which use a similar factory approach.

In addition to these changes we've also added increased test coverage for OAuth actions in Azure as they require afformentioned changes.