### PR TITLE
IALERT-3236: Address upgrade problems in helm deployments

### DIFF
--- a/deployment/helm/synopsys-alert/templates/postgres-config.yaml
+++ b/deployment/helm/synopsys-alert/templates/postgres-config.yaml
@@ -13,7 +13,11 @@ data:
   {{- end }}
   ALERT_DB_NAME: {{ .Values.postgres.databaseName }}
   {{- if not .Values.postgres.dbAdminCredential.secretName }}
+  {{- if .Values.postgres.adminUserName }}
   ALERT_DB_ADMIN_USERNAME: {{ .Values.postgres.adminUserName }}
+  {{- else }}
+  ALERT_DB_ADMIN_USERNAME: {{ .Values.postgres.userUserName }}
+  {{- end }}
   {{- end }}
 kind: ConfigMap
 metadata:

--- a/deployment/helm/synopsys-alert/templates/postgres.yaml
+++ b/deployment/helm/synopsys-alert/templates/postgres.yaml
@@ -85,6 +85,12 @@ spec:
           value: 1024MB
         - name: MIGRATE_POSTGRES
           value: "{{ if .Values.postgres.postgresMigration }}{{ .Values.postgres.postgresMigration }}{{ else }}true{{ end }}"
+        - name: PGDATA
+        {{- if .Values.postgres.postgresDataDirectory }}
+          value: {{ .Values.postgres.postgresDataDirectory }}
+        {{- else }}
+          value: "/var/lib/postgresql/data"
+        {{- end}}
         {{- if .Values.postgres.dbCredential.secretName }}
         - name: POSTGRES_USER
           valueFrom:
@@ -96,6 +102,19 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: ALERT_DB_USERNAME
+              name: {{ .Release.Name }}-db-config
+        {{- end }}
+        {{- if .Values.postgres.dbAdminCredential.secretName }}
+        - name: POSTGRES_ADMIN_USER
+          valueFrom:
+            secretKeyRef:
+              key: {{ required ".Values.postgres.dbAdminCredential.usernameKey is missing." .Values.postgres.dbAdminCredential.usernameKey }}
+              name: {{ .Values.postgres.dbAdminCredential.secretName }}
+        {{- else }}
+        - name: POSTGRES_ADMIN_USER
+          valueFrom:
+            configMapKeyRef:
+              key: ALERT_DB_ADMIN_USERNAME
               name: {{ .Release.Name }}-db-config
         {{- end }}
         - name: POSTGRES_DB
@@ -162,7 +181,7 @@ spec:
               command:
                 - /bin/bash
                 - -c
-                - LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/pg_ctl -D /var/lib/postgresql/data/userdata -l logfile stop
+                - LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/pg_ctl -D "${PGDATA}" -l logfile stop
         name: {{ .Release.Name }}-postgres
         ports:
         - containerPort: {{ .Values.postgres.port }}

--- a/deployment/helm/synopsys-alert/values.yaml
+++ b/deployment/helm/synopsys-alert/values.yaml
@@ -58,13 +58,13 @@ postgres:
   host: "" # required only for external postgres, for postgres as a container, it will point to <name>-postgres
   port: 5432
   postgresMigration:
-  postgresDataDirectory: # If you are upgrading from the Centos image used prior to Alert 6.12.0, set this value to "/var/lib/postgresql/data/userdata"
+  postgresDataDirectory: # If upgrading from the Centos image used prior to Alert 6.12.0, set this value to "/var/lib/postgresql/data/userdata"
   # NOTE: do not change usernames when using postgres as a container; only configure if using external database
   userUserName: sa
   userPassword: blackduck
   databaseName: alertdb
-  adminUserName: postgres
-  adminPassword: ""
+  adminUserName: # If upgrading from the Centos image used prior to Alert 6.12.0, set this value to your admin user. Default was postgres
+  adminPassword: # If upgrading from the Centos image used prior to Alert 6.12.0, set this value to your admin password. Default was ""
   dbCredential: #Secret that contains both the regular username & password
     secretName: ""
     usernameKey: "ALERT_DB_USERNAME"

--- a/deployment/helm/synopsys-alert/values.yaml
+++ b/deployment/helm/synopsys-alert/values.yaml
@@ -57,13 +57,14 @@ postgres:
     sslRootCertKey: "ALERT_DB_SSL_ROOT_CERT_PATH"
   host: "" # required only for external postgres, for postgres as a container, it will point to <name>-postgres
   port: 5432
+  postgresMigration:
+  postgresDataDirectory: # If you are upgrading from the Centos image used prior to Alert 6.12.0, set this value to "/var/lib/postgresql/data/userdata"
   # NOTE: do not change usernames when using postgres as a container; only configure if using external database
   userUserName: sa
   userPassword: blackduck
   databaseName: alertdb
   adminUserName: postgres
   adminPassword: ""
-  postgresMigration:
   dbCredential: #Secret that contains both the regular username & password
     secretName: ""
     usernameKey: "ALERT_DB_USERNAME"

--- a/docker/blackduck-alert-db/Dockerfile
+++ b/docker/blackduck-alert-db/Dockerfile
@@ -17,7 +17,12 @@ ARG VERSION
 LABEL com.blackducksoftware.integration.alert.vendor="Black Duck Software, Inc." \
       com.blackducksoftware.integration.alert.version="$VERSION"
 
+RUN set -ex \
+    && mkdir -p -m 775 /var/lib/pgsql \
+    && apk add --no-cache --virtual .run-deps gettext
+
 COPY alertdb-*.sh /usr/local/bin/
+COPY openshift-custom-postgresql.conf.template /var/lib/pgsql/
 
 CMD ["postgres"]
 ENTRYPOINT ["/usr/local/bin/alertdb-docker-entrypoint.sh"]

--- a/docker/blackduck-alert-db/openshift-custom-postgresql.conf.template
+++ b/docker/blackduck-alert-db/openshift-custom-postgresql.conf.template
@@ -1,0 +1,23 @@
+## This was copied from the URL below in order to facilitate migrating from Centos Postgres image to Alpine Postgres image
+## https://github.com/sclorg/postgresql-container/blob/master/src/root/usr/share/container-scripts/postgresql/openshift-custom-postgresql.conf.template
+#
+# Custom OpenShift configuration.
+#
+# NOTE: This file is rewritten every time the container is started!
+#       Changes to this file will be overwritten.
+#
+
+# Listen on all interfaces.
+listen_addresses = '*'
+
+# Determines the maximum number of concurrent connections to the database server. Default: 100
+max_connections = ${POSTGRESQL_MAX_CONNECTIONS}
+
+# Allow each connection to use a prepared transaction
+max_prepared_transactions = ${POSTGRESQL_MAX_PREPARED_TRANSACTIONS}
+
+# Sets the amount of memory the database server uses for shared memory buffers. Default: 32MB
+shared_buffers = ${POSTGRESQL_SHARED_BUFFERS}
+
+# Sets the planner's assumption about the effective size of the disk cache that is available to a single query
+effective_cache_size = ${POSTGRESQL_EFFECTIVE_CACHE_SIZE}


### PR DESCRIPTION
This address 3 different problems encountered while performing upgrades:

1. Centos image creates an Admin user and non-admin user as part of its standard deployment. Alpine does not do this. The user passed to the Alpine image is created is an admin. Because of this, we need to make the admin user used for the Centos DB initialization available to Alpine.
2. Centos creates a conf file (openshift-custom-postgresql.conf) that is included in postgresql.conf. This file is generated on every startup, and is stored outside of the volume. Because of this, we need to handle creating this file.
3. Centos stores its DB data in a different directory. Because of this, we had to handle being able to override this value.

** Please review ticket for testing scenarios done using the changes in this PR