### PR TITLE
IALERT-3240: encrypt and decrypt access tokens in new accessor.

### DIFF
--- a/api-oauth/src/test/java/com/synopsys/integration/alert/api/oauth/AlertOAuthCredentialDataStoreFactoryTest.java
+++ b/api-oauth/src/test/java/com/synopsys/integration/alert/api/oauth/AlertOAuthCredentialDataStoreFactoryTest.java
@@ -11,9 +11,14 @@ import org.junit.jupiter.api.Test;
 
 import com.google.api.client.auth.oauth2.StoredCredential;
 import com.google.api.client.util.store.DataStore;
+import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.common.model.exception.AlertRuntimeException;
 import com.synopsys.integration.alert.api.oauth.database.accessor.AlertOAuthConfigurationAccessor;
 import com.synopsys.integration.alert.api.oauth.database.accessor.MockAlertOAuthConfigurationRepository;
+import com.synopsys.integration.alert.common.AlertProperties;
+import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
+import com.synopsys.integration.alert.common.security.EncryptionUtility;
+import com.synopsys.integration.alert.test.common.MockAlertProperties;
 
 class AlertOAuthCredentialDataStoreFactoryTest {
 
@@ -24,7 +29,10 @@ class AlertOAuthCredentialDataStoreFactoryTest {
     @BeforeEach
     public void initAccessor() {
         repository = new MockAlertOAuthConfigurationRepository();
-        accessor = new AlertOAuthConfigurationAccessor(repository);
+        AlertProperties alertProperties = new MockAlertProperties();
+        FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, new Gson());
+        EncryptionUtility encryptionUtility = new EncryptionUtility(alertProperties, filePersistenceUtil);
+        accessor = new AlertOAuthConfigurationAccessor(repository, encryptionUtility);
         factory = new AlertOAuthCredentialDataStoreFactory(accessor);
     }
 

--- a/api-oauth/src/test/java/com/synopsys/integration/alert/api/oauth/AlertOAuthCredentialDataStoreTest.java
+++ b/api-oauth/src/test/java/com/synopsys/integration/alert/api/oauth/AlertOAuthCredentialDataStoreTest.java
@@ -11,10 +11,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.api.client.auth.oauth2.StoredCredential;
+import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.api.oauth.database.AlertOAuthModel;
 import com.synopsys.integration.alert.api.oauth.database.accessor.AlertOAuthConfigurationAccessor;
 import com.synopsys.integration.alert.api.oauth.database.accessor.MockAlertOAuthConfigurationRepository;
+import com.synopsys.integration.alert.common.AlertProperties;
+import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
+import com.synopsys.integration.alert.common.security.EncryptionUtility;
+import com.synopsys.integration.alert.test.common.MockAlertProperties;
 
 class AlertOAuthCredentialDataStoreTest {
 
@@ -27,7 +32,11 @@ class AlertOAuthCredentialDataStoreTest {
     @BeforeEach
     void initDataStore() {
         repository = new MockAlertOAuthConfigurationRepository();
-        accessor = new AlertOAuthConfigurationAccessor(repository);
+        Gson gson = new Gson();
+        AlertProperties alertProperties = new MockAlertProperties();
+        FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, gson);
+        EncryptionUtility encryptionUtility = new EncryptionUtility(alertProperties, filePersistenceUtil);
+        accessor = new AlertOAuthConfigurationAccessor(repository, encryptionUtility);
         factory = new AlertOAuthCredentialDataStoreFactory(accessor);
         dataStore = new AlertOAuthCredentialDataStore(factory, StoredCredential.DEFAULT_DATA_STORE_ID, accessor);
     }

--- a/api-oauth/src/test/java/com/synopsys/integration/alert/api/oauth/database/accessor/AlertOAuthConfigurationAccessorTest.java
+++ b/api-oauth/src/test/java/com/synopsys/integration/alert/api/oauth/database/accessor/AlertOAuthConfigurationAccessorTest.java
@@ -13,8 +13,13 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.api.oauth.database.AlertOAuthModel;
+import com.synopsys.integration.alert.common.AlertProperties;
+import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
+import com.synopsys.integration.alert.common.security.EncryptionUtility;
+import com.synopsys.integration.alert.test.common.MockAlertProperties;
 
 class AlertOAuthConfigurationAccessorTest {
     private MockAlertOAuthConfigurationRepository repository;
@@ -23,7 +28,10 @@ class AlertOAuthConfigurationAccessorTest {
     @BeforeEach
     void initRepository() {
         repository = new MockAlertOAuthConfigurationRepository();
-        accessor = new AlertOAuthConfigurationAccessor(repository);
+        AlertProperties alertProperties = new MockAlertProperties();
+        FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, new Gson());
+        EncryptionUtility encryptionUtility = new EncryptionUtility(alertProperties, filePersistenceUtil);
+        accessor = new AlertOAuthConfigurationAccessor(repository, encryptionUtility);
     }
 
     @Test
@@ -43,7 +51,10 @@ class AlertOAuthConfigurationAccessorTest {
 
     @Test
     void readSingleConfigurationWithUnknownId() {
-        AlertOAuthConfigurationAccessor accessor = new AlertOAuthConfigurationAccessor(repository);
+        AlertProperties alertProperties = new MockAlertProperties();
+        FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, new Gson());
+        EncryptionUtility encryptionUtility = new EncryptionUtility(alertProperties, filePersistenceUtil);
+        accessor = new AlertOAuthConfigurationAccessor(repository, encryptionUtility);
         Optional<AlertOAuthModel> configuration = accessor.getConfiguration(UUID.randomUUID());
         assertTrue(configuration.isEmpty());
     }


### PR DESCRIPTION
The refresh and access tokens are encrypted in previous versions of Alert.  Need to make sure the new class for storing OAuth  tokens encrypts and decrypts the values.