### PR TITLE
IALERT-3238 oauth validation refactor

### DIFF
--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidator.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidator.java
@@ -8,30 +8,30 @@
 package com.synopsys.integration.alert.channel.azure.boards.oauth;
 
 import java.time.Instant;
-import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.commons.collections4.map.PassiveExpiringMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class OAuthRequestValidator {
-    private static final Long TIME_TO_LIVE_IN_MILLIS = 600000L;
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final Map<UUID, OAuthRequestMapping> requestMap = Collections.synchronizedMap(new PassiveExpiringMap<>(TIME_TO_LIVE_IN_MILLIS));
+    private final Map<UUID, OAuthRequestMapping> requestMap = new ConcurrentHashMap<>();
 
     public UUID generateRequestKey() {
         return UUID.randomUUID();
     }
 
     public void addAuthorizationRequest(UUID requestKey, UUID configurationId) {
+        removeRequestsOlderThan5MinutesAgo();
         if (requestKey == null) {
             logger.error("OAuth authorization key is null, authorization request will not be added");
             return;
         }
+        requestMap.entrySet().removeIf(entry -> entry.getValue().getConfigurationId().equals(configurationId));
         logger.debug("Adding OAuth authorization key {}", requestKey);
         requestMap.put(requestKey, new OAuthRequestMapping(configurationId, Instant.now()));
     }
@@ -43,27 +43,36 @@ public class OAuthRequestValidator {
         }
         requestMap.remove(requestKey);
         logger.debug("Removed OAuth authorization key {}", requestKey);
+        removeRequestsOlderThan5MinutesAgo();
     }
 
     public boolean hasRequestKey(UUID requestKey) {
+        removeRequestsOlderThan5MinutesAgo();
         if (requestKey == null) {
             return false;
         }
         return requestMap.containsKey(requestKey);
     }
 
-    public boolean hasRequestFromConfigurationId(String configurationId) {
-        return requestMap.values().stream()
-            .map(OAuthRequestMapping::getConfigurationId)
-            .map(UUID::toString)
-            .anyMatch(configurationId::equals);
-    }
-
     public boolean hasRequests() {
+        removeRequestsOlderThan5MinutesAgo();
         return !requestMap.isEmpty();
     }
 
     public UUID getConfigurationIdFromRequest(UUID requestKey) {
+        removeRequestsOlderThan5MinutesAgo();
         return requestMap.get(requestKey).getConfigurationId();
+    }
+
+    public void removeRequestsOlderThanInstant(Instant instant) {
+        requestMap.entrySet().stream()
+            .filter(entry -> entry.getValue().getRequestTimestamp().isBefore(instant))
+            .map(Map.Entry::getKey)
+            .forEach(this::removeAuthorizationRequest);
+    }
+
+    public void removeRequestsOlderThan5MinutesAgo() {
+        Instant fiveMinutesAgo = Instant.now().minusSeconds(300);
+        removeRequestsOlderThanInstant(fiveMinutesAgo);
     }
 }

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/validator/AzureBoardsGlobalConfigurationValidator.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/validator/AzureBoardsGlobalConfigurationValidator.java
@@ -13,18 +13,14 @@ import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatus;
 import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatusMessages;
 import com.synopsys.integration.alert.channel.azure.boards.database.accessor.AzureBoardsGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
-import com.synopsys.integration.alert.channel.azure.boards.oauth.OAuthRequestValidator;
 
 @Component
 public class AzureBoardsGlobalConfigurationValidator {
-    private static final String AUTHENTICATION_IN_PROGRESS = "Authentication in progress cannot perform current action.";
     private final AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor;
-    private final OAuthRequestValidator oAuthRequestValidator;
 
     @Autowired
-    public AzureBoardsGlobalConfigurationValidator(AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor, OAuthRequestValidator oAuthRequestValidator) {
+    public AzureBoardsGlobalConfigurationValidator(AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor) {
         this.azureBoardsGlobalConfigAccessor = azureBoardsGlobalConfigAccessor;
-        this.oAuthRequestValidator = oAuthRequestValidator;
     }
 
     public ValidationResponseModel validate(AzureBoardsGlobalConfigModel model, String id) {

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/validator/AzureBoardsGlobalConfigurationValidator.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/validator/AzureBoardsGlobalConfigurationValidator.java
@@ -30,10 +30,6 @@ public class AzureBoardsGlobalConfigurationValidator {
     public ValidationResponseModel validate(AzureBoardsGlobalConfigModel model, String id) {
         Set<AlertFieldStatus> statuses = new HashSet<>();
 
-        if (model.getId() != null && oAuthRequestValidator.hasRequestFromConfigurationId(model.getId())) {
-            statuses.add(AlertFieldStatus.error("oAuth", AUTHENTICATION_IN_PROGRESS));
-        }
-
         if (StringUtils.isBlank(model.getName())) {
             statuses.add(AlertFieldStatus.error("name", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
         } else if (doesNameExist(model.getName(), id)) {

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalCrudActionsTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalCrudActionsTest.java
@@ -19,7 +19,6 @@ import com.synopsys.integration.alert.channel.azure.boards.database.accessor.Azu
 import com.synopsys.integration.alert.channel.azure.boards.database.configuration.AzureBoardsConfigurationEntity;
 import com.synopsys.integration.alert.channel.azure.boards.database.mock.MockAzureBoardsConfigurationRepository;
 import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
-import com.synopsys.integration.alert.channel.azure.boards.oauth.OAuthRequestValidator;
 import com.synopsys.integration.alert.channel.azure.boards.validator.AzureBoardsGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.action.ActionResponse;
@@ -54,7 +53,6 @@ class AzureBoardsGlobalCrudActionsTest {
     private final AlertProperties alertProperties = new MockAlertProperties();
     private final FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, gson);
     private final EncryptionUtility encryptionUtility = new EncryptionUtility(alertProperties, filePersistenceUtil);
-    private final OAuthRequestValidator oAuthRequestValidator = new OAuthRequestValidator();
 
     AzureBoardsGlobalConfigModel firstConfigModel;
     AzureBoardsGlobalCrudActions azureBoardsGlobalCrudActions;
@@ -69,7 +67,7 @@ class AzureBoardsGlobalCrudActionsTest {
         azureBoardsGlobalCrudActions = new AzureBoardsGlobalCrudActions(
             authorizationManager,
             azureBoardsGlobalConfigAccessor,
-            new AzureBoardsGlobalConfigurationValidator(azureBoardsGlobalConfigAccessor, oAuthRequestValidator)
+            new AzureBoardsGlobalConfigurationValidator(azureBoardsGlobalConfigAccessor)
         );
         firstConfigModel = new AzureBoardsGlobalConfigModel(
             "",

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestActionTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalTestActionTest.java
@@ -22,7 +22,6 @@ import com.synopsys.integration.alert.channel.azure.boards.database.accessor.Azu
 import com.synopsys.integration.alert.channel.azure.boards.database.configuration.AzureBoardsConfigurationEntity;
 import com.synopsys.integration.alert.channel.azure.boards.database.mock.MockAzureBoardsConfigurationRepository;
 import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
-import com.synopsys.integration.alert.channel.azure.boards.oauth.OAuthRequestValidator;
 import com.synopsys.integration.alert.channel.azure.boards.validator.AzureBoardsGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.action.ActionResponse;
@@ -49,7 +48,6 @@ class AzureBoardsGlobalTestActionTest {
     private final AlertProperties alertProperties = new MockAlertProperties();
     private final FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, gson);
     private final EncryptionUtility encryptionUtility = new EncryptionUtility(alertProperties, filePersistenceUtil);
-    private final OAuthRequestValidator oAuthRequestValidator = new OAuthRequestValidator();
     AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor;
     AzureBoardsGlobalConfigurationValidator azureBoardsGlobalConfigurationValidator;
 
@@ -67,7 +65,7 @@ class AzureBoardsGlobalTestActionTest {
         MockRepositorySorter<AzureBoardsConfigurationEntity> sorter = new MockRepositorySorter<>();
         MockAzureBoardsConfigurationRepository mockAzureBoardsConfigurationRepository = new MockAzureBoardsConfigurationRepository(sorter);
         azureBoardsGlobalConfigAccessor = new AzureBoardsGlobalConfigAccessor(encryptionUtility, mockAzureBoardsConfigurationRepository);
-        azureBoardsGlobalConfigurationValidator = new AzureBoardsGlobalConfigurationValidator(azureBoardsGlobalConfigAccessor, oAuthRequestValidator);
+        azureBoardsGlobalConfigurationValidator = new AzureBoardsGlobalConfigurationValidator(azureBoardsGlobalConfigAccessor);
 
         Mockito.when(mockAzureRedirectUrlCreator.createOAuthRedirectUri()).thenReturn("https://www.redirect.com");
     }

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalValidationActionTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsGlobalValidationActionTest.java
@@ -14,7 +14,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.channel.azure.boards.database.accessor.AzureBoardsGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
-import com.synopsys.integration.alert.channel.azure.boards.oauth.OAuthRequestValidator;
 import com.synopsys.integration.alert.channel.azure.boards.validator.AzureBoardsGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
@@ -30,7 +29,6 @@ class AzureBoardsGlobalValidationActionTest {
     private final AuthenticationTestUtils authenticationTestUtils = new AuthenticationTestUtils();
     private final DescriptorKey descriptorKey = ChannelKeys.AZURE_BOARDS;
     private final PermissionKey permissionKey = new PermissionKey(ConfigContextEnum.GLOBAL.name(), descriptorKey.getUniversalKey());
-    private final OAuthRequestValidator oAuthRequestValidator = new OAuthRequestValidator();
     @Mock
     private AzureBoardsGlobalConfigAccessor mockAzureBoardsGlobalConfigAccessor;
 
@@ -40,7 +38,7 @@ class AzureBoardsGlobalValidationActionTest {
     @BeforeEach
     void initEach() {
         model = new AzureBoardsGlobalConfigModel();
-        validator = new AzureBoardsGlobalConfigurationValidator(mockAzureBoardsGlobalConfigAccessor, oAuthRequestValidator);
+        validator = new AzureBoardsGlobalConfigurationValidator(mockAzureBoardsGlobalConfigAccessor);
     }
 
     @Test

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsOAuthAuthenticateActionTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/action/AzureBoardsOAuthAuthenticateActionTest.java
@@ -81,7 +81,7 @@ class AzureBoardsOAuthAuthenticateActionTest {
         alertOAuthCredentialDataStoreFactory = new AlertOAuthCredentialDataStoreFactory(alertOAuthConfigurationAccessor);
 
         //Set up azure global validation
-        azureBoardsGlobalConfigurationValidator = new AzureBoardsGlobalConfigurationValidator(azureBoardsGlobalConfigAccessor, oAuthRequestValidator);
+        azureBoardsGlobalConfigurationValidator = new AzureBoardsGlobalConfigurationValidator(azureBoardsGlobalConfigAccessor);
         validationAction = new AzureBoardsGlobalValidationAction(azureBoardsGlobalConfigurationValidator, authorizationManager);
 
         //Set up AzureRedirectUrl and AlertWebServerManager

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/convert/AzureBoardsGlobalConfigurationModelConverterTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/convert/AzureBoardsGlobalConfigurationModelConverterTest.java
@@ -18,7 +18,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.synopsys.integration.alert.channel.azure.boards.database.accessor.AzureBoardsGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
-import com.synopsys.integration.alert.channel.azure.boards.oauth.OAuthRequestValidator;
 import com.synopsys.integration.alert.channel.azure.boards.validator.AzureBoardsGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
@@ -30,7 +29,6 @@ class AzureBoardsGlobalConfigurationModelConverterTest {
     private static final String TEST_ORGANIZATION_NAME = "testOrganizationName";
     private static final String TEST_CLIENT_ID = "testClientID";
     private static final String TEST_CLIENT_SECRET = "testClientSecret";
-    private final OAuthRequestValidator oAuthRequestValidator = new OAuthRequestValidator();
     private AzureBoardsGlobalConfigurationValidator validator;
     @Mock
     private AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor;
@@ -38,7 +36,7 @@ class AzureBoardsGlobalConfigurationModelConverterTest {
     @BeforeEach
     public void init() {
         Mockito.when(azureBoardsGlobalConfigAccessor.getConfigurationByName(Mockito.anyString())).thenReturn(Optional.empty());
-        validator = new AzureBoardsGlobalConfigurationValidator(azureBoardsGlobalConfigAccessor, oAuthRequestValidator);
+        validator = new AzureBoardsGlobalConfigurationValidator(azureBoardsGlobalConfigAccessor);
     }
 
     @Test
@@ -68,7 +66,7 @@ class AzureBoardsGlobalConfigurationModelConverterTest {
             TEST_CLIENT_SECRET
         );
         Mockito.when(azureBoardsGlobalConfigAccessor.getConfigurationByName(Mockito.anyString())).thenReturn(Optional.of(azureBoardsGlobalConfigModelSaved));
-        validator = new AzureBoardsGlobalConfigurationValidator(azureBoardsGlobalConfigAccessor, oAuthRequestValidator);
+        validator = new AzureBoardsGlobalConfigurationValidator(azureBoardsGlobalConfigAccessor);
 
         AzureBoardsGlobalConfigurationModelConverter converter = new AzureBoardsGlobalConfigurationModelConverter(validator);
         Optional<AzureBoardsGlobalConfigModel> model = converter.convertAndValidate(configurationModel, uuid);

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/convert/AzureBoardsGlobalConfigurationModelSaveActionsTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/convert/AzureBoardsGlobalConfigurationModelSaveActionsTest.java
@@ -16,7 +16,6 @@ import com.synopsys.integration.alert.channel.azure.boards.action.AzureBoardsGlo
 import com.synopsys.integration.alert.channel.azure.boards.database.accessor.AzureBoardsGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.azure.boards.database.configuration.AzureBoardsConfigurationEntity;
 import com.synopsys.integration.alert.channel.azure.boards.database.mock.MockAzureBoardsConfigurationRepository;
-import com.synopsys.integration.alert.channel.azure.boards.oauth.OAuthRequestValidator;
 import com.synopsys.integration.alert.channel.azure.boards.validator.AzureBoardsGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
@@ -43,7 +42,6 @@ class AzureBoardsGlobalConfigurationModelSaveActionsTest {
     private final FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, gson);
     private final EncryptionUtility encryptionUtility = new EncryptionUtility(alertProperties, filePersistenceUtil);
     private final AuthorizationManager authorizationManager = createAuthorizationManager();
-    private final OAuthRequestValidator oAuthRequestValidator = new OAuthRequestValidator();
     private MockAzureBoardsConfigurationRepository mockAzureRepository;
     private AzureBoardsGlobalConfigAccessor configAccessor;
     private AzureBoardsGlobalCrudActions crudActions;
@@ -57,7 +55,7 @@ class AzureBoardsGlobalConfigurationModelSaveActionsTest {
         sorter.applyFieldSorter("organizationName", MockRepositorySorter.createSingleFieldSorter(AzureBoardsConfigurationEntity::getOrganizationName));
         mockAzureRepository = new MockAzureBoardsConfigurationRepository(sorter);
         configAccessor = new AzureBoardsGlobalConfigAccessor(encryptionUtility, mockAzureRepository);
-        validator = new AzureBoardsGlobalConfigurationValidator(configAccessor, oAuthRequestValidator);
+        validator = new AzureBoardsGlobalConfigurationValidator(configAccessor);
         crudActions = new AzureBoardsGlobalCrudActions(authorizationManager, configAccessor, validator);
         converter = new AzureBoardsGlobalConfigurationModelConverter(validator);
     }

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/environment/AzureBoardsEnvironmentVariableHandlerTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/environment/AzureBoardsEnvironmentVariableHandlerTest.java
@@ -17,7 +17,6 @@ import com.synopsys.integration.alert.channel.azure.boards.database.accessor.Azu
 import com.synopsys.integration.alert.channel.azure.boards.database.configuration.AzureBoardsConfigurationEntity;
 import com.synopsys.integration.alert.channel.azure.boards.database.mock.MockAzureBoardsConfigurationRepository;
 import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
-import com.synopsys.integration.alert.channel.azure.boards.oauth.OAuthRequestValidator;
 import com.synopsys.integration.alert.channel.azure.boards.validator.AzureBoardsGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
@@ -37,7 +36,6 @@ class AzureBoardsEnvironmentVariableHandlerTest {
     private final AlertProperties alertProperties = new MockAlertProperties();
     private final FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, gson);
     private final EncryptionUtility encryptionUtility = new EncryptionUtility(alertProperties, filePersistenceUtil);
-    private final OAuthRequestValidator oAuthRequestValidator = new OAuthRequestValidator();
     AzureBoardsEnvironmentVariableHandler azureBoardsEnvironmentVariableHandler;
     AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor;
     AzureBoardsGlobalConfigurationValidator azureBoardsGlobalConfigurationValidator;
@@ -49,7 +47,7 @@ class AzureBoardsEnvironmentVariableHandlerTest {
         MockRepositorySorter<AzureBoardsConfigurationEntity> sorter = new MockRepositorySorter<>();
         MockAzureBoardsConfigurationRepository mockAzureBoardsConfigurationRepository = new MockAzureBoardsConfigurationRepository(sorter);
         azureBoardsGlobalConfigAccessor = new AzureBoardsGlobalConfigAccessor(encryptionUtility, mockAzureBoardsConfigurationRepository);
-        azureBoardsGlobalConfigurationValidator = new AzureBoardsGlobalConfigurationValidator(azureBoardsGlobalConfigAccessor, oAuthRequestValidator);
+        azureBoardsGlobalConfigurationValidator = new AzureBoardsGlobalConfigurationValidator(azureBoardsGlobalConfigAccessor);
 
         mockEnvironment = new MockEnvironment();
         EnvironmentVariableUtility environmentVariableUtility = new EnvironmentVariableUtility(mockEnvironment);

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidatorTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/oauth/OAuthRequestValidatorTest.java
@@ -43,4 +43,18 @@ class OAuthRequestValidatorTest {
         assertTrue(oAuthRequestValidator.hasRequestKey(requestKey));
         assertTrue(oAuthRequestValidator.hasRequests());
     }
+
+    @Test
+    void removeDuplicateRequestsTest() {
+        OAuthRequestValidator oAuthRequestValidator = new OAuthRequestValidator();
+        UUID configId = UUID.randomUUID();
+        UUID request1 = UUID.randomUUID();
+        UUID request2 = UUID.randomUUID();
+        oAuthRequestValidator.addAuthorizationRequest(request1, configId);
+        oAuthRequestValidator.addAuthorizationRequest(request2, configId);
+
+        assertTrue(oAuthRequestValidator.hasRequests());
+        assertFalse(oAuthRequestValidator.hasRequestKey(request1));
+        assertTrue(oAuthRequestValidator.hasRequestKey(request2));
+    }
 }

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/validator/AzureBoardsGlobalConfigurationValidatorTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/validator/AzureBoardsGlobalConfigurationValidatorTest.java
@@ -17,7 +17,6 @@ import com.synopsys.integration.alert.channel.azure.boards.database.accessor.Azu
 import com.synopsys.integration.alert.channel.azure.boards.database.configuration.AzureBoardsConfigurationEntity;
 import com.synopsys.integration.alert.channel.azure.boards.database.mock.MockAzureBoardsConfigurationRepository;
 import com.synopsys.integration.alert.channel.azure.boards.model.AzureBoardsGlobalConfigModel;
-import com.synopsys.integration.alert.channel.azure.boards.oauth.OAuthRequestValidator;
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
@@ -30,7 +29,6 @@ class AzureBoardsGlobalConfigurationValidatorTest {
     private final AlertProperties alertProperties = new MockAlertProperties();
     private final FilePersistenceUtil filePersistenceUtil = new FilePersistenceUtil(alertProperties, gson);
     private final EncryptionUtility encryptionUtility = new EncryptionUtility(alertProperties, filePersistenceUtil);
-    private final OAuthRequestValidator oAuthRequestValidator = new OAuthRequestValidator();
 
     AzureBoardsGlobalConfigAccessor azureBoardsGlobalConfigAccessor;
     AzureBoardsGlobalConfigurationValidator azureBoardsGlobalConfigurationValidator;
@@ -40,7 +38,7 @@ class AzureBoardsGlobalConfigurationValidatorTest {
         MockRepositorySorter<AzureBoardsConfigurationEntity> sorter = new MockRepositorySorter<>();
         MockAzureBoardsConfigurationRepository mockAzureBoardsConfigurationRepository = new MockAzureBoardsConfigurationRepository(sorter);
         azureBoardsGlobalConfigAccessor = new AzureBoardsGlobalConfigAccessor(encryptionUtility, mockAzureBoardsConfigurationRepository);
-        azureBoardsGlobalConfigurationValidator = new AzureBoardsGlobalConfigurationValidator(azureBoardsGlobalConfigAccessor, oAuthRequestValidator);
+        azureBoardsGlobalConfigurationValidator = new AzureBoardsGlobalConfigurationValidator(azureBoardsGlobalConfigAccessor);
     }
 
     @Test


### PR DESCRIPTION
The goal of these changes is to remove the oAuth validation from Azure. If a failure occurs this will allow users to attempt to authenticate again without having to wait the timeout delay. To accomplish this, we now do thee following:

- Attempting  to add a new request will first inspect if there is already a request for that configuration. If it exists, it will delete the old entry and replace it with the new one.
- Failed requests will remain in memory until, it is either cleared by an existing configuration overwriting it (see above bullet) or it will be purged after 5 minutes. 
- As a result of these changes the global config validator no longer depends on the oAuth request validator and it can be removed from test classes.

The idea for keeping only the last successful request and run is that only the last success will be saved to the OAuth repository. The request ID uniquely created and is used in only one spot downstream in the callback controller and immediately deleted after accessing it. Therefore we do not see a reason in forcing a user to wait until a timeout to be reached in order to regenerate a new request id.