### PR TITLE
IALERT-3139 policy upgrade guidance

### DIFF
--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/AbstractRuleViolationNotificationMessageExtractor.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/AbstractRuleViolationNotificationMessageExtractor.java
@@ -9,8 +9,11 @@ package com.synopsys.integration.alert.provider.blackduck.processor.message;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.synopsys.integration.alert.common.enumeration.ItemOperation;
 import com.synopsys.integration.alert.descriptor.api.BlackDuckProviderKey;
@@ -20,20 +23,26 @@ import com.synopsys.integration.alert.processor.api.extract.model.project.Compon
 import com.synopsys.integration.alert.provider.blackduck.processor.NotificationExtractorBlackDuckServicesFactoryCache;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreator;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageBomComponentDetailsCreatorFactory;
+import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BlackDuckMessageComponentVersionUpgradeGuidanceService;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BomComponent404Handler;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.policy.BlackDuckPolicyComponentConcernCreator;
 import com.synopsys.integration.alert.provider.blackduck.processor.message.util.BlackDuckMessageLinkUtils;
 import com.synopsys.integration.alert.provider.blackduck.processor.model.AbstractRuleViolationNotificationContent;
+import com.synopsys.integration.blackduck.api.generated.view.ComponentVersionView;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionComponentVersionView;
 import com.synopsys.integration.blackduck.api.manual.component.ComponentVersionStatus;
 import com.synopsys.integration.blackduck.api.manual.enumeration.NotificationType;
 import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
 import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
 import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.function.ThrowingSupplier;
 import com.synopsys.integration.rest.HttpUrl;
 import com.synopsys.integration.rest.exception.IntegrationRestException;
 
-public abstract class AbstractRuleViolationNotificationMessageExtractor<T extends AbstractRuleViolationNotificationContent> extends AbstractBlackDuckComponentConcernMessageExtractor<T> {
+public abstract class AbstractRuleViolationNotificationMessageExtractor<T extends AbstractRuleViolationNotificationContent>
+    extends AbstractBlackDuckComponentConcernMessageExtractor<T> {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final String UPGRADE_GUIDANCE_RESPONSE_DESCRIPTION = "upgrade guidance";
     private final ItemOperation itemOperation;
     private final BlackDuckPolicyComponentConcernCreator policyComponentConcernCreator;
     private final BlackDuckMessageBomComponentDetailsCreatorFactory detailsCreatorFactory;
@@ -66,23 +75,29 @@ public abstract class AbstractRuleViolationNotificationMessageExtractor<T extend
         return bomComponentDetails;
     }
 
-    private BomComponentDetails createBomComponentDetails(BlackDuckServicesFactory blackDuckServicesFactory, T notificationContent, ComponentVersionStatus componentVersionStatus) throws IntegrationException {
+    private BomComponentDetails createBomComponentDetails(BlackDuckServicesFactory blackDuckServicesFactory, T notificationContent, ComponentVersionStatus componentVersionStatus)
+        throws IntegrationException {
         BlackDuckApiClient blackDuckApiClient = blackDuckServicesFactory.getBlackDuckApiClient();
         BlackDuckMessageBomComponentDetailsCreator bomComponentDetailsCreator = detailsCreatorFactory.createBomComponentDetailsCreator(blackDuckServicesFactory);
 
         ComponentConcern policyConcern = policyComponentConcernCreator.fromPolicyInfo(notificationContent.getPolicyInfo(), itemOperation);
         try {
-            ProjectVersionComponentVersionView bomComponent = blackDuckApiClient.getResponse(new HttpUrl(componentVersionStatus.getBomComponent()), ProjectVersionComponentVersionView.class);
-            return bomComponentDetailsCreator.createBomComponentDetails(bomComponent, policyConcern, ComponentUpgradeGuidance.none(), List.of());
+            ProjectVersionComponentVersionView bomComponent = blackDuckApiClient.getResponse(
+                new HttpUrl(componentVersionStatus.getBomComponent()),
+                ProjectVersionComponentVersionView.class
+            );
+            ComponentUpgradeGuidance componentUpgradeGuidance = createComponentUpgradeGuidance(blackDuckApiClient, bomComponent);
+            return bomComponentDetailsCreator.createBomComponentDetails(bomComponent, policyConcern, componentUpgradeGuidance, List.of());
         } catch (IntegrationRestException e) {
             bomComponent404Handler.logIf404OrThrow(e, componentVersionStatus.getComponentName(), componentVersionStatus.getComponentVersionName());
+            ComponentUpgradeGuidance componentUpgradeGuidance = createComponentUpgradeGuidance(blackDuckApiClient, componentVersionStatus);
             return bomComponentDetailsCreator.createMissingBomComponentDetails(
                 componentVersionStatus.getComponentName(),
                 createComponentUrl(componentVersionStatus),
                 componentVersionStatus.getComponentVersionName(),
                 createComponentVersionUrl(componentVersionStatus),
                 List.of(policyConcern),
-                ComponentUpgradeGuidance.none(),
+                componentUpgradeGuidance,
                 List.of()
             );
         }
@@ -100,6 +115,43 @@ public abstract class AbstractRuleViolationNotificationMessageExtractor<T extend
             return BlackDuckMessageLinkUtils.createComponentQueryLink(status.getBomComponent(), status.getComponentName());
         }
         return status.getComponentVersion();
+    }
+
+    private ComponentUpgradeGuidance createComponentUpgradeGuidance(BlackDuckApiClient blackDuckApiClient, ProjectVersionComponentVersionView bomComponent) {
+        BlackDuckMessageComponentVersionUpgradeGuidanceService upgradeGuidanceService = new BlackDuckMessageComponentVersionUpgradeGuidanceService(blackDuckApiClient);
+        return safelyRetrieveItems(() -> upgradeGuidanceService.requestUpgradeGuidanceItems(bomComponent), UPGRADE_GUIDANCE_RESPONSE_DESCRIPTION);
+    }
+
+    private ComponentUpgradeGuidance createComponentUpgradeGuidance(BlackDuckApiClient blackDuckApiClient, ComponentVersionStatus componentVersionStatus) {
+        Optional<String> componentVersion = Optional.ofNullable(componentVersionStatus.getComponentVersion());
+        if (componentVersion.isEmpty()) {
+            return ComponentUpgradeGuidance.none();
+        }
+        Optional<ComponentVersionView> componentVersionView = retrieveComponentVersionView(blackDuckApiClient, componentVersion.get());
+        if (componentVersionView.isPresent()) {
+            BlackDuckMessageComponentVersionUpgradeGuidanceService upgradeGuidanceService = new BlackDuckMessageComponentVersionUpgradeGuidanceService(blackDuckApiClient);
+            return safelyRetrieveItems(() -> upgradeGuidanceService.requestUpgradeGuidanceItems(componentVersionView.get()), UPGRADE_GUIDANCE_RESPONSE_DESCRIPTION);
+        }
+        return ComponentUpgradeGuidance.none();
+    }
+
+    private Optional<ComponentVersionView> retrieveComponentVersionView(BlackDuckApiClient blackDuckApiClient, String componentVersionUrl) {
+        try {
+            ComponentVersionView componentVersionView = blackDuckApiClient.getResponse(new HttpUrl(componentVersionUrl), ComponentVersionView.class);
+            return Optional.of(componentVersionView);
+        } catch (IntegrationException e) {
+            logger.debug("Could not retrieve component version attributes");
+            return Optional.empty();
+        }
+    }
+
+    private ComponentUpgradeGuidance safelyRetrieveItems(ThrowingSupplier<ComponentUpgradeGuidance, IntegrationException> request, String responseDescription) {
+        try {
+            return request.get();
+        } catch (IntegrationException e) {
+            logger.debug("Could not retrieve {}", responseDescription, e);
+            return ComponentUpgradeGuidance.none();
+        }
     }
 
 }

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/VulnerabilityNotificationMessageExtractor.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/VulnerabilityNotificationMessageExtractor.java
@@ -10,12 +10,9 @@ package com.synopsys.integration.alert.provider.blackduck.processor.message;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.EnumUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -32,7 +29,6 @@ import com.synopsys.integration.alert.provider.blackduck.processor.message.servi
 import com.synopsys.integration.alert.provider.blackduck.processor.message.service.BomComponent404Handler;
 import com.synopsys.integration.alert.provider.blackduck.processor.model.VulnerabilityUniqueProjectNotificationContent;
 import com.synopsys.integration.blackduck.api.generated.enumeration.VulnerabilitySeverityType;
-import com.synopsys.integration.blackduck.api.generated.view.ComponentVersionView;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionComponentVersionView;
 import com.synopsys.integration.blackduck.api.manual.component.AffectedProjectVersion;
 import com.synopsys.integration.blackduck.api.manual.component.VulnerabilitySourceQualifiedId;
@@ -40,7 +36,6 @@ import com.synopsys.integration.blackduck.api.manual.enumeration.NotificationTyp
 import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
 import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
 import com.synopsys.integration.exception.IntegrationException;
-import com.synopsys.integration.function.ThrowingSupplier;
 import com.synopsys.integration.rest.HttpUrl;
 import com.synopsys.integration.rest.exception.IntegrationRestException;
 
@@ -52,10 +47,6 @@ public class VulnerabilityNotificationMessageExtractor extends AbstractBlackDuck
         VulnerabilitySeverityType.MEDIUM, ComponentConcernSeverity.MINOR_MEDIUM,
         VulnerabilitySeverityType.LOW, ComponentConcernSeverity.TRIVIAL_LOW
     );
-    private static final String UPGRADE_GUIDANCE_RESPONSE_DESCRIPTION = "upgrade guidance";
-
-    private final Logger logger = LoggerFactory.getLogger(getClass());
-
     private final BlackDuckMessageBomComponentDetailsCreatorFactory detailsCreatorFactory;
     private final BomComponent404Handler bomComponent404Handler;
 
@@ -72,9 +63,13 @@ public class VulnerabilityNotificationMessageExtractor extends AbstractBlackDuck
     }
 
     @Override
-    protected List<BomComponentDetails> createBomComponentDetails(VulnerabilityUniqueProjectNotificationContent notificationContent, BlackDuckServicesFactory blackDuckServicesFactory) throws IntegrationException {
+    protected List<BomComponentDetails> createBomComponentDetails(
+        VulnerabilityUniqueProjectNotificationContent notificationContent,
+        BlackDuckServicesFactory blackDuckServicesFactory
+    ) throws IntegrationException {
         BlackDuckApiClient blackDuckApiClient = blackDuckServicesFactory.getBlackDuckApiClient();
         BlackDuckMessageBomComponentDetailsCreator bomComponentDetailsCreator = detailsCreatorFactory.createBomComponentDetailsCreator(blackDuckServicesFactory);
+        BlackDuckMessageComponentVersionUpgradeGuidanceService upgradeGuidanceService = new BlackDuckMessageComponentVersionUpgradeGuidanceService(blackDuckApiClient);
 
         AffectedProjectVersion affectedProjectVersion = notificationContent.getAffectedProjectVersion();
         String bomComponentUrl = affectedProjectVersion.getBomComponent();
@@ -83,11 +78,11 @@ public class VulnerabilityNotificationMessageExtractor extends AbstractBlackDuck
         BomComponentDetails bomComponentDetails;
         try {
             ProjectVersionComponentVersionView bomComponent = blackDuckApiClient.getResponse(new HttpUrl(bomComponentUrl), ProjectVersionComponentVersionView.class);
-            ComponentUpgradeGuidance componentUpgradeGuidance = createComponentUpgradeGuidance(blackDuckApiClient, bomComponent);
+            ComponentUpgradeGuidance componentUpgradeGuidance = upgradeGuidanceService.requestUpgradeGuidanceItems(bomComponent);
             bomComponentDetails = bomComponentDetailsCreator.createBomComponentDetails(bomComponent, componentConcerns, componentUpgradeGuidance, List.of());
         } catch (IntegrationRestException e) {
             bomComponent404Handler.logIf404OrThrow(e, notificationContent.getComponentName(), notificationContent.getVersionName());
-            ComponentUpgradeGuidance componentUpgradeGuidance = createComponentUpgradeGuidance(blackDuckApiClient, notificationContent);
+            ComponentUpgradeGuidance componentUpgradeGuidance = upgradeGuidanceService.requestUpgradeGuidanceItems(notificationContent.getComponentVersion());
             bomComponentDetails = bomComponentDetailsCreator.createMissingBomComponentDetailsForVulnerability(
                 notificationContent.getComponentName(),
                 bomComponentUrl,
@@ -117,9 +112,9 @@ public class VulnerabilityNotificationMessageExtractor extends AbstractBlackDuck
 
     private List<ComponentConcern> createVulnerabilityConcerns(List<VulnerabilitySourceQualifiedId> vulnerabilities, ItemOperation itemOperation) {
         return vulnerabilities
-                   .stream()
-                   .map(vuln -> createVulnerabilityConcern(vuln, itemOperation))
-                   .collect(Collectors.toList());
+            .stream()
+            .map(vuln -> createVulnerabilityConcern(vuln, itemOperation))
+            .collect(Collectors.toList());
     }
 
     private ComponentConcern createVulnerabilityConcern(VulnerabilitySourceQualifiedId vulnerability, ItemOperation itemOperation) {
@@ -131,39 +126,6 @@ public class VulnerabilityNotificationMessageExtractor extends AbstractBlackDuck
             componentConcernSeverity = SEVERITY_TYPE_MAP.getOrDefault(vulnerabilitySeverity, ComponentConcernSeverity.UNSPECIFIED_UNKNOWN);
         }
         return ComponentConcern.vulnerability(itemOperation, vulnerability.getVulnerabilityId(), componentConcernSeverity, vulnerability.getVulnerability());
-    }
-
-    private ComponentUpgradeGuidance createComponentUpgradeGuidance(BlackDuckApiClient blackDuckApiClient, ProjectVersionComponentVersionView bomComponent) {
-        BlackDuckMessageComponentVersionUpgradeGuidanceService upgradeGuidanceService = new BlackDuckMessageComponentVersionUpgradeGuidanceService(blackDuckApiClient);
-        return safelyRetrieveItems(() -> upgradeGuidanceService.requestUpgradeGuidanceItems(bomComponent), UPGRADE_GUIDANCE_RESPONSE_DESCRIPTION);
-    }
-
-    private ComponentUpgradeGuidance createComponentUpgradeGuidance(BlackDuckApiClient blackDuckApiClient, VulnerabilityUniqueProjectNotificationContent notificationContent) {
-        Optional<ComponentVersionView> componentVersionView = retrieveComponentVersionView(blackDuckApiClient, notificationContent.getComponentVersion());
-        if (componentVersionView.isPresent()) {
-            BlackDuckMessageComponentVersionUpgradeGuidanceService upgradeGuidanceService = new BlackDuckMessageComponentVersionUpgradeGuidanceService(blackDuckApiClient);
-            return safelyRetrieveItems(() -> upgradeGuidanceService.requestUpgradeGuidanceItems(componentVersionView.get()), UPGRADE_GUIDANCE_RESPONSE_DESCRIPTION);
-        }
-        return ComponentUpgradeGuidance.none();
-    }
-
-    private Optional<ComponentVersionView> retrieveComponentVersionView(BlackDuckApiClient blackDuckApiClient, String componentVersionUrl) {
-        try {
-            ComponentVersionView componentVersionView = blackDuckApiClient.getResponse(new HttpUrl(componentVersionUrl), ComponentVersionView.class);
-            return Optional.of(componentVersionView);
-        } catch (IntegrationException e) {
-            logger.debug("Could not retrieve component version attributes");
-            return Optional.empty();
-        }
-    }
-
-    private ComponentUpgradeGuidance safelyRetrieveItems(ThrowingSupplier<ComponentUpgradeGuidance, IntegrationException> request, String responseDescription) {
-        try {
-            return request.get();
-        } catch (IntegrationException e) {
-            logger.debug("Could not retrieve {}", responseDescription, e);
-            return ComponentUpgradeGuidance.none();
-        }
     }
 
 }

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/BlackDuckMessageComponentVersionUpgradeGuidanceService.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/BlackDuckMessageComponentVersionUpgradeGuidanceService.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ComponentUpgradeGuidance;
@@ -29,59 +31,82 @@ import com.synopsys.integration.rest.HttpUrl;
 
 public class BlackDuckMessageComponentVersionUpgradeGuidanceService {
     private static final String LINK_UPGRADE_GUIDANCE = "upgrade-guidance";
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final BlackDuckApiClient blackDuckApiClient;
 
     public BlackDuckMessageComponentVersionUpgradeGuidanceService(BlackDuckApiClient blackDuckApiClient) {
         this.blackDuckApiClient = blackDuckApiClient;
     }
 
-    public ComponentUpgradeGuidance requestUpgradeGuidanceItems(ProjectVersionComponentVersionView bomComponent) throws IntegrationException {
+    public ComponentUpgradeGuidance requestUpgradeGuidanceItems(ProjectVersionComponentVersionView bomComponent) {
         // TODO determine what to do with multiple origins
-        Optional<UrlSingleResponse<ComponentVersionUpgradeGuidanceView>> upgradeGuidanceUrl = bomComponent.getOrigins()
-                                                                                                  .stream()
-                                                                                                  .findFirst()
-                                                                                                  .flatMap(origin -> Optional.ofNullable(origin.getMeta()))
-                                                                                                  .flatMap(this::extractFirstUpgradeGuidanceLinkSafely)
-                                                                                                  .map(url -> new UrlSingleResponse<>(url, ComponentVersionUpgradeGuidanceView.class))
-                                                                                                  .or(() -> extractComponentVersionUpgradeGuidanceUrl(bomComponent));
-        if (upgradeGuidanceUrl.isPresent()) {
-            ComponentVersionUpgradeGuidanceView upgradeGuidanceView = blackDuckApiClient.getResponse(upgradeGuidanceUrl.get());
-            return createUpgradeGuidanceItems(upgradeGuidanceView);
+        try {
+            Optional<UrlSingleResponse<ComponentVersionUpgradeGuidanceView>> upgradeGuidanceUrl = bomComponent.getOrigins()
+                .stream()
+                .findFirst()
+                .flatMap(origin -> Optional.ofNullable(origin.getMeta()))
+                .flatMap(this::extractFirstUpgradeGuidanceLinkSafely)
+                .map(url -> new UrlSingleResponse<>(url, ComponentVersionUpgradeGuidanceView.class))
+                .or(() -> extractComponentVersionUpgradeGuidanceUrl(bomComponent));
+            if (upgradeGuidanceUrl.isPresent()) {
+                ComponentVersionUpgradeGuidanceView upgradeGuidanceView = blackDuckApiClient.getResponse(upgradeGuidanceUrl.get());
+                return createUpgradeGuidanceItems(upgradeGuidanceView);
+            }
+        } catch (IntegrationException e) {
+            logger.debug("Could not retrieve upgrade guidance", e);
         }
         return ComponentUpgradeGuidance.none();
     }
 
-    public ComponentUpgradeGuidance requestUpgradeGuidanceItems(ComponentVersionView componentVersionView) throws IntegrationException {
-        Optional<UrlSingleResponse<ComponentVersionUpgradeGuidanceView>> upgradeGuidanceUrl = componentVersionView.metaUpgradeGuidanceLinkSafely();
-        if (upgradeGuidanceUrl.isPresent()) {
-            ComponentVersionUpgradeGuidanceView upgradeGuidanceView = blackDuckApiClient.getResponse(upgradeGuidanceUrl.get());
-            return createUpgradeGuidanceItems(upgradeGuidanceView);
+    public ComponentUpgradeGuidance requestUpgradeGuidanceItems(ComponentVersionView componentVersionView) {
+        try {
+            Optional<UrlSingleResponse<ComponentVersionUpgradeGuidanceView>> upgradeGuidanceUrl = componentVersionView.metaUpgradeGuidanceLinkSafely();
+            if (upgradeGuidanceUrl.isPresent()) {
+                ComponentVersionUpgradeGuidanceView upgradeGuidanceView = blackDuckApiClient.getResponse(upgradeGuidanceUrl.get());
+                return createUpgradeGuidanceItems(upgradeGuidanceView);
+            }
+        } catch (IntegrationException e) {
+            logger.debug("Could not retrieve upgrade guidance", e);
         }
         return ComponentUpgradeGuidance.none();
+    }
+
+    public ComponentUpgradeGuidance requestUpgradeGuidanceItems(String componentVersionUrl) {
+        ComponentVersionView componentVersionView;
+        try {
+            componentVersionView = blackDuckApiClient.getResponse(new HttpUrl(componentVersionUrl), ComponentVersionView.class);
+        } catch (IntegrationException e) {
+            logger.debug("Could not retrieve component version attributes");
+            return ComponentUpgradeGuidance.none();
+        }
+        return requestUpgradeGuidanceItems(componentVersionView);
     }
 
     private Optional<HttpUrl> extractFirstUpgradeGuidanceLinkSafely(ResourceMetadata meta) {
         return meta.getLinks()
-                   .stream()
-                   .filter(resourceLink -> resourceLink.getRel().equals(LINK_UPGRADE_GUIDANCE))
-                   .map(ResourceLink::getHref)
-                   .findFirst();
+            .stream()
+            .filter(resourceLink -> resourceLink.getRel().equals(LINK_UPGRADE_GUIDANCE))
+            .map(ResourceLink::getHref)
+            .findFirst();
     }
 
     private Optional<UrlSingleResponse<ComponentVersionUpgradeGuidanceView>> extractComponentVersionUpgradeGuidanceUrl(ProjectVersionComponentVersionView bomComponent) {
-        LinkSingleResponse<ComponentVersionUpgradeGuidanceView> upgradeGuidanceViewLinkName = new LinkSingleResponse<>(LINK_UPGRADE_GUIDANCE, ComponentVersionUpgradeGuidanceView.class);
+        LinkSingleResponse<ComponentVersionUpgradeGuidanceView> upgradeGuidanceViewLinkName = new LinkSingleResponse<>(
+            LINK_UPGRADE_GUIDANCE,
+            ComponentVersionUpgradeGuidanceView.class
+        );
         return bomComponent.metaSingleResponseSafely(upgradeGuidanceViewLinkName);
     }
 
     private ComponentUpgradeGuidance createUpgradeGuidanceItems(ComponentVersionUpgradeGuidanceView upgradeGuidanceView) {
         LinkableItem shortTermGuidance = Optional.ofNullable(upgradeGuidanceView.getShortTerm())
-                                             .map(CommonUpgradeGuidanceModel::fromShortTermGuidance)
-                                             .map(guidanceModel -> createUpgradeGuidanceItem(BlackDuckMessageLabels.LABEL_GUIDANCE_SHORT_TERM, guidanceModel))
-                                             .orElse(null);
+            .map(CommonUpgradeGuidanceModel::fromShortTermGuidance)
+            .map(guidanceModel -> createUpgradeGuidanceItem(BlackDuckMessageLabels.LABEL_GUIDANCE_SHORT_TERM, guidanceModel))
+            .orElse(null);
         LinkableItem longTermGuidance = Optional.ofNullable(upgradeGuidanceView.getLongTerm())
-                                            .map(CommonUpgradeGuidanceModel::fromLongTermGuidance)
-                                            .map(guidanceModel -> createUpgradeGuidanceItem(BlackDuckMessageLabels.LABEL_GUIDANCE_LONG_TERM, guidanceModel))
-                                            .orElse(null);
+            .map(CommonUpgradeGuidanceModel::fromLongTermGuidance)
+            .map(guidanceModel -> createUpgradeGuidanceItem(BlackDuckMessageLabels.LABEL_GUIDANCE_LONG_TERM, guidanceModel))
+            .orElse(null);
         return new ComponentUpgradeGuidance(shortTermGuidance, longTermGuidance);
     }
 

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/BlackDuckMessageComponentVersionUpgradeGuidanceService.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/processor/message/service/BlackDuckMessageComponentVersionUpgradeGuidanceService.java
@@ -76,7 +76,7 @@ public class BlackDuckMessageComponentVersionUpgradeGuidanceService {
         try {
             componentVersionView = blackDuckApiClient.getResponse(new HttpUrl(componentVersionUrl), ComponentVersionView.class);
         } catch (IntegrationException e) {
-            logger.debug("Could not retrieve component version attributes");
+            logger.debug("Could not retrieve component version attributes", e);
             return ComponentUpgradeGuidance.none();
         }
         return requestUpgradeGuidanceItems(componentVersionView);

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/RuleViolationClearedNotificationMessageExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/RuleViolationClearedNotificationMessageExtractorTest.java
@@ -38,6 +38,7 @@ import com.synopsys.integration.blackduck.api.generated.view.PolicyRuleView;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionComponentVersionView;
 import com.synopsys.integration.blackduck.api.manual.component.ComponentVersionStatus;
 import com.synopsys.integration.blackduck.api.manual.component.PolicyInfo;
+import com.synopsys.integration.blackduck.api.manual.temporary.component.VersionBomOriginView;
 import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
 import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
 import com.synopsys.integration.exception.IntegrationException;
@@ -71,12 +72,22 @@ class RuleViolationClearedNotificationMessageExtractorTest {
         BlackDuckPolicySeverityConverter blackDuckPolicySeverityConverter = new BlackDuckPolicySeverityConverter();
         BlackDuckPolicyComponentConcernCreator blackDuckPolicyComponentConcernCreator = new BlackDuckPolicyComponentConcernCreator(blackDuckPolicySeverityConverter);
         BlackDuckComponentVulnerabilityDetailsCreator vulnerabilityDetailsCreator = new BlackDuckComponentVulnerabilityDetailsCreator();
-        BlackDuckComponentPolicyDetailsCreatorFactory blackDuckComponentPolicyDetailsCreatorFactory = new BlackDuckComponentPolicyDetailsCreatorFactory(blackDuckPolicySeverityConverter);
-        BlackDuckMessageBomComponentDetailsCreatorFactory detailsCreatorFactory = new BlackDuckMessageBomComponentDetailsCreatorFactory(vulnerabilityDetailsCreator, blackDuckComponentPolicyDetailsCreatorFactory);
+        BlackDuckComponentPolicyDetailsCreatorFactory blackDuckComponentPolicyDetailsCreatorFactory = new BlackDuckComponentPolicyDetailsCreatorFactory(
+            blackDuckPolicySeverityConverter);
+        BlackDuckMessageBomComponentDetailsCreatorFactory detailsCreatorFactory = new BlackDuckMessageBomComponentDetailsCreatorFactory(
+            vulnerabilityDetailsCreator,
+            blackDuckComponentPolicyDetailsCreatorFactory
+        );
 
         BomComponent404Handler bomComponent404Handler = new BomComponent404Handler();
 
-        extractor = new RuleViolationClearedNotificationMessageExtractor(providerKey, servicesFactoryCache, blackDuckPolicyComponentConcernCreator, detailsCreatorFactory, bomComponent404Handler);
+        extractor = new RuleViolationClearedNotificationMessageExtractor(
+            providerKey,
+            servicesFactoryCache,
+            blackDuckPolicyComponentConcernCreator,
+            detailsCreatorFactory,
+            bomComponent404Handler
+        );
     }
 
     @Test
@@ -101,8 +112,13 @@ class RuleViolationClearedNotificationMessageExtractorTest {
         policyRuleView.setCategory(PolicyRuleCategoryType.UNCATEGORIZED);
         Mockito.when(blackDuckApiClient.getResponse(Mockito.any(), Mockito.eq(PolicyRuleView.class))).thenReturn(policyRuleView);
 
-        RuleViolationClearedUniquePolicyNotificationContent notificationContent = new RuleViolationClearedUniquePolicyNotificationContent(PROJECT, PROJECT_VERSION, PROJECT_VERSION_URL, COMPONENT_VERSIONS_CLEARED,
-            List.of(componentVersionStatus), policyInfo);
+        RuleViolationClearedUniquePolicyNotificationContent notificationContent = new RuleViolationClearedUniquePolicyNotificationContent(PROJECT,
+            PROJECT_VERSION,
+            PROJECT_VERSION_URL,
+            COMPONENT_VERSIONS_CLEARED,
+            List.of(componentVersionStatus),
+            policyInfo
+        );
 
         List<BomComponentDetails> bomComponentDetailsList = extractor.createBomComponentDetails(notificationContent, blackDuckServicesFactory);
 
@@ -144,7 +160,8 @@ class RuleViolationClearedNotificationMessageExtractorTest {
             ))
             .when(blackDuckApiClient).getResponse(Mockito.any(), Mockito.any());
 
-        RuleViolationClearedUniquePolicyNotificationContent notificationContent = new RuleViolationClearedUniquePolicyNotificationContent(PROJECT,
+        RuleViolationClearedUniquePolicyNotificationContent notificationContent = new RuleViolationClearedUniquePolicyNotificationContent(
+            PROJECT,
             PROJECT_VERSION,
             PROJECT_VERSION_URL,
             COMPONENT_VERSIONS_CLEARED,
@@ -208,6 +225,9 @@ class RuleViolationClearedNotificationMessageExtractorTest {
         meta.setHref(new HttpUrl("https://someUrl"));
         meta.setLinks(List.of(resourceLink));
         projectVersionComponentVersionView.setMeta(meta);
+
+        VersionBomOriginView versionBomOriginView = new VersionBomOriginView();
+        projectVersionComponentVersionView.setOrigins(List.of(versionBomOriginView));
 
         return projectVersionComponentVersionView;
     }

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/RuleViolationNotificationMessageExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/RuleViolationNotificationMessageExtractorTest.java
@@ -38,6 +38,7 @@ import com.synopsys.integration.blackduck.api.generated.view.PolicyRuleView;
 import com.synopsys.integration.blackduck.api.generated.view.ProjectVersionComponentVersionView;
 import com.synopsys.integration.blackduck.api.manual.component.ComponentVersionStatus;
 import com.synopsys.integration.blackduck.api.manual.component.PolicyInfo;
+import com.synopsys.integration.blackduck.api.manual.temporary.component.VersionBomOriginView;
 import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
 import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
 import com.synopsys.integration.exception.IntegrationException;
@@ -71,12 +72,22 @@ class RuleViolationNotificationMessageExtractorTest {
         BlackDuckPolicySeverityConverter blackDuckPolicySeverityConverter = new BlackDuckPolicySeverityConverter();
         BlackDuckPolicyComponentConcernCreator blackDuckPolicyComponentConcernCreator = new BlackDuckPolicyComponentConcernCreator(blackDuckPolicySeverityConverter);
         BlackDuckComponentVulnerabilityDetailsCreator vulnerabilityDetailsCreator = new BlackDuckComponentVulnerabilityDetailsCreator();
-        BlackDuckComponentPolicyDetailsCreatorFactory blackDuckComponentPolicyDetailsCreatorFactory = new BlackDuckComponentPolicyDetailsCreatorFactory(blackDuckPolicySeverityConverter);
-        BlackDuckMessageBomComponentDetailsCreatorFactory detailsCreatorFactory = new BlackDuckMessageBomComponentDetailsCreatorFactory(vulnerabilityDetailsCreator, blackDuckComponentPolicyDetailsCreatorFactory);
+        BlackDuckComponentPolicyDetailsCreatorFactory blackDuckComponentPolicyDetailsCreatorFactory = new BlackDuckComponentPolicyDetailsCreatorFactory(
+            blackDuckPolicySeverityConverter);
+        BlackDuckMessageBomComponentDetailsCreatorFactory detailsCreatorFactory = new BlackDuckMessageBomComponentDetailsCreatorFactory(
+            vulnerabilityDetailsCreator,
+            blackDuckComponentPolicyDetailsCreatorFactory
+        );
 
         BomComponent404Handler bomComponent404Handler = new BomComponent404Handler();
 
-        extractor = new RuleViolationNotificationMessageExtractor(providerKey, servicesFactoryCache, blackDuckPolicyComponentConcernCreator, detailsCreatorFactory, bomComponent404Handler);
+        extractor = new RuleViolationNotificationMessageExtractor(
+            providerKey,
+            servicesFactoryCache,
+            blackDuckPolicyComponentConcernCreator,
+            detailsCreatorFactory,
+            bomComponent404Handler
+        );
     }
 
     @Test
@@ -101,8 +112,13 @@ class RuleViolationNotificationMessageExtractorTest {
         policyRuleView.setCategory(PolicyRuleCategoryType.UNCATEGORIZED);
         Mockito.when(blackDuckApiClient.getResponse(Mockito.any(), Mockito.eq(PolicyRuleView.class))).thenReturn(policyRuleView);
 
-        RuleViolationUniquePolicyNotificationContent notificationContent = new RuleViolationUniquePolicyNotificationContent(PROJECT, PROJECT_VERSION, PROJECT_VERSION_URL, COMPONENT_VERSIONS_IN_VIOLATION,
-            List.of(componentVersionStatus), policyInfo);
+        RuleViolationUniquePolicyNotificationContent notificationContent = new RuleViolationUniquePolicyNotificationContent(PROJECT,
+            PROJECT_VERSION,
+            PROJECT_VERSION_URL,
+            COMPONENT_VERSIONS_IN_VIOLATION,
+            List.of(componentVersionStatus),
+            policyInfo
+        );
 
         List<BomComponentDetails> bomComponentDetailsList = extractor.createBomComponentDetails(notificationContent, blackDuckServicesFactory);
 
@@ -144,7 +160,8 @@ class RuleViolationNotificationMessageExtractorTest {
             ))
             .when(blackDuckApiClient).getResponse(Mockito.any(), Mockito.any());
 
-        RuleViolationUniquePolicyNotificationContent notificationContent = new RuleViolationUniquePolicyNotificationContent(PROJECT,
+        RuleViolationUniquePolicyNotificationContent notificationContent = new RuleViolationUniquePolicyNotificationContent(
+            PROJECT,
             PROJECT_VERSION,
             PROJECT_VERSION_URL,
             COMPONENT_VERSIONS_IN_VIOLATION,
@@ -208,6 +225,9 @@ class RuleViolationNotificationMessageExtractorTest {
         meta.setHref(new HttpUrl("https://someUrl"));
         meta.setLinks(List.of(resourceLink));
         projectVersionComponentVersionView.setMeta(meta);
+
+        VersionBomOriginView versionBomOriginView = new VersionBomOriginView();
+        projectVersionComponentVersionView.setOrigins(List.of(versionBomOriginView));
 
         return projectVersionComponentVersionView;
     }

--- a/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/RuleViolationNotificationMessageExtractorTest.java
+++ b/provider-blackduck/src/test/java/com/synopsys/integration/alert/provider/blackduck/processor/message/RuleViolationNotificationMessageExtractorTest.java
@@ -112,7 +112,8 @@ class RuleViolationNotificationMessageExtractorTest {
         policyRuleView.setCategory(PolicyRuleCategoryType.UNCATEGORIZED);
         Mockito.when(blackDuckApiClient.getResponse(Mockito.any(), Mockito.eq(PolicyRuleView.class))).thenReturn(policyRuleView);
 
-        RuleViolationUniquePolicyNotificationContent notificationContent = new RuleViolationUniquePolicyNotificationContent(PROJECT,
+        RuleViolationUniquePolicyNotificationContent notificationContent = new RuleViolationUniquePolicyNotificationContent(
+            PROJECT,
             PROJECT_VERSION,
             PROJECT_VERSION_URL,
             COMPONENT_VERSIONS_IN_VIOLATION,

--- a/test-common-blackduck/src/main/java/com/synopsys/integration/alert/test/common/blackduck/BlackDuckResponseTestUtility.java
+++ b/test-common-blackduck/src/main/java/com/synopsys/integration/alert/test/common/blackduck/BlackDuckResponseTestUtility.java
@@ -21,6 +21,7 @@ import com.synopsys.integration.blackduck.api.manual.component.ComponentVersionS
 import com.synopsys.integration.blackduck.api.manual.component.PolicyInfo;
 import com.synopsys.integration.blackduck.api.manual.component.RuleViolationNotificationContent;
 import com.synopsys.integration.blackduck.api.manual.enumeration.NotificationType;
+import com.synopsys.integration.blackduck.api.manual.temporary.component.VersionBomOriginView;
 import com.synopsys.integration.blackduck.api.manual.view.RuleViolationNotificationView;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.rest.HttpUrl;
@@ -47,6 +48,9 @@ public class BlackDuckResponseTestUtility {
         meta.setHref(new HttpUrl("https://meta-url"));
         meta.setLinks(List.of(resourceLink));
         projectVersionComponentVersionView.setMeta(meta);
+
+        VersionBomOriginView versionBomOriginView = new VersionBomOriginView();
+        projectVersionComponentVersionView.setOrigins(List.of(versionBomOriginView));
 
         return projectVersionComponentVersionView;
     }


### PR DESCRIPTION
In previous versions of Alert we would not provide upgrade guidance on component policies if it was available. We now pass along the upgrade guidance information and will post it if it's available. 

As part of this change we will also remove duplication in the private methods of the extractors by building the services directly.