### PR TITLE
IALERT-3269: Handle data staying in CentOS directory

### DIFF
--- a/deployment/docker-swarm/docker-compose.local-overrides.yml
+++ b/deployment/docker-swarm/docker-compose.local-overrides.yml
@@ -10,8 +10,6 @@ version: '3.6'
 #    # uncomment the variables that end in _FILE if secrets are being used.
 #      - POSTGRES_USER_FILE=/run/secrets/ALERT_DB_USERNAME
 #      - POSTGRES_PASSWORD_FILE=/run/secrets/ALERT_DB_PASSWORD
-#    # Set MIGRATE_POSTGRES to false if Postgres migration should not be run
-#      - MIGRATE_POSTGRES=
 #    # uncomment this section if the custom user and password are stored in docker secrets.
 #    secrets:
 #      - ALERT_DB_USERNAME

--- a/deployment/helm/synopsys-alert/README.md
+++ b/deployment/helm/synopsys-alert/README.md
@@ -199,7 +199,6 @@ This contains a table briefly describing each parameter in the values.yaml file.
 | `postgres.databaseName`                  | Postgres database name where Alert data will be stored                                 | `alertdb`                                                               |
 | `postgres.adminUserName`                 | Postgres database admin user                                                           | `postgres`                                                              |
 | `postgres.adminPassword`                 | Postgres database password for the admin user                                          | `""`                                                                    |
-| `postgres.postgresMigration`             | Flag to control launching Postgres migration                                           | `"false"`                                                               |
 | `postgres.dbCredential.secretName`       | The name of the secret that contains the database user's username & password           | `""`                                                                    |
 | `postgres.dbCredential.usernameKey`      | The key containing the database user's username                                        | `"ALERT_DB_USERNAME"`                                                   |
 | `postgres.dbCredential.passwordKey`      | The key containing the database user's password                                        | `"ALERT_DB_PASSWORD"`                                                   |

--- a/deployment/helm/synopsys-alert/templates/postgres.yaml
+++ b/deployment/helm/synopsys-alert/templates/postgres.yaml
@@ -83,14 +83,6 @@ spec:
           value: "300"
         - name: POSTGRES_SHARED_BUFFERS
           value: 1024MB
-        - name: MIGRATE_POSTGRES
-          value: "{{ if .Values.postgres.postgresMigration }}{{ .Values.postgres.postgresMigration }}{{ else }}true{{ end }}"
-        - name: PGDATA
-        {{- if .Values.postgres.postgresDataDirectory }}
-          value: {{ .Values.postgres.postgresDataDirectory }}
-        {{- else }}
-          value: "/var/lib/postgresql/data"
-        {{- end}}
         {{- if .Values.postgres.dbCredential.secretName }}
         - name: POSTGRES_USER
           valueFrom:

--- a/deployment/helm/synopsys-alert/values.yaml
+++ b/deployment/helm/synopsys-alert/values.yaml
@@ -6,7 +6,7 @@ registry: "docker.io/blackducksoftware"
 
 # Storage configurations
 enablePersistentStorage: true
-storageClass: # it will apply to all PVC's storage class but it can be override at container level
+storageClass: # Will apply to all PVC's storage class, but it can be overridden at container level
 # enableStandalone deploys a cfssl instance with Alert
 enableStandalone: true
 
@@ -57,8 +57,6 @@ postgres:
     sslRootCertKey: "ALERT_DB_SSL_ROOT_CERT_PATH"
   host: "" # required only for external postgres, for postgres as a container, it will point to <name>-postgres
   port: 5432
-  postgresMigration:
-  postgresDataDirectory: # If upgrading from the Centos image used prior to Alert 6.12.0, set this value to "/var/lib/postgresql/data/userdata"
   # NOTE: do not change usernames when using postgres as a container; only configure if using external database
   userUserName: sa
   userPassword: blackduck

--- a/docker/blackduck-alert-db/alertdb-docker-entrypoint.sh
+++ b/docker/blackduck-alert-db/alertdb-docker-entrypoint.sh
@@ -76,13 +76,8 @@ function _set_values_in_environment() {
 
 function _run_DB_migration() {
   _logStart
-  if [ "false" = "${MIGRATE_POSTGRES}" ]; then
-    _logIt "Environment variable MIGRATE_POSTGRES is set to false. NOT running DB migration"
-  else
-    _logIt "Environment variable MIGRATE_POSTGRES is not set to false, launching migration script: ${alertDBMigrationScript}"
-    "${alertDBMigrationScript}" "${osUser}"
-    _checkStatus $? "Running: ${alertDBMigrationScript}"
-  fi
+  "${alertDBMigrationScript}" "${osUser}"
+  _checkStatus $? "Running: ${alertDBMigrationScript}"
   _logEnd
 }
 
@@ -114,7 +109,6 @@ _validate_environment
 _set_values_in_environment POSTGRES_USER "${dockerSecretDir}/ALERT_DB_USERNAME" "${POSTGRES_USER_FILE}" "${POSTGRES_USER}" "sa"
 _set_values_in_environment POSTGRES_PASSWORD "${dockerSecretDir}/ALERT_DB_PASSWORD" "${POSTGRES_PASSWORD_FILE}" "${POSTGRES_PASSWORD}" "blackduck"
 _set_values_in_environment POSTGRES_DB "${dockerSecretDir}/POSTGRES_DB" "" "${POSTGRES_DB}" "alertdb"
-_set_values_in_environment MIGRATE_POSTGRES "${dockerSecretDir}/MIGRATE_POSTGRES" "" "${MIGRATE_POSTGRES}" "true"
 
 _run_DB_migration
 


### PR DESCRIPTION
Because the CentOS image stores the Postgres DB in a different directory, this had to be handled in the migration and was done by adding the postgres.postgresDataDirectory value in values.yaml. This would allow the migration to proceed, but it kept the data within the CentOS directory. Going forward this would require this value to be set for any future upgrades.

This PR makes the following changes
* Remove postgres.postgresDataDirectory and it's usage from the orchestration
* Edit alertdb-pg-migrate.sh so that if the Postgres DB is found in the CentOS directory, it would move it to the Alpine directory.
* Remove the MIGRATE_POSTGRES and postgresMigration from the orchestration and scripts. The migration script will always run, as it determines if it needs to launch the PG migration or not. This was done as this value was causing too much confusion for installers of Alert.