### PR TITLE
IALERT-3271: Improve error status codes on role failures

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/accessor/RoleAccessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/descriptor/accessor/RoleAccessor.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.Set;
 
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
+import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.common.exception.AlertForbiddenOperationException;
 import com.synopsys.integration.alert.common.persistence.model.PermissionMatrixModel;
 import com.synopsys.integration.alert.common.persistence.model.UserRoleModel;
@@ -24,7 +25,7 @@ public interface RoleAccessor {
 
     UserRoleModel createRoleWithPermissions(String roleName, PermissionMatrixModel permissionMatrix);
 
-    void updateRoleName(Long roleId, String roleName) throws AlertForbiddenOperationException;
+    void updateRoleName(Long roleId, String roleName) throws AlertException;
 
     PermissionMatrixModel updatePermissionsForRole(String roleName, PermissionMatrixModel permissionMatrix) throws AlertConfigurationException;
 

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/security/authorization/AuthorizationManager.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/security/authorization/AuthorizationManager.java
@@ -26,6 +26,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
+import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.common.descriptor.accessor.RoleAccessor;
 import com.synopsys.integration.alert.common.enumeration.AccessOperation;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
@@ -157,7 +158,7 @@ public class AuthorizationManager {
             .anyMatch(name -> permissionCache.containsKey(name) && permissionCache.get(name).hasPermissions(permissionKey, operations));
     }
 
-    public void updateRoleName(Long roleId, String roleName) throws AlertForbiddenOperationException {
+    public void updateRoleName(Long roleId, String roleName) throws AlertException {
         roleAccessor.updateRoleName(roleId, roleName);
         loadPermissionsIntoCache();
     }

--- a/component/src/main/java/com/synopsys/integration/alert/component/users/web/role/RoleActions.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/users/web/role/RoleActions.java
@@ -73,8 +73,8 @@ public class RoleActions extends AbstractResourceActions<RolePermissionModel, Us
     @Override
     protected ActionResponse<RolePermissionModel> deleteWithoutChecks(Long id) {
         Optional<UserRoleModel> existingRole = roleAccessor.getRoles(List.of(id))
-                                                   .stream()
-                                                   .findFirst();
+            .stream()
+            .findFirst();
         if (existingRole.isPresent()) {
             String roleName = existingRole.get().getName();
             try {
@@ -119,8 +119,8 @@ public class RoleActions extends AbstractResourceActions<RolePermissionModel, Us
         try {
             String roleName = resource.getRoleName();
             Optional<UserRoleModel> existingRole = roleAccessor.getRoles(List.of(id))
-                                                       .stream()
-                                                       .findFirst();
+                .stream()
+                .findFirst();
             if (existingRole.isPresent()) {
                 logger.debug(actionMessageCreator.updateStartMessage("role", existingRole.get().getName()));
                 if (!existingRole.get().getName().equals(roleName)) {
@@ -136,7 +136,7 @@ public class RoleActions extends AbstractResourceActions<RolePermissionModel, Us
             return new ActionResponse<>(HttpStatus.NOT_FOUND, "Role not found.");
         } catch (AlertException ex) {
             logger.error(actionMessageCreator.updateErrorMessage("role", resource.getRoleName()));
-            return new ActionResponse<>(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+            return new ActionResponse<>(HttpStatus.BAD_REQUEST, ex.getMessage());
         }
     }
 
@@ -155,9 +155,9 @@ public class RoleActions extends AbstractResourceActions<RolePermissionModel, Us
     @Override
     protected Optional<RolePermissionModel> findExisting(Long id) {
         return roleAccessor.getRoles(List.of(id))
-                   .stream()
-                   .findFirst()
-                   .map(this::convertDatabaseModelToRestModel);
+            .stream()
+            .findFirst()
+            .map(this::convertDatabaseModelToRestModel);
     }
 
     private Set<PermissionModel> convertPermissionMatrixModel(PermissionMatrixModel permissionMatrixModel) {
@@ -165,7 +165,8 @@ public class RoleActions extends AbstractResourceActions<RolePermissionModel, Us
         for (Map.Entry<PermissionKey, Integer> matrixRow : permissionMatrixModel.getPermissions().entrySet()) {
             Integer accessOperations = matrixRow.getValue();
             PermissionKey permissionKey = matrixRow.getKey();
-            String descriptorDisplayName = descriptorMap.getDescriptorKey(permissionKey.getDescriptorName()).map(DescriptorKey::getDisplayName).orElse(permissionKey.getDescriptorName());
+            String descriptorDisplayName = descriptorMap.getDescriptorKey(permissionKey.getDescriptorName()).map(DescriptorKey::getDisplayName)
+                .orElse(permissionKey.getDescriptorName());
 
             PermissionModel permissionModel = new PermissionModel(
                 descriptorDisplayName,
@@ -214,8 +215,14 @@ public class RoleActions extends AbstractResourceActions<RolePermissionModel, Us
         for (PermissionModel permissionModel : permissionModels) {
             PermissionKey pair = new PermissionKey(permissionModel.getContext(), permissionModel.getDescriptorName());
             if (descriptorContexts.contains(pair)) {
-                return Optional.of(AlertFieldStatus.error(RoleActions.FIELD_KEY_ROLE_NAME,
-                    String.format("Can't save duplicate permissions for a role. Duplicate permission for '%s' with context '%s' found.", pair.getDescriptorName(), pair.getContext())));
+                return Optional.of(AlertFieldStatus.error(
+                    RoleActions.FIELD_KEY_ROLE_NAME,
+                    String.format(
+                        "Can't save duplicate permissions for a role. Duplicate permission for '%s' with context '%s' found.",
+                        pair.getDescriptorName(),
+                        pair.getContext()
+                    )
+                ));
             } else {
                 descriptorContexts.add(pair);
             }

--- a/src/test/java/com/synopsys/integration/alert/component/users/web/role/RoleActionsTest.java
+++ b/src/test/java/com/synopsys/integration/alert/component/users/web/role/RoleActionsTest.java
@@ -286,7 +286,8 @@ class RoleActionsTest {
     }
 
     @Test
-    void updateErrorTest() throws Exception {
+    void
+    updateErrorTest() throws Exception {
         String newRoleName = "newRoleName";
         Long longId = 1L;
         PermissionModel permissionModel = createPermissionModel();
@@ -304,7 +305,7 @@ class RoleActionsTest {
 
         assertTrue(rolePermissionModelActionResponse.isError());
         assertFalse(rolePermissionModelActionResponse.hasContent());
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, rolePermissionModelActionResponse.getHttpStatus());
+        assertEquals(HttpStatus.BAD_REQUEST, rolePermissionModelActionResponse.getHttpStatus());
     }
 
     @Test


### PR DESCRIPTION
Failures in the old roles table would default to throwing a 500 internal server error. I've changed the exception thrown and will now instead return a BAD_REQUEST.

Further improvements to this functionality should likely be done when we refactor this endpoint.