### PR TITLE
IALERT-3241: Update alpine base container image to 3.17

### DIFF
--- a/docker/blackduck-alert/Dockerfile
+++ b/docker/blackduck-alert/Dockerfile
@@ -1,5 +1,5 @@
 FROM blackducksoftware/hub-docker-common:1.0.6 as docker-common
-FROM alpine:3.16
+FROM alpine:3.17
 
 ARG VERSION
 


### PR DESCRIPTION
Alpine 3.17.0 is now available and resolves an existing vulnerability in curl that exists. This should resolve existing security issues when scanning this version of Alert.
