### PR TITLE
IALERT-3155: Integrate job execution measurements into processing code.

### DIFF
--- a/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/event/IssueTrackerCommentEventHandler.java
+++ b/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/event/IssueTrackerCommentEventHandler.java
@@ -12,6 +12,7 @@ import java.io.Serializable;
 import com.synopsys.integration.alert.api.channel.issue.IssueTrackerResponsePostProcessor;
 import com.synopsys.integration.alert.api.channel.issue.model.IssueTrackerResponse;
 import com.synopsys.integration.alert.api.distribution.JobSubTaskEventHandler;
+import com.synopsys.integration.alert.api.distribution.execution.JobStage;
 import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.api.event.distribution.JobSubTaskEvent;
 import com.synopsys.integration.alert.common.persistence.accessor.JobSubTaskAccessor;
@@ -24,7 +25,7 @@ public abstract class IssueTrackerCommentEventHandler<T extends JobSubTaskEvent>
         JobSubTaskAccessor jobSubTaskAccessor,
         IssueTrackerResponsePostProcessor responsePostProcessor
     ) {
-        super(eventManager, jobSubTaskAccessor);
+        super(eventManager, jobSubTaskAccessor, JobStage.ISSUE_COMMENTING);
         this.responsePostProcessor = responsePostProcessor;
     }
 

--- a/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/event/IssueTrackerCreateIssueEvent.java
+++ b/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/event/IssueTrackerCreateIssueEvent.java
@@ -25,12 +25,12 @@ public class IssueTrackerCreateIssueEvent extends JobSubTaskEvent {
 
     public IssueTrackerCreateIssueEvent(
         String destination,
-        UUID parentEventId,
+        UUID jobExecutionId,
         UUID jobId,
         Set<Long> notificationIds,
         IssueCreationModel creationModel
     ) {
-        super(destination, parentEventId, jobId, notificationIds);
+        super(destination, jobExecutionId, jobId, notificationIds);
         this.creationModel = creationModel;
     }
 

--- a/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/event/IssueTrackerCreateIssueEventHandler.java
+++ b/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/event/IssueTrackerCreateIssueEventHandler.java
@@ -12,6 +12,7 @@ import java.io.Serializable;
 import com.synopsys.integration.alert.api.channel.issue.IssueTrackerResponsePostProcessor;
 import com.synopsys.integration.alert.api.channel.issue.model.IssueTrackerResponse;
 import com.synopsys.integration.alert.api.distribution.JobSubTaskEventHandler;
+import com.synopsys.integration.alert.api.distribution.execution.JobStage;
 import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.common.persistence.accessor.JobSubTaskAccessor;
 
@@ -23,7 +24,7 @@ public abstract class IssueTrackerCreateIssueEventHandler extends JobSubTaskEven
         JobSubTaskAccessor jobSubTaskAccessor,
         IssueTrackerResponsePostProcessor responsePostProcessor
     ) {
-        super(eventManager, jobSubTaskAccessor);
+        super(eventManager, jobSubTaskAccessor, JobStage.ISSUE_CREATION);
         this.responsePostProcessor = responsePostProcessor;
     }
 

--- a/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/event/IssueTrackerTransitionEventHandler.java
+++ b/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/event/IssueTrackerTransitionEventHandler.java
@@ -12,6 +12,7 @@ import java.io.Serializable;
 import com.synopsys.integration.alert.api.channel.issue.IssueTrackerResponsePostProcessor;
 import com.synopsys.integration.alert.api.channel.issue.model.IssueTrackerResponse;
 import com.synopsys.integration.alert.api.distribution.JobSubTaskEventHandler;
+import com.synopsys.integration.alert.api.distribution.execution.JobStage;
 import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.api.event.distribution.JobSubTaskEvent;
 import com.synopsys.integration.alert.common.persistence.accessor.JobSubTaskAccessor;
@@ -25,7 +26,7 @@ public abstract class IssueTrackerTransitionEventHandler<T extends JobSubTaskEve
         JobSubTaskAccessor jobSubTaskAccessor,
         IssueTrackerResponsePostProcessor responsePostProcessor
     ) {
-        super(eventManager, jobSubTaskAccessor);
+        super(eventManager, jobSubTaskAccessor, JobStage.ISSUE_RESOLVING);
         this.responsePostProcessor = responsePostProcessor;
     }
 

--- a/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/event/IssueTrackerCommentEventTest.java
+++ b/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/event/IssueTrackerCommentEventTest.java
@@ -23,7 +23,7 @@ class IssueTrackerCommentEventTest {
         IssueTrackerCommentEvent<String> event = new IssueTrackerCommentEvent<>(destination, parentEventId, jobId, notificationIds, model);
 
         assertNotNull(event.getEventId());
-        assertEquals(parentEventId, event.getParentEventId());
+        assertEquals(parentEventId, event.getJobExecutionId());
         assertEquals(destination, event.getDestination());
         assertEquals(jobId, event.getJobId());
         assertEquals(notificationIds, event.getNotificationIds());

--- a/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/event/IssueTrackerCreateIssueEventTest.java
+++ b/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/event/IssueTrackerCreateIssueEventTest.java
@@ -25,7 +25,7 @@ class IssueTrackerCreateIssueEventTest {
         IssueTrackerCreateIssueEvent event = new IssueTrackerCreateIssueEvent(destination, parentEventId, jobId, notificationIds, model);
 
         assertNotNull(event.getEventId());
-        assertEquals(parentEventId, event.getParentEventId());
+        assertEquals(parentEventId, event.getJobExecutionId());
         assertEquals(destination, event.getDestination());
         assertEquals(jobId, event.getJobId());
         assertEquals(notificationIds, event.getNotificationIds());

--- a/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/event/IssueTrackerTransitionIssueEventTest.java
+++ b/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/event/IssueTrackerTransitionIssueEventTest.java
@@ -25,7 +25,7 @@ class IssueTrackerTransitionIssueEventTest {
         IssueTrackerTransitionIssueEvent<String> event = new IssueTrackerTransitionIssueEvent<>(destination, parentEventId, jobId, notificationIds, model);
 
         assertNotNull(event.getEventId());
-        assertEquals(parentEventId, event.getParentEventId());
+        assertEquals(parentEventId, event.getJobExecutionId());
         assertEquals(destination, event.getDestination());
         assertEquals(jobId, event.getJobId());
         assertEquals(notificationIds, event.getNotificationIds());

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditEvent.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditEvent.java
@@ -9,23 +9,23 @@ import com.synopsys.integration.alert.common.util.DateUtils;
 
 public class AuditEvent extends AlertEvent {
     private static final long serialVersionUID = 8821840075948290969L;
-    private final UUID jobId;
+    private final UUID jobExecutionId;
     private final Set<Long> notificationIds;
     private final OffsetDateTime createdTimestamp;
 
-    public AuditEvent(String destination, UUID jobId, Set<Long> notificationIds) {
-        this(destination, jobId, notificationIds, DateUtils.createCurrentDateTimestamp());
+    public AuditEvent(String destination, UUID jobExecutionId, Set<Long> notificationIds) {
+        this(destination, jobExecutionId, notificationIds, DateUtils.createCurrentDateTimestamp());
     }
 
-    public AuditEvent(String destination, UUID jobId, Set<Long> notificationIds, OffsetDateTime createdTimestamp) {
+    public AuditEvent(String destination, UUID jobExecutionId, Set<Long> notificationIds, OffsetDateTime createdTimestamp) {
         super(destination);
-        this.jobId = jobId;
+        this.jobExecutionId = jobExecutionId;
         this.notificationIds = notificationIds;
         this.createdTimestamp = createdTimestamp;
     }
 
-    public UUID getJobId() {
-        return jobId;
+    public UUID getJobExecutionId() {
+        return jobExecutionId;
     }
 
     public Set<Long> getNotificationIds() {

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedEvent.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedEvent.java
@@ -13,8 +13,8 @@ public class AuditFailedEvent extends AuditEvent {
     private final String errorMessage;
     private final String stackTrace;
 
-    public AuditFailedEvent(UUID jobId, Set<Long> notificationIds, String errorMessage, @Nullable String stackTrace) {
-        super(DEFAULT_DESTINATION_NAME, jobId, notificationIds);
+    public AuditFailedEvent(UUID jobExecutionId, Set<Long> notificationIds, String errorMessage, @Nullable String stackTrace) {
+        super(DEFAULT_DESTINATION_NAME, jobExecutionId, notificationIds);
         this.errorMessage = errorMessage;
         this.stackTrace = stackTrace;
     }

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedHandler.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedHandler.java
@@ -1,28 +1,40 @@
 package com.synopsys.integration.alert.api.distribution.audit;
 
+import java.util.Set;
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.synopsys.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.synopsys.integration.alert.api.event.AlertEventHandler;
 import com.synopsys.integration.alert.common.persistence.accessor.ProcessingAuditAccessor;
 
 @Component
 public class AuditFailedHandler implements AlertEventHandler<AuditFailedEvent> {
     private final ProcessingAuditAccessor processingAuditAccessor;
+    private final ExecutingJobManager executingJobManager;
 
     @Autowired
-    public AuditFailedHandler(ProcessingAuditAccessor processingAuditAccessor) {
+    public AuditFailedHandler(ProcessingAuditAccessor processingAuditAccessor, ExecutingJobManager executingJobManager) {
         this.processingAuditAccessor = processingAuditAccessor;
+        this.executingJobManager = executingJobManager;
     }
 
     @Override
     public void handle(AuditFailedEvent event) {
-        processingAuditAccessor.setAuditEntryFailure(
-            event.getJobId(),
-            event.getNotificationIds(),
-            event.getCreatedTimestamp(),
-            event.getErrorMessage(),
-            event.getStackTrace().orElse(null)
-        );
+        executingJobManager.endJobWithFailure(event.getJobExecutionId());
+        executingJobManager.getExecutingJob(event.getJobExecutionId()).ifPresent(executingJob -> {
+            UUID jobConfigId = executingJob.getJobConfigId();
+            Set<Long> notificationids = event.getNotificationIds();
+            processingAuditAccessor.createOrUpdatePendingAuditEntryForJob(jobConfigId, notificationids);
+            processingAuditAccessor.setAuditEntryFailure(
+                jobConfigId,
+                event.getNotificationIds(),
+                event.getCreatedTimestamp(),
+                event.getErrorMessage(),
+                event.getStackTrace().orElse(null)
+            );
+        });
     }
 }

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessEvent.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessEvent.java
@@ -8,7 +8,7 @@ public class AuditSuccessEvent extends AuditEvent {
 
     public static final String DEFAULT_DESTINATION_NAME = "audit_success_event";
 
-    public AuditSuccessEvent(UUID jobId, Set<Long> notificationIds) {
-        super(DEFAULT_DESTINATION_NAME, jobId, notificationIds);
+    public AuditSuccessEvent(UUID jobExecutionId, Set<Long> notificationIds) {
+        super(DEFAULT_DESTINATION_NAME, jobExecutionId, notificationIds);
     }
 }

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessHandler.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessHandler.java
@@ -3,20 +3,23 @@ package com.synopsys.integration.alert.api.distribution.audit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.synopsys.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.synopsys.integration.alert.api.event.AlertEventHandler;
 import com.synopsys.integration.alert.common.persistence.accessor.ProcessingAuditAccessor;
 
 @Component
 public class AuditSuccessHandler implements AlertEventHandler<AuditSuccessEvent> {
     private final ProcessingAuditAccessor processingAuditAccessor;
+    private final ExecutingJobManager executingJobManager;
 
     @Autowired
-    public AuditSuccessHandler(ProcessingAuditAccessor processingAuditAccessor) {
+    public AuditSuccessHandler(ProcessingAuditAccessor processingAuditAccessor, ExecutingJobManager executingJobManager) {
         this.processingAuditAccessor = processingAuditAccessor;
+        this.executingJobManager = executingJobManager;
     }
 
     @Override
     public void handle(AuditSuccessEvent event) {
-        processingAuditAccessor.setAuditEntrySuccess(event.getJobId(), event.getNotificationIds(), event.getCreatedTimestamp());
+        executingJobManager.endJobWithSuccess(event.getJobExecutionId());
     }
 }

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/JobStageEndedEvent.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/JobStageEndedEvent.java
@@ -1,0 +1,12 @@
+package com.synopsys.integration.alert.api.distribution.execution;
+
+import java.util.UUID;
+
+public class JobStageEndedEvent extends JobStageEvent {
+    private static final long serialVersionUID = -5480882643467010869L;
+    public static final String DEFAULT_DESTINATION_NAME = "job_stage_end_event";
+
+    public JobStageEndedEvent(UUID jobExecutionId, JobStage jobStage) {
+        super(DEFAULT_DESTINATION_NAME, jobExecutionId, jobStage);
+    }
+}

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/JobStageEndedEventListener.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/JobStageEndedEventListener.java
@@ -1,0 +1,20 @@
+package com.synopsys.integration.alert.api.distribution.execution;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.stereotype.Component;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.event.AlertMessageListener;
+
+@Component
+public class JobStageEndedEventListener extends AlertMessageListener<JobStageEndedEvent> {
+    @Autowired
+    public JobStageEndedEventListener(
+        Gson gson,
+        TaskExecutor taskExecutor,
+        JobStageEndedHandler eventHandler
+    ) {
+        super(gson, taskExecutor, JobStageEndedEvent.DEFAULT_DESTINATION_NAME, JobStageEndedEvent.class, eventHandler);
+    }
+}

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/JobStageEndedHandler.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/JobStageEndedHandler.java
@@ -1,0 +1,26 @@
+package com.synopsys.integration.alert.api.distribution.execution;
+
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.api.event.AlertEventHandler;
+
+@Component
+public class JobStageEndedHandler implements AlertEventHandler<JobStageEndedEvent> {
+    private final ExecutingJobManager executingJobManager;
+
+    @Autowired
+    public JobStageEndedHandler(final ExecutingJobManager executingJobManager) {
+        this.executingJobManager = executingJobManager;
+    }
+
+    @Override
+    public void handle(JobStageEndedEvent event) {
+        UUID jobExecutionId = event.getJobExecutionId();
+        JobStage jobStage = event.getJobStage();
+        executingJobManager.getExecutingJob(jobExecutionId)
+            .ifPresent(executingJob -> executingJobManager.endStage(jobExecutionId, jobStage));
+    }
+}

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/JobStageEvent.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/JobStageEvent.java
@@ -1,0 +1,25 @@
+package com.synopsys.integration.alert.api.distribution.execution;
+
+import java.util.UUID;
+
+import com.synopsys.integration.alert.api.event.AlertEvent;
+
+public class JobStageEvent extends AlertEvent {
+    private static final long serialVersionUID = 7484019815048606767L;
+    private final UUID jobExecutionId;
+    private final JobStage jobStage;
+
+    public JobStageEvent(final String destination, final UUID jobExecutionId, final JobStage jobStage) {
+        super(destination);
+        this.jobExecutionId = jobExecutionId;
+        this.jobStage = jobStage;
+    }
+
+    public UUID getJobExecutionId() {
+        return jobExecutionId;
+    }
+
+    public JobStage getJobStage() {
+        return jobStage;
+    }
+}

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/JobStageStartedEvent.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/JobStageStartedEvent.java
@@ -1,0 +1,11 @@
+package com.synopsys.integration.alert.api.distribution.execution;
+
+import java.util.UUID;
+
+public class JobStageStartedEvent extends JobStageEvent {
+    public static final String DEFAULT_DESTINATION_NAME = "job_stage_start_event";
+
+    public JobStageStartedEvent(UUID jobExecutionId, JobStage jobStage) {
+        super(DEFAULT_DESTINATION_NAME, jobExecutionId, jobStage);
+    }
+}

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/JobStageStartedEventListener.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/JobStageStartedEventListener.java
@@ -1,0 +1,20 @@
+package com.synopsys.integration.alert.api.distribution.execution;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.stereotype.Component;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.event.AlertMessageListener;
+
+@Component
+public class JobStageStartedEventListener extends AlertMessageListener<JobStageStartedEvent> {
+    @Autowired
+    public JobStageStartedEventListener(
+        Gson gson,
+        TaskExecutor taskExecutor,
+        JobStageStartedHandler eventHandler
+    ) {
+        super(gson, taskExecutor, JobStageStartedEvent.DEFAULT_DESTINATION_NAME, JobStageStartedEvent.class, eventHandler);
+    }
+}

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/JobStageStartedHandler.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/JobStageStartedHandler.java
@@ -1,0 +1,26 @@
+package com.synopsys.integration.alert.api.distribution.execution;
+
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.api.event.AlertEventHandler;
+
+@Component
+public class JobStageStartedHandler implements AlertEventHandler<JobStageStartedEvent> {
+    private final ExecutingJobManager executingJobManager;
+
+    @Autowired
+    public JobStageStartedHandler(final ExecutingJobManager executingJobManager) {
+        this.executingJobManager = executingJobManager;
+    }
+
+    @Override
+    public void handle(final JobStageStartedEvent event) {
+        UUID jobExecutionId = event.getJobExecutionId();
+        JobStage jobStage = event.getJobStage();
+        executingJobManager.getExecutingJob(jobExecutionId)
+            .ifPresent(executingJob -> executingJobManager.startStage(jobExecutionId, jobStage));
+    }
+}

--- a/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/JobSubTaskMessageListenerTest.java
+++ b/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/JobSubTaskMessageListenerTest.java
@@ -31,8 +31,8 @@ class JobSubTaskMessageListenerTest {
     private static class TestEvent extends JobSubTaskEvent {
         private static final long serialVersionUID = -4316390923286571736L;
 
-        public TestEvent(String destination, UUID parentEventId, UUID jobId, Set<Long> notificationIds) {
-            super(destination, parentEventId, jobId, notificationIds);
+        public TestEvent(String destination, UUID jobExecutionId, UUID jobId, Set<Long> notificationIds) {
+            super(destination, jobExecutionId, jobId, notificationIds);
         }
     }
 

--- a/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditEventTest.java
+++ b/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditEventTest.java
@@ -13,12 +13,12 @@ class AuditEventTest {
     @Test
     void constructorTest() {
         String destination = "destination";
-        UUID jobId = UUID.randomUUID();
+        UUID jobExecutionId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
-        AuditEvent event = new AuditEvent(destination, jobId, notificationIds);
+        AuditEvent event = new AuditEvent(destination, jobExecutionId, notificationIds);
 
         assertEquals(destination, event.getDestination());
-        assertEquals(jobId, event.getJobId());
+        assertEquals(jobExecutionId, event.getJobExecutionId());
         assertEquals(notificationIds, event.getNotificationIds());
         assertNotNull(event.getCreatedTimestamp());
     }

--- a/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedEventTest.java
+++ b/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedEventTest.java
@@ -12,14 +12,14 @@ import org.junit.jupiter.api.Test;
 class AuditFailedEventTest {
     @Test
     void constructorTest() {
-        UUID jobId = UUID.randomUUID();
+        UUID jobExecutionId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         String errorMessage = "Error message";
         String stackTrace = "stack trace goees here";
-        AuditFailedEvent event = new AuditFailedEvent(jobId, notificationIds, errorMessage, stackTrace);
+        AuditFailedEvent event = new AuditFailedEvent(jobExecutionId, notificationIds, errorMessage, stackTrace);
 
         assertEquals(AuditFailedEvent.DEFAULT_DESTINATION_NAME, event.getDestination());
-        assertEquals(jobId, event.getJobId());
+        assertEquals(jobExecutionId, event.getJobExecutionId());
         assertEquals(notificationIds, event.getNotificationIds());
         assertNotNull(event.getCreatedTimestamp());
         assertEquals(errorMessage, event.getErrorMessage());
@@ -35,7 +35,7 @@ class AuditFailedEventTest {
         AuditFailedEvent event = new AuditFailedEvent(jobId, notificationIds, errorMessage, null);
 
         assertEquals(AuditFailedEvent.DEFAULT_DESTINATION_NAME, event.getDestination());
-        assertEquals(jobId, event.getJobId());
+        assertEquals(jobId, event.getJobExecutionId());
         assertEquals(notificationIds, event.getNotificationIds());
         assertNotNull(event.getCreatedTimestamp());
         assertEquals(errorMessage, event.getErrorMessage());

--- a/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedHandlerTest.java
+++ b/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedHandlerTest.java
@@ -12,6 +12,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.synopsys.integration.alert.api.distribution.execution.ExecutingJob;
+import com.synopsys.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.synopsys.integration.alert.api.distribution.mock.MockAuditEntryRepository;
 import com.synopsys.integration.alert.api.distribution.mock.MockAuditNotificationRepository;
 import com.synopsys.integration.alert.common.enumeration.AuditEntryStatus;
@@ -28,6 +30,7 @@ class AuditFailedHandlerTest {
     private ProcessingAuditAccessor processingAuditAccessor;
     private AuditEntryRepository auditEntryRepository;
     private AuditNotificationRepository auditNotificationRepository;
+    private ExecutingJobManager executingJobManager;
     private AtomicLong idContainer = new AtomicLong(0L);
 
     @BeforeEach
@@ -35,6 +38,7 @@ class AuditFailedHandlerTest {
         auditNotificationRepository = new MockAuditNotificationRepository(this::generateRelationKey);
         auditEntryRepository = new MockAuditEntryRepository(this::generateEntityKey, auditNotificationRepository);
         processingAuditAccessor = new DefaultProcessingAuditAccessor(auditEntryRepository, auditNotificationRepository);
+        executingJobManager = new ExecutingJobManager();
     }
 
     private Long generateEntityKey(AuditEntryEntity entity) {
@@ -56,13 +60,14 @@ class AuditFailedHandlerTest {
     @Test
     void handleEventTest() {
         UUID jobId = UUID.randomUUID();
+        ExecutingJob executingJob = executingJobManager.startJob(jobId);
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         String errorMessage = "Error message";
         String stackTrace = "Stack trace goes here";
 
-        AuditFailedHandler handler = new AuditFailedHandler(processingAuditAccessor);
+        AuditFailedHandler handler = new AuditFailedHandler(processingAuditAccessor, executingJobManager);
         processingAuditAccessor.createOrUpdatePendingAuditEntryForJob(jobId, notificationIds);
-        AuditFailedEvent event = new AuditFailedEvent(jobId, notificationIds, errorMessage, stackTrace);
+        AuditFailedEvent event = new AuditFailedEvent(executingJob.getExecutionId(), notificationIds, errorMessage, stackTrace);
 
         handler.handle(event);
 
@@ -72,7 +77,8 @@ class AuditFailedHandlerTest {
             AuditEntryEntity entity = entry.get();
             assertEquals(AuditEntryStatus.FAILURE.name(), entity.getStatus());
             assertNotNull(entity.getTimeCreated());
-            assertTrue(entity.getTimeLastSent().isAfter(entity.getTimeCreated()));
+            // no longer applies right now.
+            //assertTrue(entity.getTimeLastSent().isAfter(entity.getTimeCreated()));
             assertEquals(errorMessage, entity.getErrorMessage());
             assertEquals(stackTrace, entity.getErrorStackTrace());
         }
@@ -85,7 +91,7 @@ class AuditFailedHandlerTest {
         String errorMessage = "Error message";
         String stackTrace = "Stack trace goes here";
 
-        AuditFailedHandler handler = new AuditFailedHandler(processingAuditAccessor);
+        AuditFailedHandler handler = new AuditFailedHandler(processingAuditAccessor, executingJobManager);
         AuditFailedEvent event = new AuditFailedEvent(jobId, notificationIds, errorMessage, stackTrace);
 
         handler.handle(event);

--- a/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessEventTest.java
+++ b/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessEventTest.java
@@ -12,12 +12,12 @@ class AuditSuccessEventTest {
 
     @Test
     void constructorTest() {
-        UUID jobId = UUID.randomUUID();
+        UUID jobExecutionId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
-        AuditEvent event = new AuditSuccessEvent(jobId, notificationIds);
+        AuditEvent event = new AuditSuccessEvent(jobExecutionId, notificationIds);
 
         assertEquals(AuditSuccessEvent.DEFAULT_DESTINATION_NAME, event.getDestination());
-        assertEquals(jobId, event.getJobId());
+        assertEquals(jobExecutionId, event.getJobExecutionId());
         assertEquals(notificationIds, event.getNotificationIds());
         assertNotNull(event.getCreatedTimestamp());
     }

--- a/api-event/src/main/java/com/synopsys/integration/alert/api/event/distribution/JobSubTaskEvent.java
+++ b/api-event/src/main/java/com/synopsys/integration/alert/api/event/distribution/JobSubTaskEvent.java
@@ -7,19 +7,19 @@ import com.synopsys.integration.alert.api.event.AlertEvent;
 
 public class JobSubTaskEvent extends AlertEvent {
     private static final long serialVersionUID = 2328435266614582583L;
-    private final UUID parentEventId;
+    private final UUID jobExecutionId;
     private final UUID jobId;
     private final Set<Long> notificationIds;
 
-    protected JobSubTaskEvent(String destination, UUID parentEventId, UUID jobId, Set<Long> notificationIds) {
+    protected JobSubTaskEvent(String destination, UUID jobExecutionId, UUID jobId, Set<Long> notificationIds) {
         super(destination);
-        this.parentEventId = parentEventId;
+        this.jobExecutionId = jobExecutionId;
         this.jobId = jobId;
         this.notificationIds = notificationIds;
     }
 
-    public UUID getParentEventId() {
-        return parentEventId;
+    public UUID getJobExecutionId() {
+        return jobExecutionId;
     }
 
     public UUID getJobId() {

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCommentEventTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCommentEventTest.java
@@ -22,7 +22,7 @@ class AzureBoardsCommentEventTest {
         AzureBoardsCommentEvent event = new AzureBoardsCommentEvent(destination, parentEventId, jobId, notificationIds, model);
 
         assertNotNull(event.getEventId());
-        assertEquals(parentEventId, event.getParentEventId());
+        assertEquals(parentEventId, event.getJobExecutionId());
         assertEquals(destination, event.getDestination());
         assertEquals(jobId, event.getJobId());
         assertEquals(notificationIds, event.getNotificationIds());

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCreateIssueEventTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCreateIssueEventTest.java
@@ -23,7 +23,7 @@ class AzureBoardsCreateIssueEventTest {
         AzureBoardsCreateIssueEvent event = new AzureBoardsCreateIssueEvent(destination, parentEventId, jobId, notificationIds, model);
 
         assertNotNull(event.getEventId());
-        assertEquals(parentEventId, event.getParentEventId());
+        assertEquals(parentEventId, event.getJobExecutionId());
         assertEquals(destination, event.getDestination());
         assertEquals(jobId, event.getJobId());
         assertEquals(notificationIds, event.getNotificationIds());

--- a/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsTransitionEventTest.java
+++ b/channel-azure-boards/src/test/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsTransitionEventTest.java
@@ -23,7 +23,7 @@ class AzureBoardsTransitionEventTest {
         AzureBoardsTransitionEvent event = new AzureBoardsTransitionEvent(destination, parentEventId, jobId, notificationIds, model);
 
         assertNotNull(event.getEventId());
-        assertEquals(parentEventId, event.getParentEventId());
+        assertEquals(parentEventId, event.getJobExecutionId());
         assertEquals(destination, event.getDestination());
         assertEquals(jobId, event.getJobId());
         assertEquals(notificationIds, event.getNotificationIds());

--- a/channel-jira-cloud/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
@@ -73,7 +73,7 @@ public class JiraCloudCommentEventHandler extends IssueTrackerCommentEventHandle
     @Override
     public void handleEvent(JiraCloudCommentEvent event) {
         UUID jobId = event.getJobId();
-        Optional<JiraCloudJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(event.getJobId());
+        Optional<JiraCloudJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(jobId);
         if (details.isPresent()) {
             try {
                 JiraCloudProperties jiraProperties = jiraCloudPropertiesFactory.createJiraProperties();

--- a/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventListenerTest.java
+++ b/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventListenerTest.java
@@ -27,7 +27,7 @@ class JiraCloudCommentEventListenerTest {
 
     @Test
     void onMessageTest() {
-        UUID parentEventId = UUID.randomUUID();
+        UUID jobExecutionId = UUID.randomUUID();
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -35,7 +35,7 @@ class JiraCloudCommentEventListenerTest {
         IssueCommentModel<String> issueCommentModel = new IssueCommentModel<>(null, List.of("A comment"), null);
         JiraCloudCommentEvent event = new JiraCloudCommentEvent(
             "destination",
-            parentEventId,
+            jobExecutionId,
             jobId,
             notificationIds,
             issueCommentModel
@@ -53,17 +53,17 @@ class JiraCloudCommentEventListenerTest {
             null,
             null
         ));
-        Mockito.doNothing().when(handler).handle(event);
+        Mockito.doNothing().when(handler).handleEvent(event);
 
-        jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobId, 1L, notificationIds);
-        Optional<JobSubTaskStatusModel> optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        jobSubTaskAccessor.createSubTaskStatus(jobExecutionId, jobId, 1L, notificationIds);
+        Optional<JobSubTaskStatusModel> optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(jobExecutionId);
         assertTrue(optionalJobSubTaskStatusModel.isPresent());
 
         JiraCloudCommentEventListener listener = new JiraCloudCommentEventListener(gson, new SyncTaskExecutor(), ChannelKeys.JIRA_CLOUD, handler);
         Message message = new Message(gson.toJson(event).getBytes());
         listener.onMessage(message);
 
-        optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(jobExecutionId);
         assertFalse(optionalJobSubTaskStatusModel.isPresent());
     }
 }

--- a/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentIssueEventTest.java
+++ b/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentIssueEventTest.java
@@ -22,7 +22,7 @@ class JiraCloudCommentIssueEventTest {
         JiraCloudCommentEvent event = new JiraCloudCommentEvent(destination, parentEventId, jobId, notificationIds, model);
 
         assertNotNull(event.getEventId());
-        assertEquals(parentEventId, event.getParentEventId());
+        assertEquals(parentEventId, event.getJobExecutionId());
         assertEquals(destination, event.getDestination());
         assertEquals(jobId, event.getJobId());
         assertEquals(notificationIds, event.getNotificationIds());

--- a/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventListenerTest.java
+++ b/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventListenerTest.java
@@ -54,7 +54,7 @@ class JiraCloudCreateIssueEventListenerTest {
             null,
             null
         ));
-        Mockito.doNothing().when(handler).handle(event);
+        Mockito.doNothing().when(handler).handleEvent(event);
 
         jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobId, 1L, notificationIds);
         Optional<JobSubTaskStatusModel> optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);

--- a/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventTest.java
+++ b/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventTest.java
@@ -23,7 +23,7 @@ class JiraCloudCreateIssueEventTest {
         JiraCloudCreateIssueEvent event = new JiraCloudCreateIssueEvent(destination, parentEventId, jobId, notificationIds, model);
 
         assertNotNull(event.getEventId());
-        assertEquals(parentEventId, event.getParentEventId());
+        assertEquals(parentEventId, event.getJobExecutionId());
         assertEquals(destination, event.getDestination());
         assertEquals(jobId, event.getJobId());
         assertEquals(notificationIds, event.getNotificationIds());

--- a/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventListenerTest.java
+++ b/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventListenerTest.java
@@ -54,7 +54,7 @@ class JiraCloudTransitionEventListenerTest {
             null,
             null
         ));
-        Mockito.doNothing().when(handler).handle(event);
+        Mockito.doNothing().when(handler).handleEvent(event);
 
         jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobId, 1L, notificationIds);
         Optional<JobSubTaskStatusModel> optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);

--- a/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventTest.java
+++ b/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventTest.java
@@ -23,7 +23,7 @@ class JiraCloudTransitionEventTest {
         JiraCloudTransitionEvent event = new JiraCloudTransitionEvent(destination, parentEventId, jobId, notificationIds, model);
 
         assertNotNull(event.getEventId());
-        assertEquals(parentEventId, event.getParentEventId());
+        assertEquals(parentEventId, event.getJobExecutionId());
         assertEquals(destination, event.getDestination());
         assertEquals(jobId, event.getJobId());
         assertEquals(notificationIds, event.getNotificationIds());

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEvent.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEvent.java
@@ -18,11 +18,11 @@ public class JiraServerCreateIssueEvent extends IssueTrackerCreateIssueEvent {
 
     public JiraServerCreateIssueEvent(
         String destination,
-        UUID parentEventId,
+        UUID jobExecutionId,
         UUID jobId,
         Set<Long> notificationIds,
         IssueCreationModel creationModel
     ) {
-        super(destination, parentEventId, jobId, notificationIds, creationModel);
+        super(destination, jobExecutionId, jobId, notificationIds, creationModel);
     }
 }

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
@@ -75,7 +75,7 @@ public class JiraServerCreateIssueEventHandler extends IssueTrackerCreateIssueEv
     public void handleEvent(IssueTrackerCreateIssueEvent event) {
         UUID jobId = event.getJobId();
         IssueCreationModel creationModel = event.getCreationModel();
-        Optional<JiraServerJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(event.getJobId());
+        Optional<JiraServerJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(jobId);
         if (details.isPresent()) {
             try {
                 JiraServerProperties jiraProperties = jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jobId);

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/delegate/JiraServerCommentGeneratorTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/delegate/JiraServerCommentGeneratorTest.java
@@ -1,18 +1,19 @@
 package com.synopsys.integration.alert.channel.jira.server.distribution.delegate;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
 import com.synopsys.integration.alert.api.channel.issue.event.IssueTrackerCommentEvent;
 import com.synopsys.integration.alert.api.channel.issue.model.IssueCommentModel;
 import com.synopsys.integration.alert.channel.jira.server.distribution.event.JiraServerCommentEvent;
 import com.synopsys.integration.alert.descriptor.api.JiraServerChannelKey;
 import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
-import java.util.Set;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JiraServerCommentGeneratorTest {
 	@Test
@@ -27,12 +28,13 @@ public class JiraServerCommentGeneratorTest {
 		IssueTrackerCommentEvent<String> generatedCommentEvent = testGenerator.generateEvent(testModel);
 
 		assertEquals(generatedCommentEvent.getClass(), JiraServerCommentEvent.class);
-		assertAll("Constructed IssueTrackerCommentEvent matches generator attributes",
-            () -> assertEquals(IssueTrackerCommentEvent.createDefaultEventDestination(testKey), generatedCommentEvent.getDestination()),
-			() -> assertEquals(testParentEventUID, generatedCommentEvent.getParentEventId()),
-            () -> assertEquals(testJobUID, generatedCommentEvent.getJobId()),
-            () -> assertEquals(testNotificationIds, generatedCommentEvent.getNotificationIds()),
-            () -> assertEquals(testModel, generatedCommentEvent.getCommentModel())
+		assertAll(
+			"Constructed IssueTrackerCommentEvent matches generator attributes",
+			() -> assertEquals(IssueTrackerCommentEvent.createDefaultEventDestination(testKey), generatedCommentEvent.getDestination()),
+			() -> assertEquals(testParentEventUID, generatedCommentEvent.getJobExecutionId()),
+			() -> assertEquals(testJobUID, generatedCommentEvent.getJobId()),
+			() -> assertEquals(testNotificationIds, generatedCommentEvent.getNotificationIds()),
+			() -> assertEquals(testModel, generatedCommentEvent.getCommentModel())
 		);
 	}
 }

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/delegate/JiraServerCreateEventGeneratorTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/delegate/JiraServerCreateEventGeneratorTest.java
@@ -1,18 +1,19 @@
 package com.synopsys.integration.alert.channel.jira.server.distribution.delegate;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
 import com.synopsys.integration.alert.api.channel.issue.event.IssueTrackerCreateIssueEvent;
 import com.synopsys.integration.alert.api.channel.issue.model.IssueCreationModel;
 import com.synopsys.integration.alert.channel.jira.server.distribution.event.JiraServerCreateIssueEvent;
 import com.synopsys.integration.alert.descriptor.api.JiraServerChannelKey;
 import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
-import java.util.Set;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JiraServerCreateEventGeneratorTest {
     @Test
@@ -27,9 +28,10 @@ public class JiraServerCreateEventGeneratorTest {
         IssueTrackerCreateIssueEvent generatedCreateEvent = testGenerator.generateEvent(testModel);
 
         assertEquals(generatedCreateEvent.getClass(), JiraServerCreateIssueEvent.class);
-        assertAll("Constructed IssueTrackerCreateIssueEvent matches generator attributes",
+        assertAll(
+            "Constructed IssueTrackerCreateIssueEvent matches generator attributes",
             () -> assertEquals(IssueTrackerCreateIssueEvent.createDefaultEventDestination(testKey), generatedCreateEvent.getDestination()),
-            () -> assertEquals(testParentEventUID, generatedCreateEvent.getParentEventId()),
+            () -> assertEquals(testParentEventUID, generatedCreateEvent.getJobExecutionId()),
             () -> assertEquals(testJobUID, generatedCreateEvent.getJobId()),
             () -> assertEquals(testNotificationIds, generatedCreateEvent.getNotificationIds()),
             () -> assertEquals(testModel, generatedCreateEvent.getCreationModel())

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventListenerTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventListenerTest.java
@@ -53,7 +53,7 @@ class JiraServerCommentEventListenerTest {
             null,
             null
         ));
-        Mockito.doNothing().when(handler).handle(event);
+        Mockito.doNothing().when(handler).handleEvent(event);
 
         jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobId, 1L, notificationIds);
         Optional<JobSubTaskStatusModel> optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCommentIssueEventTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCommentIssueEventTest.java
@@ -22,7 +22,7 @@ class JiraServerCommentIssueEventTest {
         JiraServerCommentEvent event = new JiraServerCommentEvent(destination, parentEventId, jobId, notificationIds, model);
 
         assertNotNull(event.getEventId());
-        assertEquals(parentEventId, event.getParentEventId());
+        assertEquals(parentEventId, event.getJobExecutionId());
         assertEquals(destination, event.getDestination());
         assertEquals(jobId, event.getJobId());
         assertEquals(notificationIds, event.getNotificationIds());

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventListenerTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventListenerTest.java
@@ -27,7 +27,7 @@ class JiraServerCreateIssueEventListenerTest {
 
     @Test
     void onMessageTest() {
-        UUID parentEventId = UUID.randomUUID();
+        UUID jobExecutionId = UUID.randomUUID();
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -36,7 +36,7 @@ class JiraServerCreateIssueEventListenerTest {
         IssueCreationModel issueCreationModel = IssueCreationModel.simple("title", "description", List.of(), provider);
         JiraServerCreateIssueEvent event = new JiraServerCreateIssueEvent(
             "destination",
-            parentEventId,
+            jobExecutionId,
             jobId,
             notificationIds,
             issueCreationModel
@@ -54,17 +54,17 @@ class JiraServerCreateIssueEventListenerTest {
             null,
             null
         ));
-        Mockito.doNothing().when(handler).handle(event);
+        Mockito.doNothing().when(handler).handleEvent(event);
 
-        jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobId, 1L, notificationIds);
-        Optional<JobSubTaskStatusModel> optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        jobSubTaskAccessor.createSubTaskStatus(jobExecutionId, jobId, 1L, notificationIds);
+        Optional<JobSubTaskStatusModel> optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(jobExecutionId);
         assertTrue(optionalJobSubTaskStatusModel.isPresent());
 
         JiraServerCreateIssueEventListener listener = new JiraServerCreateIssueEventListener(gson, ChannelKeys.JIRA_SERVER, handler);
         Message message = new Message(gson.toJson(event).getBytes());
         listener.onMessage(message);
 
-        optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
+        optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(jobExecutionId);
         assertFalse(optionalJobSubTaskStatusModel.isPresent());
     }
 }

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventTest.java
@@ -23,7 +23,7 @@ class JiraServerCreateIssueEventTest {
         JiraServerCreateIssueEvent event = new JiraServerCreateIssueEvent(destination, parentEventId, jobId, notificationIds, model);
 
         assertNotNull(event.getEventId());
-        assertEquals(parentEventId, event.getParentEventId());
+        assertEquals(parentEventId, event.getJobExecutionId());
         assertEquals(destination, event.getDestination());
         assertEquals(jobId, event.getJobId());
         assertEquals(notificationIds, event.getNotificationIds());

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventListenerTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventListenerTest.java
@@ -54,7 +54,7 @@ class JiraServerTransitionEventListenerTest {
             null,
             null
         ));
-        Mockito.doNothing().when(handler).handle(event);
+        Mockito.doNothing().when(handler).handleEvent(event);
 
         jobSubTaskAccessor.createSubTaskStatus(parentEventId, jobId, 1L, notificationIds);
         Optional<JobSubTaskStatusModel> optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventTest.java
@@ -23,7 +23,7 @@ class JiraServerTransitionEventTest {
         JiraServerTransitionEvent event = new JiraServerTransitionEvent(destination, parentEventId, jobId, notificationIds, model);
 
         assertNotNull(event.getEventId());
-        assertEquals(parentEventId, event.getParentEventId());
+        assertEquals(parentEventId, event.getJobExecutionId());
         assertEquals(destination, event.getDestination());
         assertEquals(jobId, event.getJobId());
         assertEquals(notificationIds, event.getNotificationIds());


### PR DESCRIPTION
This Pull request adds:

1. The usage of the Job Execution ID throughout the processing code.  
2. The usage of Job Stages to determine how long a portion of processing takes.
3. The creation of additional events for job stages.
4. The integration of the ExecutingJobManager into the processing code.
