### PR TITLE
IALERT-3277: Update the query to return 1 audit entry for the job.

### DIFF
--- a/alert-database-job/src/main/java/com/synopsys/integration/alert/database/distribution/DistributionRepository.java
+++ b/alert-database-job/src/main/java/com/synopsys/integration/alert/database/distribution/DistributionRepository.java
@@ -33,6 +33,7 @@ public interface DistributionRepository extends JpaRepository<DistributionJobEnt
             + "   ) AS auditMaxDate"
             + "   ON auditRequirements.common_config_id = auditMaxDate.common_config_id"
             + "   AND auditRequirements.time_last_sent = auditMaxDate.last_sent"
+            + "   LIMIT 1"
             + " ) AS filteredAudit"
             + " ON filteredAudit.common_config_id = job.job_id"
             + " WHERE job.channel_descriptor_name IN (:channelDescriptorNames)",
@@ -53,6 +54,7 @@ public interface DistributionRepository extends JpaRepository<DistributionJobEnt
             + "   ) AS auditMaxDate"
             + "   ON auditRequirements.common_config_id = auditMaxDate.common_config_id"
             + "   AND auditRequirements.time_last_sent = auditMaxDate.last_sent"
+            + "   LIMIT 1"
             + " ) AS filteredAudit"
             + " ON filteredAudit.common_config_id = job.job_id"
             + " WHERE job.channel_descriptor_name IN (:channelDescriptorNames) AND job.name LIKE %:searchTerm%",


### PR DESCRIPTION
Add LIMIT 1 to the query.  Only get 1 audit entry for the job with the latest timestamp.

Without the limit the query can return a row per audit entry in the database.