### PR TITLE
IALERT-3277: duplicate email fix

### DIFF
--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/JobNotificationContentProcessor.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/JobNotificationContentProcessor.java
@@ -1,0 +1,175 @@
+package com.synopsys.integration.alert.processor.api;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.common.enumeration.ProcessingType;
+import com.synopsys.integration.alert.common.logging.AlertLoggerFactory;
+import com.synopsys.integration.alert.common.persistence.accessor.JobAccessor;
+import com.synopsys.integration.alert.common.persistence.accessor.JobNotificationMappingAccessor;
+import com.synopsys.integration.alert.common.persistence.accessor.NotificationAccessor;
+import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobModel;
+import com.synopsys.integration.alert.common.persistence.model.job.JobToNotificationMappingModel;
+import com.synopsys.integration.alert.common.rest.model.AlertNotificationModel;
+import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
+import com.synopsys.integration.alert.processor.api.detail.DetailedNotificationContent;
+import com.synopsys.integration.alert.processor.api.detail.NotificationDetailExtractionDelegator;
+import com.synopsys.integration.alert.processor.api.digest.ProjectMessageDigester;
+import com.synopsys.integration.alert.processor.api.event.JobProcessingEvent;
+import com.synopsys.integration.alert.processor.api.extract.ProviderMessageExtractionDelegator;
+import com.synopsys.integration.alert.processor.api.extract.model.ProcessedProviderMessage;
+import com.synopsys.integration.alert.processor.api.extract.model.ProcessedProviderMessageHolder;
+import com.synopsys.integration.alert.processor.api.extract.model.SimpleMessage;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ProjectMessage;
+import com.synopsys.integration.alert.processor.api.filter.NotificationContentWrapper;
+import com.synopsys.integration.alert.processor.api.summarize.ProjectMessageSummarizer;
+
+@Component
+public class JobNotificationContentProcessor {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger notificationLogger = AlertLoggerFactory.getNotificationLogger(getClass());
+
+    private final NotificationDetailExtractionDelegator notificationDetailExtractionDelegator;
+    private final NotificationAccessor notificationAccessor;
+    private final JobAccessor jobAccessor;
+    private final JobNotificationMappingAccessor jobNotificationMappingAccessor;
+
+    private final ProviderMessageExtractionDelegator providerMessageExtractionDelegator;
+    private final ProjectMessageDigester projectMessageDigester;
+    private final ProjectMessageSummarizer projectMessageSummarizer;
+
+    @Autowired
+    public JobNotificationContentProcessor(
+        NotificationDetailExtractionDelegator notificationDetailExtractionDelegator,
+        NotificationAccessor notificationAccessor,
+        JobAccessor jobAccessor,
+        JobNotificationMappingAccessor jobNotificationMappingAccessor,
+        ProviderMessageExtractionDelegator providerMessageExtractionDelegator,
+        ProjectMessageDigester projectMessageDigester,
+        ProjectMessageSummarizer projectMessageSummarizer
+    ) {
+        this.notificationDetailExtractionDelegator = notificationDetailExtractionDelegator;
+        this.notificationAccessor = notificationAccessor;
+        this.jobAccessor = jobAccessor;
+        this.jobNotificationMappingAccessor = jobNotificationMappingAccessor;
+        this.providerMessageExtractionDelegator = providerMessageExtractionDelegator;
+        this.projectMessageDigester = projectMessageDigester;
+        this.projectMessageSummarizer = projectMessageSummarizer;
+    }
+
+    public ProcessedProviderMessageHolder processNotifications(JobProcessingEvent event, DistributionJobModel job) {
+        ProcessedProviderMessageHolder processedMessageHolder = null;
+        UUID correlationId = event.getCorrelationId();
+        UUID jobId = event.getJobId();
+        int pageNumber = 0;
+        int pageSize = 200;
+        AlertPagedModel<JobToNotificationMappingModel> jobNotificationMappings = jobNotificationMappingAccessor.getJobNotificationMappings(
+            correlationId,
+            jobId,
+            pageNumber,
+            pageSize
+        );
+
+        ProcessingType jobProcessingType = job.getProcessingType();
+        while (jobNotificationMappings.getCurrentPage() <= jobNotificationMappings.getTotalPages()) {
+            List<Long> notificationIds = extractNotificationIds(jobNotificationMappings);
+            List<AlertNotificationModel> notifications = notificationAccessor.findByIds(notificationIds);
+            logNotifications("Start", event, notificationIds);
+            List<NotificationContentWrapper> notificationContentList = notifications
+                .stream()
+                .map(notificationDetailExtractionDelegator::wrapNotification)
+                .flatMap(List::stream)
+                .map(DetailedNotificationContent::getNotificationContentWrapper)
+                .collect(Collectors.toList());
+
+            ProcessedProviderMessageHolder extractedProviderMessages = notificationContentList
+                .stream()
+                .map(providerMessageExtractionDelegator::extract)
+                .reduce(ProcessedProviderMessageHolder::reduce)
+                .orElse(ProcessedProviderMessageHolder.empty());
+            processedMessageHolder = defaultProcessing(processedMessageHolder, extractedProviderMessages);
+
+            if (ProcessingType.DIGEST == jobProcessingType || ProcessingType.SUMMARY == jobProcessingType) {
+                processedMessageHolder = digestProcessing(processedMessageHolder);
+            }
+            pageNumber++;
+            jobNotificationMappings = jobNotificationMappingAccessor.getJobNotificationMappings(
+                correlationId,
+                jobId,
+                pageNumber,
+                pageSize
+            );
+            logNotifications("Finished", event, notificationIds);
+        }
+
+        if (ProcessingType.SUMMARY == jobProcessingType) {
+            processedMessageHolder = summaryProcessing(processedMessageHolder);
+        }
+
+        return processedMessageHolder;
+    }
+
+    private List<Long> extractNotificationIds(AlertPagedModel<JobToNotificationMappingModel> pageOfMappingData) {
+        return pageOfMappingData.getModels().stream()
+            .map(JobToNotificationMappingModel::getNotificationId)
+            .collect(Collectors.toList());
+    }
+
+    private void logNotifications(String messagePrefix, JobProcessingEvent event, List<Long> notificationIds) {
+        if (logger.isDebugEnabled()) {
+            String joinedIds = StringUtils.join(notificationIds, ", ");
+            notificationLogger.debug(
+                "{} processing job: {} batch: {} {} notifications: {}",
+                messagePrefix,
+                event.getJobId(),
+                event.getCorrelationId(),
+                notificationIds.size(),
+                joinedIds
+            );
+        }
+    }
+
+    private ProcessedProviderMessageHolder defaultProcessing(ProcessedProviderMessageHolder currentMessageHolder, ProcessedProviderMessageHolder extractedProviderMessages) {
+        List<ProcessedProviderMessage<ProjectMessage>> filteredProjectMessages = filterProcessedMessages(extractedProviderMessages.getProcessedProjectMessages());
+        List<ProcessedProviderMessage<SimpleMessage>> filteredSimpleMessages = filterProcessedMessages(extractedProviderMessages.getProcessedSimpleMessages());
+
+        ProcessedProviderMessageHolder processedProviderMessageHolder = new ProcessedProviderMessageHolder(filteredProjectMessages, filteredSimpleMessages);
+        if (null == currentMessageHolder) {
+            return processedProviderMessageHolder;
+        }
+
+        return ProcessedProviderMessageHolder.reduce(currentMessageHolder, processedProviderMessageHolder);
+    }
+
+    private ProcessedProviderMessageHolder digestProcessing(ProcessedProviderMessageHolder extractedProviderMessages) {
+        List<ProcessedProviderMessage<ProjectMessage>> filteredProjectMessages = filterProcessedMessages(extractedProviderMessages.getProcessedProjectMessages());
+        List<ProcessedProviderMessage<SimpleMessage>> filteredSimpleMessages = filterProcessedMessages(extractedProviderMessages.getProcessedSimpleMessages());
+        List<ProcessedProviderMessage<ProjectMessage>> digestedMessages = projectMessageDigester.digest(filteredProjectMessages);
+        return new ProcessedProviderMessageHolder(digestedMessages, filteredSimpleMessages);
+    }
+
+    private ProcessedProviderMessageHolder summaryProcessing(ProcessedProviderMessageHolder providerMessages) {
+        List<ProcessedProviderMessage<ProjectMessage>> filteredProjectMessages = filterProcessedMessages(providerMessages.getProcessedProjectMessages());
+        List<ProcessedProviderMessage<SimpleMessage>> filteredSimpleMessages = filterProcessedMessages(providerMessages.getProcessedSimpleMessages());
+
+        List<ProcessedProviderMessage<SimpleMessage>> summarizedMessages = filteredProjectMessages
+            .stream()
+            .map(projectMessageSummarizer::summarize)
+            .collect(Collectors.toList());
+        List<ProcessedProviderMessage<SimpleMessage>> allSimpleMessages = ListUtils.union(filteredSimpleMessages, summarizedMessages);
+        return new ProcessedProviderMessageHolder(List.of(), allSimpleMessages);
+    }
+
+    private <T> List<T> filterProcessedMessages(List<T> processedProviderMessages) {
+        return processedProviderMessages.stream().distinct().collect(Collectors.toList());
+    }
+}

--- a/component/src/main/java/com/synopsys/integration/alert/component/tasks/ProcessingTask.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/tasks/ProcessingTask.java
@@ -88,10 +88,13 @@ public abstract class ProcessingTask extends StartupScheduledTask {
             List<AlertNotificationModel> notificationList = page.getModels();
             logger.info("Processing page {} of {}. {} notifications to process.", currentPage, totalPages, notificationList.size());
             notificationMappingProcessor.processNotifications(correlationId, notificationList, List.of(frequencyType));
-            eventManager.sendEvent(new JobNotificationMappedEvent(correlationId));
             page = read(dateRange, currentPage + 1, PAGE_SIZE);
             currentPage = page.getCurrentPage();
             totalPages = page.getTotalPages();
+        }
+
+        if (totalPages > 0) {
+            eventManager.sendEvent(new JobNotificationMappedEvent(correlationId));
         }
     }
 

--- a/component/src/main/java/com/synopsys/integration/alert/component/tasks/ProcessingTask.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/tasks/ProcessingTask.java
@@ -86,7 +86,7 @@ public abstract class ProcessingTask extends StartupScheduledTask {
         UUID correlationId = UUID.randomUUID();
         while (!page.getModels().isEmpty() || currentPage < totalPages) {
             List<AlertNotificationModel> notificationList = page.getModels();
-            logger.info("Processing page {} of {}. {} notifications to process.", currentPage, totalPages, notificationList.size());
+            logger.info("Processing page {} of {}. {} notifications to process.", currentPage + 1, totalPages, notificationList.size());
             notificationMappingProcessor.processNotifications(correlationId, notificationList, List.of(frequencyType));
             page = read(dateRange, currentPage + 1, PAGE_SIZE);
             currentPage = page.getCurrentPage();

--- a/src/main/java/com/synopsys/integration/alert/processing/ProcessingJobEventHandler.java
+++ b/src/main/java/com/synopsys/integration/alert/processing/ProcessingJobEventHandler.java
@@ -27,6 +27,7 @@ import com.synopsys.integration.alert.common.persistence.model.job.DistributionJ
 import com.synopsys.integration.alert.common.persistence.model.job.JobToNotificationMappingModel;
 import com.synopsys.integration.alert.common.rest.model.AlertNotificationModel;
 import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
+import com.synopsys.integration.alert.processor.api.JobNotificationContentProcessor;
 import com.synopsys.integration.alert.processor.api.NotificationContentProcessor;
 import com.synopsys.integration.alert.processor.api.NotificationProcessingLifecycleCache;
 import com.synopsys.integration.alert.processor.api.detail.DetailedNotificationContent;
@@ -49,6 +50,7 @@ public class ProcessingJobEventHandler implements AlertEventHandler<JobProcessin
     private final NotificationAccessor notificationAccessor;
     private final JobAccessor jobAccessor;
     private final JobNotificationMappingAccessor jobNotificationMappingAccessor;
+    private final JobNotificationContentProcessor jobNotificationContentProcessor;
 
     @Autowired
     public ProcessingJobEventHandler(
@@ -58,7 +60,8 @@ public class ProcessingJobEventHandler implements AlertEventHandler<JobProcessin
         List<NotificationProcessingLifecycleCache> lifecycleCaches,
         NotificationAccessor notificationAccessor,
         JobAccessor jobAccessor,
-        JobNotificationMappingAccessor jobNotificationMappingAccessor
+        JobNotificationMappingAccessor jobNotificationMappingAccessor,
+        JobNotificationContentProcessor jobNotificationContentProcessor
     ) {
         this.notificationDetailExtractionDelegator = notificationDetailExtractionDelegator;
         this.notificationContentProcessor = notificationContentProcessor;
@@ -67,6 +70,7 @@ public class ProcessingJobEventHandler implements AlertEventHandler<JobProcessin
         this.notificationAccessor = notificationAccessor;
         this.jobAccessor = jobAccessor;
         this.jobNotificationMappingAccessor = jobNotificationMappingAccessor;
+        this.jobNotificationContentProcessor = jobNotificationContentProcessor;
     }
 
     @Override
@@ -77,7 +81,7 @@ public class ProcessingJobEventHandler implements AlertEventHandler<JobProcessin
             Optional<DistributionJobModel> jobModel = jobAccessor.getJobById(jobId);
             if (jobModel.isPresent()) {
                 DistributionJobModel job = jobModel.get();
-                ProcessedProviderMessageHolder processedMessageHolder = processNotifications(event, job);
+                ProcessedProviderMessageHolder processedMessageHolder = jobNotificationContentProcessor.processNotifications(event, job);
                 ProcessedNotificationDetails processedNotificationDetails = new ProcessedNotificationDetails(
                     job.getJobId(),
                     job.getChannelDescriptorName(),

--- a/src/test/java/com/synopsys/integration/alert/processing/ProcessingJobEventHandlerTest.java
+++ b/src/test/java/com/synopsys/integration/alert/processing/ProcessingJobEventHandlerTest.java
@@ -11,11 +11,15 @@ import org.mockito.Mockito;
 import com.synopsys.integration.alert.common.persistence.accessor.JobAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.JobNotificationMappingAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.NotificationAccessor;
+import com.synopsys.integration.alert.processor.api.JobNotificationContentProcessor;
 import com.synopsys.integration.alert.processor.api.NotificationContentProcessor;
 import com.synopsys.integration.alert.processor.api.NotificationProcessingLifecycleCache;
 import com.synopsys.integration.alert.processor.api.detail.NotificationDetailExtractionDelegator;
+import com.synopsys.integration.alert.processor.api.digest.ProjectMessageDigester;
 import com.synopsys.integration.alert.processor.api.distribute.ProviderMessageDistributor;
 import com.synopsys.integration.alert.processor.api.event.JobProcessingEvent;
+import com.synopsys.integration.alert.processor.api.extract.ProviderMessageExtractionDelegator;
+import com.synopsys.integration.alert.processor.api.summarize.ProjectMessageSummarizer;
 
 class ProcessingJobEventHandlerTest {
     @Test
@@ -29,6 +33,16 @@ class ProcessingJobEventHandlerTest {
         NotificationAccessor notificationAccessor = Mockito.mock(NotificationAccessor.class);
         JobAccessor jobAccessor = Mockito.mock(JobAccessor.class);
         JobNotificationMappingAccessor jobNotificationMappingAccessor = Mockito.mock(JobNotificationMappingAccessor.class);
+        ProviderMessageExtractionDelegator providerMessageExtractionDelegator = Mockito.mock(ProviderMessageExtractionDelegator.class);
+        JobNotificationContentProcessor jobNotificationContentProcessor = new JobNotificationContentProcessor(
+            notificationDetailExtractionDelegator,
+            notificationAccessor,
+            jobAccessor,
+            jobNotificationMappingAccessor,
+            providerMessageExtractionDelegator,
+            new ProjectMessageDigester(),
+            new ProjectMessageSummarizer()
+        );
         ProcessingJobEventHandler eventHandler = new ProcessingJobEventHandler(
             notificationDetailExtractionDelegator,
             notificationContentProcessor,
@@ -36,7 +50,8 @@ class ProcessingJobEventHandlerTest {
             lifecycleCaches,
             notificationAccessor,
             jobAccessor,
-            jobNotificationMappingAccessor
+            jobNotificationMappingAccessor,
+            jobNotificationContentProcessor
         );
         try {
             eventHandler.handle(new JobProcessingEvent(correlationId, jobId));

--- a/src/test/java/com/synopsys/integration/alert/processing/ProcessingJobEventHandlerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/processing/ProcessingJobEventHandlerTestIT.java
@@ -49,6 +49,7 @@ import com.synopsys.integration.alert.database.api.DefaultConfigurationModelConf
 import com.synopsys.integration.alert.database.api.DefaultNotificationAccessor;
 import com.synopsys.integration.alert.descriptor.api.BlackDuckProviderKey;
 import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
+import com.synopsys.integration.alert.processor.api.JobNotificationContentProcessor;
 import com.synopsys.integration.alert.processor.api.NotificationContentProcessor;
 import com.synopsys.integration.alert.processor.api.NotificationMappingProcessor;
 import com.synopsys.integration.alert.processor.api.NotificationProcessingLifecycleCache;
@@ -94,6 +95,8 @@ class ProcessingJobEventHandlerTestIT {
     private EmailGlobalConfigAccessor emailGlobalConfigAccessor;
     @Autowired
     private NotificationMappingProcessor notificationProcessor;
+    @Autowired
+    JobNotificationContentProcessor jobNotificationContentProcessor;
     @Autowired
     private Gson gson;
 
@@ -161,7 +164,8 @@ class ProcessingJobEventHandlerTestIT {
             lifecycleCaches,
             notificationAccessor,
             jobAccessor,
-            jobNotificationMappingAccessor
+            jobNotificationMappingAccessor,
+            jobNotificationContentProcessor
         );
         JobProcessingEvent event = new JobProcessingEvent(correlationId, jobId);
         eventHandler.handle(event);
@@ -188,7 +192,8 @@ class ProcessingJobEventHandlerTestIT {
             lifecycleCaches,
             notificationAccessor,
             jobAccessor,
-            jobNotificationMappingAccessor
+            jobNotificationMappingAccessor,
+            jobNotificationContentProcessor
         );
         JobProcessingEvent event = new JobProcessingEvent(correlationId, jobId);
         eventHandler.handle(event);


### PR DESCRIPTION
Do not send the notification mapped event for every page of notifications found within the time range of a processing task.  Only send one event when the processing task has finished mapping the notifications.