### PR TITLE
IALERT-3277: Display correct time last sent and status

### DIFF
--- a/alert-database-job/src/main/java/com/synopsys/integration/alert/database/distribution/DistributionRepository.java
+++ b/alert-database-job/src/main/java/com/synopsys/integration/alert/database/distribution/DistributionRepository.java
@@ -24,17 +24,9 @@ public interface DistributionRepository extends JpaRepository<DistributionJobEnt
         value = "SELECT CAST(job.job_id as varchar) AS id, job.enabled, job.name, job.channel_descriptor_name, job.distribution_frequency, filteredAudit.time_last_sent, filteredAudit.status"
             + " FROM alert.distribution_jobs AS job"
             + " LEFT OUTER JOIN ("
-            + "   SELECT auditRequirements.time_last_sent, auditRequirements.status, auditRequirements.common_config_id"
-            + "   FROM alert.audit_entries AS auditRequirements"
-            + "   INNER JOIN ("
-            + "     SELECT initialAudit.common_config_id, MAX(initialAudit.time_last_sent) AS last_sent"
-            + "     FROM alert.audit_entries AS initialAudit"
-            + "     GROUP BY initialAudit.common_config_id"
-            + "   ) AS auditMaxDate"
-            + "   ON auditRequirements.common_config_id = auditMaxDate.common_config_id"
-            + "   AND auditRequirements.time_last_sent = auditMaxDate.last_sent"
-            + "   LIMIT 1"
-            + " ) AS filteredAudit"
+            + " SELECT MAX(auditRequirements.time_last_sent) AS time_last_sent, auditRequirements.status, auditRequirements.common_config_id"
+            + " FROM alert.audit_entries AS auditRequirements"
+            + " GROUP BY auditRequirements.common_config_id, auditRequirements.status) AS filteredAudit"
             + " ON filteredAudit.common_config_id = job.job_id"
             + " WHERE job.channel_descriptor_name IN (:channelDescriptorNames)",
         nativeQuery = true
@@ -42,22 +34,15 @@ public interface DistributionRepository extends JpaRepository<DistributionJobEnt
     Page<DistributionDBResponse> getDistributionWithAuditInfo(Pageable pageable, @Param("channelDescriptorNames") Collection<String> channelDescriptorNames);
 
     @Query(
-        value = "SELECT CAST(job.job_id as varchar) AS id, job.enabled, job.name, job.channel_descriptor_name, job.distribution_frequency, filteredAudit.time_last_sent, filteredAudit.status"
-            + " FROM alert.distribution_jobs AS job"
-            + " LEFT OUTER JOIN ("
-            + "   SELECT auditRequirements.time_last_sent, auditRequirements.status, auditRequirements.common_config_id"
-            + "   FROM alert.audit_entries AS auditRequirements"
-            + "   INNER JOIN ("
-            + "     SELECT initialAudit.common_config_id, MAX(initialAudit.time_last_sent) AS last_sent"
-            + "     FROM alert.audit_entries AS initialAudit"
-            + "     GROUP BY initialAudit.common_config_id"
-            + "   ) AS auditMaxDate"
-            + "   ON auditRequirements.common_config_id = auditMaxDate.common_config_id"
-            + "   AND auditRequirements.time_last_sent = auditMaxDate.last_sent"
-            + "   LIMIT 1"
-            + " ) AS filteredAudit"
-            + " ON filteredAudit.common_config_id = job.job_id"
-            + " WHERE job.channel_descriptor_name IN (:channelDescriptorNames) AND job.name LIKE %:searchTerm%",
+        value =
+            "SELECT CAST(job.job_id as varchar) AS id, job.enabled, job.name, job.channel_descriptor_name, job.distribution_frequency, filteredAudit.time_last_sent, filteredAudit.status"
+                + " FROM alert.distribution_jobs AS job"
+                + " LEFT OUTER JOIN ("
+                + " SELECT MAX(auditRequirements.time_last_sent) AS time_last_sent, auditRequirements.status, auditRequirements.common_config_id"
+                + " FROM alert.audit_entries AS auditRequirements"
+                + " GROUP BY auditRequirements.common_config_id, auditRequirements.status) AS filteredAudit"
+                + " ON filteredAudit.common_config_id = job.job_id"
+                + " WHERE job.channel_descriptor_name IN (:channelDescriptorNames) AND job.name LIKE %:searchTerm%",
         nativeQuery = true
     )
     Page<DistributionDBResponse> getDistributionWithAuditInfoWithSearch(Pageable pageable, @Param("channelDescriptorNames") Collection<String> channelDescriptorNames, @Param("searchTerm") String searchTerm);


### PR DESCRIPTION
fix: Display correct timestamp and status with multiple jobs.

- Get the max timestamp and status for each job configuration. 
- Only display 1 row per job