### PR TITLE
IALERT-3299 SAML metadata file upload

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/AlertRestConstants.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/AlertRestConstants.java
@@ -11,6 +11,7 @@ public final class AlertRestConstants {
     public static final String API = "api";
     public static final String CALLBACKS = "callbacks";
     public static final String OAUTH = "oauth";
+    public static final String UPLOAD = "upload";
     public static final String BASE_PATH = "/" + API;
     public static final String CALLBACKS_PATH = BASE_PATH + "/" + CALLBACKS;
     public static final String OAUTH_CALLBACK_PATH = CALLBACKS_PATH + "/" + OAUTH;

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/FileUploadHelper.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/FileUploadHelper.java
@@ -1,0 +1,51 @@
+package com.synopsys.integration.alert.common.rest.api;
+
+import com.synopsys.integration.alert.common.action.ActionResponse;
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.logging.AlertLoggerFactory;
+import com.synopsys.integration.alert.common.rest.model.ExistenceModel;
+import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
+import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
+import org.slf4j.Logger;
+import org.springframework.http.HttpStatus;
+
+import java.util.function.Supplier;
+
+public class FileUploadHelper {
+    private final Logger logger = AlertLoggerFactory.getLogger(getClass());
+    private final AuthorizationManager authorizationManager;
+    private final ConfigContextEnum context;
+    private final DescriptorKey descriptorKey;
+
+    private static final String FILE_UPLOAD_ACTION_TEMPLATE = "File upload action {}: ";
+    private static final String ACTION_CALLED_TEMPLATE = FILE_UPLOAD_ACTION_TEMPLATE + "{} called.";
+    private static final String ACTION_SUCCESS_TEMPLATE = FILE_UPLOAD_ACTION_TEMPLATE + "{} completed successfully.";
+    private static final String ACTION_NOT_FOUND_TEMPLATE = FILE_UPLOAD_ACTION_TEMPLATE + "{} not found.";
+    private static final String ACTION_BAD_REQUEST_TEMPLATE = FILE_UPLOAD_ACTION_TEMPLATE + "{} bad request.";
+    private static final String ACTION_MISSING_PERMISSIONS_TEMPLATE = FILE_UPLOAD_ACTION_TEMPLATE + "{} missing permissions.";
+
+    public FileUploadHelper (AuthorizationManager authorizationManager, ConfigContextEnum context, DescriptorKey descriptorKey) {
+        this.authorizationManager = authorizationManager;
+        this.context = context;
+        this.descriptorKey = descriptorKey;
+    }
+
+    public ActionResponse<ExistenceModel> fileExists(Supplier<ExistenceModel> modelSupplier) {
+        String actionName = "fileExists";
+        logger.trace(ACTION_CALLED_TEMPLATE, descriptorKey.getUniversalKey(), actionName);
+        if (!authorizationManager.hasUploadReadPermission(context, descriptorKey)) {
+            logger.trace(ACTION_MISSING_PERMISSIONS_TEMPLATE, descriptorKey.getUniversalKey(), actionName);
+            return ActionResponse.createForbiddenResponse();
+        }
+
+        ExistenceModel existenceModel = modelSupplier.get();
+
+        if (!existenceModel.getExists().booleanValue()) {
+            logger.trace(ACTION_NOT_FOUND_TEMPLATE, descriptorKey.getUniversalKey(), actionName);
+            return new ActionResponse<>(HttpStatus.NOT_FOUND);
+        }
+
+        logger.trace(ACTION_SUCCESS_TEMPLATE, descriptorKey.getUniversalKey(), actionName);
+        return new ActionResponse<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/FileUploadHelper.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/api/FileUploadHelper.java
@@ -1,14 +1,18 @@
 package com.synopsys.integration.alert.common.rest.api;
 
+import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.logging.AlertLoggerFactory;
-import com.synopsys.integration.alert.common.rest.model.ExistenceModel;
+import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
 import org.slf4j.Logger;
+import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.function.Supplier;
 
 public class FileUploadHelper {
@@ -16,6 +20,7 @@ public class FileUploadHelper {
     private final AuthorizationManager authorizationManager;
     private final ConfigContextEnum context;
     private final DescriptorKey descriptorKey;
+    private final FilePersistenceUtil filePersistenceUtil;
 
     private static final String FILE_UPLOAD_ACTION_TEMPLATE = "File upload action {}: ";
     private static final String ACTION_CALLED_TEMPLATE = FILE_UPLOAD_ACTION_TEMPLATE + "{} called.";
@@ -24,28 +29,64 @@ public class FileUploadHelper {
     private static final String ACTION_BAD_REQUEST_TEMPLATE = FILE_UPLOAD_ACTION_TEMPLATE + "{} bad request.";
     private static final String ACTION_MISSING_PERMISSIONS_TEMPLATE = FILE_UPLOAD_ACTION_TEMPLATE + "{} missing permissions.";
 
-    public FileUploadHelper (AuthorizationManager authorizationManager, ConfigContextEnum context, DescriptorKey descriptorKey) {
+    private static final String ACTION_NAME_FILE_EXISTS = "fileExists";
+    private static final String ACTION_NAME_FILE_UPLOAD = "fileUpload";
+
+    public FileUploadHelper (AuthorizationManager authorizationManager, ConfigContextEnum context, DescriptorKey descriptorKey, FilePersistenceUtil filePersistenceUtil) {
         this.authorizationManager = authorizationManager;
         this.context = context;
         this.descriptorKey = descriptorKey;
+        this.filePersistenceUtil = filePersistenceUtil;
     }
 
-    public ActionResponse<ExistenceModel> fileExists(Supplier<ExistenceModel> modelSupplier) {
-        String actionName = "fileExists";
-        logger.trace(ACTION_CALLED_TEMPLATE, descriptorKey.getUniversalKey(), actionName);
+    public ActionResponse<Boolean> fileExists(String fileName) {
+        logger.trace(ACTION_CALLED_TEMPLATE, descriptorKey.getUniversalKey(), ACTION_NAME_FILE_EXISTS);
         if (!authorizationManager.hasUploadReadPermission(context, descriptorKey)) {
-            logger.trace(ACTION_MISSING_PERMISSIONS_TEMPLATE, descriptorKey.getUniversalKey(), actionName);
+            logger.trace(ACTION_MISSING_PERMISSIONS_TEMPLATE, descriptorKey.getUniversalKey(), ACTION_NAME_FILE_EXISTS);
             return ActionResponse.createForbiddenResponse();
         }
 
-        ExistenceModel existenceModel = modelSupplier.get();
+        boolean exists = filePersistenceUtil.uploadFileExists(fileName);
 
-        if (!existenceModel.getExists().booleanValue()) {
-            logger.trace(ACTION_NOT_FOUND_TEMPLATE, descriptorKey.getUniversalKey(), actionName);
+        if (!exists) {
+            logger.trace(ACTION_NOT_FOUND_TEMPLATE, descriptorKey.getUniversalKey(), ACTION_NAME_FILE_EXISTS);
             return new ActionResponse<>(HttpStatus.NOT_FOUND);
         }
 
-        logger.trace(ACTION_SUCCESS_TEMPLATE, descriptorKey.getUniversalKey(), actionName);
+        logger.trace(ACTION_SUCCESS_TEMPLATE, descriptorKey.getUniversalKey(), ACTION_NAME_FILE_EXISTS);
         return new ActionResponse<>(HttpStatus.NO_CONTENT);
+    }
+
+    public ActionResponse<Void> fileUpload(String fileName, Resource resource, Supplier<ValidationResponseModel> validator) {
+        logger.trace(ACTION_CALLED_TEMPLATE, descriptorKey.getUniversalKey(), ACTION_NAME_FILE_UPLOAD);
+        if (!authorizationManager.hasUploadWritePermission(context, descriptorKey)) {
+            logger.trace(ACTION_MISSING_PERMISSIONS_TEMPLATE, descriptorKey.getUniversalKey(), ACTION_NAME_FILE_UPLOAD);
+            return ActionResponse.createForbiddenResponse();
+        }
+
+        ValidationResponseModel validationResponseModel = validator.get();
+        if (validationResponseModel.hasErrors()) {
+            logger.trace(ACTION_BAD_REQUEST_TEMPLATE, descriptorKey.getUniversalKey(), ACTION_NAME_FILE_UPLOAD);
+            return new ActionResponse<>(HttpStatus.BAD_REQUEST, validationResponseModel.getMessage());
+        }
+
+        try {
+            writeFile(fileName, resource);
+        } catch (IOException e) {
+            logger.error(String.format("Error uploading file - file: %s, context: %s, descriptor: %s ", fileName, context, descriptorKey));
+            logger.error(String.format("Error uploading file caused by: %s", e));
+            return new ActionResponse<>(HttpStatus.INTERNAL_SERVER_ERROR, "Error uploading file to server.");
+        }
+
+        return new ActionResponse<>(HttpStatus.NO_CONTENT);
+    }
+
+    private void writeFile(String fileName, Resource resource) throws IOException {
+        try (InputStream inputStream = resource.getInputStream()) {
+            filePersistenceUtil.writeFileToUploadsDirectory(fileName, inputStream);
+        } catch (IOException ex) {
+            logger.error(String.format("Error writing file to resource - file: %s", fileName));
+            throw ex;
+        }
     }
 }

--- a/alert-database/src/main/resources/liquibase/6.13.0/concrete-saml-configuration-table.xml
+++ b/alert-database/src/main/resources/liquibase/6.13.0/concrete-saml-configuration-table.xml
@@ -38,7 +38,7 @@
             <column name="entity_base_url" type="VARCHAR">
                 <constraints nullable="false"/>
             </column>
-            <column name="require_assertions_signed" type="BOOLEAN" defaultValueBoolean="false">
+            <column name="want_assertions_signed" type="BOOLEAN" defaultValueBoolean="false">
                 <constraints nullable="false"/>
             </column>
             <column name="role_attribute_mapping" type="VARCHAR">

--- a/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/action/SAMLFileUploadActions.java
+++ b/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/action/SAMLFileUploadActions.java
@@ -1,0 +1,57 @@
+package com.synopsys.integration.alert.authentication.saml.action;
+
+import com.synopsys.integration.alert.authentication.saml.database.accessor.SAMLConfigAccessor;
+import com.synopsys.integration.alert.authentication.saml.model.SAMLConfigModel;
+import com.synopsys.integration.alert.authentication.saml.validator.SAMLConfigurationValidator;
+import com.synopsys.integration.alert.common.action.ActionResponse;
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
+import com.synopsys.integration.alert.common.rest.api.FileUploadHelper;
+import com.synopsys.integration.alert.common.rest.model.ExistenceModel;
+import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
+import com.synopsys.integration.alert.component.authentication.descriptor.AuthenticationDescriptorKey;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+@Component
+public class SAMLFileUploadActions {
+    private final FileUploadHelper fileUploadHelper;
+    private final FilePersistenceUtil filePersistenceUtil;
+
+    private final SAMLConfigAccessor configurationAccessor;
+    private final SAMLConfigurationValidator configurationValidator;
+
+    @Autowired
+    public SAMLFileUploadActions(AuthorizationManager authorizationManager, SAMLConfigAccessor configurationAccessor, SAMLConfigurationValidator configurationValidator, AuthenticationDescriptorKey authenticationDescriptorKey, FilePersistenceUtil filePersistenceUtil) {
+        this.fileUploadHelper = new FileUploadHelper(authorizationManager, ConfigContextEnum.GLOBAL, authenticationDescriptorKey);
+        this.filePersistenceUtil = filePersistenceUtil;
+        this.configurationAccessor = configurationAccessor;
+        this.configurationValidator = configurationValidator;
+    }
+
+    public ActionResponse<ExistenceModel> metadataFileExists() {
+        return fileUploadHelper.fileExists(
+            () -> fileFromConfigFieldExists(samlConfigModel -> samlConfigModel.getMetadataFilePath().orElse(""))
+        );
+    }
+
+//    public ActionResponse<ExistenceModel> encryptionCertificateExists() {
+//        return fileUploadHelper.fileExists(
+//            () -> fileFromConfigFieldExists(samlConfigModel -> samlConfigModel.getEncryptionCertificate().orElse(""))
+//        );
+//    }
+
+    private ExistenceModel fileFromConfigFieldExists(Function<SAMLConfigModel, String> filePathFromConfigMapper) {
+        Boolean exists = Boolean.FALSE;
+        Optional<SAMLConfigModel> optionalSAMLConfigModel = configurationAccessor.getConfiguration();
+        Optional<String> optionalFilePath = optionalSAMLConfigModel.map(filePathFromConfigMapper).filter(StringUtils::isNotBlank);
+        if (optionalFilePath.isPresent()) {
+            exists = filePersistenceUtil.uploadFileExists(optionalFilePath.get());
+        }
+        return new ExistenceModel(exists);
+    }
+}

--- a/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/database/accessor/SAMLConfigAccessor.java
+++ b/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/database/accessor/SAMLConfigAccessor.java
@@ -81,7 +81,7 @@ public class SAMLConfigAccessor implements UniqueConfigurationAccessor<SAMLConfi
             samlConfigurationEntity.getMetadataFilePath(),
             samlConfigurationEntity.getEntityId(),
             samlConfigurationEntity.getEntityBaseUrl(),
-            samlConfigurationEntity.getRequireAssertionsSigned(),
+            samlConfigurationEntity.getWantAssertionsSigned(),
             samlConfigurationEntity.getRoleAttributeMapping()
         );
     }
@@ -97,7 +97,7 @@ public class SAMLConfigAccessor implements UniqueConfigurationAccessor<SAMLConfi
             samlConfigModel.getMetadataFilePath().orElse(""),
             samlConfigModel.getEntityId(),
             samlConfigModel.getEntityBaseUrl(),
-            samlConfigModel.getRequireAssertionsSigned().orElse(Boolean.FALSE),
+            samlConfigModel.getWantAssertionsSigned().orElse(Boolean.FALSE),
             samlConfigModel.getRoleAttributeMapping().orElse("")
         );
     }

--- a/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/database/configuration/SAMLConfigurationEntity.java
+++ b/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/database/configuration/SAMLConfigurationEntity.java
@@ -31,8 +31,8 @@ public class SAMLConfigurationEntity extends BaseEntity {
     private String entityId;
     @Column(name = "entity_base_url")
     private String entityBaseUrl;
-    @Column(name = "require_assertions_signed")
-    private Boolean requireAssertionsSigned;
+    @Column(name = "want_assertions_signed")
+    private Boolean wantAssertionsSigned;
     @Column(name = "role_attribute_mapping")
     private String roleAttributeMapping;
 
@@ -49,7 +49,7 @@ public class SAMLConfigurationEntity extends BaseEntity {
         String metadataFilePath,
         String entityId,
         String entityBaseUrl,
-        Boolean requireAssertionsSigned,
+        Boolean wantAssertionsSigned,
         String roleAttributeMapping
     ) {
         this.configurationId = configurationId;
@@ -62,7 +62,7 @@ public class SAMLConfigurationEntity extends BaseEntity {
         this.metadataFilePath = metadataFilePath;
         this.entityId = entityId;
         this.entityBaseUrl = entityBaseUrl;
-        this.requireAssertionsSigned = requireAssertionsSigned;
+        this.wantAssertionsSigned = wantAssertionsSigned;
         this.roleAttributeMapping = roleAttributeMapping;
     }
 
@@ -106,8 +106,8 @@ public class SAMLConfigurationEntity extends BaseEntity {
         return entityBaseUrl;
     }
 
-    public Boolean getRequireAssertionsSigned() {
-        return requireAssertionsSigned;
+    public Boolean getWantAssertionsSigned() {
+        return wantAssertionsSigned;
     }
 
     public String getRoleAttributeMapping() {

--- a/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/model/SAMLConfigModel.java
+++ b/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/model/SAMLConfigModel.java
@@ -13,7 +13,7 @@ public class SAMLConfigModel extends ConfigWithMetadata implements Obfuscated<SA
     private String metadataFilePath;
     private String entityId;
     private String entityBaseUrl;
-    private Boolean requireAssertionsSigned;
+    private Boolean wantAssertionsSigned;
     private String roleAttributeMapping;
 
     public SAMLConfigModel() {
@@ -35,7 +35,7 @@ public class SAMLConfigModel extends ConfigWithMetadata implements Obfuscated<SA
         String metadataFilePath,
         String entityId,
         String entityBaseUrl,
-        Boolean requireAssertionsSigned,
+        Boolean wantAssertionsSigned,
         String roleAttributeMapping
     ) {
         this(id);
@@ -45,7 +45,7 @@ public class SAMLConfigModel extends ConfigWithMetadata implements Obfuscated<SA
         this.metadataFilePath = metadataFilePath;
         this.entityId = entityId;
         this.entityBaseUrl = entityBaseUrl;
-        this.requireAssertionsSigned = requireAssertionsSigned;
+        this.wantAssertionsSigned = wantAssertionsSigned;
         this.roleAttributeMapping = roleAttributeMapping;
 
         setCreatedAt(createdAt);
@@ -64,7 +64,7 @@ public class SAMLConfigModel extends ConfigWithMetadata implements Obfuscated<SA
             metadataFilePath,
             entityId,
             entityBaseUrl,
-            requireAssertionsSigned,
+            wantAssertionsSigned,
             roleAttributeMapping
         );
     }
@@ -92,8 +92,8 @@ public class SAMLConfigModel extends ConfigWithMetadata implements Obfuscated<SA
         return entityBaseUrl;
     }
 
-    public Optional<Boolean> getRequireAssertionsSigned() {
-        return Optional.ofNullable(requireAssertionsSigned);
+    public Optional<Boolean> getWantAssertionsSigned() {
+        return Optional.ofNullable(wantAssertionsSigned);
     }
 
     public Optional<String> getRoleAttributeMapping() {

--- a/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/validator/SAMLConfigurationValidator.java
+++ b/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/validator/SAMLConfigurationValidator.java
@@ -30,12 +30,9 @@ public class SAMLConfigurationValidator {
 
         // Perform validation on fields if enabled
         if (model.getEnabled().orElse(false)) {
-            // Convert to empty optional for blank metadata url and file path
             Optional<String> optionalFilteredMetadataUrl = model.getMetadataUrl().filter(StringUtils::isNotBlank);
-            Optional<String> optionalFilteredMetadataFilePath = model.getMetadataFilePath().filter(StringUtils::isNotBlank);
-            boolean metadataFileExists = optionalFilteredMetadataFilePath
-                .map(filePersistenceUtil::uploadFileExists)
-                .orElse(false);
+            // Just check if file is upload - filePath is for showing to user their uploaded path and may not need to validate it
+            boolean metadataFileExists = filePersistenceUtil.uploadFileExists(AuthenticationDescriptor.SAML_METADATA_FILE);
 
             if (StringUtils.isBlank(model.getEntityId())) {
                 statuses.add(AlertFieldStatus.error(AuthenticationDescriptor.KEY_SAML_ENTITY_ID, AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
@@ -46,7 +43,7 @@ public class SAMLConfigurationValidator {
                 addErrorStatusIfInvalidUrl(model.getEntityBaseUrl(), AuthenticationDescriptor.KEY_SAML_ENTITY_BASE_URL, statuses);
             }
 
-            // One of url or filepath must exist
+            // One of url or file must exist
             if (optionalFilteredMetadataUrl.isEmpty() && !metadataFileExists) {
                 statuses.add(AlertFieldStatus.error(
                     AuthenticationDescriptor.KEY_SAML_METADATA_FILE,

--- a/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/validator/SAMLFileUploadValidator.java
+++ b/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/validator/SAMLFileUploadValidator.java
@@ -41,7 +41,7 @@ public class SAMLFileUploadValidator {
         );
     }
 
-    public ValidationResponseModel validateFile(String fileName, Resource resource, Function<File, ValidationResult> validateFunction) {
+    private ValidationResponseModel validateFile(String fileName, Resource resource, Function<File, ValidationResult> validateFunction) {
         String tempFilename = "temp_" + fileName;
         try {
             filePersistenceUtil.writeFileToUploadsDirectory(tempFilename, resource.getInputStream());

--- a/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/validator/SAMLFileUploadValidator.java
+++ b/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/validator/SAMLFileUploadValidator.java
@@ -1,4 +1,92 @@
 package com.synopsys.integration.alert.authentication.saml.validator;
 
+import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
+import com.synopsys.integration.alert.common.descriptor.config.field.validation.ValidationResult;
+import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
+import com.synopsys.integration.alert.component.authentication.descriptor.AuthenticationDescriptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Function;
+
+@Component
 public class SAMLFileUploadValidator {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final FilePersistenceUtil filePersistenceUtil;
+
+    @Autowired
+    public SAMLFileUploadValidator(FilePersistenceUtil filePersistenceUtil) {
+        this.filePersistenceUtil = filePersistenceUtil;
+    }
+
+    public ValidationResponseModel validateMetadataFile(Resource resource) {
+        return validateFile(
+            AuthenticationDescriptor.SAML_METADATA_FILE,
+            resource,
+            this::validateXMLFile
+        );
+    }
+
+    public ValidationResponseModel validateFile(String fileName, Resource resource, Function<File, ValidationResult> validateFunction) {
+        String tempFilename = "temp_" + fileName;
+        try {
+            filePersistenceUtil.writeFileToUploadsDirectory(tempFilename, resource.getInputStream());
+            File tempFileToValidate = filePersistenceUtil.createUploadsFile(tempFilename);
+            ValidationResult validationResult = validateFunction.apply(tempFileToValidate);
+            filePersistenceUtil.delete(tempFileToValidate);
+            if (validationResult.hasErrors()) {
+                return ValidationResponseModel.generalError(validationResult.combineErrorMessages());
+            }
+        } catch (IOException ex) {
+            logger.error(String.format("Error writing to or deleting %s, caused by: %s", tempFilename, ex.getMessage()));
+            return ValidationResponseModel.generalError( "Error uploading file to server.");
+        }
+        return ValidationResponseModel.success();
+    }
+
+    private ValidationResult validateXMLFile(File file) {
+        try (InputStream fileInputStream = new FileInputStream(file)) {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setValidating(false);
+            factory.setNamespaceAware(true);
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            XMLErrorHandler errorHandler = new XMLErrorHandler();
+            builder.setErrorHandler(errorHandler);
+            builder.parse(new InputSource(fileInputStream));
+        } catch (ParserConfigurationException | SAXException | IOException ex) {
+            return ValidationResult.errors(String.format("XML file error: %s", ex.getMessage()));
+        }
+        return ValidationResult.success();
+    }
+
+    private class XMLErrorHandler implements ErrorHandler {
+        @Override
+        public void warning(SAXParseException exception) throws SAXException {
+            logger.warn("File upload exception warning:", exception);
+        }
+
+        @Override
+        public void error(SAXParseException exception) throws SAXException {
+            logger.error("File upload exception error:", exception);
+        }
+
+        @Override
+        public void fatalError(SAXParseException exception) throws SAXException {
+            logger.error("File upload exception fatal error:", exception);
+        }
+    }
 }

--- a/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/validator/SAMLFileUploadValidator.java
+++ b/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/validator/SAMLFileUploadValidator.java
@@ -1,0 +1,4 @@
+package com.synopsys.integration.alert.authentication.saml.validator;
+
+public class SAMLFileUploadValidator {
+}

--- a/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/web/SAMLConfigController.java
+++ b/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/web/SAMLConfigController.java
@@ -10,7 +10,6 @@ import com.synopsys.integration.alert.common.rest.ResponseFactory;
 import com.synopsys.integration.alert.common.rest.api.StaticUniqueConfigResourceController;
 import com.synopsys.integration.alert.common.rest.api.ValidateController;
 
-import com.synopsys.integration.alert.common.rest.model.ExistenceModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -19,11 +18,11 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping(AlertRestConstants.SAML_PATH)
 public class SAMLConfigController implements StaticUniqueConfigResourceController<SAMLConfigModel>, ValidateController<SAMLConfigModel> {
+    private static final String METADATA_FILE_UPLOAD_PATH = "/" + AlertRestConstants.UPLOAD + "/metadata";
+
     private final SAMLCrudActions configActions;
     private final SAMLValidationAction validationAction;
     private final SAMLFileUploadActions fileUploadActions;
-
-    private final String METADATA_FILE_UPLOAD_PATH = "/" + AlertRestConstants.UPLOAD + "/metadata";
 
     @Autowired
     public SAMLConfigController(SAMLCrudActions configActions, SAMLValidationAction validationAction, SAMLFileUploadActions fileUploadActions) {

--- a/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/web/SAMLConfigController.java
+++ b/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/web/SAMLConfigController.java
@@ -2,6 +2,7 @@ package com.synopsys.integration.alert.authentication.saml.web;
 
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.authentication.saml.action.SAMLCrudActions;
+import com.synopsys.integration.alert.authentication.saml.action.SAMLFileUploadActions;
 import com.synopsys.integration.alert.authentication.saml.action.SAMLValidationAction;
 import com.synopsys.integration.alert.authentication.saml.model.SAMLConfigModel;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
@@ -9,20 +10,26 @@ import com.synopsys.integration.alert.common.rest.ResponseFactory;
 import com.synopsys.integration.alert.common.rest.api.StaticUniqueConfigResourceController;
 import com.synopsys.integration.alert.common.rest.api.ValidateController;
 
+import com.synopsys.integration.alert.common.rest.model.ExistenceModel;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping(AlertRestConstants.SAML_PATH)
 public class SAMLConfigController implements StaticUniqueConfigResourceController<SAMLConfigModel>, ValidateController<SAMLConfigModel> {
     private final SAMLCrudActions configActions;
     private final SAMLValidationAction validationAction;
+    private final SAMLFileUploadActions fileUploadActions;
+
+    private final String METADATA_FILE_UPLOAD_PATH = "/" + AlertRestConstants.UPLOAD + "/metadata";
 
     @Autowired
-    public SAMLConfigController(SAMLCrudActions configActions, SAMLValidationAction validationAction) {
+    public SAMLConfigController(SAMLCrudActions configActions, SAMLValidationAction validationAction, SAMLFileUploadActions fileUploadActions) {
         this.configActions = configActions;
         this.validationAction = validationAction;
+        this.fileUploadActions = fileUploadActions;
     }
 
     @Override
@@ -48,5 +55,16 @@ public class SAMLConfigController implements StaticUniqueConfigResourceControlle
     @Override
     public ValidationResponseModel validate(SAMLConfigModel requestBody) {
         return ResponseFactory.createContentResponseFromAction(validationAction.validate(requestBody));
+    }
+
+    @GetMapping(METADATA_FILE_UPLOAD_PATH)
+    public ExistenceModel checkMetadataFileExists() {
+        return ResponseFactory.createContentResponseFromAction(fileUploadActions.metadataFileExists());
+    }
+
+    @PostMapping(METADATA_FILE_UPLOAD_PATH)
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void uploadMetadataFile(@RequestParam("file") MultipartFile file) {
+        //ResponseFactory.createResponseFromAction(fileUploadActions.uploadFile(file.getResource()));
     }
 }

--- a/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/web/SAMLConfigController.java
+++ b/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/web/SAMLConfigController.java
@@ -58,13 +58,13 @@ public class SAMLConfigController implements StaticUniqueConfigResourceControlle
     }
 
     @GetMapping(METADATA_FILE_UPLOAD_PATH)
-    public ExistenceModel checkMetadataFileExists() {
+    public boolean checkMetadataFileExists() {
         return ResponseFactory.createContentResponseFromAction(fileUploadActions.metadataFileExists());
     }
 
     @PostMapping(METADATA_FILE_UPLOAD_PATH)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void uploadMetadataFile(@RequestParam("file") MultipartFile file) {
-        //ResponseFactory.createResponseFromAction(fileUploadActions.uploadFile(file.getResource()));
+        ResponseFactory.createResponseFromAction(fileUploadActions.metadataFileUpload(file.getResource()));
     }
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/authentication/web/SamlMetaDataFileUpload.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/authentication/web/SamlMetaDataFileUpload.java
@@ -34,6 +34,11 @@ import com.synopsys.integration.alert.common.security.authorization.Authorizatio
 import com.synopsys.integration.alert.component.authentication.descriptor.AuthenticationDescriptor;
 import com.synopsys.integration.alert.component.authentication.descriptor.AuthenticationDescriptorKey;
 
+/**
+ * Replaced by SAMLFileUploadActions
+ * @deprecated
+ */
+@Deprecated(since = "6.13.0", forRemoval = true)
 @Component
 public class SamlMetaDataFileUpload extends AbstractUploadAction {
     private final Logger logger = LoggerFactory.getLogger(SamlMetaDataFileUpload.class);


### PR DESCRIPTION
- Create FileUploadHelper, SAMLFileUploadValidator, SAMLFileUploadActions for uploading and validation of saml metadata file
- Fixed SAMLConfigValidator to not perform check on metadataFilePath string but on fileExists instead
