### PR TITLE
IALERT-3288 - Move classes and update for new Test Configuration

### DIFF
--- a/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/descriptor/AuthenticationDescriptor.java
+++ b/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/descriptor/AuthenticationDescriptor.java
@@ -1,10 +1,3 @@
-/*
- * component
- *
- * Copyright (c) 2022 Synopsys, Inc.
- *
- * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
- */
 package com.synopsys.integration.alert.api.authentication.descriptor;
 
 import java.util.Optional;

--- a/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/descriptor/AuthenticationDescriptorKey.java
+++ b/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/descriptor/AuthenticationDescriptorKey.java
@@ -1,10 +1,3 @@
-/*
- * component
- *
- * Copyright (c) 2022 Synopsys, Inc.
- *
- * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
- */
 package com.synopsys.integration.alert.api.authentication.descriptor;
 
 

--- a/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/security/AuthenticationPerformer.java
+++ b/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/security/AuthenticationPerformer.java
@@ -1,10 +1,3 @@
-/*
- * component
- *
- * Copyright (c) 2022 Synopsys, Inc.
- *
- * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
- */
 package com.synopsys.integration.alert.api.authentication.security;
 
 import java.util.Collection;
@@ -18,10 +11,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import com.synopsys.integration.alert.api.authentication.security.event.AuthenticationEventManager;
 import com.synopsys.integration.alert.common.descriptor.accessor.RoleAccessor;
 import com.synopsys.integration.alert.common.enumeration.AuthenticationType;
 import com.synopsys.integration.alert.common.persistence.model.UserRoleModel;
-import com.synopsys.integration.alert.api.authentication.security.event.AuthenticationEventManager;
 
 public abstract class AuthenticationPerformer {
     private AuthenticationEventManager authenticationEventManager;

--- a/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/security/UserManagementAuthoritiesPopulator.java
+++ b/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/security/UserManagementAuthoritiesPopulator.java
@@ -5,7 +5,7 @@
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
-package com.synopsys.integration.alert.component.authentication.security;
+package com.synopsys.integration.alert.api.authentication.security;
 
 import java.util.LinkedHashSet;
 import java.util.Optional;
@@ -21,6 +21,8 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
+import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptor;
+import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptorKey;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.common.enumeration.DefaultUserRole;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationModelConfigurationAccessor;
@@ -28,8 +30,6 @@ import com.synopsys.integration.alert.common.persistence.accessor.UserAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
 import com.synopsys.integration.alert.common.persistence.model.UserModel;
-import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptor;
-import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptorKey;
 
 @Component
 public class UserManagementAuthoritiesPopulator {

--- a/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/security/event/AlertAuthenticationEvent.java
+++ b/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/security/event/AlertAuthenticationEvent.java
@@ -1,10 +1,3 @@
-/*
- * component
- *
- * Copyright (c) 2022 Synopsys, Inc.
- *
- * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
- */
 package com.synopsys.integration.alert.api.authentication.security.event;
 
 import com.synopsys.integration.alert.api.event.AlertEvent;

--- a/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/security/event/AuthenticationEventHandler.java
+++ b/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/security/event/AuthenticationEventHandler.java
@@ -1,10 +1,3 @@
-/*
- * component
- *
- * Copyright (c) 2022 Synopsys, Inc.
- *
- * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
- */
 package com.synopsys.integration.alert.api.authentication.security.event;
 
 import java.util.Optional;
@@ -12,7 +5,6 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.synopsys.integration.alert.api.authentication.security.event.AlertAuthenticationEvent;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.api.event.AlertEventHandler;
 import com.synopsys.integration.alert.common.exception.AlertForbiddenOperationException;

--- a/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/security/event/AuthenticationEventListener.java
+++ b/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/security/event/AuthenticationEventListener.java
@@ -1,10 +1,3 @@
-/*
- * component
- *
- * Copyright (c) 2022 Synopsys, Inc.
- *
- * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
- */
 package com.synopsys.integration.alert.api.authentication.security.event;
 
 import org.springframework.core.task.TaskExecutor;

--- a/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/security/event/AuthenticationEventManager.java
+++ b/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/security/event/AuthenticationEventManager.java
@@ -1,10 +1,3 @@
-/*
- * component
- *
- * Copyright (c) 2022 Synopsys, Inc.
- *
- * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
- */
 package com.synopsys.integration.alert.api.authentication.security.event;
 
 import java.util.Collection;

--- a/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/validator/AuthenticationConfigurationFieldModelValidator.java
+++ b/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/validator/AuthenticationConfigurationFieldModelValidator.java
@@ -1,10 +1,3 @@
-/*
- * component
- *
- * Copyright (c) 2022 Synopsys, Inc.
- *
- * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
- */
 package com.synopsys.integration.alert.api.authentication.validator;
 
 import java.util.List;
@@ -13,12 +6,12 @@ import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptor;
 import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatus;
 import com.synopsys.integration.alert.common.descriptor.validator.ConfigurationFieldValidator;
 import com.synopsys.integration.alert.common.descriptor.validator.GlobalConfigurationFieldModelValidator;
 import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
-import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptor;
 
 @Component
 public class AuthenticationConfigurationFieldModelValidator implements GlobalConfigurationFieldModelValidator {

--- a/authentication-ldap/build.gradle
+++ b/authentication-ldap/build.gradle
@@ -8,9 +8,9 @@ dependencies {
     implementation project(':api-common-model')
     implementation project(':api-descriptor')
     implementation project(':api-authentication')
-    implementation project(':component')
 
     implementation 'jakarta.persistence:jakarta.persistence-api'
+    implementation 'org.springframework.security:spring-security-ldap'
     implementation 'org.springframework:spring-web'
 
     testImplementation project(':test-common-channel')

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/LdapAuthenticationPerformer.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/LdapAuthenticationPerformer.java
@@ -1,11 +1,4 @@
-/*
- * component
- *
- * Copyright (c) 2022 Synopsys, Inc.
- *
- * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
- */
-package com.synopsys.integration.alert.component.authentication.security.ldap;
+package com.synopsys.integration.alert.authentication.ldap;
 
 import java.util.Optional;
 
@@ -16,11 +9,12 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.ldap.authentication.LdapAuthenticationProvider;
 import org.springframework.stereotype.Component;
 
-import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
-import com.synopsys.integration.alert.common.descriptor.accessor.RoleAccessor;
-import com.synopsys.integration.alert.common.enumeration.AuthenticationType;
 import com.synopsys.integration.alert.api.authentication.security.AuthenticationPerformer;
 import com.synopsys.integration.alert.api.authentication.security.event.AuthenticationEventManager;
+import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
+import com.synopsys.integration.alert.authentication.ldap.action.LdapManager;
+import com.synopsys.integration.alert.common.descriptor.accessor.RoleAccessor;
+import com.synopsys.integration.alert.common.enumeration.AuthenticationType;
 
 @Component
 public class LdapAuthenticationPerformer extends AuthenticationPerformer {

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/LdapConfig.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/LdapConfig.java
@@ -1,11 +1,4 @@
-/*
- * component
- *
- * Copyright (c) 2022 Synopsys, Inc.
- *
- * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
- */
-package com.synopsys.integration.alert.component.authentication.security.ldap;
+package com.synopsys.integration.alert.authentication.ldap;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/MappingLdapAuthoritiesPopulator.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/MappingLdapAuthoritiesPopulator.java
@@ -1,11 +1,4 @@
-/*
- * component
- *
- * Copyright (c) 2022 Synopsys, Inc.
- *
- * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
- */
-package com.synopsys.integration.alert.component.authentication.security.ldap;
+package com.synopsys.integration.alert.authentication.ldap;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -17,15 +10,15 @@ import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.ldap.userdetails.DefaultLdapAuthoritiesPopulator;
 
-import com.synopsys.integration.alert.component.authentication.security.UserManagementAuthoritiesPopulator;
+import com.synopsys.integration.alert.api.authentication.security.UserManagementAuthoritiesPopulator;
 
 public class MappingLdapAuthoritiesPopulator extends DefaultLdapAuthoritiesPopulator {
     private final Logger logger = LoggerFactory.getLogger(MappingLdapAuthoritiesPopulator.class);
-    private final UserManagementAuthoritiesPopulator authoritiesPopulator;
+    private final UserManagementAuthoritiesPopulator userManagementAuthoritiesPopulator;
 
-    public MappingLdapAuthoritiesPopulator(ContextSource contextSource, String groupSearchBase, UserManagementAuthoritiesPopulator authoritiesPopulator) {
+    public MappingLdapAuthoritiesPopulator(ContextSource contextSource, String groupSearchBase, UserManagementAuthoritiesPopulator userManagementAuthoritiesPopulator) {
         super(contextSource, groupSearchBase);
-        this.authoritiesPopulator = authoritiesPopulator;
+        this.userManagementAuthoritiesPopulator = userManagementAuthoritiesPopulator;
     }
 
     @Override
@@ -46,6 +39,6 @@ public class MappingLdapAuthoritiesPopulator extends DefaultLdapAuthoritiesPopul
     @Override
     protected Set<GrantedAuthority> getAdditionalRoles(DirContextOperations user, String username) {
         // load the roles from the database.  These roles will be added to the set of roles for the user.
-        return authoritiesPopulator.addAdditionalRoles(username, Set.of());
+        return userManagementAuthoritiesPopulator.addAdditionalRoles(username, Set.of());
     }
 }

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/action/LDAPTestAction.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/action/LDAPTestAction.java
@@ -1,0 +1,54 @@
+package com.synopsys.integration.alert.authentication.ldap.action;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.ldap.authentication.LdapAuthenticationProvider;
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptorKey;
+import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
+import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
+import com.synopsys.integration.alert.authentication.ldap.model.LDAPConfigTestModel;
+import com.synopsys.integration.alert.authentication.ldap.validator.LDAPConfigurationValidator;
+import com.synopsys.integration.alert.common.action.ActionResponse;
+import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
+import com.synopsys.integration.alert.common.message.model.ConfigurationTestResult;
+import com.synopsys.integration.alert.common.rest.api.ConfigurationTestHelper;
+import com.synopsys.integration.alert.common.rest.api.ConfigurationValidationHelper;
+import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
+
+@Component
+public class LDAPTestAction {
+    private final ConfigurationValidationHelper configurationValidationHelper;
+    private final ConfigurationTestHelper configurationTestHelper;
+    private final LDAPConfigurationValidator ldapConfigurationValidator;
+    private final LdapManager ldapManager;
+
+    @Autowired
+    public LDAPTestAction(
+        AuthorizationManager authorizationManager,
+        AuthenticationDescriptorKey authenticationDescriptorKey,
+        LDAPConfigurationValidator ldapConfigurationValidator,
+        LdapManager ldapManager
+    ) {
+        this.configurationValidationHelper = new ConfigurationValidationHelper(authorizationManager, ConfigContextEnum.GLOBAL, authenticationDescriptorKey);
+        this.configurationTestHelper = new ConfigurationTestHelper(authorizationManager, ConfigContextEnum.GLOBAL, authenticationDescriptorKey);
+        this.ldapConfigurationValidator = ldapConfigurationValidator;
+        this.ldapManager = ldapManager;
+    }
+
+    public ActionResponse<ValidationResponseModel> testAuthentication(LDAPConfigTestModel ldapConfigTestModel) {
+        testConfigModelContent(ldapConfigTestModel);
+        return null;
+    }
+
+    protected ConfigurationTestResult testConfigModelContent(LDAPConfigTestModel ldapConfigTestModel) {
+        try {
+            Optional<LdapAuthenticationProvider> ldapProvider = ldapManager.createAuthProvider(ldapConfigTestModel.getLdapConfigModel());
+        } catch (AlertConfigurationException ex) {
+            //
+        }
+        return null;
+    }
+}

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManager.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManager.java
@@ -1,11 +1,4 @@
-/*
- * component
- *
- * Copyright (c) 2022 Synopsys, Inc.
- *
- * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
- */
-package com.synopsys.integration.alert.component.authentication.security.ldap;
+package com.synopsys.integration.alert.authentication.ldap.action;
 
 import java.util.Optional;
 
@@ -24,32 +17,33 @@ import org.springframework.security.ldap.userdetails.InetOrgPersonContextMapper;
 import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
 import org.springframework.stereotype.Component;
 
+import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptor;
+import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptorKey;
+import com.synopsys.integration.alert.api.authentication.security.UserManagementAuthoritiesPopulator;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
+import com.synopsys.integration.alert.authentication.ldap.MappingLdapAuthoritiesPopulator;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationModelConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldUtility;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
-import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptor;
-import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptorKey;
-import com.synopsys.integration.alert.component.authentication.security.UserManagementAuthoritiesPopulator;
 
 @Component
 public class LdapManager {
     private final AuthenticationDescriptorKey authenticationDescriptorKey;
     private final ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor;
-    private final UserManagementAuthoritiesPopulator authoritiesPopulator;
+    private final UserManagementAuthoritiesPopulator userManagementAuthoritiesPopulator;
     private final InetOrgPersonContextMapper inetOrgPersonContextMapper;
 
     @Autowired
     public LdapManager(
         AuthenticationDescriptorKey authenticationDescriptorKey,
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor,
-        UserManagementAuthoritiesPopulator authoritiesPopulator,
+        UserManagementAuthoritiesPopulator userManagementAuthoritiesPopulator,
         InetOrgPersonContextMapper inetOrgPersonContextMapper
     ) {
         this.authenticationDescriptorKey = authenticationDescriptorKey;
         this.configurationModelConfigurationAccessor = configurationModelConfigurationAccessor;
-        this.authoritiesPopulator = authoritiesPopulator;
+        this.userManagementAuthoritiesPopulator = userManagementAuthoritiesPopulator;
         this.inetOrgPersonContextMapper = inetOrgPersonContextMapper;
     }
 
@@ -151,7 +145,11 @@ public class LdapManager {
         String groupSearchBase = configurationModel.getStringOrEmpty(AuthenticationDescriptor.KEY_LDAP_GROUP_SEARCH_BASE);
         String groupSearchFilter = configurationModel.getStringOrEmpty(AuthenticationDescriptor.KEY_LDAP_GROUP_SEARCH_FILTER);
         String groupRoleAttribute = configurationModel.getStringOrEmpty(AuthenticationDescriptor.KEY_LDAP_GROUP_ROLE_ATTRIBUTE);
-        MappingLdapAuthoritiesPopulator mappingLdapAuthoritiesPopulator = new MappingLdapAuthoritiesPopulator(contextSource, groupSearchBase, this.authoritiesPopulator);
+        MappingLdapAuthoritiesPopulator mappingLdapAuthoritiesPopulator = new MappingLdapAuthoritiesPopulator(
+            contextSource,
+            groupSearchBase,
+            this.userManagementAuthoritiesPopulator
+        );
         mappingLdapAuthoritiesPopulator.setGroupSearchFilter(groupSearchFilter);
         mappingLdapAuthoritiesPopulator.setGroupRoleAttribute(groupRoleAttribute);
         // expect the LDAP group name for the role to be ROLE_<ROLE_NAME> where ROLE_NAME defined in UserRoles

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/model/LDAPConfigTestModel.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/model/LDAPConfigTestModel.java
@@ -1,0 +1,25 @@
+package com.synopsys.integration.alert.authentication.ldap.model;
+
+public class LDAPConfigTestModel {
+    private final LDAPConfigModel ldapConfigModel;
+    private final String testLDAPUsername;
+    private final String testLDAPPassword;
+
+    public LDAPConfigTestModel(LDAPConfigModel ldapConfigModel, String testLDAPUsername, String testLDAPPassword) {
+        this.ldapConfigModel = ldapConfigModel;
+        this.testLDAPUsername = testLDAPUsername;
+        this.testLDAPPassword = testLDAPPassword;
+    }
+
+    public LDAPConfigModel getLdapConfigModel() {
+        return ldapConfigModel;
+    }
+
+    public String getTestLDAPUsername() {
+        return testLDAPUsername;
+    }
+
+    public String getTestLDAPPassword() {
+        return testLDAPPassword;
+    }
+}

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/web/LDAPConfigController.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/web/LDAPConfigController.java
@@ -1,13 +1,17 @@
 package com.synopsys.integration.alert.authentication.ldap.web;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.authentication.ldap.action.LDAPCrudActions;
+import com.synopsys.integration.alert.authentication.ldap.action.LDAPTestAction;
 import com.synopsys.integration.alert.authentication.ldap.action.LDAPValidationAction;
 import com.synopsys.integration.alert.authentication.ldap.model.LDAPConfigModel;
+import com.synopsys.integration.alert.authentication.ldap.model.LDAPConfigTestModel;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.rest.ResponseFactory;
 import com.synopsys.integration.alert.common.rest.api.StaticUniqueConfigResourceController;
@@ -18,11 +22,13 @@ import com.synopsys.integration.alert.common.rest.api.ValidateController;
 public class LDAPConfigController implements StaticUniqueConfigResourceController<LDAPConfigModel>, ValidateController<LDAPConfigModel> {
     private final LDAPCrudActions ldapCrudActions;
     private final LDAPValidationAction ldapValidationAction;
+    private final LDAPTestAction ldapTestAction;
 
     @Autowired
-    public LDAPConfigController(LDAPCrudActions ldapCrudActions, LDAPValidationAction ldapValidationAction) {
+    public LDAPConfigController(LDAPCrudActions ldapCrudActions, LDAPValidationAction ldapValidationAction, LDAPTestAction ldapTestAction) {
         this.ldapCrudActions = ldapCrudActions;
         this.ldapValidationAction = ldapValidationAction;
+        this.ldapTestAction = ldapTestAction;
     }
 
     @Override
@@ -50,4 +56,8 @@ public class LDAPConfigController implements StaticUniqueConfigResourceControlle
         return ResponseFactory.createContentResponseFromAction(ldapValidationAction.validate(ldapConfigModel));
     }
 
+    @PostMapping("/test")
+    public ValidationResponseModel test(@RequestBody LDAPConfigTestModel ldapConfigTestModel) {
+        return ResponseFactory.createContentResponseFromAction(ldapTestAction.testAuthentication(ldapConfigTestModel));
+    }
 }

--- a/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManagerTest.java
+++ b/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManagerTest.java
@@ -1,4 +1,4 @@
-package com.synopsys.integration.alert.component.authentication.security.ldap;
+package com.synopsys.integration.alert.authentication.ldap.action;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -12,15 +12,15 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.security.ldap.userdetails.InetOrgPersonContextMapper;
 
+import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptor;
+import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptorKey;
+import com.synopsys.integration.alert.api.authentication.security.UserManagementAuthoritiesPopulator;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldUtility;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
 import com.synopsys.integration.alert.common.persistence.model.mutable.ConfigurationModelMutable;
-import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptor;
-import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptorKey;
-import com.synopsys.integration.alert.component.authentication.security.UserManagementAuthoritiesPopulator;
 import com.synopsys.integration.alert.database.api.DefaultConfigurationModelConfigurationAccessor;
 import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
 
@@ -94,34 +94,71 @@ public class LdapManagerTest {
     public void testUpdate() throws Exception {
         ConfigurationModel configurationModel = createConfigurationModel();
         DefaultConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(DefaultConfigurationModelConfigurationAccessor.class);
-        UserManagementAuthoritiesPopulator authoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
+        UserManagementAuthoritiesPopulator userManagementAuthoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKey(Mockito.any(DescriptorKey.class))).thenReturn(List.of(configurationModel));
 
-        LdapManager ldapManager = new LdapManager(AUTHENTICATION_DESCRIPTOR_KEY, configurationModelConfigurationAccessor, authoritiesPopulator, LDAP_USER_CONTEXT_MAPPER);
+        LdapManager ldapManager = new LdapManager(
+            AUTHENTICATION_DESCRIPTOR_KEY,
+            configurationModelConfigurationAccessor,
+            userManagementAuthoritiesPopulator,
+            LDAP_USER_CONTEXT_MAPPER
+        );
 
         FieldUtility updatedProperties = ldapManager.getCurrentConfiguration();
-        assertEquals(DEFAULT_ENABLED, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_ENABLED).flatMap(field -> field.getFieldValue()).orElse(null));
-        assertEquals(DEFAULT_SERVER, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_SERVER).flatMap(field -> field.getFieldValue()).orElse(null));
-        assertEquals(DEFAULT_MANAGER_DN, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_MANAGER_DN).flatMap(field -> field.getFieldValue()).orElse(null));
-        assertEquals(DEFAULT_MANAGER_PASSWORD, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_MANAGER_PWD).flatMap(field -> field.getFieldValue()).orElse(null));
-        assertEquals(DEFAULT_AUTHENTICATION_TYPE, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_AUTHENTICATION_TYPE).flatMap(field -> field.getFieldValue()).orElse(null));
-        assertEquals(DEFAULT_REFERRAL, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_REFERRAL).flatMap(field -> field.getFieldValue()).orElse(null));
-        assertEquals(DEFAULT_USER_SEARCH_BASE, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_USER_SEARCH_BASE).flatMap(field -> field.getFieldValue()).orElse(null));
-        assertEquals(DEFAULT_USER_SEARCH_FILTER, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_USER_SEARCH_FILTER).flatMap(field -> field.getFieldValue()).orElse(null));
-        assertEquals(DEFAULT_USER_DN_PATTERNS, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_USER_DN_PATTERNS).flatMap(field -> field.getFieldValue()).orElse(null));
-        assertEquals(DEFAULT_USER_ATTRIBUTES, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_USER_ATTRIBUTES).flatMap(field -> field.getFieldValue()).orElse(null));
-        assertEquals(DEFAULT_GROUP_SEARCH_BASE, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_GROUP_SEARCH_BASE).flatMap(field -> field.getFieldValue()).orElse(null));
-        assertEquals(DEFAULT_GROUP_SEARCH_FILTER, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_GROUP_SEARCH_FILTER).flatMap(field -> field.getFieldValue()).orElse(null));
-        assertEquals(DEFAULT_GROUP_ROLE_ATTRIBUTE, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_GROUP_ROLE_ATTRIBUTE).flatMap(field -> field.getFieldValue()).orElse(null));
+        assertEquals(DEFAULT_ENABLED, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_ENABLED).flatMap(ConfigurationFieldModel::getFieldValue).orElse(null));
+        assertEquals(DEFAULT_SERVER, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_SERVER).flatMap(ConfigurationFieldModel::getFieldValue).orElse(null));
+        assertEquals(DEFAULT_MANAGER_DN, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_MANAGER_DN).flatMap(ConfigurationFieldModel::getFieldValue).orElse(null));
+        assertEquals(
+            DEFAULT_MANAGER_PASSWORD,
+            updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_MANAGER_PWD).flatMap(ConfigurationFieldModel::getFieldValue).orElse(null)
+        );
+        assertEquals(
+            DEFAULT_AUTHENTICATION_TYPE,
+            updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_AUTHENTICATION_TYPE).flatMap(ConfigurationFieldModel::getFieldValue).orElse(null)
+        );
+        assertEquals(DEFAULT_REFERRAL, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_REFERRAL).flatMap(ConfigurationFieldModel::getFieldValue).orElse(null));
+        assertEquals(
+            DEFAULT_USER_SEARCH_BASE,
+            updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_USER_SEARCH_BASE).flatMap(ConfigurationFieldModel::getFieldValue).orElse(null)
+        );
+        assertEquals(
+            DEFAULT_USER_SEARCH_FILTER,
+            updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_USER_SEARCH_FILTER).flatMap(ConfigurationFieldModel::getFieldValue).orElse(null)
+        );
+        assertEquals(
+            DEFAULT_USER_DN_PATTERNS,
+            updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_USER_DN_PATTERNS).flatMap(ConfigurationFieldModel::getFieldValue).orElse(null)
+        );
+        assertEquals(
+            DEFAULT_USER_ATTRIBUTES,
+            updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_USER_ATTRIBUTES).flatMap(ConfigurationFieldModel::getFieldValue).orElse(null)
+        );
+        assertEquals(
+            DEFAULT_GROUP_SEARCH_BASE,
+            updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_GROUP_SEARCH_BASE).flatMap(ConfigurationFieldModel::getFieldValue).orElse(null)
+        );
+        assertEquals(
+            DEFAULT_GROUP_SEARCH_FILTER,
+            updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_GROUP_SEARCH_FILTER).flatMap(ConfigurationFieldModel::getFieldValue).orElse(null)
+        );
+        assertEquals(
+            DEFAULT_GROUP_ROLE_ATTRIBUTE,
+            updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_GROUP_ROLE_ATTRIBUTE).flatMap(ConfigurationFieldModel::getFieldValue).orElse(null)
+        );
     }
 
     @Test
     public void testIsEnabled() {
         ConfigurationModel configurationModel = createConfigurationModel();
         DefaultConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(DefaultConfigurationModelConfigurationAccessor.class);
-        UserManagementAuthoritiesPopulator authoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
+        UserManagementAuthoritiesPopulator userManagementAuthoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKey(Mockito.any(DescriptorKey.class))).thenReturn(List.of(configurationModel));
-        LdapManager ldapManager = new LdapManager(AUTHENTICATION_DESCRIPTOR_KEY, configurationModelConfigurationAccessor, authoritiesPopulator, LDAP_USER_CONTEXT_MAPPER);
+        LdapManager ldapManager = new LdapManager(
+            AUTHENTICATION_DESCRIPTOR_KEY,
+            configurationModelConfigurationAccessor,
+            userManagementAuthoritiesPopulator,
+            LDAP_USER_CONTEXT_MAPPER
+        );
         assertTrue(ldapManager.isLdapEnabled());
         configurationModel.getField(AuthenticationDescriptor.KEY_LDAP_ENABLED).ifPresent(field -> field.setFieldValue("false"));
         assertFalse(ldapManager.isLdapEnabled());
@@ -134,11 +171,19 @@ public class LdapManagerTest {
         configurationModel.getField(AuthenticationDescriptor.KEY_LDAP_AUTHENTICATION_TYPE).get().setFieldValue(authenticationType);
         DefaultConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(DefaultConfigurationModelConfigurationAccessor.class);
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKey(Mockito.any(DescriptorKey.class))).thenReturn(List.of(configurationModel));
-        UserManagementAuthoritiesPopulator authoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
-        LdapManager ldapManager = new LdapManager(AUTHENTICATION_DESCRIPTOR_KEY, configurationModelConfigurationAccessor, authoritiesPopulator, LDAP_USER_CONTEXT_MAPPER);
+        UserManagementAuthoritiesPopulator userManagementAuthoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
+        LdapManager ldapManager = new LdapManager(
+            AUTHENTICATION_DESCRIPTOR_KEY,
+            configurationModelConfigurationAccessor,
+            userManagementAuthoritiesPopulator,
+            LDAP_USER_CONTEXT_MAPPER
+        );
         ldapManager.getAuthenticationProvider();
         FieldUtility updatedProperties = ldapManager.getCurrentConfiguration();
-        assertEquals(authenticationType, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_AUTHENTICATION_TYPE).flatMap(ConfigurationFieldModel::getFieldValue).orElse(null));
+        assertEquals(
+            authenticationType,
+            updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_AUTHENTICATION_TYPE).flatMap(ConfigurationFieldModel::getFieldValue).orElse(null)
+        );
     }
 
     @Test
@@ -148,11 +193,19 @@ public class LdapManagerTest {
         configurationModel.getField(AuthenticationDescriptor.KEY_LDAP_AUTHENTICATION_TYPE).get().setFieldValue(authenticationType);
         DefaultConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(DefaultConfigurationModelConfigurationAccessor.class);
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKey(Mockito.any(DescriptorKey.class))).thenReturn(List.of(configurationModel));
-        UserManagementAuthoritiesPopulator authoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
-        LdapManager ldapManager = new LdapManager(AUTHENTICATION_DESCRIPTOR_KEY, configurationModelConfigurationAccessor, authoritiesPopulator, LDAP_USER_CONTEXT_MAPPER);
+        UserManagementAuthoritiesPopulator userManagementAuthoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
+        LdapManager ldapManager = new LdapManager(
+            AUTHENTICATION_DESCRIPTOR_KEY,
+            configurationModelConfigurationAccessor,
+            userManagementAuthoritiesPopulator,
+            LDAP_USER_CONTEXT_MAPPER
+        );
         ldapManager.getAuthenticationProvider();
         FieldUtility updatedProperties = ldapManager.getCurrentConfiguration();
-        assertEquals(authenticationType, updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_AUTHENTICATION_TYPE).flatMap(ConfigurationFieldModel::getFieldValue).orElse(null));
+        assertEquals(
+            authenticationType,
+            updatedProperties.getField(AuthenticationDescriptor.KEY_LDAP_AUTHENTICATION_TYPE).flatMap(ConfigurationFieldModel::getFieldValue).orElse(null)
+        );
     }
 
     @Test
@@ -160,8 +213,13 @@ public class LdapManagerTest {
         ConfigurationModel configurationModel = createConfigurationModel();
         DefaultConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(DefaultConfigurationModelConfigurationAccessor.class);
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKey(Mockito.any(DescriptorKey.class))).thenReturn(List.of(configurationModel));
-        UserManagementAuthoritiesPopulator authoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
-        LdapManager ldapManager = new LdapManager(AUTHENTICATION_DESCRIPTOR_KEY, configurationModelConfigurationAccessor, authoritiesPopulator, LDAP_USER_CONTEXT_MAPPER);
+        UserManagementAuthoritiesPopulator userManagementAuthoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
+        LdapManager ldapManager = new LdapManager(
+            AUTHENTICATION_DESCRIPTOR_KEY,
+            configurationModelConfigurationAccessor,
+            userManagementAuthoritiesPopulator,
+            LDAP_USER_CONTEXT_MAPPER
+        );
         assertNotNull(ldapManager.getAuthenticationProvider());
     }
 
@@ -176,8 +234,13 @@ public class LdapManagerTest {
         configurationModel.getField(AuthenticationDescriptor.KEY_LDAP_MANAGER_PWD).get().setFieldValue(managerPassword);
         DefaultConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(DefaultConfigurationModelConfigurationAccessor.class);
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKey(Mockito.any(DescriptorKey.class))).thenReturn(List.of(configurationModel));
-        UserManagementAuthoritiesPopulator authoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
-        LdapManager ldapManager = new LdapManager(AUTHENTICATION_DESCRIPTOR_KEY, configurationModelConfigurationAccessor, authoritiesPopulator, LDAP_USER_CONTEXT_MAPPER);
+        UserManagementAuthoritiesPopulator userManagementAuthoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
+        LdapManager ldapManager = new LdapManager(
+            AUTHENTICATION_DESCRIPTOR_KEY,
+            configurationModelConfigurationAccessor,
+            userManagementAuthoritiesPopulator,
+            LDAP_USER_CONTEXT_MAPPER
+        );
         try {
             ldapManager.getAuthenticationProvider();
             fail();
@@ -198,8 +261,13 @@ public class LdapManagerTest {
         configurationModel.getField(AuthenticationDescriptor.KEY_LDAP_USER_DN_PATTERNS).get().setFieldValue(userDNPatterns);
         DefaultConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(DefaultConfigurationModelConfigurationAccessor.class);
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationsByDescriptorKey(Mockito.any(DescriptorKey.class))).thenReturn(List.of(configurationModel));
-        UserManagementAuthoritiesPopulator authoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
-        LdapManager ldapManager = new LdapManager(AUTHENTICATION_DESCRIPTOR_KEY, configurationModelConfigurationAccessor, authoritiesPopulator, LDAP_USER_CONTEXT_MAPPER);
+        UserManagementAuthoritiesPopulator userManagementAuthoritiesPopulator = Mockito.mock(UserManagementAuthoritiesPopulator.class);
+        LdapManager ldapManager = new LdapManager(
+            AUTHENTICATION_DESCRIPTOR_KEY,
+            configurationModelConfigurationAccessor,
+            userManagementAuthoritiesPopulator,
+            LDAP_USER_CONTEXT_MAPPER
+        );
         try {
             ldapManager.getAuthenticationProvider();
             fail();

--- a/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/database/configuration/MockLDAPConfigurationRepository.java
+++ b/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/database/configuration/MockLDAPConfigurationRepository.java
@@ -1,0 +1,34 @@
+package com.synopsys.integration.alert.authentication.ldap.database.configuration;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.synopsys.integration.alert.test.common.database.MockRepositoryContainer;
+
+public class MockLDAPConfigurationRepository extends MockRepositoryContainer<UUID, LDAPConfigurationEntity> implements LDAPConfigurationRepository {
+    public MockLDAPConfigurationRepository() {
+        super(LDAPConfigurationEntity::getConfigurationId);
+    }
+
+    @Override
+    public Optional<LDAPConfigurationEntity> findByName(String name) {
+        return findAll()
+            .stream()
+            .filter(entity -> entity.getName().equals(name))
+            .findFirst();
+    }
+
+    @Override
+    public boolean existsByName(String name) {
+        return findAll()
+            .stream()
+            .anyMatch(entity -> entity.getName().equals(name));
+    }
+
+    @Override
+    public void deleteByName(String name) {
+        findByName(name)
+            .map(LDAPConfigurationEntity::getConfigurationId)
+            .ifPresent(this::deleteById);
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,7 @@ dependencies {
     implementation project(':api-provider')
     implementation project(':api-task')
 
+    implementation project(':authentication-ldap')
     implementation project(':authentication-saml')
 
     implementation project(':channel-azure-boards')

--- a/component/build.gradle
+++ b/component/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation project(':api-event')
     implementation project(':api-processor')
     implementation project(':api-task')
+    implementation project(':authentication-ldap')
     implementation project(':service-email')
 
     implementation 'org.apache.tomcat.embed:tomcat-embed-core'

--- a/component/src/main/java/com/synopsys/integration/alert/component/authentication/actions/AuthenticationFieldModelTestAction.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/authentication/actions/AuthenticationFieldModelTestAction.java
@@ -7,9 +7,11 @@
  */
 package com.synopsys.integration.alert.component.authentication.actions;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -21,17 +23,24 @@ import org.springframework.security.ldap.authentication.LdapAuthenticationProvid
 import org.springframework.security.saml.metadata.ExtendedMetadataDelegate;
 import org.springframework.stereotype.Component;
 
+import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptor;
 import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatus;
 import com.synopsys.integration.alert.authentication.ldap.action.LdapManager;
+import com.synopsys.integration.alert.authentication.ldap.model.LDAPConfigModel;
 import com.synopsys.integration.alert.common.action.FieldModelTestAction;
 import com.synopsys.integration.alert.common.exception.AlertFieldException;
 import com.synopsys.integration.alert.common.message.model.MessageResult;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldUtility;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
-import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptor;
+import com.synopsys.integration.alert.common.util.DateUtils;
 import com.synopsys.integration.alert.component.authentication.security.saml.SAMLManager;
 import com.synopsys.integration.exception.IntegrationException;
 
+/**
+ * This class should be removed in 8.0.0.
+ * @deprecated since 6.13.0
+ */
+@Deprecated(forRemoval = true, since = "6.13.0")
 @Component
 public class AuthenticationFieldModelTestAction extends FieldModelTestAction {
     private final Logger logger = LoggerFactory.getLogger(AuthenticationFieldModelTestAction.class);
@@ -71,15 +80,18 @@ public class AuthenticationFieldModelTestAction extends FieldModelTestAction {
     private void performLdapTest(FieldModel fieldModel, FieldUtility registeredFieldValues) throws IntegrationException {
         logger.info("LDAP enabled testing LDAP authentication.");
         String userName = fieldModel.getFieldValue(AuthenticationDescriptor.TEST_FIELD_KEY_USERNAME).orElse("");
-        Optional<LdapAuthenticationProvider> ldapProvider = ldapManager.createAuthProvider(registeredFieldValues);
+        LDAPConfigModel ldapConfigModel = convertToLDAPConfigModel(registeredFieldValues);
+        Optional<LdapAuthenticationProvider> ldapProvider = ldapManager.createAuthProvider(ldapConfigModel);
         String errorMessage = String.format("Ldap Authentication test failed for the test user %s.  Please check the LDAP configuration.", userName);
         List<AlertFieldStatus> errors = new ArrayList<>();
         if (!ldapProvider.isPresent()) {
             errors.add(AlertFieldStatus.error(AuthenticationDescriptor.KEY_LDAP_ENABLED, errorMessage));
         } else {
             try {
-                Authentication pendingAuthentication = new UsernamePasswordAuthenticationToken(userName,
-                    fieldModel.getFieldValue(AuthenticationDescriptor.TEST_FIELD_KEY_PASSWORD).orElse(""));
+                Authentication pendingAuthentication = new UsernamePasswordAuthenticationToken(
+                    userName,
+                    fieldModel.getFieldValue(AuthenticationDescriptor.TEST_FIELD_KEY_PASSWORD).orElse("")
+                );
                 Authentication authentication = ldapProvider.get().authenticate(pendingAuthentication);
                 if (!authentication.isAuthenticated()) {
                     errors.add(AlertFieldStatus.error(AuthenticationDescriptor.KEY_LDAP_ENABLED, errorMessage));
@@ -98,6 +110,29 @@ public class AuthenticationFieldModelTestAction extends FieldModelTestAction {
         if (!errors.isEmpty()) {
             throw new AlertFieldException(errors);
         }
+    }
+
+    private LDAPConfigModel convertToLDAPConfigModel(FieldUtility fieldUtility) {
+        OffsetDateTime createAndUpdatedDateTime = DateUtils.createCurrentDateTimestamp();
+        return new LDAPConfigModel(
+            UUID.randomUUID().toString(),
+            DateUtils.formatDate(createAndUpdatedDateTime, DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
+            DateUtils.formatDate(createAndUpdatedDateTime, DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
+            fieldUtility.getBooleanOrFalse(AuthenticationDescriptor.KEY_LDAP_ENABLED),
+            fieldUtility.getStringOrEmpty(AuthenticationDescriptor.KEY_LDAP_SERVER),
+            fieldUtility.getStringOrEmpty(AuthenticationDescriptor.KEY_LDAP_MANAGER_DN),
+            fieldUtility.getStringOrEmpty(AuthenticationDescriptor.KEY_LDAP_MANAGER_PWD),
+            StringUtils.isNotBlank(fieldUtility.getStringOrEmpty(AuthenticationDescriptor.KEY_LDAP_MANAGER_PWD)),
+            fieldUtility.getStringOrEmpty(AuthenticationDescriptor.KEY_LDAP_AUTHENTICATION_TYPE),
+            fieldUtility.getStringOrEmpty(AuthenticationDescriptor.KEY_LDAP_REFERRAL),
+            fieldUtility.getStringOrEmpty(AuthenticationDescriptor.KEY_LDAP_USER_SEARCH_BASE),
+            fieldUtility.getStringOrEmpty(AuthenticationDescriptor.KEY_LDAP_USER_SEARCH_FILTER),
+            fieldUtility.getStringOrEmpty(AuthenticationDescriptor.KEY_LDAP_USER_DN_PATTERNS),
+            fieldUtility.getStringOrEmpty(AuthenticationDescriptor.KEY_LDAP_USER_ATTRIBUTES),
+            fieldUtility.getStringOrEmpty(AuthenticationDescriptor.KEY_LDAP_GROUP_SEARCH_BASE),
+            fieldUtility.getStringOrEmpty(AuthenticationDescriptor.KEY_LDAP_GROUP_SEARCH_FILTER),
+            fieldUtility.getStringOrEmpty(AuthenticationDescriptor.KEY_LDAP_GROUP_ROLE_ATTRIBUTE)
+        );
     }
 
     private void performSAMLTest(FieldUtility registeredFieldValues) throws IntegrationException {

--- a/component/src/main/java/com/synopsys/integration/alert/component/authentication/actions/AuthenticationFieldModelTestAction.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/authentication/actions/AuthenticationFieldModelTestAction.java
@@ -22,13 +22,13 @@ import org.springframework.security.saml.metadata.ExtendedMetadataDelegate;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatus;
+import com.synopsys.integration.alert.authentication.ldap.action.LdapManager;
 import com.synopsys.integration.alert.common.action.FieldModelTestAction;
 import com.synopsys.integration.alert.common.exception.AlertFieldException;
 import com.synopsys.integration.alert.common.message.model.MessageResult;
 import com.synopsys.integration.alert.common.persistence.accessor.FieldUtility;
 import com.synopsys.integration.alert.common.rest.model.FieldModel;
 import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptor;
-import com.synopsys.integration.alert.component.authentication.security.ldap.LdapManager;
 import com.synopsys.integration.alert.component.authentication.security.saml.SAMLManager;
 import com.synopsys.integration.exception.IntegrationException;
 

--- a/component/src/main/java/com/synopsys/integration/alert/component/authentication/security/AuthenticationHandler.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/authentication/security/AuthenticationHandler.java
@@ -70,13 +70,14 @@ import org.springframework.security.web.csrf.CsrfTokenRepository;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
+import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptorKey;
+import com.synopsys.integration.alert.api.authentication.security.UserManagementAuthoritiesPopulator;
+import com.synopsys.integration.alert.api.authentication.security.event.AuthenticationEventManager;
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.descriptor.accessor.RoleAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationModelConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.model.UserRoleModel;
 import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
-import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptorKey;
-import com.synopsys.integration.alert.api.authentication.security.event.AuthenticationEventManager;
 import com.synopsys.integration.alert.component.authentication.security.saml.AlertFilterChainProxy;
 import com.synopsys.integration.alert.component.authentication.security.saml.AlertSAMLEntryPoint;
 import com.synopsys.integration.alert.component.authentication.security.saml.AlertSAMLMetadataGenerator;

--- a/component/src/main/java/com/synopsys/integration/alert/component/authentication/security/saml/UserDetailsService.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/authentication/security/saml/UserDetailsService.java
@@ -16,11 +16,11 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.saml.SAMLCredential;
 import org.springframework.security.saml.userdetails.SAMLUserDetailsService;
 
+import com.synopsys.integration.alert.api.authentication.security.UserManagementAuthoritiesPopulator;
 import com.synopsys.integration.alert.common.enumeration.AuthenticationType;
 import com.synopsys.integration.alert.common.persistence.model.UserModel;
 import com.synopsys.integration.alert.common.persistence.model.UserRoleModel;
 import com.synopsys.integration.alert.common.security.UserPrincipal;
-import com.synopsys.integration.alert.component.authentication.security.UserManagementAuthoritiesPopulator;
 
 public class UserDetailsService implements SAMLUserDetailsService {
     private final UserManagementAuthoritiesPopulator authoritiesPopulator;

--- a/component/src/test/java/com/synopsys/integration/alert/component/authentication/security/saml/UserDetailsServiceTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/authentication/security/saml/UserDetailsServiceTest.java
@@ -19,6 +19,8 @@ import org.opensaml.saml2.core.NameID;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.saml.SAMLCredential;
 
+import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptorKey;
+import com.synopsys.integration.alert.api.authentication.security.UserManagementAuthoritiesPopulator;
 import com.synopsys.integration.alert.common.enumeration.AuthenticationType;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationModelConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.UserAccessor;
@@ -26,8 +28,6 @@ import com.synopsys.integration.alert.common.persistence.model.ConfigurationMode
 import com.synopsys.integration.alert.common.persistence.model.UserModel;
 import com.synopsys.integration.alert.common.persistence.model.UserRoleModel;
 import com.synopsys.integration.alert.common.security.UserPrincipal;
-import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptorKey;
-import com.synopsys.integration.alert.component.authentication.security.UserManagementAuthoritiesPopulator;
 
 class UserDetailsServiceTest {
 

--- a/src/test/java/com/synopsys/integration/alert/component/authentication/security/UserManagementAuthoritiesPopulatorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/component/authentication/security/UserManagementAuthoritiesPopulatorTest.java
@@ -8,12 +8,13 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptor;
+import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptorKey;
+import com.synopsys.integration.alert.api.authentication.security.UserManagementAuthoritiesPopulator;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationModelConfigurationAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.UserAccessor;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationModel;
-import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptor;
-import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptorKey;
 
 class UserManagementAuthoritiesPopulatorTest {
     private final AuthenticationDescriptorKey descriptorKey = new AuthenticationDescriptorKey();

--- a/src/test/java/com/synopsys/integration/alert/component/authentication/web/AuthenticationActionsTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/authentication/web/AuthenticationActionsTestIT.java
@@ -40,6 +40,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.synopsys.integration.alert.api.authentication.security.event.AuthenticationEventManager;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
+import com.synopsys.integration.alert.authentication.ldap.LdapAuthenticationPerformer;
+import com.synopsys.integration.alert.authentication.ldap.action.LdapManager;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.descriptor.accessor.RoleAccessor;
 import com.synopsys.integration.alert.common.enumeration.AuthenticationType;
@@ -47,8 +49,6 @@ import com.synopsys.integration.alert.common.exception.AlertForbiddenOperationEx
 import com.synopsys.integration.alert.common.persistence.model.UserModel;
 import com.synopsys.integration.alert.component.authentication.security.AlertAuthenticationProvider;
 import com.synopsys.integration.alert.component.authentication.security.database.AlertDatabaseAuthenticationPerformer;
-import com.synopsys.integration.alert.component.authentication.security.ldap.LdapAuthenticationPerformer;
-import com.synopsys.integration.alert.component.authentication.security.ldap.LdapManager;
 import com.synopsys.integration.alert.database.api.DefaultUserAccessor;
 import com.synopsys.integration.alert.mock.model.MockLoginRestModel;
 import com.synopsys.integration.alert.test.common.TestProperties;

--- a/src/test/java/com/synopsys/integration/alert/component/authentication/web/AuthenticationControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/authentication/web/AuthenticationControllerTestIT.java
@@ -30,11 +30,11 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.server.ResponseStatusException;
 
+import com.synopsys.integration.alert.authentication.ldap.action.LdapManager;
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.security.authorization.AuthorizationManager;
-import com.synopsys.integration.alert.component.authentication.security.ldap.LdapManager;
 import com.synopsys.integration.alert.mock.model.MockLoginRestModel;
 import com.synopsys.integration.alert.test.common.TestProperties;
 import com.synopsys.integration.alert.test.common.TestPropertyKey;


### PR DESCRIPTION
* Move following classes out of component and into authentication-ldap
LdapAuthenticationPerformer.java
LdapConfig.java
MappingLdapAuthoritiesPopulator.java
LdapManager.java
MappingLdapAuthoritiesPopulatorTest.java
LdapManagerTest.java
* Move the following class out of component and into api-authentication
UserManagementAuthoritiesPopulator.java
* Adjust gradle files to handle move
* Adjust classes for moved files
* Remove copyright headers
* Create new classes to begin implementing Test Configuration
LDAPTestAction.java  **Not fully implemented
LDAPConfigTestModel.java
* Update LDAPConfigController.java to use TestAction
* Update LdapManager to work with new ConfigModel and remove logic for FieldUtility
* Update some variable names for clarity
* Add MockLDAPConfigurationRepository.java to help with testing
* Update tests to work with new ConfigModel
* Deprecate old Test Configuration