### PR TITLE
IALERT-3155: Audit failure fix

### DIFF
--- a/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/DistributionEventHandlerTest.java
+++ b/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/DistributionEventHandlerTest.java
@@ -13,7 +13,6 @@ import org.mockito.Mockito;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.common.persistence.accessor.JobDetailsAccessor;
-import com.synopsys.integration.alert.common.persistence.accessor.ProcessingAuditAccessor;
 import com.synopsys.integration.alert.common.persistence.model.job.details.DistributionJobDetailsModel;
 import com.synopsys.integration.alert.descriptor.api.model.ChannelKey;
 import com.synopsys.integration.alert.processor.api.distribute.DistributionEvent;
@@ -24,8 +23,7 @@ class DistributionEventHandlerTest {
     @Test
     void handleEventSuccessTest() {
         AtomicInteger count = new AtomicInteger(0);
-        ProcessingAuditAccessor auditAccessor = Mockito.mock(ProcessingAuditAccessor.class);
-        Mockito.doNothing().when(auditAccessor).setAuditEntrySuccess(Mockito.any(), Mockito.anySet());
+
         EventManager eventManager = Mockito.mock(EventManager.class);
         DistributionJobDetailsModel details = new DistributionJobDetailsModel(null, null) {};
         JobDetailsAccessor<DistributionJobDetailsModel> jobDetailsAccessor = x -> Optional.of(details);
@@ -35,7 +33,7 @@ class DistributionEventHandlerTest {
             return null;
         };
 
-        DistributionEventHandler<DistributionJobDetailsModel> eventHandler = new DistributionEventHandler<>(channel, jobDetailsAccessor, auditAccessor, eventManager);
+        DistributionEventHandler<DistributionJobDetailsModel> eventHandler = new DistributionEventHandler<>(channel, jobDetailsAccessor, eventManager);
 
         UUID testJobId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
@@ -50,8 +48,6 @@ class DistributionEventHandlerTest {
     @Test
     void handleEventExceptionTest() {
         AtomicInteger count = new AtomicInteger(0);
-        ProcessingAuditAccessor auditAccessor = Mockito.mock(ProcessingAuditAccessor.class);
-        Mockito.doNothing().when(auditAccessor).setAuditEntryFailure(Mockito.any(), Mockito.anySet(), Mockito.anyString(), Mockito.any(Throwable.class));
         EventManager eventManager = Mockito.mock(EventManager.class);
         DistributionJobDetailsModel details = new DistributionJobDetailsModel(null, null) {};
         JobDetailsAccessor<DistributionJobDetailsModel> jobDetailsAccessor = x -> Optional.of(details);
@@ -62,7 +58,7 @@ class DistributionEventHandlerTest {
             throw testException;
         };
 
-        DistributionEventHandler<DistributionJobDetailsModel> eventHandler = new DistributionEventHandler<>(channel, jobDetailsAccessor, auditAccessor, eventManager);
+        DistributionEventHandler<DistributionJobDetailsModel> eventHandler = new DistributionEventHandler<>(channel, jobDetailsAccessor, eventManager);
 
         UUID testJobId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
@@ -77,15 +73,13 @@ class DistributionEventHandlerTest {
     @Test
     void handleEventJobDetailsMissingTest() {
         AtomicInteger count = new AtomicInteger(0);
-        ProcessingAuditAccessor auditAccessor = Mockito.mock(ProcessingAuditAccessor.class);
-        Mockito.doNothing().when(auditAccessor).setAuditEntryFailure(Mockito.any(), Mockito.anySet(), Mockito.anyString(), Mockito.any(Throwable.class));
         EventManager eventManager = Mockito.mock(EventManager.class);
         JobDetailsAccessor<DistributionJobDetailsModel> jobDetailsAccessor = x -> Optional.empty();
         DistributionChannel<DistributionJobDetailsModel> channel = (u, v, w, x, y, z) -> {
             count.incrementAndGet();
             return null;
         };
-        DistributionEventHandler<DistributionJobDetailsModel> eventHandler = new DistributionEventHandler<>(channel, jobDetailsAccessor, auditAccessor, eventManager);
+        DistributionEventHandler<DistributionJobDetailsModel> eventHandler = new DistributionEventHandler<>(channel, jobDetailsAccessor, eventManager);
 
         UUID testJobId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/AzureBoardsDistributionEventHandler.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/AzureBoardsDistributionEventHandler.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.api.channel.DistributionEventHandler;
 import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.common.persistence.accessor.AzureBoardsJobDetailsAccessor;
-import com.synopsys.integration.alert.common.persistence.accessor.ProcessingAuditAccessor;
 import com.synopsys.integration.alert.common.persistence.model.job.details.AzureBoardsJobDetailsModel;
 
 @Component
@@ -22,10 +21,9 @@ public class AzureBoardsDistributionEventHandler extends DistributionEventHandle
     public AzureBoardsDistributionEventHandler(
         AzureBoardsChannel channel,
         AzureBoardsJobDetailsAccessor jobDetailsAccessor,
-        ProcessingAuditAccessor auditAccessor,
         EventManager eventManager
     ) {
-        super(channel, jobDetailsAccessor, auditAccessor, eventManager);
+        super(channel, jobDetailsAccessor, eventManager);
     }
 
 }

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/distribution/EmailDistributionEventHandler.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/distribution/EmailDistributionEventHandler.java
@@ -13,14 +13,13 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.api.channel.DistributionEventHandler;
 import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.common.persistence.accessor.EmailJobDetailsAccessor;
-import com.synopsys.integration.alert.common.persistence.accessor.ProcessingAuditAccessor;
 import com.synopsys.integration.alert.common.persistence.model.job.details.EmailJobDetailsModel;
 
 @Component
 public class EmailDistributionEventHandler extends DistributionEventHandler<EmailJobDetailsModel> {
     @Autowired
-    public EmailDistributionEventHandler(EmailChannel channel, EmailJobDetailsAccessor jobDetailsAccessor, ProcessingAuditAccessor auditAccessor, EventManager eventManager) {
-        super(channel, jobDetailsAccessor, auditAccessor, eventManager);
+    public EmailDistributionEventHandler(EmailChannel channel, EmailJobDetailsAccessor jobDetailsAccessor, EventManager eventManager) {
+        super(channel, jobDetailsAccessor, eventManager);
     }
 
 }

--- a/channel-jira-cloud/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/JiraCloudDistributionEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/JiraCloudDistributionEventHandler.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.api.channel.DistributionEventHandler;
 import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.common.persistence.accessor.JiraCloudJobDetailsAccessor;
-import com.synopsys.integration.alert.common.persistence.accessor.ProcessingAuditAccessor;
 import com.synopsys.integration.alert.common.persistence.model.job.details.JiraCloudJobDetailsModel;
 
 @Component
@@ -22,10 +21,9 @@ public class JiraCloudDistributionEventHandler extends DistributionEventHandler<
     public JiraCloudDistributionEventHandler(
         JiraCloudChannel channel,
         JiraCloudJobDetailsAccessor jobDetailsAccessor,
-        ProcessingAuditAccessor auditAccessor,
         EventManager eventManager
     ) {
-        super(channel, jobDetailsAccessor, auditAccessor, eventManager);
+        super(channel, jobDetailsAccessor, eventManager);
     }
 
 }

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/distribution/JiraServerDistributionEventHandler.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/distribution/JiraServerDistributionEventHandler.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.api.channel.DistributionEventHandler;
 import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.common.persistence.accessor.JiraServerJobDetailsAccessor;
-import com.synopsys.integration.alert.common.persistence.accessor.ProcessingAuditAccessor;
 import com.synopsys.integration.alert.common.persistence.model.job.details.JiraServerJobDetailsModel;
 
 @Component
@@ -22,10 +21,9 @@ public class JiraServerDistributionEventHandler extends DistributionEventHandler
     public JiraServerDistributionEventHandler(
         JiraServerChannel channel,
         JiraServerJobDetailsAccessor jobDetailsAccessor,
-        ProcessingAuditAccessor auditAccessor,
         EventManager eventManager
     ) {
-        super(channel, jobDetailsAccessor, auditAccessor, eventManager);
+        super(channel, jobDetailsAccessor, eventManager);
     }
 
 }

--- a/channel-msteams/src/main/java/com/synopsys/integration/alert/channel/msteams/distribution/MSTeamsDistributionEventHandler.java
+++ b/channel-msteams/src/main/java/com/synopsys/integration/alert/channel/msteams/distribution/MSTeamsDistributionEventHandler.java
@@ -13,14 +13,13 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.api.channel.DistributionEventHandler;
 import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.common.persistence.accessor.MSTeamsJobDetailsAccessor;
-import com.synopsys.integration.alert.common.persistence.accessor.ProcessingAuditAccessor;
 import com.synopsys.integration.alert.common.persistence.model.job.details.MSTeamsJobDetailsModel;
 
 @Component
 public class MSTeamsDistributionEventHandler extends DistributionEventHandler<MSTeamsJobDetailsModel> {
     @Autowired
-    public MSTeamsDistributionEventHandler(MSTeamsChannel channel, MSTeamsJobDetailsAccessor jobDetailsAccessor, ProcessingAuditAccessor auditAccessor, EventManager eventManager) {
-        super(channel, jobDetailsAccessor, auditAccessor, eventManager);
+    public MSTeamsDistributionEventHandler(MSTeamsChannel channel, MSTeamsJobDetailsAccessor jobDetailsAccessor, EventManager eventManager) {
+        super(channel, jobDetailsAccessor, eventManager);
     }
 
 }

--- a/channel-slack/src/main/java/com/synopsys/integration/alert/channel/slack/distribution/SlackDistributionEventHandler.java
+++ b/channel-slack/src/main/java/com/synopsys/integration/alert/channel/slack/distribution/SlackDistributionEventHandler.java
@@ -12,15 +12,14 @@ import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.api.channel.DistributionEventHandler;
 import com.synopsys.integration.alert.api.event.EventManager;
-import com.synopsys.integration.alert.common.persistence.accessor.ProcessingAuditAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.SlackJobDetailsAccessor;
 import com.synopsys.integration.alert.common.persistence.model.job.details.SlackJobDetailsModel;
 
 @Component
 public class SlackDistributionEventHandler extends DistributionEventHandler<SlackJobDetailsModel> {
     @Autowired
-    public SlackDistributionEventHandler(SlackChannel channel, SlackJobDetailsAccessor jobDetailsAccessor, ProcessingAuditAccessor auditAccessor, EventManager eventManager) {
-        super(channel, jobDetailsAccessor, auditAccessor, eventManager);
+    public SlackDistributionEventHandler(SlackChannel channel, SlackJobDetailsAccessor jobDetailsAccessor, EventManager eventManager) {
+        super(channel, jobDetailsAccessor, eventManager);
     }
 
 }

--- a/channel-slack/src/test/java/com/synopsys/integration/alert/channel/slack/distribution/SlackDistributionEventHandlerTest.java
+++ b/channel-slack/src/test/java/com/synopsys/integration/alert/channel/slack/distribution/SlackDistributionEventHandlerTest.java
@@ -1,7 +1,6 @@
 package com.synopsys.integration.alert.channel.slack.distribution;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
@@ -16,9 +15,9 @@ import org.mockito.Mockito;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.channel.rest.ChannelRestConnectionFactory;
+import com.synopsys.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.synopsys.integration.alert.api.distribution.audit.AuditSuccessEvent;
 import com.synopsys.integration.alert.api.event.EventManager;
-import com.synopsys.integration.alert.channel.slack.distribution.mock.MockProcessingAuditAccessor;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.common.persistence.accessor.SlackJobDetailsAccessor;
 import com.synopsys.integration.alert.common.persistence.model.job.details.SlackJobDetailsModel;
@@ -43,7 +42,6 @@ class SlackDistributionEventHandlerTest {
     private final SlackChannelKey slackChannelKey = new SlackChannelKey();
 
     private SlackDistributionEventHandler distributionEventHandler;
-    private final MockProcessingAuditAccessor processingAuditAccessor = new MockProcessingAuditAccessor();
     private final MockWebServer mockSlackServer = new MockWebServer();
 
     private final Gson gson = new Gson();
@@ -64,7 +62,7 @@ class SlackDistributionEventHandlerTest {
 
         SlackJobDetailsAccessor slackJobDetailsAccessor = jobId -> Optional.of(slackJobDetailsModel);
 
-        distributionEventHandler = new SlackDistributionEventHandler(slackChannel, slackJobDetailsAccessor, processingAuditAccessor, eventManager);
+        distributionEventHandler = new SlackDistributionEventHandler(slackChannel, slackJobDetailsAccessor, eventManager);
     }
 
     @AfterEach
@@ -81,12 +79,9 @@ class SlackDistributionEventHandlerTest {
 
         distributionEventHandler.handle(createSlackDistributionEvent(FIRST_MESSAGE_NOTIFICATION_IDS, createTwoMessages()));
 
-        //assertEquals(0, processingAuditAccessor.getSuccessfulIds().size());
-        assertEquals(3, processingAuditAccessor.getFailureIds().size());
-        assertTrue(processingAuditAccessor.getFailureIds().containsAll(FIRST_MESSAGE_NOTIFICATION_IDS));
-
         assertEquals(2, mockSlackServer.getRequestCount());
         Mockito.verify(eventManager, Mockito.times(0)).sendEvent(Mockito.any(AuditSuccessEvent.class));
+        Mockito.verify(eventManager, Mockito.times(1)).sendEvent(Mockito.any(AuditFailedEvent.class));
     }
 
     @Test
@@ -101,11 +96,9 @@ class SlackDistributionEventHandlerTest {
         distributionEventHandler.handle(createSlackDistributionEvent(FIRST_MESSAGE_NOTIFICATION_IDS, createTwoMessages()));
         distributionEventHandler.handle(createSlackDistributionEvent(SECOND_MESSAGE_NOTIFICATION_IDS, createTwoMessages()));
 
-        assertEquals(3, processingAuditAccessor.getFailureIds().size());
-        assertTrue(processingAuditAccessor.getFailureIds().containsAll(FIRST_MESSAGE_NOTIFICATION_IDS));
-
         assertEquals(4, mockSlackServer.getRequestCount());
         Mockito.verify(eventManager, Mockito.times(1)).sendEvent(Mockito.any(AuditSuccessEvent.class));
+        Mockito.verify(eventManager, Mockito.times(1)).sendEvent(Mockito.any(AuditFailedEvent.class));
     }
 
     private ChannelRestConnectionFactory createConnectionFactory() {


### PR DESCRIPTION
- Fix an issue where audit failures aren't sent.
- Remove unused dependencies to old audit class.