### PR TITLE
IALERT-3155: wait task

### DIFF
--- a/alert-database-job/src/main/java/com/synopsys/integration/alert/database/api/DefaultDistributionAccessor.java
+++ b/alert-database-job/src/main/java/com/synopsys/integration/alert/database/api/DefaultDistributionAccessor.java
@@ -7,13 +7,13 @@
  */
 package com.synopsys.integration.alert.database.api;
 
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -26,6 +26,7 @@ import com.synopsys.integration.alert.common.enumeration.FrequencyType;
 import com.synopsys.integration.alert.common.persistence.accessor.DistributionAccessor;
 import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 import com.synopsys.integration.alert.common.rest.model.DistributionWithAuditInfo;
+import com.synopsys.integration.alert.common.util.DateUtils;
 import com.synopsys.integration.alert.database.distribution.DistributionRepository;
 import com.synopsys.integration.alert.database.distribution.DistributionRepository.DistributionDBResponse;
 
@@ -75,12 +76,11 @@ public class DefaultDistributionAccessor implements DistributionAccessor {
         );
     }
 
-    private String formatAuditDate(String dateTime) {
+    private String formatAuditDate(Timestamp dateTime) {
         if (dateTime == null) {
             return null;
         }
 
-        String removedDashes = StringUtils.replace(dateTime, "-", "/");
-        return StringUtils.substringBeforeLast(removedDashes, ".");
+        return DateUtils.formatDate(DateUtils.fromInstantUTC(dateTime.toInstant()), DateUtils.AUDIT_DATE_FORMAT);
     }
 }

--- a/alert-database-job/src/main/java/com/synopsys/integration/alert/database/distribution/DistributionRepository.java
+++ b/alert-database-job/src/main/java/com/synopsys/integration/alert/database/distribution/DistributionRepository.java
@@ -7,6 +7,7 @@
  */
 package com.synopsys.integration.alert.database.distribution;
 
+import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.UUID;
 
@@ -55,7 +56,7 @@ public interface DistributionRepository extends JpaRepository<DistributionJobEnt
 
         String getDistribution_Frequency();
 
-        String getTime_Last_Sent();
+        Timestamp getTime_Last_Sent();
 
         String getStatus();
 

--- a/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/send/IssueTrackerAsyncMessageSender.java
+++ b/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/send/IssueTrackerAsyncMessageSender.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 
 import com.synopsys.integration.alert.api.channel.issue.model.IssueTrackerModelHolder;
-import com.synopsys.integration.alert.api.distribution.audit.AuditSuccessEvent;
 import com.synopsys.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.synopsys.integration.alert.api.distribution.execution.JobStage;
 import com.synopsys.integration.alert.api.distribution.execution.JobStageStartedEvent;
@@ -61,8 +60,6 @@ public class IssueTrackerAsyncMessageSender<T extends Serializable> {
 
 
         if (eventList.isEmpty()) {
-            // nothing further to send downstream. Channel handled message successfully.
-            eventManager.sendEvent(new AuditSuccessEvent(jobExecutionId, notificationIds));
             jobSubTaskAccessor.removeSubTaskStatus(parentEventId);
         } else {
             jobSubTaskAccessor.updateTaskCount(parentEventId, (long) eventList.size());

--- a/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/send/IssueTrackerAsyncMessageSenderTest.java
+++ b/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/send/IssueTrackerAsyncMessageSenderTest.java
@@ -56,7 +56,7 @@ class IssueTrackerAsyncMessageSenderTest {
         );
 
         sender.sendAsyncMessages(List.of(modelHolder));
-        Mockito.verify(mockEventManager).sendEvent(Mockito.any());
+        Mockito.verify(mockEventManager, Mockito.times(0)).sendEvent(Mockito.any());
         Mockito.verify(mockJobSubTaskAccessor, Mockito.times(0)).updateTaskCount(Mockito.eq(parentEventId), Mockito.anyLong());
 
     }

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/JobSubTaskEventHandler.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/JobSubTaskEventHandler.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.api.distribution.audit.AuditFailedEvent;
-import com.synopsys.integration.alert.api.distribution.audit.AuditSuccessEvent;
 import com.synopsys.integration.alert.api.distribution.execution.ExecutingJob;
 import com.synopsys.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.synopsys.integration.alert.api.distribution.execution.JobStage;
@@ -49,7 +48,7 @@ public abstract class JobSubTaskEventHandler<T extends JobSubTaskEvent> implemen
             executingJobManager.endStage(jobExecutionId, jobStage, Instant.now());
             executingJobManager.getExecutingJob(jobExecutionId)
                 .filter(ExecutingJob::isCompleted)
-                .ifPresent(executingJob -> eventManager.sendEvent(new AuditSuccessEvent(jobExecutionId, event.getNotificationIds())));
+                .ifPresent(executingJob -> executingJobManager.endJobWithSuccess(jobExecutionId, Instant.now()));
         } catch (AlertException exception) {
             executingJobManager.endStage(jobExecutionId, jobStage, Instant.now());
             //eventManager.sendEvent(new JobStageEndedEvent(jobExecutionId, jobStage, Instant.now().toEpochMilli()));

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/JobSubTaskEventHandler.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/JobSubTaskEventHandler.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Predicate;
 
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.api.distribution.audit.AuditFailedEvent;
@@ -47,7 +48,7 @@ public abstract class JobSubTaskEventHandler<T extends JobSubTaskEvent> implemen
                 });
             executingJobManager.endStage(jobExecutionId, jobStage, Instant.now());
             executingJobManager.getExecutingJob(jobExecutionId)
-                .filter(ExecutingJob::isCompleted)
+                .filter(Predicate.not(ExecutingJob::isCompleted))
                 .ifPresent(executingJob -> executingJobManager.endJobWithSuccess(jobExecutionId, Instant.now()));
         } catch (AlertException exception) {
             executingJobManager.endStage(jobExecutionId, jobStage, Instant.now());

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessHandler.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessHandler.java
@@ -23,10 +23,6 @@ public class AuditSuccessHandler implements AlertEventHandler<AuditSuccessEvent>
         UUID jobExecutionId = event.getJobExecutionId();
         executingJobManager.getExecutingJob(jobExecutionId)
             .filter(ExecutingJob::isCompleted)
-            .ifPresent(executingJob -> {
-                if (executingJob.isCompleted()) {
-                    executingJobManager.endJobWithSuccess(jobExecutionId, event.getCreatedTimestamp().toInstant());
-                }
-            });
+            .ifPresent(executingJob -> executingJobManager.endJobWithSuccess(jobExecutionId, event.getCreatedTimestamp().toInstant()));
     }
 }

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessHandler.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessHandler.java
@@ -1,6 +1,7 @@
 package com.synopsys.integration.alert.api.distribution.audit;
 
 import java.util.UUID;
+import java.util.function.Predicate;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -22,7 +23,7 @@ public class AuditSuccessHandler implements AlertEventHandler<AuditSuccessEvent>
     public void handle(AuditSuccessEvent event) {
         UUID jobExecutionId = event.getJobExecutionId();
         executingJobManager.getExecutingJob(jobExecutionId)
-            .filter(ExecutingJob::isCompleted)
+            .filter(Predicate.not(ExecutingJob::isCompleted))
             .ifPresent(executingJob -> executingJobManager.endJobWithSuccess(jobExecutionId, event.getCreatedTimestamp().toInstant()));
     }
 }

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/ExecutingJob.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/ExecutingJob.java
@@ -107,10 +107,10 @@ public class ExecutingJob {
     }
 
     public boolean isCompleted() {
-        return !hasCompletedStatus() || hasRemainingEvents();
+        return !hasRemainingEvents() && hasCompletedStatus();
     }
 
-    private boolean hasCompletedStatus() {
+    public boolean hasCompletedStatus() {
         return AuditEntryStatus.SUCCESS == getStatus() ||
             AuditEntryStatus.FAILURE == getStatus();
     }

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/ExecutingJobManager.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/ExecutingJobManager.java
@@ -39,7 +39,7 @@ public class ExecutingJobManager {
     public void endJobWithSuccess(UUID executionId, Instant endTime) {
         Optional<ExecutingJob> executingJob = Optional.ofNullable(executingJobMap.getOrDefault(executionId, null));
         executingJob.ifPresent(execution -> {
-            execution.jobSucceeded(endTime);
+            execution.jobSucceeded(DateUtils.fromInstantUTC(endTime).toInstant());
             jobCompletionStatusAccessor.saveExecutionStatus(createStatusModel(execution, AuditEntryStatus.SUCCESS));
             purgeJob(executionId);
         });
@@ -48,7 +48,7 @@ public class ExecutingJobManager {
     public void endJobWithFailure(UUID executionId, Instant endTime) {
         Optional<ExecutingJob> executingJob = Optional.ofNullable(executingJobMap.getOrDefault(executionId, null));
         executingJob.ifPresent(execution -> {
-            execution.jobFailed(endTime);
+            execution.jobFailed(DateUtils.fromInstantUTC(endTime).toInstant());
             jobCompletionStatusAccessor.saveExecutionStatus(createStatusModel(execution, AuditEntryStatus.FAILURE));
             purgeJob(executionId);
         });
@@ -75,7 +75,7 @@ public class ExecutingJobManager {
     public void startStage(UUID executionId, JobStage stage, Instant start) {
         Optional<ExecutingJob> executingJob = Optional.ofNullable(executingJobMap.getOrDefault(executionId, null));
         executingJob.ifPresent(job -> {
-            job.addStage(ExecutingJobStage.createStage(executionId, stage, start));
+            job.addStage(ExecutingJobStage.createStage(executionId, stage, DateUtils.fromInstantUTC(start).toInstant()));
         });
     }
 
@@ -83,7 +83,7 @@ public class ExecutingJobManager {
         Optional<ExecutingJob> executingJob = Optional.ofNullable(executingJobMap.getOrDefault(executionId, null));
         executingJob
             .flatMap(job -> job.getStage(stage))
-            .ifPresent(jobStage -> jobStage.endStage(end));
+            .ifPresent(jobStage -> jobStage.endStage(DateUtils.fromInstantUTC(end).toInstant()));
     }
 
     public void purgeJob(UUID executionId) {

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/JobNotificationContentProcessor.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/JobNotificationContentProcessor.java
@@ -83,7 +83,6 @@ public class JobNotificationContentProcessor {
         while (jobNotificationMappings.getCurrentPage() <= jobNotificationMappings.getTotalPages()) {
             List<Long> notificationIds = extractNotificationIds(jobNotificationMappings);
             List<AlertNotificationModel> notifications = notificationAccessor.findByIds(notificationIds);
-            executingJobManager.incrementProcessedNotificationCount(jobExecutionId, notifications.size());
             logNotifications("Start", event, notificationIds);
             List<NotificationContentWrapper> notificationContentList = notifications
                 .stream()
@@ -102,6 +101,7 @@ public class JobNotificationContentProcessor {
             if (ProcessingType.DIGEST == jobProcessingType || ProcessingType.SUMMARY == jobProcessingType) {
                 processedMessageHolder = digestProcessing(processedMessageHolder);
             }
+            executingJobManager.incrementProcessedNotificationCount(jobExecutionId, notifications.size());
             pageNumber++;
             jobNotificationMappings = jobNotificationMappingAccessor.getJobNotificationMappings(
                 correlationId,

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/distribute/ProviderMessageDistributor.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/distribute/ProviderMessageDistributor.java
@@ -61,7 +61,7 @@ public class ProviderMessageDistributor {
 
     public void distributeIndividually(UUID jobExecutionId, UUID jobId, String jobName, ChannelKey destinationKey, ProcessedProviderMessageHolder processedMessageHolder) {
         Set<Long> notificationIds = processedMessageHolder.extractAllNotificationIds();
-        auditAccessor.createOrUpdatePendingAuditEntryForJob(jobId, notificationIds);
+        //auditAccessor.createOrUpdatePendingAuditEntryForJob(jobId, notificationIds);
 
         DistributionEvent event = new DistributionEvent(destinationKey, jobId, jobExecutionId, jobName, notificationIds, processedMessageHolder.toProviderMessageHolder());
         logger.info("Sending {}. Event ID: {}. Job ID: {}. Destination: {}", EVENT_CLASS_NAME, event.getEventId(), jobId, destinationKey);

--- a/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/JobNotificationProcessorTest.java
+++ b/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/JobNotificationProcessorTest.java
@@ -1,11 +1,7 @@
 package com.synopsys.integration.alert.processor.api;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -98,11 +94,7 @@ class JobNotificationProcessorTest {
         JobNotificationProcessor jobNotificationProcessor = new JobNotificationProcessor(notificationDetailExtractionDelegator, notificationContentProcessor, providerMessageDistributor, List.of(lifecycleCaches));
         jobNotificationProcessor.processNotificationForJob(processedNotificationDetails, ProcessingType.DEFAULT, List.of(notificationModel));
 
-        Set<Long> auditNotificationIds = processingAuditAccessor.getNotificationIds(uuid);
-
         Mockito.verify(eventManager, Mockito.times(1)).sendEvent(Mockito.any());
-        assertEquals(1, auditNotificationIds.size());
-        assertTrue(auditNotificationIds.contains(notificationId));
     }
 
     private RuleViolationNotificationMessageExtractor createRuleViolationNotificationMessageExtractor() throws IntegrationException {

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
 }
 
 mainClassName = 'com.synopsys.integration.alert.Application'
-version = '6.13.0-SNAPSHOT'
+version = '6.13.0-TESTPERF-SNAPSHOT'
 
 ext.isSnapshot = project.version.endsWith('-SNAPSHOT')
 

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/database/DefaultDiagnosticAccessor.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/database/DefaultDiagnosticAccessor.java
@@ -210,10 +210,10 @@ public class DefaultDiagnosticAccessor implements DiagnosticAccessor {
             DateUtils.formatDurationFromNanos(durationsModel.getJobDuration()),
             List.of(
                 createJobStageDuration(JobStage.NOTIFICATION_PROCESSING, durationsModel.getNotificationProcessingDuration().orElse(0L)),
-                createJobStageDuration(JobStage.CHANNEL_PROCESSING, durationsModel.getNotificationProcessingDuration().orElse(0L)),
-                createJobStageDuration(JobStage.ISSUE_CREATION, durationsModel.getNotificationProcessingDuration().orElse(0L)),
-                createJobStageDuration(JobStage.ISSUE_COMMENTING, durationsModel.getNotificationProcessingDuration().orElse(0L)),
-                createJobStageDuration(JobStage.ISSUE_TRANSITION, durationsModel.getNotificationProcessingDuration().orElse(0L))
+                createJobStageDuration(JobStage.CHANNEL_PROCESSING, durationsModel.getChannelProcessingDuration().orElse(0L)),
+                createJobStageDuration(JobStage.ISSUE_CREATION, durationsModel.getIssueCreationDuration().orElse(0L)),
+                createJobStageDuration(JobStage.ISSUE_COMMENTING, durationsModel.getIssueCommentingDuration().orElse(0L)),
+                createJobStageDuration(JobStage.ISSUE_TRANSITION, durationsModel.getIssueTransitionDuration().orElse(0L))
             )
         );
 

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/database/DefaultDiagnosticAccessor.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/database/DefaultDiagnosticAccessor.java
@@ -22,6 +22,7 @@ import com.synopsys.integration.alert.api.distribution.execution.AggregatedExecu
 import com.synopsys.integration.alert.api.distribution.execution.ExecutingJob;
 import com.synopsys.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.synopsys.integration.alert.api.distribution.execution.ExecutingJobStage;
+import com.synopsys.integration.alert.api.distribution.execution.JobStage;
 import com.synopsys.integration.alert.common.enumeration.AuditEntryStatus;
 import com.synopsys.integration.alert.common.persistence.accessor.DiagnosticAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.JobExecutionStatusAccessor;
@@ -35,6 +36,7 @@ import com.synopsys.integration.alert.common.util.DateUtils;
 import com.synopsys.integration.alert.component.diagnostic.model.AuditDiagnosticModel;
 import com.synopsys.integration.alert.component.diagnostic.model.CompletedJobDiagnosticModel;
 import com.synopsys.integration.alert.component.diagnostic.model.CompletedJobDurationDiagnosticModel;
+import com.synopsys.integration.alert.component.diagnostic.model.CompletedJobStageDurationModel;
 import com.synopsys.integration.alert.component.diagnostic.model.CompletedJobsDiagnosticModel;
 import com.synopsys.integration.alert.component.diagnostic.model.DiagnosticModel;
 import com.synopsys.integration.alert.component.diagnostic.model.JobExecutionDiagnosticModel;
@@ -206,11 +208,13 @@ public class DefaultDiagnosticAccessor implements DiagnosticAccessor {
         JobExecutionStatusDurations durationsModel = jobCompletionStatusModel.getDurations();
         CompletedJobDurationDiagnosticModel durationDiagnosticModel = new CompletedJobDurationDiagnosticModel(
             DateUtils.formatDurationFromNanos(durationsModel.getJobDuration()),
-            DateUtils.formatDurationFromNanos(durationsModel.getNotificationProcessingDuration().orElse(0L)),
-            DateUtils.formatDurationFromNanos(durationsModel.getChannelProcessingDuration().orElse(0L)),
-            DateUtils.formatDurationFromNanos(durationsModel.getIssueCreationDuration().orElse(0L)),
-            DateUtils.formatDurationFromNanos(durationsModel.getIssueCommentingDuration().orElse(0L)),
-            DateUtils.formatDurationFromNanos(durationsModel.getIssueTransitionDuration().orElse(0L))
+            List.of(
+                createJobStageDuration(JobStage.NOTIFICATION_PROCESSING, durationsModel.getNotificationProcessingDuration().orElse(0L)),
+                createJobStageDuration(JobStage.CHANNEL_PROCESSING, durationsModel.getNotificationProcessingDuration().orElse(0L)),
+                createJobStageDuration(JobStage.ISSUE_CREATION, durationsModel.getNotificationProcessingDuration().orElse(0L)),
+                createJobStageDuration(JobStage.ISSUE_COMMENTING, durationsModel.getNotificationProcessingDuration().orElse(0L)),
+                createJobStageDuration(JobStage.ISSUE_TRANSITION, durationsModel.getNotificationProcessingDuration().orElse(0L))
+            )
         );
 
         String jobName = getJobName(jobCompletionStatusModel.getJobConfigId());
@@ -226,6 +230,10 @@ public class DefaultDiagnosticAccessor implements DiagnosticAccessor {
             durationDiagnosticModel
         );
 
+    }
+
+    private CompletedJobStageDurationModel createJobStageDuration(JobStage jobStage, long nanosecondDuration) {
+        return new CompletedJobStageDurationModel(jobStage.name(), DateUtils.formatDurationFromNanos(nanosecondDuration));
     }
 
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/CompletedJobDurationDiagnosticModel.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/CompletedJobDurationDiagnosticModel.java
@@ -1,5 +1,7 @@
 package com.synopsys.integration.alert.component.diagnostic.model;
 
+import java.util.List;
+
 import com.synopsys.integration.alert.api.common.model.AlertSerializableModel;
 
 public class CompletedJobDurationDiagnosticModel extends AlertSerializableModel {
@@ -7,49 +9,22 @@ public class CompletedJobDurationDiagnosticModel extends AlertSerializableModel 
     private static final long serialVersionUID = -7963260099077205918L;
 
     private final String jobDuration;
-    private final String notificationProcessing;
-    private final String channelProcessing;
-    private final String issueCreation;
-    private final String issueCommenting;
-    private final String issueTransition;
+
+    private final List<CompletedJobStageDurationModel> stageDurations;
 
     public CompletedJobDurationDiagnosticModel(
         String jobDuration,
-        String notificationProcessing,
-        String channelProcessing,
-        String issueCreation,
-        String issueCommenting,
-        String issueTransition
+        List<CompletedJobStageDurationModel> stageDurations
     ) {
         this.jobDuration = jobDuration;
-        this.notificationProcessing = notificationProcessing;
-        this.channelProcessing = channelProcessing;
-        this.issueCreation = issueCreation;
-        this.issueCommenting = issueCommenting;
-        this.issueTransition = issueTransition;
+        this.stageDurations = stageDurations;
     }
 
     public String getJobDuration() {
         return jobDuration;
     }
 
-    public String getNotificationProcessing() {
-        return notificationProcessing;
-    }
-
-    public String getChannelProcessing() {
-        return channelProcessing;
-    }
-
-    public String getIssueCreation() {
-        return issueCreation;
-    }
-
-    public String getIssueCommenting() {
-        return issueCommenting;
-    }
-
-    public String getIssueTransition() {
-        return issueTransition;
+    public List<CompletedJobStageDurationModel> getStageDurations() {
+        return stageDurations;
     }
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/CompletedJobStageDurationModel.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/diagnostic/model/CompletedJobStageDurationModel.java
@@ -1,0 +1,23 @@
+package com.synopsys.integration.alert.component.diagnostic.model;
+
+import com.synopsys.integration.alert.api.common.model.AlertSerializableModel;
+
+public class CompletedJobStageDurationModel extends AlertSerializableModel {
+
+    private static final long serialVersionUID = -6215504690854338841L;
+    private final String name;
+    private final String duration;
+
+    public CompletedJobStageDurationModel(String name, String duration) {
+        this.name = name;
+        this.duration = duration;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDuration() {
+        return duration;
+    }
+}

--- a/component/src/test/java/com/synopsys/integration/alert/component/diagnostic/database/DefaultDiagnosticAccessorTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/diagnostic/database/DefaultDiagnosticAccessorTest.java
@@ -3,19 +3,37 @@ package com.synopsys.integration.alert.component.diagnostic.database;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.synopsys.integration.alert.api.distribution.execution.ExecutingJob;
 import com.synopsys.integration.alert.api.distribution.execution.ExecutingJobManager;
+import com.synopsys.integration.alert.api.distribution.execution.JobStage;
 import com.synopsys.integration.alert.common.enumeration.AuditEntryStatus;
+import com.synopsys.integration.alert.common.enumeration.FrequencyType;
+import com.synopsys.integration.alert.common.enumeration.ProcessingType;
 import com.synopsys.integration.alert.common.persistence.accessor.JobExecutionStatusAccessor;
+import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobModel;
+import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobModelBuilder;
+import com.synopsys.integration.alert.common.persistence.model.job.executions.JobExecutionStatusDurations;
+import com.synopsys.integration.alert.common.persistence.model.job.executions.JobExecutionStatusModel;
+import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
+import com.synopsys.integration.alert.common.rest.model.AlertPagedQueryDetails;
+import com.synopsys.integration.alert.common.util.DateUtils;
 import com.synopsys.integration.alert.component.diagnostic.model.AlertQueueInformation;
 import com.synopsys.integration.alert.component.diagnostic.model.AuditDiagnosticModel;
+import com.synopsys.integration.alert.component.diagnostic.model.CompletedJobDiagnosticModel;
+import com.synopsys.integration.alert.component.diagnostic.model.CompletedJobDurationDiagnosticModel;
+import com.synopsys.integration.alert.component.diagnostic.model.CompletedJobStageDurationModel;
+import com.synopsys.integration.alert.component.diagnostic.model.CompletedJobsDiagnosticModel;
 import com.synopsys.integration.alert.component.diagnostic.model.DiagnosticModel;
+import com.synopsys.integration.alert.component.diagnostic.model.JobExecutionsDiagnosticModel;
 import com.synopsys.integration.alert.component.diagnostic.model.NotificationDiagnosticModel;
 import com.synopsys.integration.alert.component.diagnostic.model.RabbitMQDiagnosticModel;
 import com.synopsys.integration.alert.component.diagnostic.model.SystemDiagnosticModel;
@@ -23,8 +41,10 @@ import com.synopsys.integration.alert.component.diagnostic.utility.RabbitMQDiagn
 import com.synopsys.integration.alert.database.api.StaticJobAccessor;
 import com.synopsys.integration.alert.database.audit.AuditEntryRepository;
 import com.synopsys.integration.alert.database.notification.NotificationContentRepository;
+import com.synopsys.integration.alert.descriptor.api.model.ChannelKeys;
 
 class DefaultDiagnosticAccessorTest {
+    public static final String TEST_JOB_NAME = "Job Name";
     private NotificationContentRepository notificationContentRepository;
     private AuditEntryRepository auditEntryRepository;
     private RabbitMQDiagnosticUtility rabbitMQDiagnosticUtility;
@@ -53,14 +73,18 @@ class DefaultDiagnosticAccessorTest {
             completedJobsAccessor,
             executingJobManager
         );
+        addJobExecutions();
         NotificationDiagnosticModel notificationDiagnosticModel = createNotificationDiagnosticModel();
         AuditDiagnosticModel auditDiagnosticModel = createAuditDiagnosticModel();
         RabbitMQDiagnosticModel rabbitMQDiagnosticModel = createRabbitMQDiagnosticModel();
+        CompletedJobsDiagnosticModel completedJobsDiagnosticModel = createJobDiagnosticModel();
         DiagnosticModel diagnosticModel = diagnosticAccessor.getDiagnosticInfo();
 
         assertEquals(notificationDiagnosticModel, diagnosticModel.getNotificationDiagnosticModel());
         assertEquals(auditDiagnosticModel, diagnosticModel.getAuditDiagnosticModel());
         assertEquals(rabbitMQDiagnosticModel, diagnosticModel.getRabbitMQDiagnosticModel());
+        assertEquals(completedJobsDiagnosticModel, diagnosticModel.getCompletedJobsDiagnosticModel());
+        assertExecutingJobDetails(diagnosticModel.getJobExecutionsDiagnosticModel());
         assertSystemDiagnostics(diagnosticModel.getSystemDiagnosticModel());
     }
 
@@ -92,6 +116,115 @@ class DefaultDiagnosticAccessorTest {
         RabbitMQDiagnosticModel rabbitMQDiagnosticModel = new RabbitMQDiagnosticModel(List.of(queue1, queue2));
         Mockito.when(rabbitMQDiagnosticUtility.getRabbitMQDiagnostics()).thenReturn(rabbitMQDiagnosticModel);
         return rabbitMQDiagnosticModel;
+    }
+
+    private CompletedJobsDiagnosticModel createJobDiagnosticModel() {
+        UUID jobConfigId = UUID.randomUUID();
+        Long notificationCount = 10L;
+        Long successCount = 1L;
+        Long failureCount = 0L;
+        String latestStatus = AuditEntryStatus.SUCCESS.name();
+        OffsetDateTime lastRun = DateUtils.createCurrentDateTimestamp();
+        Long jobDuration = 100000L;
+        JobExecutionStatusDurations durations = new JobExecutionStatusDurations(jobDuration, 1000000L, 300000L, 0L, 0L, 0L);
+
+        JobExecutionStatusModel statusModel = new JobExecutionStatusModel(
+            jobConfigId,
+            notificationCount,
+            notificationCount,
+            successCount,
+            failureCount,
+            latestStatus,
+            lastRun,
+            durations
+        );
+        AlertPagedModel<JobExecutionStatusModel> pageModel = new AlertPagedModel<>(1, 0, 10, List.of(statusModel));
+        Mockito.when(completedJobsAccessor.getJobExecutionStatus(Mockito.any(AlertPagedQueryDetails.class))).thenReturn(pageModel);
+        DistributionJobModelBuilder jobModelBuilder = DistributionJobModel.builder()
+            .jobId(UUID.randomUUID())
+            .name(TEST_JOB_NAME)
+            .processingType(ProcessingType.DEFAULT)
+            .distributionFrequency(FrequencyType.REAL_TIME)
+            .blackDuckGlobalConfigId(1L)
+            .createdAt(OffsetDateTime.now())
+            .channelDescriptorName(ChannelKeys.SLACK.getUniversalKey())
+            .notificationTypes(List.of("VULNERABILITY"));
+
+        Mockito.when(staticJobAccessor.getJobById(Mockito.any())).thenReturn(Optional.of(jobModelBuilder.build()));
+        CompletedJobStageDurationModel firstStage = new CompletedJobStageDurationModel(
+            JobStage.NOTIFICATION_PROCESSING.name(),
+            DateUtils.formatDurationFromNanos(1000000L)
+        );
+        CompletedJobStageDurationModel secondStage = new CompletedJobStageDurationModel(
+            JobStage.CHANNEL_PROCESSING.name(),
+            DateUtils.formatDurationFromNanos(300000L)
+        );
+        CompletedJobStageDurationModel thirdStage = new CompletedJobStageDurationModel(
+            JobStage.ISSUE_CREATION.name(),
+            DateUtils.formatDurationFromNanos(0L)
+        );
+        CompletedJobStageDurationModel fourthStage = new CompletedJobStageDurationModel(
+            JobStage.ISSUE_COMMENTING.name(),
+            DateUtils.formatDurationFromNanos(0L)
+        );
+        CompletedJobStageDurationModel fifthStage = new CompletedJobStageDurationModel(
+            JobStage.ISSUE_TRANSITION.name(),
+            DateUtils.formatDurationFromNanos(0L)
+        );
+
+        CompletedJobDurationDiagnosticModel durationDisgnostics = new CompletedJobDurationDiagnosticModel(
+            DateUtils.formatDurationFromNanos(jobDuration),
+            List.of(firstStage, secondStage, thirdStage, fourthStage, fifthStage)
+        );
+        List<CompletedJobDiagnosticModel> jobs = List.of(new CompletedJobDiagnosticModel(
+            jobConfigId,
+            TEST_JOB_NAME,
+            notificationCount,
+            notificationCount,
+            successCount,
+            failureCount,
+            latestStatus,
+            DateUtils.formatDateAsJsonString(lastRun),
+            durationDisgnostics
+        ));
+        return new CompletedJobsDiagnosticModel(jobs);
+    }
+
+    private void addJobExecutions() {
+        UUID jobConfigId = UUID.randomUUID();
+        int processedNotificationCount = 10;
+        int totalNotificationCount = 100;
+
+        ExecutingJob executingJob = executingJobManager.startJob(jobConfigId, totalNotificationCount);
+        executingJob.updateNotificationCount(processedNotificationCount);
+        UUID jobExecutionId = executingJob.getExecutionId();
+
+        OffsetDateTime firstStageStart = DateUtils.createCurrentDateTimestamp();
+        OffsetDateTime firstStageEnd = DateUtils.createCurrentDateTimestamp();
+        executingJobManager.startStage(jobExecutionId, JobStage.NOTIFICATION_PROCESSING, firstStageStart.toInstant());
+        executingJobManager.endStage(jobExecutionId, JobStage.NOTIFICATION_PROCESSING, firstStageEnd.toInstant());
+
+        OffsetDateTime secondStageStart = DateUtils.createCurrentDateTimestamp();
+        OffsetDateTime secondStageEnd = DateUtils.createCurrentDateTimestamp();
+        executingJobManager.startStage(jobExecutionId, JobStage.NOTIFICATION_PROCESSING, secondStageStart.toInstant());
+        executingJobManager.endStage(jobExecutionId, JobStage.NOTIFICATION_PROCESSING, secondStageEnd.toInstant());
+
+        DistributionJobModelBuilder jobModelBuilder = DistributionJobModel.builder()
+            .jobId(jobConfigId)
+            .name(TEST_JOB_NAME)
+            .processingType(ProcessingType.DEFAULT)
+            .distributionFrequency(FrequencyType.REAL_TIME)
+            .blackDuckGlobalConfigId(1L)
+            .createdAt(OffsetDateTime.now())
+            .channelDescriptorName(ChannelKeys.SLACK.getUniversalKey())
+            .notificationTypes(List.of("VULNERABILITY"));
+
+        DistributionJobModel distributionJobModel = jobModelBuilder.build();
+        Mockito.when(staticJobAccessor.getJobById(Mockito.any())).thenReturn(Optional.of(distributionJobModel));
+    }
+
+    private void assertExecutingJobDetails(JobExecutionsDiagnosticModel jobExecutionsDiagnosticModel) {
+
     }
 
     private void assertSystemDiagnostics(SystemDiagnosticModel systemDiagnosticModel) {

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckAccumulator.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckAccumulator.java
@@ -11,7 +11,7 @@ import java.time.OffsetDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -57,7 +57,7 @@ public class BlackDuckAccumulator extends ProviderTask {
     private final BlackDuckNotificationRetrieverFactory notificationRetrieverFactory;
     private final BlackDuckAccumulatorSearchDateManager searchDateManager;
 
-    private final AtomicBoolean accumulatingNotifications = new AtomicBoolean(false);
+    private final ReentrantLock accumulationLock = new ReentrantLock();
 
     public BlackDuckAccumulator(
         BlackDuckProviderKey blackDuckProviderKey,
@@ -86,9 +86,7 @@ public class BlackDuckAccumulator extends ProviderTask {
     @Override
     protected void runProviderTask() {
         BlackDuckProperties blackDuckProperties = getProviderProperties();
-        if (!accumulatingNotifications.get()
-
-            && blackDuckSystemValidator.canConnect(blackDuckProperties, new BlackDuckApiTokenValidator(blackDuckProperties))) {
+        if (blackDuckSystemValidator.canConnect(blackDuckProperties, new BlackDuckApiTokenValidator(blackDuckProperties))) {
             accumulateNotifications();
         } else {
             logger.info("Accumulation already occurring.  Skipping this accumulation cycle.");
@@ -101,20 +99,20 @@ public class BlackDuckAccumulator extends ProviderTask {
     }
 
     private void accumulateNotifications() {
-        accumulatingNotifications.set(true);
-        logger.info("Accumulating set to true. Preventing other accumulation cycles.");
+        accumulationLock.lock();
+        logger.info("Accumulator: Accumulating lock acquired. Preventing other accumulation cycles.");
         Optional<BlackDuckNotificationRetriever> optionalNotificationRetriever = notificationRetrieverFactory.createBlackDuckNotificationRetriever(getProviderProperties());
         if (optionalNotificationRetriever.isPresent()) {
             DateRange dateRange = searchDateManager.retrieveNextSearchDateRange();
             logger.info(
-                "Accumulating notifications between {} and {} ",
+                "Accumulator: Accumulating notifications between {} and {} ",
                 DateUtils.formatDateAsJsonString(dateRange.getStart()),
                 DateUtils.formatDateAsJsonString(dateRange.getEnd())
             );
             retrieveAndStoreNotificationsSafely(optionalNotificationRetriever.get(), dateRange);
         }
-        logger.info("Accumulating set to false. Allowing other accumulation cycles.");
-        accumulatingNotifications.set(false);
+        logger.info("Accumulator: Allowing other accumulation cycles.");
+        accumulationLock.unlock();
     }
 
     private void retrieveAndStoreNotificationsSafely(BlackDuckNotificationRetriever notificationRetriever, DateRange dateRange) {

--- a/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckAccumulator.java
+++ b/provider-blackduck/src/main/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckAccumulator.java
@@ -57,7 +57,7 @@ public class BlackDuckAccumulator extends ProviderTask {
     private final BlackDuckNotificationRetrieverFactory notificationRetrieverFactory;
     private final BlackDuckAccumulatorSearchDateManager searchDateManager;
 
-    private final ReentrantLock accumulatingLock = new ReentrantLock();
+    private static final ReentrantLock accumulatingLock = new ReentrantLock();
 
     public BlackDuckAccumulator(
         BlackDuckProviderKey blackDuckProviderKey,

--- a/src/test/java/com/synopsys/integration/alert/database/api/DefaultDistributionAccessorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/database/api/DefaultDistributionAccessorTestIT.java
@@ -1,13 +1,12 @@
 package com.synopsys.integration.alert.database.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.ParseException;
+import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -19,7 +18,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -28,17 +26,21 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.synopsys.integration.alert.api.distribution.execution.ExecutingJob;
+import com.synopsys.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.synopsys.integration.alert.common.descriptor.DescriptorMap;
 import com.synopsys.integration.alert.common.enumeration.AuditEntryStatus;
 import com.synopsys.integration.alert.common.enumeration.FrequencyType;
 import com.synopsys.integration.alert.common.enumeration.ProcessingType;
 import com.synopsys.integration.alert.common.persistence.accessor.DistributionAccessor;
 import com.synopsys.integration.alert.common.persistence.accessor.JobAccessor;
+import com.synopsys.integration.alert.common.persistence.accessor.JobExecutionStatusAccessor;
 import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobModel;
 import com.synopsys.integration.alert.common.persistence.model.job.DistributionJobRequestModel;
 import com.synopsys.integration.alert.common.persistence.model.job.details.DistributionJobDetailsModel;
 import com.synopsys.integration.alert.common.persistence.model.job.details.MSTeamsJobDetailsModel;
 import com.synopsys.integration.alert.common.persistence.model.job.details.SlackJobDetailsModel;
+import com.synopsys.integration.alert.common.persistence.model.job.executions.JobExecutionStatusModel;
 import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 import com.synopsys.integration.alert.common.rest.model.DistributionWithAuditInfo;
 import com.synopsys.integration.alert.common.util.DateUtils;
@@ -50,7 +52,7 @@ import com.synopsys.integration.alert.descriptor.api.model.DescriptorKey;
 import com.synopsys.integration.alert.util.AlertIntegrationTest;
 
 @AlertIntegrationTest
-public class DefaultDistributionAccessorTestIT {
+class DefaultDistributionAccessorTestIT {
     private final int TOTAL_NUMBER_OF_RECORDS = 6;
 
     public static final String SORT_LAST_SENT = "filteredAudit.time_last_sent";
@@ -71,6 +73,11 @@ public class DefaultDistributionAccessorTestIT {
     @Autowired
     private DescriptorMap descriptorMap;
 
+    @Autowired
+    private ExecutingJobManager executingJobManager;
+    @Autowired
+    private JobExecutionStatusAccessor jobCompletionStatusAccessor;
+
     private final List<UUID> createdJobs = new LinkedList<>();
 
     @AfterEach
@@ -82,8 +89,14 @@ public class DefaultDistributionAccessorTestIT {
     @Test
     @Transactional
     @Modifying
-    public void verifyQueryBuildsTest() {
-        AlertPagedModel<DistributionWithAuditInfo> distributionWithAuditInfo = distributionAccessor.getDistributionWithAuditInfo(0, 100, "name", Direction.ASC, getAllDescriptorNames());
+    void verifyQueryBuildsTest() {
+        AlertPagedModel<DistributionWithAuditInfo> distributionWithAuditInfo = distributionAccessor.getDistributionWithAuditInfo(
+            0,
+            100,
+            "name",
+            Direction.ASC,
+            getAllDescriptorNames()
+        );
 
         assertNotNull(distributionWithAuditInfo);
     }
@@ -91,49 +104,49 @@ public class DefaultDistributionAccessorTestIT {
     @Test
     @Transactional
     @Modifying
-    public void verifyValidityOfQueryTest() throws ParseException {
+    void verifyValidityOfQueryTest() throws ParseException {
         assertValidQueryFunctionality(TOTAL_NUMBER_OF_RECORDS, () -> distributionAccessor.getDistributionWithAuditInfo(0, 100, "name", Direction.ASC, getAllDescriptorNames()));
     }
 
     @Test
     @Transactional
     @Modifying
-    public void verifyValidityOfQueryWithNullsTest() throws ParseException {
+    void verifyValidityOfQueryWithNullsTest() throws ParseException {
         assertValidQueryFunctionality(TOTAL_NUMBER_OF_RECORDS, () -> distributionAccessor.getDistributionWithAuditInfo(0, 100, null, null, getAllDescriptorNames()));
     }
 
     @Test
     @Transactional
     @Modifying
-    public void sortByNameDESCLowPageSizeTest() throws ParseException {
+    void sortByNameDESCLowPageSizeTest() throws ParseException {
         assertSorted(3, 3, SORT_NAME, Direction.DESC, DistributionWithAuditInfo::getJobName);
     }
 
     @Test
     @Transactional
     @Modifying
-    public void sortByNameDESCTest() throws ParseException {
+    void sortByNameDESCTest() throws ParseException {
         assertSorted(TOTAL_NUMBER_OF_RECORDS, 100, SORT_NAME, Direction.DESC, DistributionWithAuditInfo::getJobName);
     }
 
     @Test
     @Transactional
     @Modifying
-    public void sortByNameASCTest() throws ParseException {
+    void sortByNameASCTest() throws ParseException {
         assertSorted(TOTAL_NUMBER_OF_RECORDS, 100, SORT_NAME, Direction.ASC, DistributionWithAuditInfo::getJobName);
     }
 
     @Test
     @Transactional
     @Modifying
-    public void sortByFrequencyASCTest() throws ParseException {
+    void sortByFrequencyASCTest() throws ParseException {
         assertSorted(TOTAL_NUMBER_OF_RECORDS, 100, SORT_FREQUENCY, Direction.ASC, DistributionWithAuditInfo::getFrequencyType);
     }
 
     @Test
     @Transactional
     @Modifying
-    public void sortByFrequencyDESCTest() throws ParseException {
+    void sortByFrequencyDESCTest() throws ParseException {
         assertSorted(TOTAL_NUMBER_OF_RECORDS, 100, SORT_FREQUENCY, Direction.DESC, DistributionWithAuditInfo::getFrequencyType);
     }
 
@@ -141,7 +154,7 @@ public class DefaultDistributionAccessorTestIT {
     @Transactional
     @Modifying
     @Disabled("This feature is not currently supported due to limitations in hibernate")
-    public void sortByAuditLastTimeSentDESCTest() throws ParseException {
+    void sortByAuditLastTimeSentDESCTest() throws ParseException {
         assertAuditLastTimeSent(Direction.DESC);
     }
 
@@ -149,7 +162,7 @@ public class DefaultDistributionAccessorTestIT {
     @Transactional
     @Modifying
     @Disabled("This feature is not currently supported due to limitations in hibernate")
-    public void sortByAuditLastTimeSentASCTest() throws ParseException {
+    void sortByAuditLastTimeSentASCTest() throws ParseException {
         assertAuditLastTimeSent(Direction.ASC);
     }
 
@@ -206,7 +219,7 @@ public class DefaultDistributionAccessorTestIT {
     }
 
     private AlertPagedModel<DistributionWithAuditInfo> assertValidQueryFunctionality(int expectedNumberOfResults, Supplier<AlertPagedModel<DistributionWithAuditInfo>> dBQuery) throws ParseException {
-        Map<UUID, Pair<DistributionJobModel, List<AuditEntryEntity>>> jobAndAuditData = createAndSave6JobAndAudit();
+        Map<UUID, DistributionJobModel> jobAndAuditData = createAndSave6JobAndAudit();
         assertEquals(TOTAL_NUMBER_OF_RECORDS, jobAndAuditData.keySet().size());
 
         jobAndAuditData.keySet().stream().forEach(uuid -> {
@@ -219,24 +232,19 @@ public class DefaultDistributionAccessorTestIT {
         assertEquals(expectedNumberOfResults, queryResult.getModels().size());
 
         for (DistributionWithAuditInfo distributionWithAuditInfo : queryResult.getModels()) {
-            Pair<DistributionJobModel, List<AuditEntryEntity>> distributionJobModelListPair = jobAndAuditData.get(distributionWithAuditInfo.getJobId());
-            DistributionJobModel distributionJobModel = distributionJobModelListPair.getLeft();
+            DistributionJobModel distributionJobModel = jobAndAuditData.get(distributionWithAuditInfo.getJobId());
 
             assertEquals(distributionJobModel.getName(), distributionWithAuditInfo.getJobName());
-            assertNotEquals(AuditEntryStatus.PENDING.name(), distributionWithAuditInfo.getAuditStatus());
 
-            List<AuditEntryEntity> audits = distributionJobModelListPair.getRight();
-            if (!audits.isEmpty()) {
-                OffsetDateTime mostRecentAuditEntryTime = audits.stream().filter(auditEntryEntity -> auditEntryEntity.getTimeLastSent() != null).max(Comparator.comparing(AuditEntryEntity::getTimeLastSent))
-                    .map(AuditEntryEntity::getTimeLastSent).orElse(null);
-
-                String formattedTime = null;
-                if (null != mostRecentAuditEntryTime) {
-                    formattedTime = DateUtils.formatDate(mostRecentAuditEntryTime, DateUtils.AUDIT_DATE_FORMAT);
-                }
-
-                assertEquals(formattedTime, distributionWithAuditInfo.getAuditTimeLastSent());
+            Optional<JobExecutionStatusModel> jobExecutionStatusModel = jobCompletionStatusAccessor.getJobExecutionStatus(distributionWithAuditInfo.getJobId());
+            if (jobExecutionStatusModel.isPresent()) {
+                assertEquals(jobExecutionStatusModel.get().getLatestStatus(), distributionWithAuditInfo.getAuditStatus());
+                String jsonFormattedString = DateUtils.formatDate(jobExecutionStatusModel.get().getLastRun(), DateUtils.AUDIT_DATE_FORMAT);
+                String removedDashes = StringUtils.replace(jsonFormattedString, "-", "/");
+                String formattedTimestamp = StringUtils.substringBeforeLast(removedDashes, ".");
+                assertEquals(formattedTimestamp, distributionWithAuditInfo.getAuditTimeLastSent());
             }
+
         }
 
         return queryResult;
@@ -293,7 +301,7 @@ public class DefaultDistributionAccessorTestIT {
         );
     }
 
-    private Map<UUID, Pair<DistributionJobModel, List<AuditEntryEntity>>> createAndSave6JobAndAudit() {
+    private Map<UUID, DistributionJobModel> createAndSave6JobAndAudit() {
         DistributionJobRequestModel firstJob = createSlackJob(true);
         DistributionJobRequestModel secondJob = createSlackJob(false);
         DistributionJobRequestModel thirdJob = createSlackJob(true);
@@ -315,29 +323,26 @@ public class DefaultDistributionAccessorTestIT {
         createdJobs.add(fifthJobSaved.getJobId());
         createdJobs.add(sixthJobSaved.getJobId());
 
-        AuditEntryEntity firstAudit = createAuditEntryEntity(firstJobSaved.getJobId(), OffsetDateTime.now(), AuditEntryStatus.SUCCESS);
-        AuditEntryEntity secondAudit = createAuditEntryEntity(firstJobSaved.getJobId(), OffsetDateTime.now().minusDays(1), AuditEntryStatus.PENDING);
-        AuditEntryEntity thirdAudit = createAuditEntryEntity(secondJobSaved.getJobId(), OffsetDateTime.now().minusMinutes(1), AuditEntryStatus.FAILURE);
-        AuditEntryEntity fourthAudit = createAuditEntryEntity(fourthJobSaved.getJobId(), OffsetDateTime.now().minusHours(1), AuditEntryStatus.SUCCESS);
-        AuditEntryEntity fifthAudit = createAuditEntryEntity(fifthJobSaved.getJobId(), OffsetDateTime.now().minusHours(2), AuditEntryStatus.SUCCESS);
-        AuditEntryEntity sixthAudit = createAuditEntryEntity(fifthJobSaved.getJobId(), OffsetDateTime.now().minusMinutes(2), AuditEntryStatus.FAILURE);
-        AuditEntryEntity seventhAudit = createAuditEntryEntity(sixthJobSaved.getJobId(), null, AuditEntryStatus.SUCCESS);
-        AuditEntryEntity eighthAudit = createAuditEntryEntity(sixthJobSaved.getJobId(), OffsetDateTime.now(), AuditEntryStatus.FAILURE);
-        AuditEntryEntity ninthAudit = createAuditEntryEntity(sixthJobSaved.getJobId(), null, AuditEntryStatus.PENDING);
+        ExecutingJob executingJob1 = executingJobManager.startJob(firstJobSaved.getJobId(), 1);
+        ExecutingJob executingJob2 = executingJobManager.startJob(secondJobSaved.getJobId(), 2);
+        executingJobManager.startJob(thirdJobSaved.getJobId(), 3);
+        ExecutingJob executingJob4 = executingJobManager.startJob(fourthJobSaved.getJobId(), 4);
+        ExecutingJob executingJob5 = executingJobManager.startJob(fifthJobSaved.getJobId(), 5);
+        ExecutingJob executingJob6 = executingJobManager.startJob(sixthJobSaved.getJobId(), 6);
 
-        saveAllAudits(List.of(firstAudit, secondAudit, thirdAudit, fourthAudit, fifthAudit, sixthAudit, seventhAudit, eighthAudit, ninthAudit));
+        executingJobManager.endJobWithSuccess(executingJob1.getExecutionId(), Instant.now());
+        executingJobManager.endJobWithSuccess(executingJob2.getExecutionId(), Instant.now());
+        executingJobManager.endJobWithFailure(executingJob4.getExecutionId(), Instant.now());
+        executingJobManager.endJobWithSuccess(executingJob5.getExecutionId(), Instant.now());
+        executingJobManager.endJobWithFailure(executingJob6.getExecutionId(), Instant.now());
 
         return Map.of(
-            firstJobSaved.getJobId(), Pair.of(firstJobSaved, List.of(firstAudit, secondAudit)),
-            secondJobSaved.getJobId(), Pair.of(secondJobSaved, List.of(thirdAudit)),
-            thirdJobSaved.getJobId(), Pair.of(thirdJobSaved, List.of()),
-            fourthJobSaved.getJobId(), Pair.of(fourthJobSaved, List.of(fourthAudit)),
-            fifthJobSaved.getJobId(), Pair.of(fifthJobSaved, List.of(fifthAudit, sixthAudit)),
-            sixthJobSaved.getJobId(), Pair.of(sixthJobSaved, List.of(seventhAudit, eighthAudit, ninthAudit))
+            firstJobSaved.getJobId(), firstJobSaved,
+            secondJobSaved.getJobId(), secondJobSaved,
+            thirdJobSaved.getJobId(), thirdJobSaved,
+            fourthJobSaved.getJobId(), fourthJobSaved,
+            fifthJobSaved.getJobId(), fifthJobSaved,
+            sixthJobSaved.getJobId(), sixthJobSaved
         );
-    }
-
-    private List<AuditEntryEntity> saveAllAudits(List<AuditEntryEntity> audits) {
-        return auditEntryRepository.saveAll(audits);
     }
 }

--- a/src/test/java/com/synopsys/integration/alert/performance/utility/IntegrationPerformanceTestRunner.java
+++ b/src/test/java/com/synopsys/integration/alert/performance/utility/IntegrationPerformanceTestRunner.java
@@ -164,11 +164,9 @@ public class IntegrationPerformanceTestRunner {
         }
 
         WaitJobCondition waitJobCondition = createWaitJobCondition(
-            waitForAuditComplete,
             Set.of(jobId),
             startingNotificationTime,
-            numberOfExpectedAuditEntries,
-            NotificationType.RULE_VIOLATION
+            numberOfExpectedAuditEntries
         );
         return waitForJobToFinish(startingNotificationTime, waitJobCondition);
     }
@@ -190,11 +188,9 @@ public class IntegrationPerformanceTestRunner {
         }
 
         WaitJobCondition waitJobCondition = createWaitJobCondition(
-            waitForAuditComplete,
             jobIds,
             startingNotificationTime,
-            numberOfExpectedAuditEntries,
-            NotificationType.RULE_VIOLATION
+            numberOfExpectedAuditEntries
         );
         return waitForJobToFinish(startingNotificationTime, waitJobCondition);
     }
@@ -241,55 +237,11 @@ public class IntegrationPerformanceTestRunner {
         }
     }
 
-    private AuditCompleteWaitJobTask createAuditCompleteWaitTask(
-        Set<String> jobIds,
-        LocalDateTime startingNotificationTime,
-        int numberOfExpectedAuditEntries,
-        NotificationType notificationType
-    ) {
-        return new AuditCompleteWaitJobTask(
-            intLogger,
-            dateTimeFormatter,
-            gson,
-            alertRequestUtility,
-            startingNotificationTime,
-            numberOfExpectedAuditEntries,
-            notificationType,
-            jobIds
-        );
-    }
-
-    private AuditProcessingWaitJobTask createAuditProcessingWaitTask(
-        Set<String> jobIds,
-        LocalDateTime startingNotificationTime,
-        int numberOfExpectedAuditEntries,
-        NotificationType notificationType
-    ) {
-        return new AuditProcessingWaitJobTask(
-            intLogger,
-            dateTimeFormatter,
-            gson,
-            alertRequestUtility,
-            startingNotificationTime,
-            numberOfExpectedAuditEntries,
-            notificationType,
-            jobIds
-        );
-    }
-
     private WaitJobCondition createWaitJobCondition(
-        boolean waitForAuditComplete,
         Set<String> jobIds,
         LocalDateTime startingNotificationTime,
-        int numberOfExpectedAuditEntries,
-        NotificationType notificationType
+        int numberOfExpectedAuditEntries
     ) {
-        WaitJobCondition waitJobCondition;
-        if (waitForAuditComplete) {
-            waitJobCondition = createAuditCompleteWaitTask(jobIds, startingNotificationTime, numberOfExpectedAuditEntries, notificationType);
-        } else {
-            waitJobCondition = createAuditProcessingWaitTask(jobIds, startingNotificationTime, numberOfExpectedAuditEntries, notificationType);
-        }
-        return waitJobCondition;
+        return new ProcessingCompleteWaitJobTask(intLogger, gson, alertRequestUtility, startingNotificationTime, numberOfExpectedAuditEntries, jobIds);
     }
 }

--- a/src/test/java/com/synopsys/integration/alert/performance/utility/ProcessingCompleteWaitJobTask.java
+++ b/src/test/java/com/synopsys/integration/alert/performance/utility/ProcessingCompleteWaitJobTask.java
@@ -179,6 +179,13 @@ public class ProcessingCompleteWaitJobTask implements WaitJobCondition {
             });
         intLogger.info("Performance: Executing Job Diagnostics");
 
+        completedJobsDiagnosticModel.getCompletedJobs()
+            .stream()
+            .filter(jobDiagnostics -> expectedJobIds.contains(jobDiagnostics.getJobConfigId().toString()))
+            .forEach(jobDiagnostics -> {
+                intLogger.info(String.format(
+                    "Job: %s average time: %s", jobDiagnostics.getJobName(), jobDiagnostics.getDurations().getJobDuration()));
+            });
         auditDiagnosticModel.getAverageAuditTime().ifPresent(auditTime -> intLogger.info(String.format("Average audit time: %s", auditTime)));
     }
 }

--- a/src/test/java/com/synopsys/integration/alert/performance/utility/ProcessingCompleteWaitJobTask.java
+++ b/src/test/java/com/synopsys/integration/alert/performance/utility/ProcessingCompleteWaitJobTask.java
@@ -1,0 +1,184 @@
+package com.synopsys.integration.alert.performance.utility;
+
+import java.text.ParseException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.common.util.DateUtils;
+import com.synopsys.integration.alert.component.diagnostic.model.AlertQueueInformation;
+import com.synopsys.integration.alert.component.diagnostic.model.AuditDiagnosticModel;
+import com.synopsys.integration.alert.component.diagnostic.model.CompletedJobDiagnosticModel;
+import com.synopsys.integration.alert.component.diagnostic.model.CompletedJobDurationDiagnosticModel;
+import com.synopsys.integration.alert.component.diagnostic.model.CompletedJobsDiagnosticModel;
+import com.synopsys.integration.alert.component.diagnostic.model.DiagnosticModel;
+import com.synopsys.integration.alert.component.diagnostic.model.JobExecutionsDiagnosticModel;
+import com.synopsys.integration.alert.component.diagnostic.model.NotificationDiagnosticModel;
+import com.synopsys.integration.alert.component.diagnostic.model.RabbitMQDiagnosticModel;
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.log.IntLogger;
+import com.synopsys.integration.rest.exception.IntegrationRestException;
+import com.synopsys.integration.wait.WaitJobCondition;
+
+public class ProcessingCompleteWaitJobTask implements WaitJobCondition {
+    private static final String DIAGNOSTIC_ERROR_RESPONSE_MESSAGE = "Diagnostic unavailable";
+
+    private final IntLogger intLogger;
+    private final Gson gson;
+    private final AlertRequestUtility alertRequestUtility;
+    private final LocalDateTime startSearchTime;
+    private final int numberOfExpectedNotifications;
+    private final Set<String> expectedJobIds;
+
+    public ProcessingCompleteWaitJobTask(
+        IntLogger intLogger,
+        Gson gson,
+        AlertRequestUtility alertRequestUtility,
+        LocalDateTime startSearchTime,
+        int numberOfExpectedNotifications,
+        Set<String> expectedJobIds
+    ) {
+        this.intLogger = intLogger;
+        this.gson = gson;
+        this.alertRequestUtility = alertRequestUtility;
+        this.startSearchTime = startSearchTime;
+        this.numberOfExpectedNotifications = numberOfExpectedNotifications;
+        this.expectedJobIds = expectedJobIds;
+    }
+
+    @Override
+    public boolean isComplete() throws IntegrationException {
+        return waitForNotificationToBeProcessedByAllJobs();
+    }
+
+    private boolean waitForNotificationToBeProcessedByAllJobs() throws IntegrationException {
+        Optional<DiagnosticModel> diagnosticModelOptional = findDiagnosticsIfAvailable();
+        if (diagnosticModelOptional.isEmpty()) {
+            return false;
+        }
+        DiagnosticModel diagnosticModel = diagnosticModelOptional.get();
+        logDiagnostics(diagnosticModel);
+        Set<String> jobIds = getJobIdsFromDiagnosticModel(diagnosticModel);
+
+        intLogger.info(String.format("Performance: Job IDs discovered:  %s", jobIds.toString()));
+        intLogger.info(String.format("Performance: Expected Job Ids:    %s", expectedJobIds.toString()));
+
+        boolean expectedJobIdsDiscovered = expectedJobIds.size() == jobIds.size() && expectedJobIds.containsAll(jobIds);
+        if (expectedJobIdsDiscovered) {
+            boolean allQueuesEmpty = diagnosticModel.getRabbitMQDiagnosticModel().getQueues()
+                .stream()
+                .map(AlertQueueInformation::getMessageCount)
+                .allMatch(count -> count == 0);
+
+            boolean allExecutingJobsEmpty = diagnosticModel.getJobExecutionsDiagnosticModel().getJobExecutions().isEmpty();
+
+            CompletedJobsDiagnosticModel jobDiagnosticModel = diagnosticModel.getCompletedJobsDiagnosticModel();
+
+            int totalNotifications = jobDiagnosticModel.getCompletedJobs()
+                .stream()
+                .filter(jobStatusDiagnosticModel -> expectedJobIds.contains(jobStatusDiagnosticModel.getJobConfigId().toString()))
+                .filter(this::isAfterSearchTime)
+                .map(CompletedJobDiagnosticModel::getTotalNotificationCount)
+                .map(Long::intValue)
+                .reduce(0, Integer::sum);
+
+            intLogger.info(String.format("Performance: Found %s notifications, expected %s. ", totalNotifications, numberOfExpectedNotifications));
+            boolean allJobsHaveRun = jobDiagnosticModel.getCompletedJobs()
+                .stream()
+                .filter(jobStatusDiagnosticModel -> expectedJobIds.contains(jobStatusDiagnosticModel.getJobConfigId().toString()))
+                .allMatch(this::isAfterSearchTime);
+
+            boolean expectedNotifications = totalNotifications >= numberOfExpectedNotifications;
+
+            return expectedNotifications && allJobsHaveRun && allExecutingJobsEmpty && allQueuesEmpty;
+        }
+        return false;
+    }
+
+    private boolean isAfterSearchTime(CompletedJobDiagnosticModel jobStatusDiagnosticModel) {
+        try {
+            return DateUtils.parseDateFromJsonString(jobStatusDiagnosticModel.getLastRun()).isAfter(DateUtils.fromInstantUTC(startSearchTime.toInstant(
+                ZoneOffset.UTC)));
+        } catch (ParseException e) {
+            return false;
+        }
+    }
+
+    private Set<String> getJobIdsFromDiagnosticModel(DiagnosticModel diagnosticModel) {
+        return diagnosticModel.getCompletedJobsDiagnosticModel().getCompletedJobs()
+            .stream()
+            .map(CompletedJobDiagnosticModel::getJobConfigId)
+            .map(UUID::toString)
+            .collect(Collectors.toSet());
+    }
+
+    private Optional<DiagnosticModel> findDiagnosticsIfAvailable() throws IntegrationException {
+        DiagnosticModel diagnosticModel;
+        try {
+            String diagnosticResponse = alertRequestUtility.executeGetRequest("/api/diagnostic", DIAGNOSTIC_ERROR_RESPONSE_MESSAGE);
+            diagnosticModel = gson.fromJson(diagnosticResponse, DiagnosticModel.class);
+        } catch (IntegrationRestException e) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(diagnosticModel);
+    }
+
+    private void logDiagnostics(DiagnosticModel diagnosticModel) {
+        NotificationDiagnosticModel notificationDiagnosticModel = diagnosticModel.getNotificationDiagnosticModel();
+        AuditDiagnosticModel auditDiagnosticModel = diagnosticModel.getAuditDiagnosticModel();
+        RabbitMQDiagnosticModel rabbitMQDiagnosticModel = diagnosticModel.getRabbitMQDiagnosticModel();
+        CompletedJobsDiagnosticModel completedJobsDiagnosticModel = diagnosticModel.getCompletedJobsDiagnosticModel();
+        JobExecutionsDiagnosticModel executingJobsModel = diagnosticModel.getJobExecutionsDiagnosticModel();
+
+        intLogger.info(String.format("Diagnostic Info: %s", diagnosticModel.getRequestTimestamp()));
+        intLogger.info("Performance: Notification Diagnostics");
+        intLogger.info(String.format("Total # Notifications: %s", notificationDiagnosticModel.getNumberOfNotifications()));
+        intLogger.info("Performance: RabbitMQ Diagnostics");
+        rabbitMQDiagnosticModel.getQueues().forEach(queueInformation ->
+            intLogger.info(String.format("Queue Name: %s, Message Count: %s", queueInformation.getName(), queueInformation.getMessageCount()))
+        );
+        intLogger.info("Performance: RabbitMQ Diagnostics");
+        intLogger.info("Performance: Job Diagnostics");
+        completedJobsDiagnosticModel.getCompletedJobs()
+            .forEach(jobStatus -> {
+                intLogger.info(String.format(
+                    "Job: %s, last status: %s, last run: %s, notifications: (latest: %d total: %d), iterations: (SUCCESS: %s FAILURE: %s)",
+                    jobStatus.getJobName(),
+                    jobStatus.getLatestStatus(),
+                    jobStatus.getLastRun(),
+                    jobStatus.getLatestNotificationCount(),
+                    jobStatus.getTotalNotificationCount(),
+                    jobStatus.getSuccessCount(),
+                    jobStatus.getFailureCount()
+                ));
+                CompletedJobDurationDiagnosticModel jobDurationModel = jobStatus.getDurations();
+                intLogger.info(String.format("Job duration: %s", jobDurationModel.getJobDuration()));
+                jobDurationModel.getStageDurations().forEach(stage ->
+                    intLogger.info(String.format("    %s: %s", stage.getName(), stage.getDuration())));
+            });
+        intLogger.info("Performance: Job Diagnostics");
+        intLogger.info("Performance: Executing Job Diagnostics");
+        executingJobsModel.getJobExecutions()
+            .forEach(execution -> {
+                intLogger.info(String.format(
+                    "Job: %s, status: %s, notifications: (%d of %d), channel: %s, start: %s, end: %s",
+                    execution.getJobName(),
+                    execution.getStatus(),
+                    execution.getProcessedNotificationCount(),
+                    execution.getTotalNotificationCount(),
+                    execution.getChannelName(),
+                    execution.getStart(),
+                    execution.getEnd()
+                ));
+                execution.getStages()
+                    .forEach(stage -> intLogger.info(String.format("    Stage: %s, start: %s, end: %s", stage.getStage(), stage.getStart(), stage.getEnd())));
+            });
+        intLogger.info("Performance: Executing Job Diagnostics");
+
+        auditDiagnosticModel.getAverageAuditTime().ifPresent(auditTime -> intLogger.info(String.format("Average audit time: %s", auditTime)));
+    }
+}


### PR DESCRIPTION
- Implement missing diagnostics models for the executing jobs.
- Create wait task which relies on the job execution diagnostic data.
- Fix unit tests and IT tests to pass in the builds.
- Don't use the database for the jobSubTask handler to fire success events use the ExecutingJobManager directly.
- No longer create pending audit entries to cut down on the number of items in the database.

Additional refactoring to the classes will be done separately.  These changes get the test to complete.