### PR TITLE
IALERT-3074: Address issues with sslmode

### DIFF
--- a/deployment/helm/synopsys-alert/templates/alert.yaml
+++ b/deployment/helm/synopsys-alert/templates/alert.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
       - env:
         - name: RUN_SECRETS_DIR
-          value: /tmp/secrets
+          value: {{ required ".Values.secretsDirectory is missing." .Values.secretsDirectory }}
         {{- if .Values.postgres.dbCredential.secretName }}
         - name: ALERT_DB_USERNAME
           valueFrom:
@@ -75,20 +75,11 @@ spec:
         {{- end }}
         {{- if (eq .Values.postgres.sslUseFiles true) }}
         - name: ALERT_DB_SSL_KEY_PATH
-          valueFrom:
-            secretKeyRef:
-              key: {{ required ".Values.postgres.sslSecrets.sslKeyKey is missing." .Values.postgres.sslSecrets.sslKeyKey }}
-              name: {{ .Values.postgres.sslSecrets.secretName }}
+          value: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslKeyKey }}
         - name: ALERT_DB_SSL_CERT_PATH
-          valueFrom:
-            secretKeyRef:
-              key: {{ required ".Values.postgres.sslSecrets.sslCertKey is missing." .Values.postgres.sslSecrets.sslCertKey }}
-              name: {{ .Values.postgres.sslSecrets.secretName }}
+          value: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslCertKey }}
         - name: ALERT_DB_SSL_ROOT_CERT_PATH
-          valueFrom:
-            secretKeyRef:
-              key: {{ required ".Values.postgres.sslSecrets.sslRootCertKey is missing." .Values.postgres.sslSecrets.sslRootCertKey }}
-              name: {{ .Values.postgres.sslSecrets.secretName }}
+          value: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslRootCertKey }}
         {{- end }}
         {{- if .Values.rabbitmq.credential.secretName }}
         - name: ALERT_RABBITMQ_USER
@@ -139,16 +130,27 @@ spec:
         volumeMounts:
         - mountPath: /opt/blackduck/alert/alert-config
           name: dir-alert
+        {{- if .Values.postgres.sslUseFiles }}
+        - mountPath: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslKeyKey }}
+          name: dbcert
+          subPath: {{ .Values.postgres.sslSecrets.sslKeyKey }}
+        - mountPath: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslCertKey }}
+          name: dbcert
+          subPath: {{ .Values.postgres.sslSecrets.sslCertKey }}
+        - mountPath: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslRootCertKey }}
+          name: dbcert
+          subPath: {{ .Values.postgres.sslSecrets.sslRootCertKey }}
+        {{- end }}
         {{- if .Values.webserverCustomCertificatesSecretName }}
-        - mountPath: /tmp/secrets/WEBSERVER_CUSTOM_CERT_FILE
+        - mountPath: {{ .Values.secretsDirectory }}/WEBSERVER_CUSTOM_CERT_FILE
           name: certificate
           subPath: WEBSERVER_CUSTOM_CERT_FILE
-        - mountPath: /tmp/secrets/WEBSERVER_CUSTOM_KEY_FILE
+        - mountPath: {{ .Values.secretsDirectory }}/WEBSERVER_CUSTOM_KEY_FILE
           name: certificate
           subPath: WEBSERVER_CUSTOM_KEY_FILE
         {{- end }}
         {{- if .Values.javaKeystoreSecretName }}
-        - mountPath: /tmp/secrets/cacerts
+        - mountPath: {{ .Values.secretsDirectory }}/cacerts
           name: java-keystore
           subPath: cacerts
         {{- end }}
@@ -178,6 +180,12 @@ spec:
       {{- else }}
       - emptyDir: {}
         name: dir-alert
+      {{- end }}
+      {{- if .Values.postgres.sslUseFiles }}
+      - name: dbcert
+        secret:
+          defaultMode: 0400
+          secretName: {{ .Values.postgres.sslSecrets.secretName }}
       {{- end }}
       {{- if.Values.webserverCustomCertificatesSecretName }}
       - name: certificate

--- a/deployment/helm/synopsys-alert/values.yaml
+++ b/deployment/helm/synopsys-alert/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 registry: "docker.io/blackducksoftware"
+secretsDirectory: "/tmp/secrets"
 
 # Storage configurations
 enablePersistentStorage: true

--- a/docker/blackduck-alert/docker-entrypoint.sh
+++ b/docker/blackduck-alert/docker-entrypoint.sh
@@ -18,9 +18,9 @@ alertDatabasePassword="${ALERT_DB_PASSWORD:-blackduck}"
 alertDatabaseAdminUser="${ALERT_DB_ADMIN_USERNAME:-$alertDatabaseUser}"
 alertDatabaseAdminPassword="${ALERT_DB_ADMIN_PASSWORD:-$alertDatabasePassword}"
 alertDatabaseSslMode="${ALERT_DB_SSL_MODE:-allow}"
-alertDatabaseSslKey=${ALERT_DB_SSL_KEY}
-alertDatabaseSslCert=${ALERT_DB_SSL_CERT}
-alertDatabaseSslRootCert=${ALERT_DB_SSL_ROOT_CERT}
+alertDatabaseSslKey=${ALERT_DB_SSL_KEY_PATH}
+alertDatabaseSslCert=${ALERT_DB_SSL_CERT_PATH}
+alertDatabaseSslRootCert=${ALERT_DB_SSL_ROOT_CERT_PATH}
 alertHostName="${ALERT_HOSTNAME:-localhost}"
 
 ## CERTIFICATE VARIABLES ##
@@ -414,7 +414,7 @@ setVariablesFromFilePath() {
   globalVariableName="${3}"
   if [ -s "${filename}" ];
   then
-    logIt "${globalVariableName} variables set from ${filename}"
+    logIt "${globalVariableName} variable set from ${filename}"
     eval "${localVariableName}=${filename}"
     eval "export ${globalVariableName}=${filename}"
   fi
@@ -458,17 +458,31 @@ validateEnvironment() {
   fi
 }
 
+logIsVariableConfigured() {
+  if [ -n "${2}" ]; then
+    logIt "${1} is not configured"
+  else
+    logIt "${1} is configured"
+  fi
+}
+
 [ -z "${ALERT_HOSTNAME}" ] && logIt "Alert Host: [$alertHostName]. Wrong host name? Restart the container with the right host name configured in blackduck-alert.env"
 
 setOverrideVariables
 validateEnvironment
 
-alertDatabaseAdminConfig="host=$alertDatabaseHost port=$alertDatabasePort dbname=$alertDatabaseName user=$alertDatabaseAdminUser password=$alertDatabaseAdminPassword sslmode=$alertDatabaseSslMode sslkey=$alertDatabaseSslKey sslcert=$alertDatabaseSslCert sslrootcert=$alertDatabaseSslRootCert"
-alertDatabaseConfig="host=$alertDatabaseHost port=$alertDatabasePort dbname=$alertDatabaseName user=$alertDatabaseUser password=$alertDatabasePassword sslmode=$alertDatabaseSslMode sslkey=$alertDatabaseSslKey sslcert=$alertDatabaseSslCert sslrootcert=$alertDatabaseSslRootCert"
+alertBaseDatabaseConfig="host=$alertDatabaseHost port=$alertDatabasePort dbname=$alertDatabaseName sslmode=$alertDatabaseSslMode sslkey=$alertDatabaseSslKey sslcert=$alertDatabaseSslCert sslrootcert=$alertDatabaseSslRootCert"
+alertDatabaseAdminConfig="user=$alertDatabaseAdminUser password=$alertDatabaseAdminPassword $alertBaseDatabaseConfig"
+alertDatabaseConfig="user=$alertDatabaseUser password=$alertDatabasePassword $alertBaseDatabaseConfig"
 
 logIt "Alert max heap size: ${ALERT_MAX_HEAP_SIZE}"
 logIt "Certificate authority host: $targetCAHost"
 logIt "Certificate authority port: $targetCAPort"
+
+logIt "sslmode is set as ${alertDatabaseSslMode}"
+logIsVariableConfigured sslkey "${alertDatabaseSslKey}"
+logIsVariableConfigured sslcert "${alertDatabaseSslCert}"
+logIsVariableConfigured sssslrootcertlkey "${alertDatabaseSslRootCert}"
 
 if [ ! -f "${CERTIFICATE_MANAGER_DIR}/certificate-manager.sh" ];
 then


### PR DESCRIPTION
The current implementation did not volume mount in the certs/keys needed, and set the variables to the value of the cert/key instead of pointing to the file.

Edits include:
* Create and use variable for secrets directory.
* Set helm SSL variables to file path
* Volume mount the secrets into the pod
* Correct default variable names in entrypoint
* Readability and supportability edits in entrypoint

Follow instructions [HERE](https://sig-confluence.internal.synopsys.com/display/integration/Configuring+and+Verifying+SSL+within+Helm+using+external+DB) for set-up and validation.