### PR TITLE
IALERT-3206: Do not fail if image does not exist

### DIFF
--- a/buildSrc/docker-v2.gradle
+++ b/buildSrc/docker-v2.gradle
@@ -104,7 +104,22 @@ dockerImagesToBuild.each { imageName ->
             logger.lifecycle('Removing docker image:: ' + fullDockerImageName)
         }
 
+        ignoreExitValue = true
+        errorOutput = new ByteArrayOutputStream()
+
         commandLine 'docker', 'image', 'rm', fullDockerImageName
+
+        doLast {
+            String stdErr = errorOutput.toString()
+
+            if (stdErr?.trim() && !stdErr.contains("Deleted: ")) {
+                if (stdErr.contains("Error: No such image")) {
+                    logger.lifecycle("Image does not exist, continuing.")
+                } else {
+                    throw new GradleException("${stdErr}")
+                }
+            }
+        }
     }
     project.tasks.findByName(dockerRemoveAllImages).dependsOn dockerImageRemoveTaskName
 


### PR DESCRIPTION
Prior to this change, if an image didn't exist, the task would fail. Now, this will show the following output:

```
> Task :dockerRemoveBlackduckAlert
Removing docker image:: blackducksoftware/blackduck-alert:6.13.0-SNAPSHOT
Image does not exist, continuing.
```

If the image can not be removed, we will still fail, the output being:

```
> Task :dockerRemoveBlackduckAlert FAILED
Removing docker image:: blackducksoftware/blackduck-alert:6.13.0-SNAPSHOT

FAILURE: Build failed with an exception.

* Where:
Script '/home/serv-builder/hudson-build/workspace/integration-builds-v2/generated-builds/solutions/blackduck-alert/comprehensive/ps-IALERT-3155-wait-task/buildSrc/docker-v2.gradle' line: 119

* What went wrong:
Execution failed for task ':dockerRemoveBlackduckAlert'.
> Error response from daemon: conflict: unable to remove repository reference "blackducksoftware/blackduck-alert:6.13.0-SNAPSHOT" (must force) - container 7ebdd37a71b9 is using its referenced image 506efe8f6d32
```