### PR TITLE
fix: Update LDAP ConfigModel to not return Optional for Booleans

### DIFF
--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManager.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManager.java
@@ -40,12 +40,12 @@ public class LdapManager {
         this.inetOrgPersonContextMapper = inetOrgPersonContextMapper;
     }
 
-    public boolean isLdapEnabled() {
+    public Boolean isLdapEnabled() {
         if (getCurrentConfiguration().isEmpty()) {
             return false;
         }
 
-        return getCurrentConfiguration().get().getEnabled().orElse(false);
+        return getCurrentConfiguration().get().getEnabled();
     }
 
     public Optional<LDAPConfigModel> getCurrentConfiguration() {
@@ -63,7 +63,7 @@ public class LdapManager {
 
     public Optional<LdapAuthenticationProvider> createAuthProvider(LDAPConfigModel ldapConfigModel) throws AlertConfigurationException {
         try {
-            Boolean ldapEnabled = ldapConfigModel.getEnabled().orElse(false);
+            Boolean ldapEnabled = ldapConfigModel.getEnabled();
             if (!ldapEnabled) {
                 return Optional.empty();
             }

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/database/accessor/LDAPConfigAccessor.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/database/accessor/LDAPConfigAccessor.java
@@ -64,7 +64,7 @@ public class LDAPConfigAccessor implements UniqueConfigurationAccessor<LDAPConfi
                 .findByName(AlertRestConstants.DEFAULT_CONFIGURATION_NAME)
                 .orElseThrow(() -> new AlertConfigurationException("An LDAP configuration does not exist"));
 
-        if (ldapConfigModel.getIsManagerPasswordSet().isPresent() && ldapConfigModel.getIsManagerPasswordSet().get()) {
+        if (ldapConfigModel.getIsManagerPasswordSet()) {
             String decryptedPassword = encryptionUtility.decrypt(existingLDAPConfigurationEntity.getManagerPassword());
             ldapConfigModel.setManagerPassword(decryptedPassword);
         }
@@ -113,7 +113,7 @@ public class LDAPConfigAccessor implements UniqueConfigurationAccessor<LDAPConfi
             configurationId,
             createdTime,
             lastUpdated,
-            ldapConfigModel.getEnabled().orElse(Boolean.FALSE),
+            ldapConfigModel.getEnabled(),
             ldapConfigModel.getServerName(),
             ldapConfigModel.getManagerDn(),
             ldapConfigModel.getManagerPassword().orElse(""),

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/environment/LDAPEnvironmentVariableHandler.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/environment/LDAPEnvironmentVariableHandler.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.synopsys.integration.alert.api.common.model.AlertConstants;
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.authentication.ldap.database.accessor.LDAPConfigAccessor;
@@ -100,14 +101,16 @@ public class LDAPEnvironmentVariableHandler extends EnvironmentVariableHandler<L
 
         builder.addVariableValue(LDAP_ENABLED_KEY, String.valueOf(obfuscatedConfigModel.getEnabled()));
 
-        if (StringUtils.isNotBlank(obfuscatedConfigModel.getManagerDn())) {
-            builder.addVariableValue(LDAP_MANAGER_DN_KEY, obfuscatedConfigModel.getManagerDn());
-        }
         if (StringUtils.isNotBlank(obfuscatedConfigModel.getServerName())) {
             builder.addVariableValue(LDAP_SERVER_KEY, obfuscatedConfigModel.getServerName());
         }
+        if (StringUtils.isNotBlank(obfuscatedConfigModel.getManagerDn())) {
+            builder.addVariableValue(LDAP_MANAGER_DN_KEY, obfuscatedConfigModel.getManagerDn());
+        }
 
-        builder.addVariableValue(LDAP_MANAGER_PASSWORD_KEY, String.valueOf(obfuscatedConfigModel.getIsManagerPasswordSet()));
+        if (obfuscatedConfigModel.getIsManagerPasswordSet()) {
+            builder.addVariableValue(LDAP_MANAGER_PASSWORD_KEY, AlertConstants.MASKED_VALUE);
+        }
 
         obfuscatedConfigModel.getAuthenticationType()
             .ifPresent(value -> builder.addVariableValue(LDAP_AUTHENTICATION_TYPE_KEY, value));

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/environment/LDAPEnvironmentVariableHandler.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/environment/LDAPEnvironmentVariableHandler.java
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.synopsys.integration.alert.api.common.model.AlertConstants;
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.authentication.ldap.database.accessor.LDAPConfigAccessor;
@@ -99,9 +98,7 @@ public class LDAPEnvironmentVariableHandler extends EnvironmentVariableHandler<L
     protected EnvironmentProcessingResult buildProcessingResult(LDAPConfigModel obfuscatedConfigModel) {
         EnvironmentProcessingResult.Builder builder = new EnvironmentProcessingResult.Builder(LDAP_CONFIGURATION_KEY_SET);
 
-        obfuscatedConfigModel.getEnabled()
-            .map(String::valueOf)
-            .ifPresent(value -> builder.addVariableValue(LDAP_ENABLED_KEY, value));
+        builder.addVariableValue(LDAP_ENABLED_KEY, String.valueOf(obfuscatedConfigModel.getEnabled()));
 
         if (StringUtils.isNotBlank(obfuscatedConfigModel.getManagerDn())) {
             builder.addVariableValue(LDAP_MANAGER_DN_KEY, obfuscatedConfigModel.getManagerDn());
@@ -110,9 +107,7 @@ public class LDAPEnvironmentVariableHandler extends EnvironmentVariableHandler<L
             builder.addVariableValue(LDAP_SERVER_KEY, obfuscatedConfigModel.getServerName());
         }
 
-        obfuscatedConfigModel.getIsManagerPasswordSet()
-            .filter(Boolean::booleanValue)
-            .ifPresent(ignored -> builder.addVariableValue(LDAP_MANAGER_PASSWORD_KEY, AlertConstants.MASKED_VALUE));
+        builder.addVariableValue(LDAP_MANAGER_PASSWORD_KEY, String.valueOf(obfuscatedConfigModel.getIsManagerPasswordSet()));
 
         obfuscatedConfigModel.getAuthenticationType()
             .ifPresent(value -> builder.addVariableValue(LDAP_AUTHENTICATION_TYPE_KEY, value));

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/model/LDAPConfigModel.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/model/LDAPConfigModel.java
@@ -95,8 +95,8 @@ public class LDAPConfigModel extends ConfigWithMetadata implements Obfuscated<LD
         );
     }
 
-    public Optional<Boolean> getEnabled() {
-        return Optional.ofNullable(enabled);
+    public Boolean getEnabled() {
+        return enabled;
     }
 
     public void setEnabled(Boolean enabled) {
@@ -127,8 +127,8 @@ public class LDAPConfigModel extends ConfigWithMetadata implements Obfuscated<LD
         this.managerPassword = managerPassword;
     }
 
-    public Optional<Boolean> getIsManagerPasswordSet() {
-        return Optional.ofNullable(isManagerPasswordSet);
+    public Boolean getIsManagerPasswordSet() {
+        return isManagerPasswordSet;
     }
 
     public void setIsManagerPasswordSet(Boolean managerPasswordSet) {

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidator.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidator.java
@@ -28,7 +28,7 @@ public class LDAPConfigurationValidator {
         if (StringUtils.isBlank(ldapConfigModel.getManagerDn())) {
             statuses.add(AlertFieldStatus.error("managerDn", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
         }
-        if (ldapConfigModel.getManagerPassword().isEmpty()) {
+        if (ldapConfigModel.getManagerPassword().isEmpty() && !ldapConfigModel.getIsManagerPasswordSet()) {
             statuses.add(AlertFieldStatus.error("managerPassword", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
         }
 

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidator.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidator.java
@@ -16,8 +16,11 @@ public class LDAPConfigurationValidator {
     public ValidationResponseModel validate(LDAPConfigModel ldapConfigModel) {
         Set<AlertFieldStatus> statuses = new HashSet<>();
 
-        if (StringUtils.isBlank(ldapConfigModel.getName())) {
-            statuses.add(AlertFieldStatus.error("name", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
+        if (null == ldapConfigModel.getEnabled()) {
+            statuses.add(AlertFieldStatus.error("enabled", AlertFieldStatusMessages.INVALID_OPTION));
+        }
+        if (null == ldapConfigModel.getIsManagerPasswordSet()) {
+            statuses.add(AlertFieldStatus.error("isManagerPasswordSet", AlertFieldStatusMessages.INVALID_OPTION));
         }
         if (StringUtils.isBlank(ldapConfigModel.getServerName())) {
             statuses.add(AlertFieldStatus.error("serverName", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
@@ -25,7 +28,7 @@ public class LDAPConfigurationValidator {
         if (StringUtils.isBlank(ldapConfigModel.getManagerDn())) {
             statuses.add(AlertFieldStatus.error("managerDn", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
         }
-        if (ldapConfigModel.getManagerPassword().isEmpty() && !ldapConfigModel.getIsManagerPasswordSet().orElse(Boolean.FALSE)) {
+        if (ldapConfigModel.getManagerPassword().isEmpty()) {
             statuses.add(AlertFieldStatus.error("managerPassword", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
         }
 

--- a/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManagerTest.java
+++ b/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManagerTest.java
@@ -81,7 +81,7 @@ public class LdapManagerTest {
         assertEquals(AlertRestConstants.DEFAULT_CONFIGURATION_NAME, expectedLDAPConfigModel.getName());
         assertTrue(ldapManager.isLdapEnabled());
         assertNotEquals(DEFAULT_CONFIG_ID, expectedLDAPConfigModel.getId());
-        assertEquals(true, expectedLDAPConfigModel.getEnabled().orElse(false));
+        assertEquals(true, expectedLDAPConfigModel.getEnabled());
         assertEquals(DEFAULT_SERVER, expectedLDAPConfigModel.getServerName());
         assertEquals(DEFAULT_MANAGER_DN, expectedLDAPConfigModel.getManagerDn());
         assertEquals(DEFAULT_MANAGER_PASSWORD, expectedLDAPConfigModel.getManagerPassword().orElse(""));


### PR DESCRIPTION
* As the DB field for isEnabled is not nullable, change the data model to not return Optional.ofNullable for boolean values
* Update any impacted areas
* Update validation to not allow null for input data model