### PR TITLE
fix: Catch any exception to fail test endpoint

### DIFF
--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/action/LDAPTestAction.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/action/LDAPTestAction.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptorKey;
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
-import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.authentication.ldap.model.LDAPConfigTestModel;
 import com.synopsys.integration.alert.authentication.ldap.validator.LDAPConfigurationValidator;
 import com.synopsys.integration.alert.common.action.ActionResponse;
@@ -63,7 +62,7 @@ public class LDAPTestAction {
                 }
                 authentication.setAuthenticated(false);
             }
-        } catch (AlertConfigurationException ex) {
+        } catch (Exception ex) {
             return ConfigurationTestResult.failure("LDAP Test Configuration failed." + ex.getMessage());
         }
         return ConfigurationTestResult.success("LDAP Test Configuration successful.");


### PR DESCRIPTION
With bad test credentials, this throws an exception:

```
Authentication authentication = ldapAuthenticationProvider.get().authenticate(pendingAuthentication)
```

This exception was not being caught, and the test was always coming back positive. The original implementation was also catching Exception.