### PR TITLE
IALERT-3342 - LdapManager fixes and tests

### DIFF
--- a/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManagerTest.java
+++ b/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManagerTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,12 +72,10 @@ public class LdapManagerTest {
     public void testCreateConfiguration() {
         assertFalse(ldapManager.getCurrentConfiguration().isPresent());
         assertFalse(ldapManager.isLdapEnabled());
-
         LDAPConfigModel ldapConfigModel = createLDAPConfigModel(true, "");
         assertDoesNotThrow(() -> ldapConfigAccessor.createConfiguration(ldapConfigModel));
         LDAPConfigModel expectedLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Expected LDAPConfigModel did not exist"));
-
         assertTrue(ldapManager.getCurrentConfiguration().isPresent());
         assertEquals(AlertRestConstants.DEFAULT_CONFIGURATION_NAME, expectedLDAPConfigModel.getName());
         assertTrue(ldapManager.isLdapEnabled());
@@ -85,24 +84,16 @@ public class LdapManagerTest {
         assertEquals(DEFAULT_SERVER, expectedLDAPConfigModel.getServerName());
         assertEquals(DEFAULT_MANAGER_DN, expectedLDAPConfigModel.getManagerDn());
         assertTrue(expectedLDAPConfigModel.getManagerPassword().isPresent());
-        assertEquals(DEFAULT_MANAGER_PASSWORD, expectedLDAPConfigModel.getManagerPassword().get());
+        assertOptionalField(DEFAULT_MANAGER_PASSWORD, expectedLDAPConfigModel::getManagerPassword);
         assertEquals("", expectedLDAPConfigModel.getAuthenticationType().orElse(""));
-        assertTrue(expectedLDAPConfigModel.getReferral().isPresent());
-        assertEquals(DEFAULT_REFERRAL, expectedLDAPConfigModel.getReferral().get());
-        assertTrue(expectedLDAPConfigModel.getUserSearchBase().isPresent());
-        assertEquals(DEFAULT_USER_SEARCH_BASE, expectedLDAPConfigModel.getUserSearchBase().get());
-        assertTrue(expectedLDAPConfigModel.getUserSearchFilter().isPresent());
-        assertEquals(DEFAULT_USER_SEARCH_FILTER, expectedLDAPConfigModel.getUserSearchFilter().get());
-        assertTrue(expectedLDAPConfigModel.getUserDnPatterns().isPresent());
-        assertEquals(DEFAULT_USER_DN_PATTERNS, expectedLDAPConfigModel.getUserDnPatterns().get());
-        assertTrue(expectedLDAPConfigModel.getUserAttributes().isPresent());
-        assertEquals(DEFAULT_USER_ATTRIBUTES, expectedLDAPConfigModel.getUserAttributes().get());
-        assertTrue(expectedLDAPConfigModel.getGroupSearchBase().isPresent());
-        assertEquals(DEFAULT_GROUP_SEARCH_BASE, expectedLDAPConfigModel.getGroupSearchBase().get());
-        assertTrue(expectedLDAPConfigModel.getGroupSearchFilter().isPresent());
-        assertEquals(DEFAULT_GROUP_SEARCH_FILTER, expectedLDAPConfigModel.getGroupSearchFilter().get());
-        assertTrue(expectedLDAPConfigModel.getGroupRoleAttribute().isPresent());
-        assertEquals(DEFAULT_GROUP_ROLE_ATTRIBUTE, expectedLDAPConfigModel.getGroupRoleAttribute().get());
+        assertOptionalField(DEFAULT_REFERRAL, expectedLDAPConfigModel::getReferral);
+        assertOptionalField(DEFAULT_USER_SEARCH_BASE, expectedLDAPConfigModel::getUserSearchBase);
+        assertOptionalField(DEFAULT_USER_SEARCH_FILTER, expectedLDAPConfigModel::getUserSearchFilter);
+        assertOptionalField(DEFAULT_USER_DN_PATTERNS, expectedLDAPConfigModel::getUserDnPatterns);
+        assertOptionalField(DEFAULT_USER_ATTRIBUTES, expectedLDAPConfigModel::getUserAttributes);
+        assertOptionalField(DEFAULT_GROUP_SEARCH_BASE, expectedLDAPConfigModel::getGroupSearchBase);
+        assertOptionalField(DEFAULT_GROUP_SEARCH_FILTER, expectedLDAPConfigModel::getGroupSearchFilter);
+        assertOptionalField(DEFAULT_GROUP_ROLE_ATTRIBUTE, expectedLDAPConfigModel::getGroupRoleAttribute);
     }
 
     @Test
@@ -155,8 +146,7 @@ public class LdapManagerTest {
         LDAPConfigModel expectedLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Expected LDAPConfigModel did not exist"));
         assertDoesNotThrow(() -> ldapManager.getAuthenticationProvider());
-        assertTrue(expectedLDAPConfigModel.getAuthenticationType().isPresent());
-        assertEquals(DEFAULT_AUTHENTICATION_TYPE_SIMPLE, expectedLDAPConfigModel.getAuthenticationType().get());
+        assertOptionalField(DEFAULT_AUTHENTICATION_TYPE_SIMPLE, expectedLDAPConfigModel::getAuthenticationType);
     }
 
     @Test
@@ -166,8 +156,7 @@ public class LdapManagerTest {
         LDAPConfigModel expectedLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Expected LDAPConfigModel did not exist"));
         assertDoesNotThrow(() -> ldapManager.getAuthenticationProvider());
-        assertTrue(expectedLDAPConfigModel.getAuthenticationType().isPresent());
-        assertEquals(DEFAULT_AUTHENTICATION_TYPE_DIGEST, expectedLDAPConfigModel.getAuthenticationType().get());
+        assertOptionalField(DEFAULT_AUTHENTICATION_TYPE_DIGEST, expectedLDAPConfigModel::getAuthenticationType);
     }
 
     @Test
@@ -177,8 +166,7 @@ public class LdapManagerTest {
         LDAPConfigModel expectedLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Expected LDAPConfigModel did not exist"));
         assertDoesNotThrow(() -> ldapManager.getAuthenticationProvider());
-        assertTrue(expectedLDAPConfigModel.getAuthenticationType().isPresent());
-        assertEquals("Unsupported authentication type", expectedLDAPConfigModel.getAuthenticationType().get());
+        assertOptionalField("Unsupported authentication type", expectedLDAPConfigModel::getAuthenticationType);
     }
 
     @Test
@@ -242,10 +230,8 @@ public class LdapManagerTest {
         LDAPConfigModel retrievedInputLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Raw input LDAPConfigModel does not exist"));
         assertEquals(true, retrievedInputLDAPConfigModel.getEnabled());
-        assertTrue(retrievedInputLDAPConfigModel.getAuthenticationType().isPresent());
-        assertEquals(DEFAULT_AUTHENTICATION_TYPE_SIMPLE, retrievedInputLDAPConfigModel.getAuthenticationType().get());
-        assertTrue(retrievedInputLDAPConfigModel.getManagerPassword().isPresent());
-        assertEquals(DEFAULT_MANAGER_PASSWORD, retrievedInputLDAPConfigModel.getManagerPassword().get());
+        assertOptionalField(DEFAULT_AUTHENTICATION_TYPE_SIMPLE, retrievedInputLDAPConfigModel::getAuthenticationType);
+        assertOptionalField(DEFAULT_MANAGER_PASSWORD, retrievedInputLDAPConfigModel::getManagerPassword);
 
         // Set up and verify updated LDAPConfigModel
         // Verify updated values were in fact updated
@@ -255,12 +241,10 @@ public class LdapManagerTest {
         LDAPConfigModel retrievedUpdatedLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Updated LDAPConfigModel did not exist"));
         assertEquals(false, retrievedUpdatedLDAPConfigModel.getEnabled());
-        assertTrue(retrievedUpdatedLDAPConfigModel.getAuthenticationType().isPresent());
-        assertEquals(DEFAULT_AUTHENTICATION_TYPE_DIGEST, retrievedUpdatedLDAPConfigModel.getAuthenticationType().get());
+        assertOptionalField(DEFAULT_AUTHENTICATION_TYPE_DIGEST, retrievedUpdatedLDAPConfigModel::getAuthenticationType);
 
         // Verify password was updated
-        assertTrue(retrievedUpdatedLDAPConfigModel.getManagerPassword().isPresent());
-        assertEquals("My Password", retrievedUpdatedLDAPConfigModel.getManagerPassword().get());
+        assertOptionalField("My Password", retrievedUpdatedLDAPConfigModel::getManagerPassword);
 
         // Verify we are still using the same LDAPConfigModel based on the ID
         assertEquals(retrievedInputLDAPConfigModel.getId(), retrievedUpdatedLDAPConfigModel.getId());
@@ -275,10 +259,8 @@ public class LdapManagerTest {
         LDAPConfigModel retrievedInputLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Input LDAPConfigModel does not exist"));
         assertEquals(true, retrievedInputLDAPConfigModel.getEnabled());
-        assertTrue(retrievedInputLDAPConfigModel.getAuthenticationType().isPresent());
-        assertEquals(DEFAULT_AUTHENTICATION_TYPE_SIMPLE, retrievedInputLDAPConfigModel.getAuthenticationType().get());
-        assertTrue(retrievedInputLDAPConfigModel.getManagerPassword().isPresent());
-        assertEquals(DEFAULT_MANAGER_PASSWORD, retrievedInputLDAPConfigModel.getManagerPassword().get());
+        assertOptionalField(DEFAULT_AUTHENTICATION_TYPE_SIMPLE, retrievedInputLDAPConfigModel::getAuthenticationType);
+        assertOptionalField(DEFAULT_MANAGER_PASSWORD, retrievedInputLDAPConfigModel::getManagerPassword);
 
         // Set up and verify updated LDAPConfigModel
         // Verify updated values were in fact updated
@@ -289,12 +271,10 @@ public class LdapManagerTest {
         LDAPConfigModel retrievedUpdatedLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Updated LDAPConfigModel does not exist"));
         assertEquals(false, retrievedUpdatedLDAPConfigModel.getEnabled());
-        assertTrue(retrievedUpdatedLDAPConfigModel.getAuthenticationType().isPresent());
-        assertEquals(DEFAULT_AUTHENTICATION_TYPE_DIGEST, retrievedUpdatedLDAPConfigModel.getAuthenticationType().get());
+        assertOptionalField(DEFAULT_AUTHENTICATION_TYPE_DIGEST, retrievedUpdatedLDAPConfigModel::getAuthenticationType);
 
         // Verify password is same as input ConfigModel
-        assertTrue(retrievedUpdatedLDAPConfigModel.getManagerPassword().isPresent());
-        assertEquals(retrievedInputLDAPConfigModel.getManagerPassword().get(), retrievedUpdatedLDAPConfigModel.getManagerPassword().get());
+        assertOptionalField(DEFAULT_MANAGER_PASSWORD, retrievedUpdatedLDAPConfigModel::getManagerPassword);
 
         // Verify we are still using the same LDAPConfigModel based on the ID
         assertEquals(retrievedInputLDAPConfigModel.getId(), retrievedUpdatedLDAPConfigModel.getId());
@@ -343,6 +323,12 @@ public class LdapManagerTest {
             DEFAULT_GROUP_SEARCH_FILTER,
             DEFAULT_GROUP_ROLE_ATTRIBUTE
         );
+    }
+
+    private void assertOptionalField(String expectedValue, Supplier<Optional<String>> fieldSupplier) {
+        Optional<String> optional = fieldSupplier.get();
+        assertTrue(optional.isPresent());
+        assertEquals(expectedValue, optional.get());
     }
 
 }

--- a/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManagerTest.java
+++ b/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManagerTest.java
@@ -84,16 +84,25 @@ public class LdapManagerTest {
         assertEquals(true, expectedLDAPConfigModel.getEnabled());
         assertEquals(DEFAULT_SERVER, expectedLDAPConfigModel.getServerName());
         assertEquals(DEFAULT_MANAGER_DN, expectedLDAPConfigModel.getManagerDn());
-        assertEquals(DEFAULT_MANAGER_PASSWORD, expectedLDAPConfigModel.getManagerPassword().orElse(""));
+        assertTrue(expectedLDAPConfigModel.getManagerPassword().isPresent());
+        assertEquals(DEFAULT_MANAGER_PASSWORD, expectedLDAPConfigModel.getManagerPassword().get());
         assertEquals("", expectedLDAPConfigModel.getAuthenticationType().orElse(""));
-        assertEquals(DEFAULT_REFERRAL, expectedLDAPConfigModel.getReferral().orElse(""));
-        assertEquals(DEFAULT_USER_SEARCH_BASE, expectedLDAPConfigModel.getUserSearchBase().orElse(""));
-        assertEquals(DEFAULT_USER_SEARCH_FILTER, expectedLDAPConfigModel.getUserSearchFilter().orElse(""));
-        assertEquals(DEFAULT_USER_DN_PATTERNS, expectedLDAPConfigModel.getUserDnPatterns().orElse(""));
-        assertEquals(DEFAULT_USER_ATTRIBUTES, expectedLDAPConfigModel.getUserAttributes().orElse(""));
-        assertEquals(DEFAULT_GROUP_SEARCH_BASE, expectedLDAPConfigModel.getGroupSearchBase().orElse(""));
-        assertEquals(DEFAULT_GROUP_SEARCH_FILTER, expectedLDAPConfigModel.getGroupSearchFilter().orElse(""));
-        assertEquals(DEFAULT_GROUP_ROLE_ATTRIBUTE, expectedLDAPConfigModel.getGroupRoleAttribute().orElse(""));
+        assertTrue(expectedLDAPConfigModel.getReferral().isPresent());
+        assertEquals(DEFAULT_REFERRAL, expectedLDAPConfigModel.getReferral().get());
+        assertTrue(expectedLDAPConfigModel.getUserSearchBase().isPresent());
+        assertEquals(DEFAULT_USER_SEARCH_BASE, expectedLDAPConfigModel.getUserSearchBase().get());
+        assertTrue(expectedLDAPConfigModel.getUserSearchFilter().isPresent());
+        assertEquals(DEFAULT_USER_SEARCH_FILTER, expectedLDAPConfigModel.getUserSearchFilter().get());
+        assertTrue(expectedLDAPConfigModel.getUserDnPatterns().isPresent());
+        assertEquals(DEFAULT_USER_DN_PATTERNS, expectedLDAPConfigModel.getUserDnPatterns().get());
+        assertTrue(expectedLDAPConfigModel.getUserAttributes().isPresent());
+        assertEquals(DEFAULT_USER_ATTRIBUTES, expectedLDAPConfigModel.getUserAttributes().get());
+        assertTrue(expectedLDAPConfigModel.getGroupSearchBase().isPresent());
+        assertEquals(DEFAULT_GROUP_SEARCH_BASE, expectedLDAPConfigModel.getGroupSearchBase().get());
+        assertTrue(expectedLDAPConfigModel.getGroupSearchFilter().isPresent());
+        assertEquals(DEFAULT_GROUP_SEARCH_FILTER, expectedLDAPConfigModel.getGroupSearchFilter().get());
+        assertTrue(expectedLDAPConfigModel.getGroupRoleAttribute().isPresent());
+        assertEquals(DEFAULT_GROUP_ROLE_ATTRIBUTE, expectedLDAPConfigModel.getGroupRoleAttribute().get());
     }
 
     @Test
@@ -146,7 +155,8 @@ public class LdapManagerTest {
         LDAPConfigModel expectedLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Expected LDAPConfigModel did not exist"));
         assertDoesNotThrow(() -> ldapManager.getAuthenticationProvider());
-        assertEquals(DEFAULT_AUTHENTICATION_TYPE_SIMPLE, expectedLDAPConfigModel.getAuthenticationType().orElse(""));
+        assertTrue(expectedLDAPConfigModel.getAuthenticationType().isPresent());
+        assertEquals(DEFAULT_AUTHENTICATION_TYPE_SIMPLE, expectedLDAPConfigModel.getAuthenticationType().get());
     }
 
     @Test
@@ -156,7 +166,8 @@ public class LdapManagerTest {
         LDAPConfigModel expectedLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Expected LDAPConfigModel did not exist"));
         assertDoesNotThrow(() -> ldapManager.getAuthenticationProvider());
-        assertEquals(DEFAULT_AUTHENTICATION_TYPE_DIGEST, expectedLDAPConfigModel.getAuthenticationType().orElse(""));
+        assertTrue(expectedLDAPConfigModel.getAuthenticationType().isPresent());
+        assertEquals(DEFAULT_AUTHENTICATION_TYPE_DIGEST, expectedLDAPConfigModel.getAuthenticationType().get());
     }
 
     @Test
@@ -166,7 +177,8 @@ public class LdapManagerTest {
         LDAPConfigModel expectedLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Expected LDAPConfigModel did not exist"));
         assertDoesNotThrow(() -> ldapManager.getAuthenticationProvider());
-        assertEquals("Unsupported authentication type", expectedLDAPConfigModel.getAuthenticationType().orElse(""));
+        assertTrue(expectedLDAPConfigModel.getAuthenticationType().isPresent());
+        assertEquals("Unsupported authentication type", expectedLDAPConfigModel.getAuthenticationType().get());
     }
 
     @Test
@@ -230,8 +242,10 @@ public class LdapManagerTest {
         LDAPConfigModel retrievedInputLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Raw input LDAPConfigModel does not exist"));
         assertEquals(true, retrievedInputLDAPConfigModel.getEnabled());
-        assertEquals(DEFAULT_AUTHENTICATION_TYPE_SIMPLE, retrievedInputLDAPConfigModel.getAuthenticationType().orElse(""));
-        assertEquals(DEFAULT_MANAGER_PASSWORD, retrievedInputLDAPConfigModel.getManagerPassword().orElse(""));
+        assertTrue(retrievedInputLDAPConfigModel.getAuthenticationType().isPresent());
+        assertEquals(DEFAULT_AUTHENTICATION_TYPE_SIMPLE, retrievedInputLDAPConfigModel.getAuthenticationType().get());
+        assertTrue(retrievedInputLDAPConfigModel.getManagerPassword().isPresent());
+        assertEquals(DEFAULT_MANAGER_PASSWORD, retrievedInputLDAPConfigModel.getManagerPassword().get());
 
         // Set up and verify updated LDAPConfigModel
         // Verify updated values were in fact updated
@@ -241,10 +255,12 @@ public class LdapManagerTest {
         LDAPConfigModel retrievedUpdatedLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Updated LDAPConfigModel did not exist"));
         assertEquals(false, retrievedUpdatedLDAPConfigModel.getEnabled());
-        assertEquals(DEFAULT_AUTHENTICATION_TYPE_DIGEST, retrievedUpdatedLDAPConfigModel.getAuthenticationType().orElse(""));
+        assertTrue(retrievedUpdatedLDAPConfigModel.getAuthenticationType().isPresent());
+        assertEquals(DEFAULT_AUTHENTICATION_TYPE_DIGEST, retrievedUpdatedLDAPConfigModel.getAuthenticationType().get());
 
         // Verify password was updated
-        assertEquals("My Password", retrievedUpdatedLDAPConfigModel.getManagerPassword().orElse(""));
+        assertTrue(retrievedUpdatedLDAPConfigModel.getManagerPassword().isPresent());
+        assertEquals("My Password", retrievedUpdatedLDAPConfigModel.getManagerPassword().get());
 
         // Verify we are still using the same LDAPConfigModel based on the ID
         assertEquals(retrievedInputLDAPConfigModel.getId(), retrievedUpdatedLDAPConfigModel.getId());
@@ -259,8 +275,10 @@ public class LdapManagerTest {
         LDAPConfigModel retrievedInputLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Input LDAPConfigModel does not exist"));
         assertEquals(true, retrievedInputLDAPConfigModel.getEnabled());
-        assertEquals(DEFAULT_AUTHENTICATION_TYPE_SIMPLE, retrievedInputLDAPConfigModel.getAuthenticationType().orElse(""));
-        assertEquals(DEFAULT_MANAGER_PASSWORD, retrievedInputLDAPConfigModel.getManagerPassword().orElse(""));
+        assertTrue(retrievedInputLDAPConfigModel.getAuthenticationType().isPresent());
+        assertEquals(DEFAULT_AUTHENTICATION_TYPE_SIMPLE, retrievedInputLDAPConfigModel.getAuthenticationType().get());
+        assertTrue(retrievedInputLDAPConfigModel.getManagerPassword().isPresent());
+        assertEquals(DEFAULT_MANAGER_PASSWORD, retrievedInputLDAPConfigModel.getManagerPassword().get());
 
         // Set up and verify updated LDAPConfigModel
         // Verify updated values were in fact updated
@@ -271,10 +289,12 @@ public class LdapManagerTest {
         LDAPConfigModel retrievedUpdatedLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Updated LDAPConfigModel does not exist"));
         assertEquals(false, retrievedUpdatedLDAPConfigModel.getEnabled());
-        assertEquals(DEFAULT_AUTHENTICATION_TYPE_DIGEST, retrievedUpdatedLDAPConfigModel.getAuthenticationType().orElse(""));
+        assertTrue(retrievedUpdatedLDAPConfigModel.getAuthenticationType().isPresent());
+        assertEquals(DEFAULT_AUTHENTICATION_TYPE_DIGEST, retrievedUpdatedLDAPConfigModel.getAuthenticationType().get());
 
-        // Verify password is sam as input ConfigModel
-        assertEquals(retrievedInputLDAPConfigModel.getManagerPassword().orElse(""), retrievedUpdatedLDAPConfigModel.getManagerPassword().orElse(""));
+        // Verify password is same as input ConfigModel
+        assertTrue(retrievedUpdatedLDAPConfigModel.getManagerPassword().isPresent());
+        assertEquals(retrievedInputLDAPConfigModel.getManagerPassword().get(), retrievedUpdatedLDAPConfigModel.getManagerPassword().get());
 
         // Verify we are still using the same LDAPConfigModel based on the ID
         assertEquals(retrievedInputLDAPConfigModel.getId(), retrievedUpdatedLDAPConfigModel.getId());
@@ -300,7 +320,7 @@ public class LdapManagerTest {
         assertDoesNotThrow(() -> ldapConfigAccessor.updateConfiguration(updatedLDAPConfigModel));
         LDAPConfigModel retrievedUpdatedLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Updated LDAPConfigModel does not exist"));
-        assertEquals("", retrievedInputLDAPConfigModel.getManagerPassword().orElse(""));
+        assertEquals("", retrievedUpdatedLDAPConfigModel.getManagerPassword().orElse(""));
     }
 
     private LDAPConfigModel createLDAPConfigModel(Boolean enabled, String authenticationType) {


### PR DESCRIPTION
* ConfigAccessor was not encrypting/decrypting data when posting/getting data from DB
* ConfigAccessor fix: If user is editing existing configuration, which has a PW saved, AND not changing the password, we should use the password that exists in the DB.
* Test coverage