### PR TITLE
IALERT-3342 -  LDAPConfigurationValidator cleanup and tests

### DIFF
--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidator.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidator.java
@@ -22,10 +22,9 @@ public class LDAPConfigurationValidator {
         if (StringUtils.isBlank(ldapConfigModel.getManagerDn())) {
             statuses.add(AlertFieldStatus.error("managerDn", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
         }
-        if (ldapConfigModel.getManagerPassword().isEmpty()) {
-            if (Boolean.FALSE.equals(ldapConfigModel.getIsManagerPasswordSet())) {
+      if (ldapConfigModel.getManagerPassword().isEmpty()
+            && Boolean.FALSE.equals(ldapConfigModel.getIsManagerPasswordSet())) {
                 statuses.add(AlertFieldStatus.error("managerPassword", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
-            }
         }
 
         if (!statuses.isEmpty()) {

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidator.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidator.java
@@ -16,20 +16,16 @@ public class LDAPConfigurationValidator {
     public ValidationResponseModel validate(LDAPConfigModel ldapConfigModel) {
         Set<AlertFieldStatus> statuses = new HashSet<>();
 
-        if (null == ldapConfigModel.getEnabled()) {
-            statuses.add(AlertFieldStatus.error("enabled", AlertFieldStatusMessages.INVALID_OPTION));
-        }
-        if (null == ldapConfigModel.getIsManagerPasswordSet()) {
-            statuses.add(AlertFieldStatus.error("isManagerPasswordSet", AlertFieldStatusMessages.INVALID_OPTION));
-        }
         if (StringUtils.isBlank(ldapConfigModel.getServerName())) {
             statuses.add(AlertFieldStatus.error("serverName", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
         }
         if (StringUtils.isBlank(ldapConfigModel.getManagerDn())) {
             statuses.add(AlertFieldStatus.error("managerDn", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
         }
-        if (ldapConfigModel.getManagerPassword().isEmpty() && !Boolean.TRUE.equals(ldapConfigModel.getIsManagerPasswordSet())) {
-            statuses.add(AlertFieldStatus.error("managerPassword", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
+        if (ldapConfigModel.getManagerPassword().isEmpty()) {
+            if (Boolean.FALSE.equals(ldapConfigModel.getIsManagerPasswordSet())) {
+                statuses.add(AlertFieldStatus.error("managerPassword", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
+            }
         }
 
         if (!statuses.isEmpty()) {

--- a/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidatorTest.java
+++ b/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidatorTest.java
@@ -1,2 +1,84 @@
-package com.synopsys.integration.alert.authentication.ldap.validator;public class LDAPConfigurationValidatorTest {
+package com.synopsys.integration.alert.authentication.ldap.validator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
+import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatusMessages;
+import com.synopsys.integration.alert.authentication.ldap.model.LDAPConfigModel;
+
+public class LDAPConfigurationValidatorTest {
+    private final LDAPConfigModel ldapConfigModel = new LDAPConfigModel();
+    private final LDAPConfigurationValidator ldapConfigurationValidator = new LDAPConfigurationValidator();
+
+    @Test
+    public void testNewValidModel() {
+        ldapConfigModel.setServerName("valid");
+        ldapConfigModel.setManagerDn("valid");
+        ldapConfigModel.setManagerPassword("valid");
+        ldapConfigModel.setIsManagerPasswordSet(true);
+
+        ValidationResponseModel validationResponseModel = ldapConfigurationValidator.validate(ldapConfigModel);
+        assertEquals(ValidationResponseModel.VALIDATION_SUCCESS_MESSAGE, validationResponseModel.getMessage());
+        assertEquals(0, validationResponseModel.getErrors().size());
+    }
+
+    @Test
+    public void testUpdatedValidModel() {
+        // The scenario can come up when updating a configuration via the UI
+        //   ldapConfigModel.getManagerPassword().isEmpty() = true
+        //   ldapConfigModel.getIsManagerPasswordSet() = true
+
+        ldapConfigModel.setServerName("valid");
+        ldapConfigModel.setManagerDn("valid");
+        ldapConfigModel.setManagerPassword("valid");
+        ldapConfigModel.setIsManagerPasswordSet(true);
+        LDAPConfigModel obfuscatedLDAPConfigModel = ldapConfigModel.obfuscate();
+
+        ValidationResponseModel validationResponseModel = ldapConfigurationValidator.validate(obfuscatedLDAPConfigModel);
+        assertEquals(ValidationResponseModel.VALIDATION_SUCCESS_MESSAGE, validationResponseModel.getMessage());
+        assertEquals(0, validationResponseModel.getErrors().size());
+    }
+
+    @Test
+    public void testInvalidServerName() {
+        ldapConfigModel.setManagerDn("valid");
+        ldapConfigModel.setManagerPassword("valid");
+        ldapConfigModel.setIsManagerPasswordSet(true);
+
+        ValidationResponseModel validationResponseModel = ldapConfigurationValidator.validate(ldapConfigModel);
+        assertEquals(ValidationResponseModel.VALIDATION_FAILURE_MESSAGE, validationResponseModel.getMessage());
+        assertEquals(1, validationResponseModel.getErrors().size());
+        assertTrue(validationResponseModel.getErrors().containsKey("serverName"));
+        assertEquals(AlertFieldStatusMessages.REQUIRED_FIELD_MISSING, validationResponseModel.getErrors().get("serverName").getFieldMessage());
+    }
+
+    @Test
+    public void testInvalidManagerDn() {
+        ldapConfigModel.setServerName("valid");
+        ldapConfigModel.setManagerPassword("valid");
+        ldapConfigModel.setIsManagerPasswordSet(true);
+
+        ValidationResponseModel validationResponseModel = ldapConfigurationValidator.validate(ldapConfigModel);
+        assertEquals(ValidationResponseModel.VALIDATION_FAILURE_MESSAGE, validationResponseModel.getMessage());
+        assertEquals(1, validationResponseModel.getErrors().size());
+        assertTrue(validationResponseModel.getErrors().containsKey("managerDn"));
+        assertEquals(AlertFieldStatusMessages.REQUIRED_FIELD_MISSING, validationResponseModel.getErrors().get("managerDn").getFieldMessage());
+    }
+
+    @Test
+    public void testInvalidManagerPassword() {
+        ldapConfigModel.setServerName("valid");
+        ldapConfigModel.setManagerDn("valid");
+        ldapConfigModel.setIsManagerPasswordSet(false);
+
+        ValidationResponseModel validationResponseModel = ldapConfigurationValidator.validate(ldapConfigModel);
+        assertEquals(ValidationResponseModel.VALIDATION_FAILURE_MESSAGE, validationResponseModel.getMessage());
+        assertEquals(1, validationResponseModel.getErrors().size());
+        assertTrue(validationResponseModel.getErrors().containsKey("managerPassword"));
+        assertEquals(AlertFieldStatusMessages.REQUIRED_FIELD_MISSING, validationResponseModel.getErrors().get("managerPassword").getFieldMessage());
+    }
+
 }

--- a/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidatorTest.java
+++ b/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidatorTest.java
@@ -1,0 +1,2 @@
+package com.synopsys.integration.alert.authentication.ldap.validator;public class LDAPConfigurationValidatorTest {
+}


### PR DESCRIPTION
* Remove unnecessary logic as LDAPConfigModel now returns `BooleanUtils.toBoolean()`
* Readability change to `if` statement
* Implement test coverage