### PR TITLE
LDAP fixes from UI testing

### DIFF
--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManager.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManager.java
@@ -63,23 +63,24 @@ public class LdapManager {
 
     public Optional<LdapAuthenticationProvider> createAuthProvider(LDAPConfigModel ldapConfigModel) throws AlertConfigurationException {
         try {
-            Boolean ldapEnabled = ldapConfigModel.getEnabled();
-            if (!Boolean.TRUE.equals(ldapEnabled)) {
-                return Optional.empty();
-            }
             LdapContextSource ldapContextSource = new LdapContextSource();
 
+            Boolean ldapEnabled = ldapConfigModel.getEnabled();
             String ldapServer = ldapConfigModel.getServerName();
             String managerDN = ldapConfigModel.getManagerDn();
             String managerPassword = ldapConfigModel.getManagerPassword().orElse("");
             String ldapReferral = ldapConfigModel.getReferral().orElse("");
-            if (StringUtils.isNotBlank(ldapServer)) {
-                ldapContextSource.setUrl(ldapServer);
-                ldapContextSource.setUserDn(managerDN);
-                ldapContextSource.setPassword(managerPassword);
-                ldapContextSource.setReferral(ldapReferral);
-                ldapContextSource.setAuthenticationStrategy(createAuthenticationStrategy(ldapConfigModel));
+
+            if (Boolean.FALSE.equals(ldapEnabled) || StringUtils.isBlank(ldapServer) || StringUtils.isBlank(managerDN) || StringUtils.isBlank(managerPassword)) {
+                return Optional.empty();
             }
+
+            ldapContextSource.setUrl(ldapServer);
+            ldapContextSource.setUserDn(managerDN);
+            ldapContextSource.setPassword(managerPassword);
+            ldapContextSource.setReferral(ldapReferral);
+            ldapContextSource.setAuthenticationStrategy(createAuthenticationStrategy(ldapConfigModel));
+
             ldapContextSource.afterPropertiesSet();
             LdapAuthenticationProvider ldapAuthenticationProvider = updateAuthenticationProvider(ldapConfigModel, ldapContextSource);
             return Optional.of(ldapAuthenticationProvider);

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidator.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidator.java
@@ -16,15 +16,17 @@ public class LDAPConfigurationValidator {
     public ValidationResponseModel validate(LDAPConfigModel ldapConfigModel) {
         Set<AlertFieldStatus> statuses = new HashSet<>();
 
+        if (Boolean.FALSE.equals(ldapConfigModel.getIsManagerPasswordSet())) {
+            statuses.add(AlertFieldStatus.error("isManagerPasswordSet", AlertFieldStatusMessages.INVALID_OPTION));
+        }
         if (StringUtils.isBlank(ldapConfigModel.getServerName())) {
             statuses.add(AlertFieldStatus.error("serverName", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
         }
         if (StringUtils.isBlank(ldapConfigModel.getManagerDn())) {
             statuses.add(AlertFieldStatus.error("managerDn", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
         }
-      if (ldapConfigModel.getManagerPassword().isEmpty()
-            && Boolean.FALSE.equals(ldapConfigModel.getIsManagerPasswordSet())) {
-                statuses.add(AlertFieldStatus.error("managerPassword", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
+        if (StringUtils.isBlank(ldapConfigModel.getManagerPassword().orElse("")) && Boolean.FALSE.equals(ldapConfigModel.getIsManagerPasswordSet())) {
+            statuses.add(AlertFieldStatus.error("managerPassword", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
         }
 
         if (!statuses.isEmpty()) {

--- a/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManagerTest.java
+++ b/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManagerTest.java
@@ -170,18 +170,22 @@ public class LdapManagerTest {
     }
 
     @Test
-    public void testCreateAuthProviderDisabled() throws AlertConfigurationException {
-        LDAPConfigModel ldapConfigModel = createLDAPConfigModel(false, DEFAULT_AUTHENTICATION_TYPE_DIGEST);
-        assertDoesNotThrow(() -> ldapConfigAccessor.createConfiguration(ldapConfigModel));
-        Optional<LdapAuthenticationProvider> expectedLDAPAuthenticationProvider = ldapManager.createAuthProvider(ldapConfigModel);
-        assertEquals(Optional.empty(), expectedLDAPAuthenticationProvider);
-    }
+    public void testCreateAuthProviderInvalidValues() {
+        LDAPConfigModel invalidConfigModel = new LDAPConfigModel();
+        Optional<LdapAuthenticationProvider> ldapAuthenticationProvider = assertDoesNotThrow(() -> ldapManager.createAuthProvider(invalidConfigModel));
+        assertEquals(Optional.empty(), ldapAuthenticationProvider);
 
-    @Test
-    public void testExceptionOnContext() {
-        LDAPConfigModel invalidConfigModel = new LDAPConfigModel("", "", "", true, "", "", "", false, "", "", "", "", "", "", "", "", "");
-        AlertConfigurationException alertConfigurationException = assertThrows(AlertConfigurationException.class, () -> ldapManager.createAuthProvider(invalidConfigModel));
-        assertTrue(alertConfigurationException.getMessage().contains("Error creating LDAP Context Source"));
+        invalidConfigModel.setEnabled(true);
+        ldapAuthenticationProvider = assertDoesNotThrow(() -> ldapManager.createAuthProvider(invalidConfigModel));
+        assertEquals(Optional.empty(), ldapAuthenticationProvider);
+
+        invalidConfigModel.setServerName("serverName");
+        ldapAuthenticationProvider = assertDoesNotThrow(() -> ldapManager.createAuthProvider(invalidConfigModel));
+        assertEquals(Optional.empty(), ldapAuthenticationProvider);
+
+        invalidConfigModel.setManagerDn("managerDn");
+        ldapAuthenticationProvider = assertDoesNotThrow(() -> ldapManager.createAuthProvider(invalidConfigModel));
+        assertEquals(Optional.empty(), ldapAuthenticationProvider);
     }
 
     @Test

--- a/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidatorTest.java
+++ b/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidatorTest.java
@@ -72,12 +72,14 @@ public class LDAPConfigurationValidatorTest {
     public void testInvalidManagerPassword() {
         ldapConfigModel.setServerName("valid");
         ldapConfigModel.setManagerDn("valid");
+        ldapConfigModel.setManagerPassword("");
         ldapConfigModel.setIsManagerPasswordSet(false);
 
         ValidationResponseModel validationResponseModel = ldapConfigurationValidator.validate(ldapConfigModel);
         assertEquals(ValidationResponseModel.VALIDATION_FAILURE_MESSAGE, validationResponseModel.getMessage());
-        assertEquals(1, validationResponseModel.getErrors().size());
+        assertEquals(2, validationResponseModel.getErrors().size());
         assertTrue(validationResponseModel.getErrors().containsKey("managerPassword"));
+        assertEquals(AlertFieldStatusMessages.INVALID_OPTION, validationResponseModel.getErrors().get("isManagerPasswordSet").getFieldMessage());
         assertEquals(AlertFieldStatusMessages.REQUIRED_FIELD_MISSING, validationResponseModel.getErrors().get("managerPassword").getFieldMessage());
     }
 


### PR DESCRIPTION
* LDAPTestAction - If using a previously saved LDAP configuration, the PW will not be present in the UI. If that is the case, get the PW from the DB
* LDAPTestAction - Testing the LDAP configuration should require you to enable LDAP
* LdapManager - 4 fields are required, including being enabled. Re-work to perform a check on all 4
* LDAPConfigurationValidator - isManagerPasswordSet should have been doing a Boolean test. Update getIsManagerPasswordSet to use StringUtils as Optional.isEmpty() is false if it's an empty string
* Update tests