### PR TITLE
fix: Write the failed audit entries if the job hasn't completed.

### DIFF
--- a/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/IssueTrackerChannel.java
+++ b/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/IssueTrackerChannel.java
@@ -43,6 +43,7 @@ public abstract class IssueTrackerChannel<D extends DistributionJobDetailsModel,
         D distributionDetails,
         ProviderMessageHolder messages,
         String jobName,
+        UUID jobConfigId,
         UUID parentEventId,
         UUID jobExecutionId,
         Set<Long> notificationIds

--- a/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/IssueTrackerChannelTest.java
+++ b/api-channel-issue-tracker/src/test/java/com/synopsys/integration/alert/api/channel/issue/IssueTrackerChannelTest.java
@@ -55,6 +55,7 @@ class IssueTrackerChannelTest {
             null,
             UUID.randomUUID(),
             UUID.randomUUID(),
+            UUID.randomUUID(),
             Set.of()
         );
 

--- a/api-channel/src/main/java/com/synopsys/integration/alert/api/channel/DistributionChannel.java
+++ b/api-channel/src/main/java/com/synopsys/integration/alert/api/channel/DistributionChannel.java
@@ -16,7 +16,15 @@ import com.synopsys.integration.alert.common.persistence.model.job.details.Distr
 import com.synopsys.integration.alert.processor.api.extract.model.ProviderMessageHolder;
 
 public interface DistributionChannel<D extends DistributionJobDetailsModel> {
-    MessageResult distributeMessages(D distributionDetails, ProviderMessageHolder messages, String jobName, UUID parentEventId, UUID jobExecutionId, Set<Long> notificationIds)
+    MessageResult distributeMessages(
+        D distributionDetails,
+        ProviderMessageHolder messages,
+        String jobName,
+        UUID jobConfigId,
+        UUID parentEventId,
+        UUID jobExecutionId,
+        Set<Long> notificationIds
+    )
         throws AlertException;
 
 }

--- a/api-channel/src/main/java/com/synopsys/integration/alert/api/channel/DistributionEventHandler.java
+++ b/api-channel/src/main/java/com/synopsys/integration/alert/api/channel/DistributionEventHandler.java
@@ -52,6 +52,7 @@ public class DistributionEventHandler<D extends DistributionJobDetailsModel> imp
                     details.get(),
                     event.getProviderMessages(),
                     event.getJobName(),
+                    event.getJobId(),
                     UUID.fromString(event.getEventId()),
                     jobExecutionId,
                     event.getNotificationIds()
@@ -72,6 +73,7 @@ public class DistributionEventHandler<D extends DistributionJobDetailsModel> imp
         notificationLogger.error("An exception occurred while handling the following event: {}.", event.getEventId(), e);
         eventManager.sendEvent(new AuditFailedEvent(
             event.getJobExecutionId(),
+            event.getJobId(),
             event.getNotificationIds(),
             String.format("An exception occurred while handling the following event: %s.", event.getEventId()),
             AuditStackTraceUtil.createStackTraceString(e)
@@ -82,6 +84,7 @@ public class DistributionEventHandler<D extends DistributionJobDetailsModel> imp
         notificationLogger.error("An unexpected error occurred while handling the following event: {}.", event.getEventId(), e);
         eventManager.sendEvent(new AuditFailedEvent(
             event.getJobExecutionId(),
+            event.getJobId(),
             event.getNotificationIds(),
             "An unexpected error occurred during message distribution. Please refer to the logs for more details.",
             AuditStackTraceUtil.createStackTraceString(e)
@@ -91,6 +94,7 @@ public class DistributionEventHandler<D extends DistributionJobDetailsModel> imp
     protected void handleJobDetailsMissing(DistributionEvent event) {
         eventManager.sendEvent(new AuditFailedEvent(
             event.getJobExecutionId(),
+            event.getJobId(),
             event.getNotificationIds(),
             "Received a distribution event for a Job that no longer exists",
             null

--- a/api-channel/src/main/java/com/synopsys/integration/alert/api/channel/MessageBoardChannel.java
+++ b/api-channel/src/main/java/com/synopsys/integration/alert/api/channel/MessageBoardChannel.java
@@ -48,6 +48,7 @@ public abstract class MessageBoardChannel<D extends DistributionJobDetailsModel,
         D distributionDetails,
         ProviderMessageHolder messages,
         String jobName,
+        UUID jobConfigId,
         UUID parentEventId,
         UUID jobExecutionId,
         Set<Long> notificationIds
@@ -56,7 +57,7 @@ public abstract class MessageBoardChannel<D extends DistributionJobDetailsModel,
         List<T> channelMessages = channelMessageConverter.convertToChannelMessages(distributionDetails, messages, jobName);
         MessageResult messageResult = channelMessageSender.sendMessages(distributionDetails, channelMessages);
         executingJobManager.incrementSentNotificationCount(jobExecutionId, notificationIds.size());
-        eventManager.sendEvent(new AuditSuccessEvent(jobExecutionId, notificationIds));
+        eventManager.sendEvent(new AuditSuccessEvent(jobExecutionId, jobConfigId, notificationIds));
         return messageResult;
     }
 

--- a/api-channel/src/main/java/com/synopsys/integration/alert/api/channel/action/DistributionChannelMessageTestAction.java
+++ b/api-channel/src/main/java/com/synopsys/integration/alert/api/channel/action/DistributionChannelMessageTestAction.java
@@ -44,7 +44,7 @@ public abstract class DistributionChannelMessageTestAction<D extends Distributio
 
         D distributionJobDetails = resolveTestDistributionDetails(testJobModel);
         ProviderMessageHolder messages = createTestMessageHolder(testJobModel, topicString, messageString);
-        return distributionChannel.distributeMessages(distributionJobDetails, messages, jobName, UUID.randomUUID(), UUID.randomUUID(), Set.of());
+        return distributionChannel.distributeMessages(distributionJobDetails, messages, jobName, UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), Set.of());
     }
 
     protected D resolveTestDistributionDetails(DistributionJobModel testJobModel) throws AlertException {

--- a/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/DistributionEventHandlerTest.java
+++ b/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/DistributionEventHandlerTest.java
@@ -28,7 +28,7 @@ class DistributionEventHandlerTest {
         DistributionJobDetailsModel details = new DistributionJobDetailsModel(null, null) {};
         JobDetailsAccessor<DistributionJobDetailsModel> jobDetailsAccessor = x -> Optional.of(details);
 
-        DistributionChannel<DistributionJobDetailsModel> channel = (u, v, w, x, y, z) -> {
+        DistributionChannel<DistributionJobDetailsModel> channel = (t, u, v, w, x, y, z) -> {
             count.incrementAndGet();
             return null;
         };
@@ -53,7 +53,7 @@ class DistributionEventHandlerTest {
         JobDetailsAccessor<DistributionJobDetailsModel> jobDetailsAccessor = x -> Optional.of(details);
 
         AlertException testException = new AlertException("Test exception");
-        DistributionChannel<DistributionJobDetailsModel> channel = (u, v, w, x, y, z) -> {
+        DistributionChannel<DistributionJobDetailsModel> channel = (t, u, v, w, x, y, z) -> {
             count.incrementAndGet();
             throw testException;
         };
@@ -75,7 +75,7 @@ class DistributionEventHandlerTest {
         AtomicInteger count = new AtomicInteger(0);
         EventManager eventManager = Mockito.mock(EventManager.class);
         JobDetailsAccessor<DistributionJobDetailsModel> jobDetailsAccessor = x -> Optional.empty();
-        DistributionChannel<DistributionJobDetailsModel> channel = (u, v, w, x, y, z) -> {
+        DistributionChannel<DistributionJobDetailsModel> channel = (t, u, v, w, x, y, z) -> {
             count.incrementAndGet();
             return null;
         };

--- a/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/MessageBoardChannelTest.java
+++ b/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/MessageBoardChannelTest.java
@@ -32,7 +32,15 @@ class MessageBoardChannelTest {
         ChannelMessageSender<DistributionJobDetailsModel, Object, MessageResult> sender = (x, y) -> expectedResult;
         MessageBoardChannel<DistributionJobDetailsModel, Object> messageBoardChannel = new MessageBoardChannel<>(converter, sender, eventManager, executingJobManager) {};
 
-        MessageResult testResult = messageBoardChannel.distributeMessages(testDetails, ProviderMessageHolder.empty(), "jobName", UUID.randomUUID(), UUID.randomUUID(), Set.of());
+        MessageResult testResult = messageBoardChannel.distributeMessages(
+            testDetails,
+            ProviderMessageHolder.empty(),
+            "jobName",
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            Set.of()
+        );
         assertEquals(expectedResult, testResult);
     }
 

--- a/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/action/DistributionChannelMessageFieldModelTestActionTest.java
+++ b/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/action/DistributionChannelMessageFieldModelTestActionTest.java
@@ -50,7 +50,7 @@ public class DistributionChannelMessageFieldModelTestActionTest {
     }
 
     private DistributionChannel<MockDistributionJobDetailsModel> createDistributionChannel(String expectedStatusMessage) {
-        return (distributionDetails, messages, jobName, eventId, jobExecutionId, notificationIds) -> new MessageResult(expectedStatusMessage);
+        return (distributionDetails, messages, jobName, jobId, eventId, jobExecutionId, notificationIds) -> new MessageResult(expectedStatusMessage);
     }
 
     private DistributionJobModel createDistributionJobModel() {

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditEvent.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditEvent.java
@@ -10,22 +10,28 @@ import com.synopsys.integration.alert.common.util.DateUtils;
 public class AuditEvent extends AlertEvent {
     private static final long serialVersionUID = 8821840075948290969L;
     private final UUID jobExecutionId;
+    private final UUID jobConfigId;
     private final Set<Long> notificationIds;
     private final OffsetDateTime createdTimestamp;
 
-    public AuditEvent(String destination, UUID jobExecutionId, Set<Long> notificationIds) {
-        this(destination, jobExecutionId, notificationIds, DateUtils.createCurrentDateTimestamp());
+    public AuditEvent(String destination, UUID jobExecutionId, UUID jobConfigId, Set<Long> notificationIds) {
+        this(destination, jobExecutionId, jobConfigId, notificationIds, DateUtils.createCurrentDateTimestamp());
     }
 
-    public AuditEvent(String destination, UUID jobExecutionId, Set<Long> notificationIds, OffsetDateTime createdTimestamp) {
+    public AuditEvent(String destination, UUID jobExecutionId, UUID jobConfigId, Set<Long> notificationIds, OffsetDateTime createdTimestamp) {
         super(destination);
         this.jobExecutionId = jobExecutionId;
+        this.jobConfigId = jobConfigId;
         this.notificationIds = notificationIds;
         this.createdTimestamp = createdTimestamp;
     }
 
     public UUID getJobExecutionId() {
         return jobExecutionId;
+    }
+
+    public UUID getJobConfigId() {
+        return jobConfigId;
     }
 
     public Set<Long> getNotificationIds() {

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedEvent.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedEvent.java
@@ -13,8 +13,8 @@ public class AuditFailedEvent extends AuditEvent {
     private final String errorMessage;
     private final String stackTrace;
 
-    public AuditFailedEvent(UUID jobExecutionId, Set<Long> notificationIds, String errorMessage, @Nullable String stackTrace) {
-        super(DEFAULT_DESTINATION_NAME, jobExecutionId, notificationIds);
+    public AuditFailedEvent(UUID jobExecutionId, UUID jobConfigId, Set<Long> notificationIds, String errorMessage, @Nullable String stackTrace) {
+        super(DEFAULT_DESTINATION_NAME, jobExecutionId, jobConfigId, notificationIds);
         this.errorMessage = errorMessage;
         this.stackTrace = stackTrace;
     }

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessEvent.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessEvent.java
@@ -8,7 +8,7 @@ public class AuditSuccessEvent extends AuditEvent {
 
     public static final String DEFAULT_DESTINATION_NAME = "audit_success_event";
 
-    public AuditSuccessEvent(UUID jobExecutionId, Set<Long> notificationIds) {
-        super(DEFAULT_DESTINATION_NAME, jobExecutionId, notificationIds);
+    public AuditSuccessEvent(UUID jobExecutionId, UUID jobConfigId, Set<Long> notificationIds) {
+        super(DEFAULT_DESTINATION_NAME, jobExecutionId, jobConfigId, notificationIds);
     }
 }

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessHandler.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessHandler.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import com.synopsys.integration.alert.api.distribution.execution.ExecutingJob;
 import com.synopsys.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.synopsys.integration.alert.api.event.AlertEventHandler;
+import com.synopsys.integration.alert.common.enumeration.AuditEntryStatus;
 
 @Component
 public class AuditSuccessHandler implements AlertEventHandler<AuditSuccessEvent> {
@@ -24,6 +25,9 @@ public class AuditSuccessHandler implements AlertEventHandler<AuditSuccessEvent>
         UUID jobExecutionId = event.getJobExecutionId();
         executingJobManager.getExecutingJob(jobExecutionId)
             .filter(Predicate.not(ExecutingJob::isCompleted))
-            .ifPresent(executingJob -> executingJobManager.endJobWithSuccess(jobExecutionId, event.getCreatedTimestamp().toInstant()));
+            .ifPresent(executingJob -> {
+                executingJobManager.updateJobStatus(jobExecutionId, AuditEntryStatus.SUCCESS);
+                executingJobManager.endJob(jobExecutionId, event.getCreatedTimestamp().toInstant());
+            });
     }
 }

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/ExecutingJob.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/ExecutingJob.java
@@ -39,6 +39,21 @@ public class ExecutingJob {
         this.notificationsSent = new AtomicInteger(0);
     }
 
+    public void endJob(Instant endTime) {
+        synchronized (this) {
+            this.end = endTime;
+        }
+    }
+
+    public void updateStatus(AuditEntryStatus status) {
+        synchronized (this) {
+            if (AuditEntryStatus.FAILURE == status
+                || !hasCompletedStatus()) {
+                this.status = status;
+            }
+        }
+    }
+
     public void jobSucceeded(Instant endTime) {
         completeJobWithStatus(AuditEntryStatus.SUCCESS, endTime);
     }

--- a/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditEventTest.java
+++ b/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditEventTest.java
@@ -13,9 +13,10 @@ class AuditEventTest {
     @Test
     void constructorTest() {
         String destination = "destination";
+        UUID jobConfigId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
-        AuditEvent event = new AuditEvent(destination, jobExecutionId, notificationIds);
+        AuditEvent event = new AuditEvent(destination, jobExecutionId, jobConfigId, notificationIds);
 
         assertEquals(destination, event.getDestination());
         assertEquals(jobExecutionId, event.getJobExecutionId());

--- a/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedEventListenerTest.java
+++ b/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedEventListenerTest.java
@@ -143,7 +143,7 @@ class AuditFailedEventListenerTest {
             .map(this::createNotification)
             .forEach(notificationContentRepository::save);
         AuditFailedEventListener listener = new AuditFailedEventListener(gson, taskExecutor, handler);
-        AuditFailedEvent event = new AuditFailedEvent(executingJobId, notificationIds, errorMessage, stackTrace);
+        AuditFailedEvent event = new AuditFailedEvent(executingJobId, jobConfigId, notificationIds, errorMessage, stackTrace);
         Message message = new Message(gson.toJson(event).getBytes());
         listener.onMessage(message);
 

--- a/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedEventTest.java
+++ b/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedEventTest.java
@@ -12,14 +12,16 @@ import org.junit.jupiter.api.Test;
 class AuditFailedEventTest {
     @Test
     void constructorTest() {
+        UUID jobConfigId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         String errorMessage = "Error message";
         String stackTrace = "stack trace goees here";
-        AuditFailedEvent event = new AuditFailedEvent(jobExecutionId, notificationIds, errorMessage, stackTrace);
+        AuditFailedEvent event = new AuditFailedEvent(jobExecutionId, jobConfigId, notificationIds, errorMessage, stackTrace);
 
         assertEquals(AuditFailedEvent.DEFAULT_DESTINATION_NAME, event.getDestination());
         assertEquals(jobExecutionId, event.getJobExecutionId());
+        assertEquals(jobConfigId, event.getJobConfigId());
         assertEquals(notificationIds, event.getNotificationIds());
         assertNotNull(event.getCreatedTimestamp());
         assertEquals(errorMessage, event.getErrorMessage());
@@ -30,12 +32,14 @@ class AuditFailedEventTest {
     @Test
     void constructorStackTraceNullTest() {
         UUID jobId = UUID.randomUUID();
+        UUID jobExecutionId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         String errorMessage = "Error message";
-        AuditFailedEvent event = new AuditFailedEvent(jobId, notificationIds, errorMessage, null);
+        AuditFailedEvent event = new AuditFailedEvent(jobExecutionId, jobId, notificationIds, errorMessage, null);
 
         assertEquals(AuditFailedEvent.DEFAULT_DESTINATION_NAME, event.getDestination());
-        assertEquals(jobId, event.getJobExecutionId());
+        assertEquals(jobExecutionId, event.getJobExecutionId());
+        assertEquals(jobId, event.getJobConfigId());
         assertEquals(notificationIds, event.getNotificationIds());
         assertNotNull(event.getCreatedTimestamp());
         assertEquals(errorMessage, event.getErrorMessage());

--- a/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedHandlerTest.java
+++ b/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedHandlerTest.java
@@ -122,6 +122,7 @@ class AuditFailedHandlerTest {
             notificationAccessor,
             jobAccessor
         );
+        UUID jobConfigId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         ExecutingJob executingJob = executingJobManager.startJob(jobExecutionId, notificationIds.size());
@@ -133,7 +134,7 @@ class AuditFailedHandlerTest {
         notificationIds.stream()
             .map(this::createNotification)
             .forEach(notificationContentRepository::save);
-        AuditFailedEvent event = new AuditFailedEvent(executingJobId, notificationIds, errorMessage, stackTrace);
+        AuditFailedEvent event = new AuditFailedEvent(executingJobId, jobConfigId, notificationIds, errorMessage, stackTrace);
 
         handler.handle(event);
 
@@ -167,6 +168,7 @@ class AuditFailedHandlerTest {
             notificationAccessor,
             jobAccessor
         );
+        UUID jobConfigId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         String errorMessage = "Error message";
@@ -176,7 +178,7 @@ class AuditFailedHandlerTest {
             .map(this::createNotification)
             .forEach(notificationContentRepository::save);
         AuditFailedHandler handler = new AuditFailedHandler(processingFailedAccessor, executingJobManager);
-        AuditFailedEvent event = new AuditFailedEvent(jobExecutionId, notificationIds, errorMessage, stackTrace);
+        AuditFailedEvent event = new AuditFailedEvent(jobExecutionId, jobConfigId, notificationIds, errorMessage, stackTrace);
 
         handler.handle(event);
 

--- a/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessEventListenerTest.java
+++ b/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessEventListenerTest.java
@@ -49,7 +49,7 @@ class AuditSuccessEventListenerTest {
         UUID executingJobId = executingJob.getExecutionId();
 
         AuditSuccessEventListener listener = new AuditSuccessEventListener(gson, taskExecutor, handler);
-        AuditSuccessEvent event = new AuditSuccessEvent(executingJobId, notificationIds);
+        AuditSuccessEvent event = new AuditSuccessEvent(executingJobId, jobId, notificationIds);
         Message message = new Message(gson.toJson(event).getBytes());
         listener.onMessage(message);
 

--- a/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessEventTest.java
+++ b/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessEventTest.java
@@ -12,12 +12,14 @@ class AuditSuccessEventTest {
 
     @Test
     void constructorTest() {
+        UUID jobId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
-        AuditEvent event = new AuditSuccessEvent(jobExecutionId, notificationIds);
+        AuditEvent event = new AuditSuccessEvent(jobExecutionId, jobId, notificationIds);
 
         assertEquals(AuditSuccessEvent.DEFAULT_DESTINATION_NAME, event.getDestination());
         assertEquals(jobExecutionId, event.getJobExecutionId());
+        assertEquals(jobId, event.getJobConfigId());
         assertEquals(notificationIds, event.getNotificationIds());
         assertNotNull(event.getCreatedTimestamp());
     }

--- a/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessHandlerTest.java
+++ b/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessHandlerTest.java
@@ -40,7 +40,7 @@ class AuditSuccessHandlerTest {
         ExecutingJob executingJob = executingJobManager.startJob(jobId, 0);
         UUID jobExecutionId = executingJob.getExecutionId();
         AuditSuccessHandler handler = new AuditSuccessHandler(executingJobManager);
-        AuditSuccessEvent event = new AuditSuccessEvent(jobExecutionId, Set.of());
+        AuditSuccessEvent event = new AuditSuccessEvent(jobExecutionId, jobId, Set.of());
         handler.handle(event);
         JobCompletionStatusModel statusModel = jobCompletionStatusModelAccessor.getJobExecutionStatus(jobId)
             .orElseThrow(() -> new AssertionError("Executing Job cannot be missing from the test."));
@@ -53,11 +53,12 @@ class AuditSuccessHandlerTest {
 
     @Test
     void handleEventAuditMissingTest() {
+        UUID jobId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         AlertPagedQueryDetails pagedQueryDetails = new AlertPagedQueryDetails(1, 10);
         AuditSuccessHandler handler = new AuditSuccessHandler(executingJobManager);
-        AuditSuccessEvent event = new AuditSuccessEvent(jobExecutionId, notificationIds);
+        AuditSuccessEvent event = new AuditSuccessEvent(jobExecutionId, jobId, notificationIds);
         handler.handle(event);
         Optional<ExecutingJob> executingJob = executingJobManager.getExecutingJob(jobExecutionId);
         assertTrue(executingJob.isEmpty());

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/EmailITTestAssertions.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/EmailITTestAssertions.java
@@ -37,7 +37,7 @@ public final class EmailITTestAssertions {
     public static <D extends DistributionJobDetailsModel> void assertSendSimpleMessageSuccess(DistributionChannel<D> channel, D distributionDetails) {
         MessageResult messageResult = null;
         try {
-            messageResult = channel.distributeMessages(distributionDetails, TEST_MESSAGE_HOLDER, "jobName", UUID.randomUUID(), UUID.randomUUID(), Set.of());
+            messageResult = channel.distributeMessages(distributionDetails, TEST_MESSAGE_HOLDER, "jobName", UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), Set.of());
         } catch (AlertException e) {
             Assertions.fail("Failed to distribute simple channel message due to an exception", e);
         }
@@ -52,7 +52,7 @@ public final class EmailITTestAssertions {
 
     public static <D extends DistributionJobDetailsModel> void assertSendSimpleMessageException(DistributionChannel<D> channel, D distributionDetails, @Nullable String expectedExceptionMessage) {
         try {
-            channel.distributeMessages(distributionDetails, TEST_MESSAGE_HOLDER, "jobName", UUID.randomUUID(), UUID.randomUUID(), Set.of());
+            channel.distributeMessages(distributionDetails, TEST_MESSAGE_HOLDER, "jobName", UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), Set.of());
             Assertions.fail("Expected an exception to be thrown");
         } catch (AlertException e) {
             if (null != expectedExceptionMessage) {

--- a/channel-msteams/src/test/java/com/synopsys/integration/alert/channel/msteams/distribution/MsTeamsChannelTest.java
+++ b/channel-msteams/src/test/java/com/synopsys/integration/alert/channel/msteams/distribution/MsTeamsChannelTest.java
@@ -72,7 +72,15 @@ class MsTeamsChannelTest {
 
         MessageResult messageResult = null;
         try {
-            messageResult = msTeamsChannel.distributeMessages(msTeamsJobDetailsModel, TEST_MESSAGE_HOLDER, "jobName", UUID.randomUUID(), UUID.randomUUID(), Set.of());
+            messageResult = msTeamsChannel.distributeMessages(
+                msTeamsJobDetailsModel,
+                TEST_MESSAGE_HOLDER,
+                "jobName",
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                Set.of()
+            );
         } catch (AlertException e) {
             Assertions.fail("Failed to distribute simple channel message due to an exception", e);
         }

--- a/channel-slack/src/test/java/com/synopsys/integration/alert/channel/slack/ChannelITTestAssertions.java
+++ b/channel-slack/src/test/java/com/synopsys/integration/alert/channel/slack/ChannelITTestAssertions.java
@@ -37,7 +37,7 @@ public class ChannelITTestAssertions {
     public static <D extends DistributionJobDetailsModel> void assertSendSimpleMessageSuccess(DistributionChannel<D> channel, D distributionDetails) {
         MessageResult messageResult = null;
         try {
-            messageResult = channel.distributeMessages(distributionDetails, TEST_MESSAGE_HOLDER, "jobName", UUID.randomUUID(), UUID.randomUUID(), Set.of());
+            messageResult = channel.distributeMessages(distributionDetails, TEST_MESSAGE_HOLDER, "jobName", UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), Set.of());
         } catch (AlertException e) {
             Assertions.fail("Failed to distribute simple channel message due to an exception", e);
         }
@@ -52,7 +52,7 @@ public class ChannelITTestAssertions {
 
     public static <D extends DistributionJobDetailsModel> void assertSendSimpleMessageException(DistributionChannel<D> channel, D distributionDetails, @Nullable String expectedExceptionMessage) {
         try {
-            channel.distributeMessages(distributionDetails, TEST_MESSAGE_HOLDER, "jobName", UUID.randomUUID(), UUID.randomUUID(), Set.of());
+            channel.distributeMessages(distributionDetails, TEST_MESSAGE_HOLDER, "jobName", UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), Set.of());
             Assertions.fail("Expected an exception to be thrown");
         } catch (AlertException e) {
             if (null != expectedExceptionMessage) {

--- a/src/test/java/com/synopsys/integration/alert/database/api/DefaultDistributionAccessorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/database/api/DefaultDistributionAccessorTestIT.java
@@ -330,11 +330,16 @@ class DefaultDistributionAccessorTestIT {
         ExecutingJob executingJob5 = executingJobManager.startJob(fifthJobSaved.getJobId(), 5);
         ExecutingJob executingJob6 = executingJobManager.startJob(sixthJobSaved.getJobId(), 6);
 
-        executingJobManager.endJobWithSuccess(executingJob1.getExecutionId(), Instant.now());
-        executingJobManager.endJobWithSuccess(executingJob2.getExecutionId(), Instant.now());
-        executingJobManager.endJobWithFailure(executingJob4.getExecutionId(), Instant.now());
-        executingJobManager.endJobWithSuccess(executingJob5.getExecutionId(), Instant.now());
-        executingJobManager.endJobWithFailure(executingJob6.getExecutionId(), Instant.now());
+        executingJobManager.updateJobStatus(executingJob1.getExecutionId(), AuditEntryStatus.SUCCESS);
+        executingJobManager.endJob(executingJob1.getExecutionId(), Instant.now());
+        executingJobManager.updateJobStatus(executingJob2.getExecutionId(), AuditEntryStatus.SUCCESS);
+        executingJobManager.endJob(executingJob2.getExecutionId(), Instant.now());
+        executingJobManager.updateJobStatus(executingJob4.getExecutionId(), AuditEntryStatus.FAILURE);
+        executingJobManager.endJob(executingJob4.getExecutionId(), Instant.now());
+        executingJobManager.updateJobStatus(executingJob5.getExecutionId(), AuditEntryStatus.SUCCESS);
+        executingJobManager.endJob(executingJob5.getExecutionId(), Instant.now());
+        executingJobManager.updateJobStatus(executingJob6.getExecutionId(), AuditEntryStatus.FAILURE);
+        executingJobManager.endJob(executingJob6.getExecutionId(), Instant.now());
 
         return Map.of(
             firstJobSaved.getJobId(), firstJobSaved,


### PR DESCRIPTION
Write the failed audit entries per notification if the job hasn't completed to collect them all.
Need to add the Job Configuration ID to the audit events to save the notification data per audit failed entry.