### PR TITLE
fix: Update Audit title and scheduling page fixes.

### DIFF
--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/FailedAuditPurgeTask.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/audit/FailedAuditPurgeTask.java
@@ -61,7 +61,7 @@ public class FailedAuditPurgeTask extends StartupScheduledTask {
 
     private Boolean purgeOldData() {
         OffsetDateTime purgeDate = DateUtils.createCurrentDateTimestamp()
-            .minusDays(10)
+            .minusDays(getConfiguredFrequency())
             .withHour(0).withMinute(0).withSecond(0).withNano(0);
         logger.info("Purging old failed Audit entries older than {}", purgeDate);
         failedAuditAccessor.deleteAuditEntriesBefore(purgeDate);

--- a/component/src/main/java/com/synopsys/integration/alert/component/scheduling/actions/SchedulingGlobalApiAction.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/scheduling/actions/SchedulingGlobalApiAction.java
@@ -86,9 +86,9 @@ public class SchedulingGlobalApiAction extends ApiAction {
             SchedulingDescriptor.KEY_PURGE_AUDIT_FAILED_NEXT_RUN,
             new FieldValueModel(List.of(taskManager.getNextRunTime(ScheduledTask.computeTaskName(FailedAuditPurgeTask.class)).orElse("")), true)
         );
-        String purgeAuditFailedFrequency = fieldModel.getFieldValue(SchedulingDescriptor.KEY_PURGE_AUDIT_FAILED_NEXT_RUN)
+        String purgeAuditFailedFrequency = fieldModel.getFieldValue(SchedulingDescriptor.KEY_PURGE_AUDIT_FAILED_FREQUENCY_DAYS)
             .orElse(String.valueOf(FailedAuditPurgeTask.DEFAULT_FREQUENCY));
-        fieldModel.putField(SchedulingDescriptor.KEY_PURGE_AUDIT_FAILED_NEXT_RUN, new FieldValueModel(List.of(purgeAuditFailedFrequency), true));
+        fieldModel.putField(SchedulingDescriptor.KEY_PURGE_AUDIT_FAILED_FREQUENCY_DAYS, new FieldValueModel(List.of(purgeAuditFailedFrequency), true));
 
         return fieldModel;
     }

--- a/ui/src/main/js/page/audit/AuditModel.js
+++ b/ui/src/main/js/page/audit/AuditModel.js
@@ -1,5 +1,5 @@
 export const AUDIT_INFO = {
     key: 'component_audit',
     url: 'audit',
-    label: 'Audit'
+    label: 'Audit Failures'
 };

--- a/ui/src/main/js/page/scheduling/SchedulingConfiguration.js
+++ b/ui/src/main/js/page/scheduling/SchedulingConfiguration.js
@@ -75,8 +75,8 @@ const SchedulingConfiguration = ({ csrfToken, errorHandler, readonly, displaySav
                 <DynamicSelectInput
                     id={SCHEDULING_FIELD_KEYS.purgeDataFrequencyDays}
                     name={SCHEDULING_FIELD_KEYS.purgeDataFrequencyDays}
-                    label="Purge Data Frequency In Days"
-                    description="Choose a frequency for cleaning up provider data; the default value is three days. When the purge runs, it deletes all data that is older than the selected value. EX: data older than 3 days will be deleted."
+                    label="Purge Notification Data"
+                    description="Choose a frequency for cleaning up provider notification data; the default value is three days. When the purge runs, it deletes all notification data that is older than the selected value. EX: data older than 3 days will be deleted."
                     required
                     readOnly={readonly}
                     onChange={FieldModelUtilities.handleChange(formData, setFormData)}
@@ -89,8 +89,8 @@ const SchedulingConfiguration = ({ csrfToken, errorHandler, readonly, displaySav
                 <ReadOnlyField
                     id={SCHEDULING_FIELD_KEYS.purgeDataNextRun}
                     name={SCHEDULING_FIELD_KEYS.purgeDataNextRun}
-                    label="Purge Cron Next Run"
-                    description="This is the next time Alert will purge provider data."
+                    label="Purge Notification Data Cron Next Run"
+                    description="This is the next time Alert will purge provider notification data."
                     onChange={FieldModelUtilities.handleChange(formData, setFormData)}
                     value={FieldModelUtilities.getFieldModelSingleValue(formData, SCHEDULING_FIELD_KEYS.purgeDataNextRun)}
                     errorName={FieldModelUtilities.createFieldModelErrorKey(SCHEDULING_FIELD_KEYS.purgeDataNextRun)}
@@ -99,7 +99,7 @@ const SchedulingConfiguration = ({ csrfToken, errorHandler, readonly, displaySav
                 <DynamicSelectInput
                     id={SCHEDULING_FIELD_KEYS.purgeDataAuditFailedFrequencyDays}
                     name={SCHEDULING_FIELD_KEYS.purgeDataAuditFailedFrequencyDays}
-                    label="Purge Audit Failed Data Frequency In Days"
+                    label="Purge Audit Failed Data"
                     description="Choose a frequency for cleaning up failed audit data; the default value is ten days. When the purge runs, it deletes all data that is older than the selected value. EX: data older than 10 days will be deleted."
                     required
                     readOnly={readonly}


### PR DESCRIPTION
- Change Audit title page to Audit Failures
- Change the title of the purge data to purge notification data
- Change purge audit failed data frequency to purge audit failed data
- Fix the issue setting the default purge of audit data to 10
- Remove the in Days portion of the purge field titles since the number of days are in the selection.