### PR TITLE
IALERT-3356: Limit Batch Size

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/JobNotificationMappingAccessor.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/persistence/accessor/JobNotificationMappingAccessor.java
@@ -26,4 +26,6 @@ public interface JobNotificationMappingAccessor {
     void removeJobMapping(UUID correlationId, UUID jobId);
 
     int getNotificationCountForJob(UUID correlationId, UUID jobId);
+
+    int getCountByCorrelationId(UUID correlationId);
 }

--- a/alert-database-job/src/main/java/com/synopsys/integration/alert/database/api/DefaultJobNotificationMappingAccessor.java
+++ b/alert-database-job/src/main/java/com/synopsys/integration/alert/database/api/DefaultJobNotificationMappingAccessor.java
@@ -82,6 +82,12 @@ public class DefaultJobNotificationMappingAccessor implements JobNotificationMap
         return jobToNotificationRelationRepository.countAllByCorrelationIdAndJobId(correlationId, jobId);
     }
 
+    @Override
+    @Transactional
+    public int getCountByCorrelationId(UUID correlationId) {
+        return jobToNotificationRelationRepository.countAllByCorrelationId(correlationId);
+    }
+
     private JobToNotificationRelation convertToEntity(JobToNotificationMappingModel model) {
         return new JobToNotificationRelation(model.getCorrelationId(), model.getJobId(), model.getNotificationId());
     }

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProcessingFailedAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProcessingFailedAccessor.java
@@ -99,6 +99,7 @@ public class DefaultProcessingFailedAccessor implements ProcessingFailedAccessor
             auditedNotifications.put(notificationId, notificationModel.getContent());
         }
         List<AuditFailedNotificationEntity> notificationEntities = auditedNotifications.entrySet().stream()
+            .filter(notification -> !auditFailedNotificationRepository.existsById(notification.getKey()))
             .map(notification -> new AuditFailedNotificationEntity(notification.getKey(), notification.getValue()))
             .collect(Collectors.toList());
         auditFailedNotificationRepository.saveAllAndFlush(notificationEntities);
@@ -129,6 +130,7 @@ public class DefaultProcessingFailedAccessor implements ProcessingFailedAccessor
         }
 
         List<AuditFailedNotificationEntity> notificationEntities = auditedNotifications.entrySet().stream()
+            .filter(notification -> !auditFailedNotificationRepository.existsById(notification.getKey()))
             .map(notification -> new AuditFailedNotificationEntity(notification.getKey(), notification.getValue()))
             .collect(Collectors.toList());
         auditFailedNotificationRepository.saveAllAndFlush(notificationEntities);

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/ExecutingJobManager.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/ExecutingJobManager.java
@@ -47,7 +47,7 @@ public class ExecutingJobManager {
     }
 
     public void endJob(UUID executionId, Instant endTime) {
-        logger.debug("Ending job execution with success {} at {}", executionId, DateUtils.formatDateAsJsonString(DateUtils.fromInstantUTC(endTime)));
+        logger.debug("Ending job execution {} at {}", executionId, DateUtils.formatDateAsJsonString(DateUtils.fromInstantUTC(endTime)));
         Optional<ExecutingJob> executingJob = Optional.ofNullable(executingJobMap.getOrDefault(executionId, null));
         executingJob.ifPresent(execution -> {
             execution.endJob(DateUtils.fromInstantUTC(endTime).toInstant());
@@ -57,6 +57,7 @@ public class ExecutingJobManager {
     }
 
     public void updateJobStatus(UUID executionId, AuditEntryStatus status) {
+        logger.debug("Updating status for job execution {} to {}", executionId, status.name());
         Optional<ExecutingJob> executingJob = Optional.ofNullable(executingJobMap.getOrDefault(executionId, null));
         executingJob.ifPresent(execution -> execution.updateStatus(status));
     }

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/NotificationMappingProcessor.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/NotificationMappingProcessor.java
@@ -27,6 +27,7 @@ import com.synopsys.integration.alert.processor.api.mapping.JobNotificationMappe
 
 @Component
 public class NotificationMappingProcessor {
+    public static final int DEFAULT_BATCH_LIMIT = 10000;
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final Logger notificationLogger = AlertLoggerFactory.getNotificationLogger(getClass());
     private final NotificationDetailExtractionDelegator notificationDetailExtractionDelegator;
@@ -54,6 +55,10 @@ public class NotificationMappingProcessor {
         jobNotificationMapper.mapJobsToNotifications(correlationID, filterableNotifications, frequencies);
         notificationAccessor.setNotificationsProcessed(notifications);
         logNotifications("Finished mapping notifications: {}", notifications);
+    }
+
+    public boolean hasExceededBatchLimit(UUID correlationID) {
+        return jobNotificationMapper.hasBatchReachedSizeLimit(correlationID, DEFAULT_BATCH_LIMIT);
     }
 
     private void logNotifications(String messageFormat, List<AlertNotificationModel> notifications) {

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/mapping/JobNotificationMapper2.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/mapping/JobNotificationMapper2.java
@@ -50,6 +50,10 @@ public class JobNotificationMapper2 {
             .forEach(jobRequestModel -> retrieveResponse(correlationID, jobRequestModel));
     }
 
+    public boolean hasBatchReachedSizeLimit(UUID correlationID, int limit) {
+        return limit < jobNotificationMappingAccessor.getCountByCorrelationId(correlationID);
+    }
+
     private FilteredDistributionJobRequestModel convertToRequest(DetailedNotificationContent detailedNotificationContent, List<FrequencyType> frequencies) {
         FilteredDistributionJobRequestModel filteredDistributionJobRequestModel = new FilteredDistributionJobRequestModel(
             detailedNotificationContent.getProviderConfigId(),

--- a/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/mapping/JobNotificationMapper2Test.java
+++ b/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/mapping/JobNotificationMapper2Test.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -324,10 +325,21 @@ class JobNotificationMapper2Test {
             }
 
             @Override
-            public int getNotificationCountForJob(final UUID correlationId, final UUID jobId) {
+            public int getNotificationCountForJob(UUID correlationId, UUID jobId) {
                 return dataMap.getOrDefault(correlationId, Map.of())
                     .getOrDefault(jobId, List.of())
                     .size();
+            }
+
+            @Override
+            public int getCountByCorrelationId(UUID correlationId) {
+                return dataMap.values()
+                    .stream()
+                    .map(Map::values)
+                    .flatMap(Collection::stream)
+                    .map(Collection::size)
+                    .reduce(Integer::sum)
+                    .orElse(0);
             }
         };
     }

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
 }
 
 mainClassName = 'com.synopsys.integration.alert.Application'
-version = '6.13.0-SIGQA4-SNAPSHOT'
+version = '6.13.0-TESTPERF-SNAPSHOT'
 
 ext.isSnapshot = project.version.endsWith('-SNAPSHOT')
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
 }
 
 mainClassName = 'com.synopsys.integration.alert.Application'
-version = '6.13.0-TESTPERF-SNAPSHOT'
+version = '6.13.0-SIGQA4-SNAPSHOT'
 
 ext.isSnapshot = project.version.endsWith('-SNAPSHOT')
 

--- a/src/main/java/com/synopsys/integration/alert/processing/NotificationReceivedEventHandler.java
+++ b/src/main/java/com/synopsys/integration/alert/processing/NotificationReceivedEventHandler.java
@@ -65,7 +65,14 @@ public class NotificationReceivedEventHandler implements AlertEventHandler<Notif
             notificationMappingProcessor.processNotifications(correlationID, notifications, List.of(FrequencyType.REAL_TIME));
             boolean hasMoreNotificationsToProcess = notificationAccessor.hasMoreNotificationsToProcess(providerConfigId);
             if (hasMoreNotificationsToProcess) {
-                eventManager.sendEvent(new NotificationReceivedEvent(correlationID, providerConfigId));
+                NotificationReceivedEvent continueProcessingEvent;
+                if (notificationMappingProcessor.hasExceededBatchLimit(correlationID)) {
+                    eventManager.sendEvent(new JobNotificationMappedEvent(correlationID));
+                    continueProcessingEvent = new NotificationReceivedEvent(providerConfigId);
+                } else {
+                    continueProcessingEvent = new NotificationReceivedEvent(correlationID, providerConfigId);
+                }
+                eventManager.sendEvent(continueProcessingEvent);
             } else {
                 eventManager.sendEvent(new JobNotificationMappedEvent(correlationID));
             }


### PR DESCRIPTION
- For each Correlation ID limit the maximum number of notifications that are mapped to jobs for that correlation ID to 10000.
 - Fix a database issue with the audit failures table when multiple jobs map to the same notifications.