### PR TITLE
IALERT-2535: Add validation

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/action/api/AbstractResourceActions.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/action/api/AbstractResourceActions.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.springframework.http.HttpStatus;
 
@@ -100,6 +101,11 @@ public abstract class AbstractResourceActions<T extends Config, D extends AlertS
         if (!authorizationManager.hasWritePermission(context, descriptorKey)) {
             logger.debug(String.format(FORBIDDEN_ACTION_FORMAT, "Update"));
             return ActionResponse.createForbiddenResponse();
+        }
+
+        String resourceId = resource.getId();
+        if (StringUtils.isBlank(resourceId) || !resourceId.equals(Long.toString(id))) {
+            return new ActionResponse<>(HttpStatus.BAD_REQUEST, "IDs in request do not match");
         }
 
         Optional<T> existingItem = findExisting(id);

--- a/src/test/java/com/synopsys/integration/alert/component/users/web/role/RoleActionsTest.java
+++ b/src/test/java/com/synopsys/integration/alert/component/users/web/role/RoleActionsTest.java
@@ -1,5 +1,6 @@
 package com.synopsys.integration.alert.component.users.web.role;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -55,7 +56,6 @@ class RoleActionsTest {
         Mockito.when(authorizationManager.hasDeletePermission(Mockito.anyString(), Mockito.anyString())).thenReturn(true);
         Mockito.when(authorizationManager.hasExecutePermission(Mockito.anyString(), Mockito.anyString())).thenReturn(true);
         Mockito.when(authorizationManager.hasWritePermission(Mockito.anyString(), Mockito.anyString())).thenReturn(true);
-
     }
 
     @Test
@@ -248,11 +248,11 @@ class RoleActionsTest {
     }
 
     @Test
-    void updateTest() throws Exception {
+    void updateTest() {
         String newRoleName = "newRoleName";
         Long longId = 1L;
         PermissionModel permissionModel = createPermissionModel();
-        RolePermissionModel rolePermissionModel = new RolePermissionModel(null, newRoleName, Set.of(permissionModel));
+        RolePermissionModel rolePermissionModel = new RolePermissionModel("1", newRoleName, Set.of(permissionModel));
         UserRoleModel userRoleModel = new UserRoleModel(longId, roleName, false, PermissionModelUtil.convertToPermissionMatrixModel(Set.of(permissionModel)));
 
         Mockito.when(roleAccessor.getRoles(Mockito.anyCollection())).thenReturn(Set.of(userRoleModel));
@@ -261,8 +261,8 @@ class RoleActionsTest {
         RoleActions roleActions = new RoleActions(userManagementDescriptorKey, roleAccessor, authorizationManager, descriptorMap);
         ActionResponse<RolePermissionModel> rolePermissionModelActionResponse = roleActions.update(1L, rolePermissionModel);
 
-        Mockito.verify(authorizationManager).updateRoleName(longId, newRoleName);
-        Mockito.verify(authorizationManager).updatePermissionsForRole(Mockito.anyString(), Mockito.any());
+        assertDoesNotThrow(() -> Mockito.verify(authorizationManager).updateRoleName(longId, newRoleName));
+        assertDoesNotThrow(() -> Mockito.verify(authorizationManager).updatePermissionsForRole(Mockito.anyString(), Mockito.any()));
 
         assertTrue(rolePermissionModelActionResponse.isSuccessful());
         assertFalse(rolePermissionModelActionResponse.hasContent());
@@ -286,22 +286,22 @@ class RoleActionsTest {
     }
 
     @Test
-    void
-    updateErrorTest() throws Exception {
+    void updateErrorTest() {
         String newRoleName = "newRoleName";
         Long longId = 1L;
         PermissionModel permissionModel = createPermissionModel();
-        RolePermissionModel rolePermissionModel = new RolePermissionModel(null, newRoleName, Set.of(permissionModel));
+        RolePermissionModel rolePermissionModel = new RolePermissionModel("1", newRoleName, Set.of(permissionModel));
         UserRoleModel userRoleModel = new UserRoleModel(longId, roleName, false, PermissionModelUtil.convertToPermissionMatrixModel(Set.of(permissionModel)));
 
         Mockito.when(roleAccessor.getRoles(Mockito.anyCollection())).thenReturn(Set.of(userRoleModel));
         Mockito.when(roleAccessor.getRoles()).thenReturn(Set.of());
-        Mockito.doThrow(new AlertConfigurationException("Exception for test")).when(authorizationManager).updatePermissionsForRole(Mockito.anyString(), Mockito.any());
+        assertDoesNotThrow(() -> Mockito.doThrow(new AlertConfigurationException("Exception for test")).when(authorizationManager)
+            .updatePermissionsForRole(Mockito.anyString(), Mockito.any()));
 
         RoleActions roleActions = new RoleActions(userManagementDescriptorKey, roleAccessor, authorizationManager, descriptorMap);
         ActionResponse<RolePermissionModel> rolePermissionModelActionResponse = roleActions.update(1L, rolePermissionModel);
 
-        Mockito.verify(authorizationManager).updateRoleName(longId, newRoleName);
+        assertDoesNotThrow(() -> Mockito.verify(authorizationManager).updateRoleName(longId, newRoleName));
 
         assertTrue(rolePermissionModelActionResponse.isError());
         assertFalse(rolePermissionModelActionResponse.hasContent());


### PR DESCRIPTION
Add validation that the ID provided as part of the URL and the ID provided as part of the json is the same. This will affect certificates, users, and roles. If they are not, you will get an error similar to the following (from postman)

```
{
    "timestamp": "2023-02-23T21:13:03.914+00:00",
    "status": 400,
    "error": "Bad Request",
    "message": "IDs in request do not match",
    "path": "/alert/api/configuration/role/5"
}
```