### PR TITLE
IALERT-3059: fix issue check

### DIFF
--- a/channel-jira-cloud/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/action/JiraCloudGlobalFieldModelTestAction.java
+++ b/channel-jira-cloud/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/action/JiraCloudGlobalFieldModelTestAction.java
@@ -61,7 +61,7 @@ public class JiraCloudGlobalFieldModelTestAction extends JiraGlobalFieldModelTes
         JiraCloudServiceFactory jiraCloudServiceFactory = jiraProperties.createJiraServicesCloudFactory(logger, gson);
         IssueSearchService issueSearchService = jiraCloudServiceFactory.createIssueSearchService();
         IssueSearchResponseModel issueSearchResponseModel = issueSearchService.queryForIssuePage("", 0, 1);
-        return !issueSearchResponseModel.getIssues().isEmpty();
+        return null != issueSearchResponseModel.getIssues();
     }
 
     @Override

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/action/JiraServerGlobalTestActionWrapper.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/action/JiraServerGlobalTestActionWrapper.java
@@ -50,8 +50,9 @@ public class JiraServerGlobalTestActionWrapper {
         IssueSearchService issueSearchService = jiraServerServiceFactory.createIssueSearchService();
         // Updated the JQL to support customers using "Disable empty JQL queries" in Jira Server.
         // https://confluence.atlassian.com/adminjiraserver0820/configuring-jira-application-options-1095777704.html#settings:~:text=Disable%20empty%20JQL%20queries
+        // if the user doesn't have permissions to get issues then an exception for a HTTP 403 forbidden is thrown.
         IssueSearchResponseModel issueSearchResponseModel = issueSearchService.queryForIssuePage("created <= now()", 0, 1);
-        return !issueSearchResponseModel.getIssues().isEmpty();
+        return null != issueSearchResponseModel;
     }
 
     public boolean isUserAdmin() throws IntegrationException {


### PR DESCRIPTION
Make a request to the issue service.  If the user cannot search for issues because a role is missing on the user then an HTTP 403 will cause an exception to be thrown.  A user can be a valid user for Jira but the Jira server may not have any issues because it is a new instance or a new project is getting setup.