### PR TITLE
IALERT-3346 - Implement validation for LDAPConfigTestModel

### DIFF
--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/action/LDAPTestAction.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/action/LDAPTestAction.java
@@ -48,7 +48,7 @@ public class LDAPTestAction {
     }
 
     public ActionResponse<ValidationResponseModel> testAuthentication(LDAPConfigTestModel ldapConfigTestModel) {
-        Supplier<ValidationActionResponse> validationSupplier = () -> configurationValidationHelper.validate(() -> ldapConfigurationValidator.validate(ldapConfigTestModel.getLdapConfigModel()));
+        Supplier<ValidationActionResponse> validationSupplier = () -> configurationValidationHelper.validate(() -> ldapConfigurationValidator.validate(ldapConfigTestModel));
         return configurationTestHelper.test(validationSupplier, () -> testConfigModelContent(ldapConfigTestModel));
     }
 

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidator.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/validator/LDAPConfigurationValidator.java
@@ -10,6 +10,7 @@ import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatus;
 import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatusMessages;
 import com.synopsys.integration.alert.authentication.ldap.model.LDAPConfigModel;
+import com.synopsys.integration.alert.authentication.ldap.model.LDAPConfigTestModel;
 
 @Component
 public class LDAPConfigurationValidator {
@@ -35,4 +36,29 @@ public class LDAPConfigurationValidator {
 
         return ValidationResponseModel.success();
     }
+
+    public ValidationResponseModel validate(LDAPConfigTestModel ldapConfigTestModel) {
+        Set<AlertFieldStatus> statuses = new HashSet<>();
+        LDAPConfigModel ldapConfigModel = ldapConfigTestModel.getLdapConfigModel();
+
+        if (null == ldapConfigModel) {
+            statuses.add(AlertFieldStatus.error("ldapConfigModel", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
+        } else {
+            ValidationResponseModel ldapConfigModelValidate = validate(ldapConfigTestModel.getLdapConfigModel());
+            statuses.addAll(ldapConfigModelValidate.getErrors().values());
+        }
+        if (StringUtils.isBlank(ldapConfigTestModel.getTestLDAPUsername())) {
+            statuses.add(AlertFieldStatus.error("testLDAPUsername", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
+        }
+        if (StringUtils.isBlank(ldapConfigTestModel.getTestLDAPPassword())) {
+            statuses.add(AlertFieldStatus.error("testLDAPPassword", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
+        }
+
+        if (!statuses.isEmpty()) {
+            return ValidationResponseModel.fromStatusCollection(statuses);
+        }
+
+        return ValidationResponseModel.success();
+    }
+
 }

--- a/ui/src/main/js/application/auth/LdapForm.js
+++ b/ui/src/main/js/application/auth/LdapForm.js
@@ -94,6 +94,12 @@ const LdapForm = ({ csrfToken, errorHandler, readonly, displayTest }) => {
         return ConfigurationRequestBuilder.createValidateRequest(ldapRequestUrl, csrfToken, formData);
     }
 
+    const isTestFormComplete = () => {
+        // This check will determine whether we enable or disable the Test Submit button within the Test Configuration modal
+        return (testFormData[AUTHENTICATION_LDAP_GLOBAL_TEST_FIELD_KEYS.testLDAPUsername]?.length > 0 &&
+            testFormData[AUTHENTICATION_LDAP_GLOBAL_TEST_FIELD_KEYS.testLDAPPassword]?.length > 0)
+    }
+
     // Revise this to it's own modal when we overhaul the modal changes.
     const testFields = (
         <div>
@@ -139,6 +145,9 @@ const LdapForm = ({ csrfToken, errorHandler, readonly, displayTest }) => {
                 testLabel="Test LDAP Configuration"
                 testFields={testFields}
                 testButtonClicked={testButtonClicked}
+                disableTestModalSubmit={!isTestFormComplete()}
+                modalSubmitText="Test User Connection"
+                testModalButtonTitle="Enter Username and Password to enable test"
             >
                 <CheckboxInput
                     id={AUTHENTICATION_LDAP_GLOBAL_FIELD_KEYS.enabled}

--- a/ui/src/main/js/common/configuration/global/GlobalTestModal.js
+++ b/ui/src/main/js/common/configuration/global/GlobalTestModal.js
@@ -4,7 +4,7 @@ import { Modal } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 const GlobalTestModal = ({
-    children, showTestModal, handleTest, handleCancel, buttonIdPrefix, performingAction
+    children, showTestModal, handleTest, handleCancel, buttonIdPrefix, performingAction, modalSubmitText, disableTestModalSubmit, testModalButtonTitle
 }) => (
     <Modal show={showTestModal} onHide={handleCancel}>
         <Modal.Header closeButton>
@@ -25,8 +25,10 @@ const GlobalTestModal = ({
                 type="submit"
                 className="btn btn-primary"
                 onClick={handleTest}
+                disabled={disableTestModalSubmit}
+                title={testModalButtonTitle}
             >
-                Send Test Message
+                { modalSubmitText || 'Send Test Message'}
             </button>
             <button id={`${buttonIdPrefix}-cancel`} type="button" className="btn btn-link" onClick={handleCancel}>
                 Cancel

--- a/ui/src/main/js/common/configuration/global/concrete/ConcreteConfigurationForm.js
+++ b/ui/src/main/js/common/configuration/global/concrete/ConcreteConfigurationForm.js
@@ -30,7 +30,10 @@ const ConcreteConfigurationForm = ({
     submitLabel,
     testLabel,
     testButtonClicked,
-    postDeleteAction
+    postDeleteAction,
+    disableTestModalSubmit,
+    modalSubmitText,
+    testModalButtonTitle
 }) => {
     const [showTest, setShowTest] = useState(false);
     const [errorMessage, setErrorMessage] = useState(null);
@@ -186,6 +189,9 @@ const ConcreteConfigurationForm = ({
                 handleCancel={handleTestCancel}
                 buttonIdPrefix={buttonIdPrefix}
                 performingAction={testing}
+                disableTestModalSubmit={disableTestModalSubmit}
+                modalSubmitText={modalSubmitText}
+                testModalButtonTitle={testModalButtonTitle}
             >
                 <div>
                     {testFields}
@@ -220,7 +226,10 @@ ConcreteConfigurationForm.propTypes = {
     submitLabel: PropTypes.string,
     testLabel: PropTypes.string,
     testButtonClicked: PropTypes.func,
-    postDeleteAction: PropTypes.func
+    postDeleteAction: PropTypes.func,
+    disableTestModalSubmit: PropTypes.func,
+    modalSubmitText: PropTypes.string,
+    testModalButtonTitle: PropTypes.string
 };
 
 ConcreteConfigurationForm.defaultProps = {


### PR DESCRIPTION
* Perform validation on the LDAPConfigTestModel prior to executing the test connection. This checks combines errors found while validating LDAPConfigModel with any while found validating LDAPConfigTestModel
* Implement JUnit test coverage for new logic

UI changes by @bseifert14 
* In pop-up when prompting for testLDAPUsername and testLDAPPassword, change name of button from "Send Test Message" -> "Test User Connection".
* On same pop-up, prevent user from clicking Test User Connection button until testLDAPUsername and testLDAPPassword are filled in.

NOTE: The UI does not send in a null if no data is supplied for the LDAP configuration. Instead, it sends a valid LDAPConfigModel, with no values. So, the null check is really only for when users hit the API directly, such as when using postman.