### PR TITLE
IALERT-3356: block before create

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
 }
 
 mainClassName = 'com.synopsys.integration.alert.Application'
-version = '6.13.0-SIGQA4-SNAPSHOT'
+version = '6.13.0-TESTPERF-SNAPSHOT'
 
 ext.isSnapshot = project.version.endsWith('-SNAPSHOT')
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
 }
 
 mainClassName = 'com.synopsys.integration.alert.Application'
-version = '6.13.0-TESTPERF-SNAPSHOT'
+version = '6.13.0-SIGQA4-SNAPSHOT'
 
 ext.isSnapshot = project.version.endsWith('-SNAPSHOT')
 

--- a/channel-jira-cloud/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandler.java
@@ -111,14 +111,16 @@ public class JiraCloudCreateIssueEventHandler extends IssueTrackerCreateIssueEve
                 );
 
                 String jqlQuery = creationModel.getQueryString().orElse(null);
-                boolean issueDoesNotExist = checkIfIssueDoesNotExist(jiraCloudQueryExecutor, jqlQuery);
-                if (issueDoesNotExist) {
-                    List<IssueTrackerIssueResponseModel<String>> responses = messageSender.sendMessage(creationModel);
-                    postProcess(new IssueTrackerResponse<>("Success", responses));
-                    List<String> issueKeys = responses.stream()
-                        .map(IssueTrackerIssueResponseModel::getIssueId)
-                        .collect(Collectors.toList());
-                    logger.info("Created issues: {}", issueKeys);
+                synchronized (this) {
+                    boolean issueDoesNotExist = checkIfIssueDoesNotExist(jiraCloudQueryExecutor, jqlQuery);
+                    if (issueDoesNotExist) {
+                        List<IssueTrackerIssueResponseModel<String>> responses = messageSender.sendMessage(creationModel);
+                        postProcess(new IssueTrackerResponse<>("Success", responses));
+                        List<String> issueKeys = responses.stream()
+                            .map(IssueTrackerIssueResponseModel::getIssueId)
+                            .collect(Collectors.toList());
+                        logger.info("Created issues: {}", issueKeys);
+                    }
                 }
             } catch (AlertException ex) {
                 logger.error("Cannot create issue for job {}", jobId);

--- a/src/test/java/com/synopsys/integration/alert/performance/utility/ProcessingCompleteWaitJobTask.java
+++ b/src/test/java/com/synopsys/integration/alert/performance/utility/ProcessingCompleteWaitJobTask.java
@@ -94,6 +94,8 @@ public class ProcessingCompleteWaitJobTask implements WaitJobCondition {
             .filter(notificationTypeCount -> NotificationType.RULE_VIOLATION.equals(notificationTypeCount.getNotificationType()))
             .map(NotificationTypeCount::getCount)
             .reduce(0L, Long::sum);
+        // multiply be the number of expected Job IDs.
+        totalProviderNotificationCounts = totalProviderNotificationCounts * expectedJobIds.size();
 
         intLogger.info(String.format(
             "Performance: Found %s notifications, expected %s after time: %s. ",


### PR DESCRIPTION
use synchronized to lock on the search and creation of issues to deal with concurrency.