### PR TITLE
IALERT-3356: synchronize create

### DIFF
--- a/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/event/IssueTrackerCreateIssueEventListener.java
+++ b/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/event/IssueTrackerCreateIssueEventListener.java
@@ -7,7 +7,7 @@
  */
 package com.synopsys.integration.alert.api.channel.issue.event;
 
-import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.SyncTaskExecutor;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.distribution.JobSubTaskMessageListener;
@@ -16,10 +16,11 @@ import com.synopsys.integration.alert.descriptor.api.model.ChannelKey;
 public abstract class IssueTrackerCreateIssueEventListener extends JobSubTaskMessageListener<IssueTrackerCreateIssueEvent> {
     protected IssueTrackerCreateIssueEventListener(
         Gson gson,
-        TaskExecutor taskExecutor,
         ChannelKey channelKey,
         IssueTrackerCreateIssueEventHandler eventHandler
     ) {
-        super(gson, taskExecutor, IssueTrackerCreateIssueEvent.createDefaultEventDestination(channelKey), IssueTrackerCreateIssueEvent.class, eventHandler);
+        // Use the sync task executor to create issues in Jira synchronously.  This avoids creating duplicate issues concurrently.
+        // Pull one creation event off the queue at a time and create the issue.
+        super(gson, new SyncTaskExecutor(), IssueTrackerCreateIssueEvent.createDefaultEventDestination(channelKey), IssueTrackerCreateIssueEvent.class, eventHandler);
     }
 }

--- a/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCreateIssueEventListener.java
+++ b/channel-azure-boards/src/main/java/com/synopsys/integration/alert/channel/azure/boards/distribution/event/AzureBoardsCreateIssueEventListener.java
@@ -8,7 +8,6 @@
 package com.synopsys.integration.alert.channel.azure.boards.distribution.event;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Component;
 
 import com.google.gson.Gson;
@@ -20,10 +19,9 @@ public class AzureBoardsCreateIssueEventListener extends IssueTrackerCreateIssue
     @Autowired
     public AzureBoardsCreateIssueEventListener(
         Gson gson,
-        TaskExecutor taskExecutor,
         AzureBoardsChannelKey channelKey,
         AzureBoardsCreateIssueEventHandler eventHandler
     ) {
-        super(gson, taskExecutor, channelKey, eventHandler);
+        super(gson, channelKey, eventHandler);
     }
 }

--- a/channel-jira-cloud/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventListener.java
+++ b/channel-jira-cloud/src/main/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventListener.java
@@ -8,7 +8,6 @@
 package com.synopsys.integration.alert.channel.jira.cloud.distribution.event;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Component;
 
 import com.google.gson.Gson;
@@ -20,10 +19,9 @@ public class JiraCloudCreateIssueEventListener extends IssueTrackerCreateIssueEv
     @Autowired
     public JiraCloudCreateIssueEventListener(
         Gson gson,
-        TaskExecutor taskExecutor,
         JiraCloudChannelKey channelKey,
         JiraCloudCreateIssueEventHandler eventHandler
     ) {
-        super(gson, taskExecutor, channelKey, eventHandler);
+        super(gson, channelKey, eventHandler);
     }
 }

--- a/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventListenerTest.java
+++ b/channel-jira-cloud/src/test/java/com/synopsys/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventListenerTest.java
@@ -11,7 +11,6 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.amqp.core.Message;
-import org.springframework.core.task.SyncTaskExecutor;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.channel.issue.model.IssueCreationModel;
@@ -66,7 +65,7 @@ class JiraCloudCreateIssueEventListenerTest {
         Optional<JobSubTaskStatusModel> optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
         assertTrue(optionalJobSubTaskStatusModel.isPresent());
 
-        JiraCloudCreateIssueEventListener listener = new JiraCloudCreateIssueEventListener(gson, new SyncTaskExecutor(), ChannelKeys.JIRA_CLOUD, handler);
+        JiraCloudCreateIssueEventListener listener = new JiraCloudCreateIssueEventListener(gson, ChannelKeys.JIRA_CLOUD, handler);
         Message message = new Message(gson.toJson(event).getBytes());
         listener.onMessage(message);
 

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventListener.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventListener.java
@@ -8,7 +8,6 @@
 package com.synopsys.integration.alert.channel.jira.server.distribution.event;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Component;
 
 import com.google.gson.Gson;
@@ -20,10 +19,9 @@ public class JiraServerCreateIssueEventListener extends IssueTrackerCreateIssueE
     @Autowired
     public JiraServerCreateIssueEventListener(
         Gson gson,
-        TaskExecutor taskExecutor,
         JiraServerChannelKey channelKey,
         JiraServerCreateIssueEventHandler eventHandler
     ) {
-        super(gson, taskExecutor, channelKey, eventHandler);
+        super(gson, channelKey, eventHandler);
     }
 }

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventListenerTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventListenerTest.java
@@ -11,7 +11,6 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.amqp.core.Message;
-import org.springframework.core.task.SyncTaskExecutor;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.channel.issue.model.IssueCreationModel;
@@ -66,7 +65,7 @@ class JiraServerCreateIssueEventListenerTest {
         Optional<JobSubTaskStatusModel> optionalJobSubTaskStatusModel = jobSubTaskAccessor.getSubTaskStatus(parentEventId);
         assertTrue(optionalJobSubTaskStatusModel.isPresent());
 
-        JiraServerCreateIssueEventListener listener = new JiraServerCreateIssueEventListener(gson, new SyncTaskExecutor(), ChannelKeys.JIRA_SERVER, handler);
+        JiraServerCreateIssueEventListener listener = new JiraServerCreateIssueEventListener(gson, ChannelKeys.JIRA_SERVER, handler);
         Message message = new Message(gson.toJson(event).getBytes());
         listener.onMessage(message);
 


### PR DESCRIPTION
- Revert the change to autowire the task executor. 
- Use SyncTaskExecutor like in previous Alert versions.