### PR TITLE
IALERT-3364 : Handle issues found with LDAP

### DIFF
--- a/alert-database/src/main/resources/liquibase/6.13.0/migrate-ldap-configuration.xml
+++ b/alert-database/src/main/resources/liquibase/6.13.0/migrate-ldap-configuration.xml
@@ -26,7 +26,7 @@
                        null,
                        null,
                        null,
-                       null,
+                       'uniqueMember={0}',
                        null
                 FROM GET_GLOBAL_CONFIG_SOURCE_KEY_AND_FIELD_VALUE('component_authentication') configFields
                 WHERE configFields.source_key IS NOT NULL LIMIT 1;

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/MappingLdapAuthoritiesPopulator.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/MappingLdapAuthoritiesPopulator.java
@@ -31,7 +31,7 @@ public class MappingLdapAuthoritiesPopulator extends DefaultLdapAuthoritiesPopul
         try {
             grantedAuthorities.addAll(super.getGroupMembershipRoles(userDn, userName));
         } catch (Exception ex) {
-            logger.error("Error determining LDAP group membership.", ex);
+            logger.error("Could not map any roles from the LDAP server. Check Alert LDAP configuration and LDAP server configuration concerning group roles.", ex);
         }
         return grantedAuthorities;
     }

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManager.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManager.java
@@ -3,6 +3,8 @@ package com.synopsys.integration.alert.authentication.ldap.action;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ldap.core.support.DigestMd5DirContextAuthenticationStrategy;
 import org.springframework.ldap.core.support.DirContextAuthenticationStrategy;
@@ -25,6 +27,7 @@ import com.synopsys.integration.alert.authentication.ldap.model.LDAPConfigModel;
 
 @Component
 public class LdapManager {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final LDAPConfigAccessor ldapConfigAccessor;
     private final UserManagementAuthoritiesPopulator userManagementAuthoritiesPopulator;
     private final InetOrgPersonContextMapper inetOrgPersonContextMapper;
@@ -91,13 +94,15 @@ public class LdapManager {
 
     private DirContextAuthenticationStrategy createAuthenticationStrategy(LDAPConfigModel ldapConfigModel) {
         String authenticationType = ldapConfigModel.getAuthenticationType().orElse("");
-        DirContextAuthenticationStrategy strategy = null;
-        if (StringUtils.isNotBlank(authenticationType)) {
-            if ("digest".equalsIgnoreCase(authenticationType)) {
-                strategy = new DigestMd5DirContextAuthenticationStrategy();
-            } else if ("simple".equalsIgnoreCase(authenticationType)) {
-                strategy = new SimpleDirContextAuthenticationStrategy();
-            }
+        DirContextAuthenticationStrategy strategy;
+        logger.debug("LDAP Authentication Strategy: {}", authenticationType);
+
+        if ("none".equalsIgnoreCase(authenticationType)) {
+            strategy = null;
+        } else if ("digest".equalsIgnoreCase(authenticationType)) {
+            strategy = new DigestMd5DirContextAuthenticationStrategy();
+        } else {
+            strategy = new SimpleDirContextAuthenticationStrategy();
         }
 
         return strategy;

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/model/LDAPAuthenticationType.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/model/LDAPAuthenticationType.java
@@ -1,0 +1,20 @@
+package com.synopsys.integration.alert.authentication.ldap.model;
+
+import org.apache.commons.lang3.StringUtils;
+
+public enum LDAPAuthenticationType {
+    simple,
+    digest,
+    none;
+
+    public static String fromString(String authenticationType) {
+        if (StringUtils.isNotBlank(authenticationType)) {
+            try {
+                return LDAPAuthenticationType.valueOf(authenticationType.toLowerCase()).toString();
+            } catch (IllegalArgumentException e) {
+                // Ignored
+            }
+        }
+        return LDAPAuthenticationType.simple.toString();
+    }
+}

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/model/LDAPConfigModel.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/model/LDAPConfigModel.java
@@ -59,7 +59,7 @@ public class LDAPConfigModel extends ConfigWithMetadata implements Obfuscated<LD
         this(id, serverName, managerDn, managerPassword);
         this.enabled = enabled;
         this.isManagerPasswordSet = isManagerPasswordSet;
-        this.authenticationType = authenticationType;
+        this.authenticationType = LDAPAuthenticationType.fromString(authenticationType);
         this.referral = referral;
         this.userSearchBase = userSearchBase;
         this.userSearchFilter = userSearchFilter;
@@ -141,7 +141,7 @@ public class LDAPConfigModel extends ConfigWithMetadata implements Obfuscated<LD
     }
 
     public void setAuthenticationType(String authenticationType) {
-        this.authenticationType = authenticationType;
+        this.authenticationType = LDAPAuthenticationType.fromString(authenticationType);
     }
 
     public Optional<String> getReferral() {

--- a/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/action/LDAPCrudActionsTest.java
+++ b/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/action/LDAPCrudActionsTest.java
@@ -15,6 +15,7 @@ import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.authentication.descriptor.AuthenticationDescriptorKey;
 import com.synopsys.integration.alert.authentication.ldap.database.accessor.LDAPConfigAccessor;
 import com.synopsys.integration.alert.authentication.ldap.database.configuration.MockLDAPConfigurationRepository;
+import com.synopsys.integration.alert.authentication.ldap.model.LDAPAuthenticationType;
 import com.synopsys.integration.alert.authentication.ldap.model.LDAPConfigModel;
 import com.synopsys.integration.alert.authentication.ldap.validator.LDAPConfigurationValidator;
 import com.synopsys.integration.alert.common.AlertProperties;
@@ -29,6 +30,9 @@ import com.synopsys.integration.alert.test.common.AuthenticationTestUtils;
 import com.synopsys.integration.alert.test.common.MockAlertProperties;
 
 class LDAPCrudActionsTest {
+    private static final String DEFAULT_AUTHENTICATION_TYPE_SIMPLE = LDAPAuthenticationType.simple.name();
+    private static final String DEFAULT_AUTHENTICATION_TYPE_DIGEST = LDAPAuthenticationType.digest.name();
+
     private static LDAPCrudActions ldapCrudActions;
     private static LDAPConfigModel ldapConfigModel;
 
@@ -95,15 +99,15 @@ class LDAPCrudActionsTest {
         assertTrue(actionResponseCreate.isSuccessful());
         assertEquals(HttpStatus.OK, actionResponseCreate.getHttpStatus());
         assertTrue(actionResponseCreate.hasContent());
-        assertEquals("authenticationType", createdLDAPConfigModel.getAuthenticationType().orElse("FAIL"));
+        assertEquals(DEFAULT_AUTHENTICATION_TYPE_SIMPLE, createdLDAPConfigModel.getAuthenticationType().orElse("FAIL"));
 
-        ldapConfigModel.setAuthenticationType("UPDATE");
+        ldapConfigModel.setAuthenticationType(DEFAULT_AUTHENTICATION_TYPE_DIGEST);
         ActionResponse<LDAPConfigModel> actionResponseUpdate = ldapCrudActions.update(ldapConfigModel);
         LDAPConfigModel updatedLDAPConfigModel = actionResponseUpdate.getContent().orElseThrow(() -> new AssertionFailedError("Updated LDAPConfigModel did not exist"));
         assertTrue(actionResponseUpdate.isSuccessful());
         assertEquals(HttpStatus.OK, actionResponseUpdate.getHttpStatus());
         assertTrue(actionResponseUpdate.hasContent());
-        assertEquals("UPDATE", updatedLDAPConfigModel.getAuthenticationType().orElse("FAIL"));
+        assertEquals(DEFAULT_AUTHENTICATION_TYPE_DIGEST, updatedLDAPConfigModel.getAuthenticationType().orElse("FAIL"));
     }
 
     @Test
@@ -137,7 +141,7 @@ class LDAPCrudActionsTest {
             "managerDn",
             "managerPassword",
             true,
-            "authenticationType",
+            DEFAULT_AUTHENTICATION_TYPE_SIMPLE,
             "referral",
             "userSearchBase",
             "userSearchFilter",

--- a/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManagerTest.java
+++ b/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/action/LdapManagerTest.java
@@ -24,6 +24,7 @@ import com.synopsys.integration.alert.api.authentication.security.UserManagement
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.authentication.ldap.database.accessor.LDAPConfigAccessor;
 import com.synopsys.integration.alert.authentication.ldap.database.configuration.MockLDAPConfigurationRepository;
+import com.synopsys.integration.alert.authentication.ldap.model.LDAPAuthenticationType;
 import com.synopsys.integration.alert.authentication.ldap.model.LDAPConfigModel;
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
@@ -35,8 +36,8 @@ import com.synopsys.integration.alert.test.common.MockAlertProperties;
 public class LdapManagerTest {
     private static final String DEFAULT_CONFIG_ID = UUID.randomUUID().toString();
     private static final String DEFAULT_DATE_STRING = DateUtils.createCurrentDateString(DateUtils.UTC_DATE_FORMAT_TO_MINUTE);
-    private static final String DEFAULT_AUTHENTICATION_TYPE_SIMPLE = "simple";
-    private static final String DEFAULT_AUTHENTICATION_TYPE_DIGEST = "digest";
+    private static final String DEFAULT_AUTHENTICATION_TYPE_SIMPLE = LDAPAuthenticationType.simple.name();
+    private static final String DEFAULT_AUTHENTICATION_TYPE_DIGEST = LDAPAuthenticationType.digest.name();
     private static final String DEFAULT_GROUP_ROLE_ATTRIBUTE = "groupRoleAttribute";
     private static final String DEFAULT_GROUP_SEARCH_BASE = "groupSearchBase";
     private static final String DEFAULT_GROUP_SEARCH_FILTER = "groupSearchFilter";
@@ -85,7 +86,7 @@ public class LdapManagerTest {
         assertEquals(DEFAULT_MANAGER_DN, expectedLDAPConfigModel.getManagerDn());
         assertTrue(expectedLDAPConfigModel.getManagerPassword().isPresent());
         assertOptionalField(DEFAULT_MANAGER_PASSWORD, expectedLDAPConfigModel::getManagerPassword);
-        assertEquals("", expectedLDAPConfigModel.getAuthenticationType().orElse(""));
+        assertEquals(DEFAULT_AUTHENTICATION_TYPE_SIMPLE, expectedLDAPConfigModel.getAuthenticationType().orElse(""));
         assertOptionalField(DEFAULT_REFERRAL, expectedLDAPConfigModel::getReferral);
         assertOptionalField(DEFAULT_USER_SEARCH_BASE, expectedLDAPConfigModel::getUserSearchBase);
         assertOptionalField(DEFAULT_USER_SEARCH_FILTER, expectedLDAPConfigModel::getUserSearchFilter);
@@ -136,7 +137,7 @@ public class LdapManagerTest {
         LDAPConfigModel expectedLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Expected LDAPConfigModel did not exist"));
         assertDoesNotThrow(() -> ldapManager.getAuthenticationProvider());
-        assertEquals("", expectedLDAPConfigModel.getAuthenticationType().orElse(""));
+        assertEquals(DEFAULT_AUTHENTICATION_TYPE_SIMPLE, expectedLDAPConfigModel.getAuthenticationType().orElse(""));
     }
 
     @Test
@@ -166,7 +167,7 @@ public class LdapManagerTest {
         LDAPConfigModel expectedLDAPConfigModel = ldapManager.getCurrentConfiguration()
             .orElseThrow(() -> new AssertionFailedError("Expected LDAPConfigModel did not exist"));
         assertDoesNotThrow(() -> ldapManager.getAuthenticationProvider());
-        assertOptionalField("Unsupported authentication type", expectedLDAPConfigModel::getAuthenticationType);
+        assertOptionalField(DEFAULT_AUTHENTICATION_TYPE_SIMPLE, expectedLDAPConfigModel::getAuthenticationType);
     }
 
     @Test

--- a/ui/src/main/js/application/auth/LdapForm.js
+++ b/ui/src/main/js/application/auth/LdapForm.js
@@ -22,14 +22,14 @@ const useStyles = createUseStyles({
 });
 
 const AUTH_TYPES = [
-    { label: 'Simple', value: 'simple' },
+    { label: 'Digest-MD5', value: 'digest' },
     { label: 'None', value: 'none' },
-    { label: 'Digest-MD5', value: 'digest' }
+    { label: 'Simple', value: 'simple' }
 ];
 
 const REFERRAL_TYPES = [
-    { label: 'Ignore', value: 'ignore' },
     { label: 'Follow', value: 'follow' },
+    { label: 'Ignore', value: 'ignore' },
     { label: 'Throw', value: 'throw' }
 ];
 
@@ -94,7 +94,7 @@ const LdapForm = ({ csrfToken, errorHandler, readonly, displayTest }) => {
         return ConfigurationRequestBuilder.createValidateRequest(ldapRequestUrl, csrfToken, formData);
     }
 
-    // Revise this to it's own modal when we overhaul the modal changes.
+    // Revise this to its own modal when we overhaul the modal changes.
     const testFields = (
         <div>
             <h2>LDAP Configuration</h2>

--- a/ui/src/main/js/application/auth/LdapForm.js
+++ b/ui/src/main/js/application/auth/LdapForm.js
@@ -43,6 +43,8 @@ const LdapForm = ({ csrfToken, errorHandler, readonly, displayTest }) => {
     function processFormData() {
         if (formData?.authenticationType && formData?.authenticationType.length > 0 && Array.isArray(formData?.authenticationType)) {
             formData.authenticationType = formData.authenticationType[0];
+        } else {
+            formData.authenticationType = 'simple'
         }
 
         if (formData?.referral && formData?.referral.length > 0 && Array.isArray(formData?.referral)) {


### PR DESCRIPTION
* Prior versions of Alert set a default for Group Search Filter that was not saved in the DB. Update liquibase migration to set this default in the DB when performing a migration.
* Improve error message when Group settings aren't set.
* Reorder items in UI for "Authentication Type" and "Referral".
* When setting Authentication Type, set default too simple if value is empty, null, or not one of the supported values.
* Update tests

**Tests were changed to leverage a new LDAPTestHelper in master. These tests will be updated when v6.13.0 is merged into master.**