### PR TITLE
IALERT-3369: Address getting username for LDAP users

### DIFF
--- a/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/security/event/AuthenticationEventManager.java
+++ b/api-authentication/src/main/java/com/synopsys/integration/alert/api/authentication/security/event/AuthenticationEventManager.java
@@ -33,14 +33,13 @@ public class AuthenticationEventManager {
     }
 
     public void sendAuthenticationEvent(Authentication authentication, AuthenticationType authenticationType) {
-        String username = null;
-        String emailAddress = null;
+        String emailAddress;
         try {
+            String username = authentication.getName();
             Object authPrincipal = authentication.getPrincipal();
             if (authPrincipal instanceof InetOrgPerson) {
                 emailAddress = ((InetOrgPerson) authPrincipal).getMail();
             } else {
-                username = authentication.getName();
                 emailAddress = StringUtils.contains(username, "@") ? username : null;
             }
             sendAuthenticationEvent(username, emailAddress, authenticationType, authentication.getAuthorities());


### PR DESCRIPTION
Correct issue of username not being set when authenticating via LDAP.