### PR TITLE
fix: Issue tracking jobs in pending status.

### DIFF
--- a/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/send/IssueTrackerAsyncMessageSender.java
+++ b/api-channel-issue-tracker/src/main/java/com/synopsys/integration/alert/api/channel/issue/send/IssueTrackerAsyncMessageSender.java
@@ -17,6 +17,7 @@ import com.synopsys.integration.alert.api.distribution.execution.JobStage;
 import com.synopsys.integration.alert.api.distribution.execution.JobStageStartedEvent;
 import com.synopsys.integration.alert.api.event.AlertEvent;
 import com.synopsys.integration.alert.api.event.EventManager;
+import com.synopsys.integration.alert.common.enumeration.AuditEntryStatus;
 import com.synopsys.integration.alert.common.persistence.accessor.JobSubTaskAccessor;
 
 public class IssueTrackerAsyncMessageSender<T extends Serializable> {
@@ -63,6 +64,11 @@ public class IssueTrackerAsyncMessageSender<T extends Serializable> {
         executingJobManager.incrementSentNotificationCount(jobExecutionId, notificationIds.size());
         if (eventList.isEmpty()) {
             jobSubTaskAccessor.removeSubTaskStatus(parentEventId);
+            if (!executingJobManager.hasRemainingEvents(jobExecutionId)
+                && executingJobManager.hasSentExpectedNotifications(jobExecutionId)) {
+                executingJobManager.updateJobStatus(jobExecutionId, AuditEntryStatus.SUCCESS);
+                executingJobManager.endJob(jobExecutionId, Instant.now());
+            }
         } else {
             jobSubTaskAccessor.updateTaskCount(parentEventId, (long) eventList.size());
             executingJobManager.incrementRemainingEvents(jobExecutionId, eventList.size());

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/ExecutingJob.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/ExecutingJob.java
@@ -20,6 +20,7 @@ public class ExecutingJob {
 
     private final AtomicInteger remainingEvents;
 
+    private final AtomicInteger expectedNotificationsToSend;
     private final AtomicInteger notificationsSent;
 
     private final Map<JobStage, ExecutingJobStage> stages = new ConcurrentHashMap<>();
@@ -36,6 +37,7 @@ public class ExecutingJob {
         this.processedNotificationCount = new AtomicInteger(0);
         this.totalNotificationCount = new AtomicInteger(totalNotificationCount);
         this.remainingEvents = new AtomicInteger(0);
+        this.expectedNotificationsToSend = new AtomicInteger(0);
         this.notificationsSent = new AtomicInteger(0);
     }
 
@@ -72,6 +74,12 @@ public class ExecutingJob {
     public void updateNotificationCount(int notificationCount) {
         synchronized (this) {
             this.processedNotificationCount.addAndGet(notificationCount);
+        }
+    }
+
+    public void incrementExpectedNotificationsSent(int notificationCount) {
+        synchronized (this) {
+            this.expectedNotificationsToSend.addAndGet(notificationCount);
         }
     }
 
@@ -117,6 +125,10 @@ public class ExecutingJob {
 
     public int getTotalNotificationCount() {
         return totalNotificationCount.get();
+    }
+
+    public int getExpectedNotificationsToSend() {
+        return expectedNotificationsToSend.get();
     }
 
     public int getNotificationsSent() {

--- a/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/ExecutingJobManager.java
+++ b/api-distribution/src/main/java/com/synopsys/integration/alert/api/distribution/execution/ExecutingJobManager.java
@@ -125,6 +125,18 @@ public class ExecutingJobManager {
             .stream().anyMatch(remainingEventCount -> remainingEventCount > 0);
     }
 
+    public boolean hasSentExpectedNotifications(UUID jobExecutionId) {
+        return getExecutingJob(jobExecutionId)
+            .stream()
+            .anyMatch(executingJob -> executingJob.getExpectedNotificationsToSend() == executingJob.getNotificationsSent());
+    }
+
+    public void incrementExpectedNotificationsSent(UUID jobExecutionId, int notificationCount) {
+        logger.debug("Incrementing sent notification count for job execution {} by {}", jobExecutionId, notificationCount);
+        Optional<ExecutingJob> executingJob = getExecutingJob(jobExecutionId);
+        executingJob.ifPresent(execution -> execution.incrementExpectedNotificationsSent(notificationCount));
+    }
+
     public void incrementSentNotificationCount(UUID jobExecutionId, int notificationCount) {
         logger.debug("Incrementing sent notification count for job execution {} by {}", jobExecutionId, notificationCount);
         Optional<ExecutingJob> executingJob = getExecutingJob(jobExecutionId);

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/distribute/ProviderMessageDistributor.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/distribute/ProviderMessageDistributor.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.synopsys.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.common.logging.AlertLoggerFactory;
 import com.synopsys.integration.alert.common.persistence.accessor.ProcessingAuditAccessor;
@@ -33,11 +34,13 @@ public class ProviderMessageDistributor {
 
     private final ProcessingAuditAccessor auditAccessor;
     private final EventManager eventManager;
+    private final ExecutingJobManager executingJobManager;
 
     @Autowired
-    public ProviderMessageDistributor(ProcessingAuditAccessor auditAccessor, EventManager eventManager) {
+    public ProviderMessageDistributor(ProcessingAuditAccessor auditAccessor, EventManager eventManager, ExecutingJobManager executingJobManager) {
         this.auditAccessor = auditAccessor;
         this.eventManager = eventManager;
+        this.executingJobManager = executingJobManager;
     }
 
     public void distribute(ProcessedNotificationDetails processedNotificationDetails, ProcessedProviderMessageHolder processedMessageHolder) {
@@ -62,7 +65,7 @@ public class ProviderMessageDistributor {
     public void distributeIndividually(UUID jobExecutionId, UUID jobId, String jobName, ChannelKey destinationKey, ProcessedProviderMessageHolder processedMessageHolder) {
         Set<Long> notificationIds = processedMessageHolder.extractAllNotificationIds();
         //auditAccessor.createOrUpdatePendingAuditEntryForJob(jobId, notificationIds);
-
+        executingJobManager.incrementExpectedNotificationsSent(jobExecutionId, notificationIds.size());
         DistributionEvent event = new DistributionEvent(destinationKey, jobId, jobExecutionId, jobName, notificationIds, processedMessageHolder.toProviderMessageHolder());
         logger.info("Sending {}. Event ID: {}. Job ID: {}. Destination: {}", EVENT_CLASS_NAME, event.getEventId(), jobId, destinationKey);
         if (logger.isDebugEnabled()) {

--- a/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/JobNotificationProcessorTest.java
+++ b/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/JobNotificationProcessorTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mockito;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.synopsys.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.enumeration.ProcessingType;
@@ -80,7 +81,8 @@ class JobNotificationProcessorTest {
 
         MockProcessingAuditAccessor processingAuditAccessor = new MockProcessingAuditAccessor();
         EventManager eventManager = Mockito.mock(EventManager.class);
-        ProviderMessageDistributor providerMessageDistributor = new ProviderMessageDistributor(processingAuditAccessor, eventManager);
+        ExecutingJobManager executingJobManager = Mockito.mock(ExecutingJobManager.class);
+        ProviderMessageDistributor providerMessageDistributor = new ProviderMessageDistributor(processingAuditAccessor, eventManager, executingJobManager);
 
         NotificationExtractorBlackDuckServicesFactoryCache lifecycleCaches = createNotificationExtractorBlackDuckServicesFactoryCache();
 

--- a/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/distribute/ProviderMessageDistributorTest.java
+++ b/api-processor/src/test/java/com/synopsys/integration/alert/processor/api/distribute/ProviderMessageDistributorTest.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.synopsys.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.synopsys.integration.alert.api.event.EventManager;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
 import com.synopsys.integration.alert.descriptor.api.SlackChannelKey;
@@ -27,11 +28,12 @@ import com.synopsys.integration.alert.processor.api.extract.model.project.Projec
      void distributeTest() {
          MockProcessingAuditAccessor processingAuditAccessor = new MockProcessingAuditAccessor();
          EventManager eventManager = Mockito.mock(EventManager.class);
+         ExecutingJobManager executingJobManager = Mockito.mock(ExecutingJobManager.class);
 
          ProcessedNotificationDetails processedNotificationDetails = new ProcessedNotificationDetails(jobExecutionId, uuid, slackChannelKey.getUniversalKey(), "JobName");
          ProcessedProviderMessageHolder processedMessageHolder = createProcessedProviderMessageHolder(2, 2);
 
-         ProviderMessageDistributor providerMessageDistributor = new ProviderMessageDistributor(processingAuditAccessor, eventManager);
+         ProviderMessageDistributor providerMessageDistributor = new ProviderMessageDistributor(processingAuditAccessor, eventManager, executingJobManager);
          providerMessageDistributor.distribute(processedNotificationDetails, processedMessageHolder);
 
          Mockito.verify(eventManager, Mockito.times(4)).sendEvent(Mockito.any());
@@ -41,11 +43,12 @@ import com.synopsys.integration.alert.processor.api.extract.model.project.Projec
      void distributeMissingDestinationKeyTest() {
          MockProcessingAuditAccessor processingAuditAccessor = new MockProcessingAuditAccessor();
          EventManager eventManager = Mockito.mock(EventManager.class);
+         ExecutingJobManager executingJobManager = Mockito.mock(ExecutingJobManager.class);
 
          ProcessedNotificationDetails processedNotificationDetails = new ProcessedNotificationDetails(jobExecutionId, uuid, "bad channel key", "JobName");
          ProcessedProviderMessageHolder processedMessageHolder = createProcessedProviderMessageHolder(1, 0);
 
-         ProviderMessageDistributor providerMessageDistributor = new ProviderMessageDistributor(processingAuditAccessor, eventManager);
+         ProviderMessageDistributor providerMessageDistributor = new ProviderMessageDistributor(processingAuditAccessor, eventManager, executingJobManager);
          providerMessageDistributor.distribute(processedNotificationDetails, processedMessageHolder);
 
          Mockito.verify(eventManager, Mockito.times(0)).sendEvent(Mockito.any());

--- a/src/test/java/com/synopsys/integration/alert/processing/ProcessingJobEventHandlerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/processing/ProcessingJobEventHandlerTestIT.java
@@ -374,6 +374,6 @@ class ProcessingJobEventHandlerTestIT {
     private ProviderMessageDistributor createMockMessageDistributor() {
         EventManager eventManager = createMockEventManager();
         ProcessingAuditAccessor auditAccessor = createMockAuditAccessor();
-        return new ProviderMessageDistributor(auditAccessor, eventManager);
+        return new ProviderMessageDistributor(auditAccessor, eventManager, executingJobManager);
     }
 }


### PR DESCRIPTION
- Add a count of expected notifications.
- Increment the count of expected notifications before sending a distribution event.
- In the issue tracker if there are no remaining events and the expected number of notifications has been reached end the job with success.