### PR TITLE
IALERT-3384: Use lowercase search strings.

### DIFF
--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProcessingFailedAccessor.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/api/DefaultProcessingFailedAccessor.java
@@ -68,7 +68,7 @@ public class DefaultProcessingFailedAccessor implements ProcessingFailedAccessor
         PageRequest pageRequest = getPageRequestForFailures(pageNumber, pageSize, sortField, sortOrder);
         Page<AuditFailedEntity> matchingAuditEntities;
         if (StringUtils.isNotBlank(searchTerm)) {
-            matchingAuditEntities = auditFailedEntryRepository.findAllWithSearchTerm(searchTerm, pageRequest);
+            matchingAuditEntities = auditFailedEntryRepository.findAllWithSearchTerm(searchTerm.toLowerCase(), pageRequest);
         } else {
             matchingAuditEntities = auditFailedEntryRepository.findAll(pageRequest);
         }
@@ -243,15 +243,16 @@ public class DefaultProcessingFailedAccessor implements ProcessingFailedAccessor
 
     private PageRequest getPageRequestForFailures(Integer pageNumber, Integer pageSize, @Nullable String sortField, @Nullable String sortOrder) {
         boolean sortQuery = false;
+        String defaultSortField = "createdAt";
         String inputSortField;
-        String sortingField = "createdAt";
-        if ("lastSent".equals(sortField)) {
-            inputSortField = "createdAt";
+        String sortingField = defaultSortField;
+        if (!"lastSent".equals(sortField)) {
+            inputSortField = defaultSortField;
         } else {
             inputSortField = sortField;
         }
         List<String> validFields = List.of(
-            "createdAt",
+            defaultSortField,
             "jobName",
             "providerName",
             "channelName",

--- a/alert-database/src/main/resources/liquibase/6.13.0/audit-failed-table.xml
+++ b/alert-database/src/main/resources/liquibase/6.13.0/audit-failed-table.xml
@@ -11,7 +11,7 @@
             <column name="id" type="UUID" defaultValueComputed="uuid_generate_v4()">
                 <constraints primaryKey="true"/>
             </column>
-            <column name="time_created" type="TIMESTAMP">
+            <column name="time_created" type="TIMESTAMP WITH TIME ZONE">
                 <constraints nullable="false"/>
             </column>
             <column name="job_name" type="VARCHAR">


### PR DESCRIPTION
- Make the search string lowercase.
- Add the timezone to the audit failed table.

While testing this it has been uncovered that there is a known issue.  Searching for timestamps with JPQL using this in the query will not find the timestamps in the audit table:
`"COALESCE(to_char(failedAuditEntry.createdAt, 'MM/DD/YYYY, HH24:MI:SS'), '') LIKE %:searchTerm% OR "`

The search finds the timestamp that is in the raw notification content not the created at or last sent timestamp in the audit table.
