### PR TITLE
IALERT-3394 saml distjob not showing

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/security/authorization/AuthorizationManager.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/security/authorization/AuthorizationManager.java
@@ -22,7 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;

--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/security/authorization/AuthorizationManager.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/security/authorization/AuthorizationManager.java
@@ -234,8 +234,7 @@ public class AuthorizationManager {
             return Optional.empty();
         }
 
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        return Optional.of(userDetails.getUsername());
+        return Optional.of(authentication.getName());
     }
 
     private void loadPermissionsIntoCache() {


### PR DESCRIPTION
SAML principals cant be casted to UserDetails. Use authentication.getName instead (better support for different princpal types as well). Confirmed authentication.getName and UserDetails.getUsername values are the same for both db and saml login.