### PR TITLE
 Single SAML version defined in alert-platform only.

### DIFF
--- a/alert-platform/build.gradle
+++ b/alert-platform/build.gradle
@@ -32,6 +32,10 @@ dependencies {
         api 'org.javassist:javassist:3.24.0-GA'
         api 'io.springfox:springfox-boot-starter:3.0.0'
 
+        api "org.opensaml:opensaml-core:4.1.1"
+        api "org.opensaml:opensaml-saml-api:4.1.1"
+        api "org.opensaml:opensaml-saml-impl:4.1.1"
+
         runtime 'org.liquibase:liquibase-core:3.8.9'
         runtime 'io.springfox:springfox-swagger-ui:2.8.0'
     }

--- a/component/build.gradle
+++ b/component/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation 'org.apache.tomcat.embed:tomcat-embed-core'
     implementation 'org.springframework.amqp:spring-amqp'
 
+    // SAML
     implementation "org.opensaml:opensaml-core"
     implementation "org.opensaml:opensaml-saml-api"
     implementation "org.opensaml:opensaml-saml-impl"

--- a/component/build.gradle
+++ b/component/build.gradle
@@ -1,12 +1,6 @@
 ext.moduleName = 'com.synopsys.integration.alert.component'
 
 dependencies {
-    constraints {
-        implementation "org.opensaml:opensaml-core:4.1.1"
-        implementation "org.opensaml:opensaml-saml-api:4.1.1"
-        implementation "org.opensaml:opensaml-saml-impl:4.1.1"
-    }
-
     implementation platform(project(':alert-platform'))
 
     implementation project(':alert-common')
@@ -27,6 +21,10 @@ dependencies {
     implementation 'org.apache.tomcat.embed:tomcat-embed-core'
     implementation 'org.springframework.amqp:spring-amqp'
 
+    implementation "org.opensaml:opensaml-core"
+    implementation "org.opensaml:opensaml-saml-api"
+    implementation "org.opensaml:opensaml-saml-impl"
+
     // Spring Security
     implementation 'org.springframework.security:spring-security-config'
     implementation 'org.springframework.security:spring-security-core'
@@ -34,6 +32,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-web'
 
     implementation 'org.springframework.security:spring-security-saml2-service-provider'
+
 
     //rabbitmq
     implementation 'org.springframework.amqp:spring-amqp'


### PR DESCRIPTION
 - All specific versions being used in Alert should be defined in alert-platform.
 - There were openSAML libraries of version 3.4.6 in the dependency tree as a transitive in addition to 4.1.1 defined direct dependencies in the component project.
 - Specify the openSAML library versions to 4.1.1 accross the board. 