### PR TITLE
IALERT-3337: Policy filtering fix

### DIFF
--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/JobNotificationContentProcessor.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/JobNotificationContentProcessor.java
@@ -88,8 +88,6 @@ public class JobNotificationContentProcessor {
                 .stream()
                 .map(notificationDetailExtractionDelegator::wrapNotification)
                 .flatMap(List::stream)
-                //TODO lambda to filter by job details (filter by policy name/severity)
-                //create a private method that takes the notification and job info and looks if Policies exist. If so, perform the filter.
                 .filter(notificationContent -> applyDistributionJobFilters(notificationContent, job))
                 .map(DetailedNotificationContent::getNotificationContentWrapper)
                 .collect(Collectors.toList());

--- a/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/extract/ProviderMessageExtractionDelegator.java
+++ b/api-processor/src/main/java/com/synopsys/integration/alert/processor/api/extract/ProviderMessageExtractionDelegator.java
@@ -51,8 +51,8 @@ public final class ProviderMessageExtractionDelegator {
 
     private EnumMap<NotificationType, ProviderMessageExtractor> initializeExtractorMap(List<ProviderMessageExtractor> providerMessageExtractors) {
         return providerMessageExtractors
-                   .stream()
-                   .collect(DataStructureUtils.toEnumMap(ProviderMessageExtractor::getNotificationType, NotificationType.class));
+            .stream()
+            .collect(DataStructureUtils.toEnumMap(ProviderMessageExtractor::getNotificationType, NotificationType.class));
     }
 
 }


### PR DESCRIPTION
Policy notification, if they happen against the same component, can contain multiple policies in one notification. This is filtered during mapping but as a result of message extraction further down the line these policies are re-introduced as messages. This fix is it to perform an additional layer of filtering during message extraction by looking at the job details.