### PR TITLE
IALERT-3345/IALERT-3201 - Automate copyright year, add CommitHash to about page

### DIFF
--- a/buildSrc/buildTasks.gradle
+++ b/buildSrc/buildTasks.gradle
@@ -31,8 +31,16 @@ task cleanBundles(type: Delete) {
 tasks.clean.finalizedBy(cleanBundles)
 
 task createAboutText(type: Task) {
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+        standardOutput = stdout
+    }
+    def commitHash = stdout.toString().trim()
+
     final def aboutFile = new File("${projectDir}/src/main/resources/about.txt")
     aboutFile.delete()
+
     def readmeContentArray = new File("${projectDir}/README.md").text.readLines()
     def descriptionStart = readmeContentArray.indexOf("<!-- description-text-start -->") + 1
     def descriptionEnd = readmeContentArray.indexOf("<!-- description-text-end -->")
@@ -45,8 +53,10 @@ task createAboutText(type: Task) {
     gitUrl = gitUrl.substring(0, gitUrl.indexOf("releases"))
 
     def time = new Date().format('yyyy-MM-dd\'T\'HH:mm:ss.SSSSSS\'Z\'');
-    final def aboutJson = JsonOutput.toJson([version: version, projectUrl: gitUrl, description: description, created: time])
-    logger.info("About text file: {} content: {}", aboutFile, aboutJson)
+    def year = new Date().format('yyyy');
+
+    final def aboutJson = JsonOutput.toJson([version: version, projectUrl: gitUrl, description: description, created: time, copyrightYear: year, commitHash: commitHash])
+    logger.lifecycle("\nAbout text file: {} content: {}\n", aboutFile, aboutJson)
     aboutFile << aboutJson
 }
 

--- a/buildSrc/docker-v2.gradle
+++ b/buildSrc/docker-v2.gradle
@@ -161,4 +161,4 @@ dockerImagesToBuild.each { imageName ->
     project.tasks.findByName(dockerPublishAllImages).dependsOn dockerImagePublishTaskName
 }
 
-logger.lifecycle('The following Docker specific tasks were added --> ' + dockerTasksCreated)
+logger.lifecycle('\nThe following Docker specific tasks were added --> ' + dockerTasksCreated)

--- a/src/test/java/com/synopsys/integration/alert/common/message/model/AboutModelTest.java
+++ b/src/test/java/com/synopsys/integration/alert/common/message/model/AboutModelTest.java
@@ -1,6 +1,6 @@
 package com.synopsys.integration.alert.common.message.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Set;
 
@@ -17,6 +17,8 @@ public class AboutModelTest {
         String created = "date";
         String description = "description";
         String projectUrl = "https://www.google.com";
+        String commitHash = "abc123xyz";
+        String copyrightYear = "year";
         String documentationUrl = "https://www.google.com";
         boolean initialized = true;
         String startupTime = "startup time is now";
@@ -25,11 +27,14 @@ public class AboutModelTest {
         Set<DescriptorMetadata> providers = Set.of(providerMetadata);
         Set<DescriptorMetadata> channels = Set.of(channelMetadata);
 
-        AboutModel model = new AboutModel(version, created, description, projectUrl, documentationUrl, initialized, startupTime, providers, channels);
+        AboutModel model = new AboutModel(version, created, description, projectUrl, copyrightYear, documentationUrl, commitHash, initialized, startupTime, providers, channels);
 
         assertEquals(version, model.getVersion());
+        assertEquals(created, model.getCreated());
         assertEquals(description, model.getDescription());
         assertEquals(projectUrl, model.getProjectUrl());
+        assertEquals(commitHash, model.getCommitHash());
+        assertEquals(copyrightYear, model.getCopyrightYear());
         assertEquals(documentationUrl, model.getDocumentationUrl());
         assertEquals(initialized, model.isInitialized());
         assertEquals(startupTime, model.getStartupTime());

--- a/ui/src/main/js/page/about/AboutInfo.js
+++ b/ui/src/main/js/page/about/AboutInfo.js
@@ -11,7 +11,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { EXISTING_CHANNELS, EXISTING_PROVIDERS } from 'common/DescriptorInfo';
 
 const AboutInfo = ({
-    getAbout, version, projectUrl, documentationUrl, globalDescriptorMap, distributionDescriptorMap
+    getAbout, version, projectUrl, commitHash, documentationUrl, globalDescriptorMap, distributionDescriptorMap
 }) => {
     useEffect(() => {
         getAbout();
@@ -85,6 +85,7 @@ const AboutInfo = ({
     const channelTable = createDescriptorTable('about-channels', channelData, '/alert/channels/', 'Distribution Channels');
     const providersMissing = !providerData || providerData.length <= 0;
     const channelsMissing = !channelData || channelData.length <= 0;
+    const commitHashUrl = projectUrl + "/commit/" + commitHash
 
     return (
         <div>
@@ -98,6 +99,7 @@ const AboutInfo = ({
                     value="This application provides the ability to send notifications from a provider to various distribution channels."
                 />
                 <ReadOnlyField id="about-version" label="Version" name="version" readOnly="true" value={version} />
+                <ReadOnlyField id="about-commit-hash" label="Commit Hash" name="commitHash" readOnly="true" value={commitHash} url={commitHashUrl} />
                 <ReadOnlyField
                     id="about-url"
                     label="Project URL"
@@ -149,6 +151,7 @@ AboutInfo.propTypes = {
     getAbout: PropTypes.func.isRequired,
     version: PropTypes.string.isRequired,
     projectUrl: PropTypes.string.isRequired,
+    commitHash: PropTypes.string.isRequired,
     documentationUrl: PropTypes.string.isRequired,
     globalDescriptorMap: PropTypes.object.isRequired,
     distributionDescriptorMap: PropTypes.object.isRequired
@@ -157,6 +160,7 @@ AboutInfo.propTypes = {
 const mapStateToProps = (state) => ({
     version: state.about.version,
     projectUrl: state.about.projectUrl,
+    commitHash: state.about.commitHash,
     documentationUrl: state.about.documentationUrl
 });
 

--- a/ui/src/main/js/page/about/AboutInfoFooter.js
+++ b/ui/src/main/js/page/about/AboutInfoFooter.js
@@ -152,7 +152,7 @@ class AboutInfoFooter extends React.Component {
     }
 
     render() {
-        const { version, projectUrl } = this.props;
+        const { version, projectUrl, copyrightYear } = this.props;
         const errorComponent = this.createErrorComponent();
         return (
             <div className="footer">
@@ -171,7 +171,7 @@ class AboutInfoFooter extends React.Component {
                     {version}
                 </span>
                 <span className="copyright">
-                    &nbsp;© 2023&nbsp;
+                    &nbsp;© {copyrightYear}&nbsp;
                     <a id="aboutLink" href="https://www.synopsys.com/">Synopsys, Inc.</a>
                     &nbsp;All rights reserved
                 </span>
@@ -188,6 +188,7 @@ AboutInfoFooter.propTypes = {
     version: PropTypes.string.isRequired,
     description: PropTypes.string,
     projectUrl: PropTypes.string.isRequired,
+    copyrightYear: PropTypes.string.isRequired,
     latestMessages: PropTypes.arrayOf(PropTypes.object)
 };
 
@@ -202,6 +203,7 @@ const mapStateToProps = (state) => ({
     version: state.about.version,
     description: state.about.description,
     projectUrl: state.about.projectUrl,
+    copyrightYear: state.about.copyrightYear,
     latestMessages: state.system.latestMessages
 });
 

--- a/ui/src/main/js/store/reducers/about.js
+++ b/ui/src/main/js/store/reducers/about.js
@@ -5,6 +5,8 @@ const initialState = {
     version: '',
     description: '',
     projectUrl: '',
+    commitHash: '',
+    copyrightYear: '',
     documentationUrl: '',
     channelList: [],
     providerList: [],
@@ -24,10 +26,12 @@ const config = (state = initialState, action) => {
                 version: action.version,
                 description: action.description,
                 projectUrl: action.projectUrl,
+                commitHash: action.commitHash,
+                copyrightYear: action.copyrightYear,
                 documentationUrl: action.documentationUrl,
                 initialized: action.initialized,
                 startupTime: action.startupTime,
-                providerList: action.providers,
+                providerList: action.providerList,
                 channelList: action.channels
             };
         case ABOUT_INFO_FETCH_ERROR:

--- a/web/src/main/java/com/synopsys/integration/alert/web/api/about/AboutModel.java
+++ b/web/src/main/java/com/synopsys/integration/alert/web/api/about/AboutModel.java
@@ -17,6 +17,8 @@ public class AboutModel extends AlertSerializableModel {
     private String created;
     private String description;
     private String projectUrl;
+    private String commitHash;
+    private String copyrightYear;
     private String documentationUrl;
     private boolean initialized;
     private String startupTime;
@@ -32,6 +34,8 @@ public class AboutModel extends AlertSerializableModel {
         String created,
         String description,
         String projectUrl,
+        String commitHash,
+        String copyrightYear,
         String documentationUrl,
         boolean initialized,
         String startupTime,
@@ -42,6 +46,8 @@ public class AboutModel extends AlertSerializableModel {
         this.created = created;
         this.description = description;
         this.projectUrl = projectUrl;
+        this.commitHash = commitHash;
+        this.copyrightYear = copyrightYear;
         this.documentationUrl = documentationUrl;
         this.initialized = initialized;
         this.startupTime = startupTime;
@@ -63,6 +69,14 @@ public class AboutModel extends AlertSerializableModel {
 
     public String getProjectUrl() {
         return projectUrl;
+    }
+
+    public String getCommitHash() {
+        return commitHash;
+    }
+
+    public String getCopyrightYear() {
+        return copyrightYear;
     }
 
     public String getDocumentationUrl() {

--- a/web/src/main/java/com/synopsys/integration/alert/web/api/about/AboutReader.java
+++ b/web/src/main/java/com/synopsys/integration/alert/web/api/about/AboutReader.java
@@ -54,8 +54,19 @@ public class AboutReader {
             String startupDate = systemStatusAccessor.getStartupTime() != null ? DateUtils.formatDateAsJsonString(systemStatusAccessor.getStartupTime()) : "";
             Set<DescriptorMetadata> providers = getDescriptorData(DescriptorType.PROVIDER);
             Set<DescriptorMetadata> channels = getDescriptorData(DescriptorType.CHANNEL);
-            AboutModel model = new AboutModel(aboutModel.getVersion(), aboutModel.getCreated(), aboutModel.getDescription(), aboutModel.getProjectUrl(),
-                createSwaggerUrl(SwaggerConfiguration.SWAGGER_DEFAULT_PATH_SPEC), systemStatusAccessor.isSystemInitialized(), startupDate, providers, channels);
+            AboutModel model = new AboutModel(
+                aboutModel.getVersion(),
+                aboutModel.getCreated(),
+                aboutModel.getDescription(),
+                aboutModel.getProjectUrl(),
+                aboutModel.getCommitHash(),
+                aboutModel.getCopyrightYear(),
+                createSwaggerUrl(SwaggerConfiguration.SWAGGER_DEFAULT_PATH_SPEC),
+                systemStatusAccessor.isSystemInitialized(),
+                startupDate,
+                providers,
+                channels
+            );
             return Optional.of(model);
         } catch (Exception e) {
             logger.error(e.getMessage(), e);

--- a/web/src/test/java/com/synopsys/integration/alert/web/api/about/AboutActionsTest.java
+++ b/web/src/test/java/com/synopsys/integration/alert/web/api/about/AboutActionsTest.java
@@ -25,6 +25,8 @@ public class AboutActionsTest {
         String created = "date";
         String description = "description";
         String aUrl = "https://www.google.com";
+        String commitHash = "abc123xyz";
+        String copyrightYear = "year";
         boolean initialized = true;
         String startupTime = "startup time is now";
         DescriptorMetadata providerMetadata = Mockito.mock(DescriptorMetadata.class);
@@ -32,7 +34,7 @@ public class AboutActionsTest {
         Set<DescriptorMetadata> providers = Set.of(providerMetadata);
         Set<DescriptorMetadata> channels = Set.of(channelMetadata);
 
-        AboutModel model = new AboutModel(version, created, description, aUrl, aUrl, initialized, startupTime, providers, channels);
+        AboutModel model = new AboutModel(version, created, description, aUrl, commitHash, copyrightYear, aUrl, initialized, startupTime, providers, channels);
         AboutReader aboutReader = Mockito.mock(AboutReader.class);
         Mockito.when(aboutReader.getAboutModel()).thenReturn(Optional.of(model));
         AboutActions aboutActions = new AboutActions(aboutReader);


### PR DESCRIPTION
* (IALERT-3345) Update setting the copyright year at build time
* (IALERT-3201) Add the git commit hash to the about page as a link to the github repository
* Update tests to reflect changes above

<img width="763" alt="IALERT-3201-ScreenShot" src="https://user-images.githubusercontent.com/30127554/225716480-96ade313-888f-476b-89cd-e36f96d8f023.png">
