### PR TITLE
IALERT-3307 email attachment fix

### DIFF
--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/attachment/EmailAttachmentFileCreator.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/attachment/EmailAttachmentFileCreator.java
@@ -25,10 +25,12 @@ import com.google.gson.Gson;
 import com.synopsys.integration.alert.channel.email.attachment.compatibility.MessageContentGroup;
 import com.synopsys.integration.alert.channel.email.distribution.ProjectMessageToMessageContentGroupConversionUtils;
 import com.synopsys.integration.alert.common.AlertProperties;
+import com.synopsys.integration.alert.common.util.DateUtils;
 import com.synopsys.integration.alert.processor.api.extract.model.project.ProjectMessage;
 
 @Component
 public class EmailAttachmentFileCreator {
+    public static final String EMAIL_ATTACHMENT_DATE_FORMAT = "yyyy-MM-dd'T'HH-mm-ss.SSSSSS'Z'";
     private final Logger logger = LoggerFactory.getLogger(EmailAttachmentFileCreator.class);
 
     private final AlertProperties alertProperties;
@@ -113,7 +115,9 @@ public class EmailAttachmentFileCreator {
     }
 
     private File createFile(String messageString, File writeDir, String fileExtension) throws IOException {
-        File messageFile = new File(writeDir, "message." + fileExtension);
+        String timeStamp = DateUtils.createCurrentDateString(EMAIL_ATTACHMENT_DATE_FORMAT);
+        String fileName = String.format("message-%s.%s", timeStamp, fileExtension);
+        File messageFile = new File(writeDir, fileName);
         FileUtils.writeStringToFile(messageFile, messageString, Charset.defaultCharset());
         return messageFile;
     }

--- a/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/distribution/EmailChannelMessagingService.java
+++ b/channel-email/src/main/java/com/synopsys/integration/alert/channel/email/distribution/EmailChannelMessagingService.java
@@ -47,7 +47,12 @@ public class EmailChannelMessagingService {
         return sendMessageWithAttachedProjectMessage(smtpConfig, emailTarget, null, EmailAttachmentFormat.NONE);
     }
 
-    public MessageResult sendMessageWithAttachedProjectMessage(SmtpConfig smtpConfig, EmailTarget emailTarget, ProjectMessage message, EmailAttachmentFormat attachmentFormat) throws AlertException {
+    public MessageResult sendMessageWithAttachedProjectMessage(
+        SmtpConfig smtpConfig,
+        EmailTarget emailTarget,
+        ProjectMessage message,
+        EmailAttachmentFormat attachmentFormat
+    ) throws AlertException {
         sendMessageWithAttachmentAndCleanUp(smtpConfig, emailTarget, message, attachmentFormat);
 
         return new MessageResult(String.format("Successfully sent %d email(s)", emailTarget.getEmailAddresses().size()));
@@ -75,7 +80,12 @@ public class EmailChannelMessagingService {
         return new EmailTarget(gatheredEmailAddresses, FILE_NAME_MESSAGE_TEMPLATE, model, contentIdsToFilePaths);
     }
 
-    private void sendMessageWithAttachmentAndCleanUp(SmtpConfig smtpConfig, EmailTarget emailTarget, ProjectMessage projectMessage, EmailAttachmentFormat attachmentFormat) throws AlertException {
+    private void sendMessageWithAttachmentAndCleanUp(
+        SmtpConfig smtpConfig,
+        EmailTarget emailTarget,
+        ProjectMessage projectMessage,
+        EmailAttachmentFormat attachmentFormat
+    ) throws AlertException {
         Optional<File> optionalAttachmentFile = Optional.empty();
 
         if (projectMessage != null) {

--- a/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/EmailAttachmentFileCreatorTest.java
+++ b/channel-email/src/test/java/com/synopsys/integration/alert/channel/email/attachment/EmailAttachmentFileCreatorTest.java
@@ -1,0 +1,75 @@
+package com.synopsys.integration.alert.channel.email.attachment;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.Optional;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.alert.common.message.model.LinkableItem;
+import com.synopsys.integration.alert.processor.api.extract.model.ProviderDetails;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ProjectMessage;
+import com.synopsys.integration.alert.processor.api.extract.model.project.ProjectOperation;
+import com.synopsys.integration.alert.test.common.MockAlertProperties;
+
+class EmailAttachmentFileCreatorTest {
+    private static MockAlertProperties alertProperties;
+    private final MessageContentGroupCsvCreator messageContentGroupCsvCreator = new MessageContentGroupCsvCreator();
+    private final Gson gson = new Gson();
+
+    private final String providerTestString = "Provider Test Message";
+    private final String projectTestString = "Common Project Test Message";
+    private ProjectMessage projectMessage;
+
+    @BeforeEach
+    void init() {
+        alertProperties = new MockAlertProperties();
+        alertProperties.setAlertEmailAttachmentsDir("/tmp");
+
+        LinkableItem provider = new LinkableItem("Provider", providerTestString);
+        ProviderDetails providerDetails = new ProviderDetails(1L, provider);
+        projectMessage = ProjectMessage.projectStatusInfo(providerDetails, new LinkableItem("Project", projectTestString), ProjectOperation.CREATE);
+    }
+
+    @Test
+    void testCreateCsv() {
+        EmailAttachmentFileCreator emailAttachmentFileCreator = new EmailAttachmentFileCreator(alertProperties, messageContentGroupCsvCreator, gson);
+        Optional<File> csvFile = emailAttachmentFileCreator.createAttachmentFile(EmailAttachmentFormat.CSV, projectMessage);
+
+        assertTrue(csvFile.isPresent());
+        String csvContent = assertDoesNotThrow(() -> FileUtils.readFileToString(csvFile.get(), Charset.defaultCharset()));
+        assertTrue(csvContent.contains(providerTestString));
+        assertTrue(csvContent.contains(projectTestString));
+        assertDoesNotThrow(() -> emailAttachmentFileCreator.cleanUpAttachmentFile(csvFile.get()));
+    }
+
+    @Test
+    void testCreateJson() {
+        EmailAttachmentFileCreator emailAttachmentFileCreator = new EmailAttachmentFileCreator(alertProperties, messageContentGroupCsvCreator, gson);
+        Optional<File> jsonFile = emailAttachmentFileCreator.createAttachmentFile(EmailAttachmentFormat.JSON, projectMessage);
+
+        assertTrue(jsonFile.isPresent());
+        String jsonContent = assertDoesNotThrow(() -> FileUtils.readFileToString(jsonFile.get(), Charset.defaultCharset()));
+        assertTrue(jsonContent.contains(providerTestString));
+        assertTrue(jsonContent.contains(projectTestString));
+        assertDoesNotThrow(() -> emailAttachmentFileCreator.cleanUpAttachmentFile(jsonFile.get()));
+    }
+
+    @Test
+    void testCreateXml() {
+        EmailAttachmentFileCreator emailAttachmentFileCreator = new EmailAttachmentFileCreator(alertProperties, messageContentGroupCsvCreator, gson);
+        Optional<File> xmlFile = emailAttachmentFileCreator.createAttachmentFile(EmailAttachmentFormat.XML, projectMessage);
+
+        assertTrue(xmlFile.isPresent());
+        String xmlContent = assertDoesNotThrow(() -> FileUtils.readFileToString(xmlFile.get(), Charset.defaultCharset()));
+        assertTrue(xmlContent.contains(providerTestString));
+        assertTrue(xmlContent.contains(projectTestString));
+        assertDoesNotThrow(() -> emailAttachmentFileCreator.cleanUpAttachmentFile(xmlFile.get()));
+    }
+}

--- a/test-common/src/main/java/com/synopsys/integration/alert/test/common/MockAlertProperties.java
+++ b/test-common/src/main/java/com/synopsys/integration/alert/test/common/MockAlertProperties.java
@@ -34,6 +34,7 @@ public class MockAlertProperties extends AlertProperties {
     private boolean sslEnabled = false;
     private String encryptionPassword;
     private String encryptionSalt;
+    private String alertEmailAttachmentsDir;
 
     public MockAlertProperties() {
         alertImagesDir = computeImagesDirPath().toString();
@@ -113,6 +114,15 @@ public class MockAlertProperties extends AlertProperties {
 
     public void setAlertSecretsDir(String alertSecretsDir) {
         this.alertSecretsDir = alertSecretsDir;
+    }
+
+    @Override
+    public String getAlertEmailAttachmentsDir() {
+        return this.alertEmailAttachmentsDir;
+    }
+
+    public void setAlertEmailAttachmentsDir(String alertEmailAttachmentsDir) {
+        this.alertEmailAttachmentsDir = alertEmailAttachmentsDir;
     }
 
     private Path computeImagesDirPath() {


### PR DESCRIPTION
Email attachments when occurring for multiple projects are broken up and distributed per project. Due to our concurrency changes this resulted in us having concurrency issue where we were trying to write to the same file multiple times. This resulted in an IOException, and submitting the wrong csv for the wrong project.

We will now create attachment files by adding a date timestamp to the file name.