### PR TITLE
Fix test to check primitive timestamps.

### DIFF
--- a/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditEventTest.java
+++ b/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditEventTest.java
@@ -1,8 +1,9 @@
 package com.synopsys.integration.alert.api.distribution.audit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Instant;
 import java.util.Set;
 import java.util.UUID;
 
@@ -12,6 +13,7 @@ class AuditEventTest {
 
     @Test
     void constructorTest() {
+        long testTime = Instant.now().toEpochMilli();
         String destination = "destination";
         UUID jobConfigId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
@@ -21,6 +23,6 @@ class AuditEventTest {
         assertEquals(destination, event.getDestination());
         assertEquals(jobExecutionId, event.getJobExecutionId());
         assertEquals(notificationIds, event.getNotificationIds());
-        assertNotNull(event.getCreatedTimestamp());
+        assertTrue(testTime <= event.getCreatedTimestamp());
     }
 }

--- a/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedEventTest.java
+++ b/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditFailedEventTest.java
@@ -1,9 +1,9 @@
 package com.synopsys.integration.alert.api.distribution.audit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Instant;
 import java.util.Set;
 import java.util.UUID;
 
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 class AuditFailedEventTest {
     @Test
     void constructorTest() {
+        long testTime = Instant.now().toEpochMilli();
         UUID jobConfigId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
@@ -23,7 +24,7 @@ class AuditFailedEventTest {
         assertEquals(jobExecutionId, event.getJobExecutionId());
         assertEquals(jobConfigId, event.getJobConfigId());
         assertEquals(notificationIds, event.getNotificationIds());
-        assertNotNull(event.getCreatedTimestamp());
+        assertTrue(testTime <= event.getCreatedTimestamp());
         assertEquals(errorMessage, event.getErrorMessage());
         assertTrue(event.getStackTrace().isPresent());
         assertEquals(stackTrace, event.getStackTrace().get());
@@ -31,6 +32,7 @@ class AuditFailedEventTest {
 
     @Test
     void constructorStackTraceNullTest() {
+        long testTime = Instant.now().toEpochMilli();
         UUID jobId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
@@ -41,7 +43,7 @@ class AuditFailedEventTest {
         assertEquals(jobExecutionId, event.getJobExecutionId());
         assertEquals(jobId, event.getJobConfigId());
         assertEquals(notificationIds, event.getNotificationIds());
-        assertNotNull(event.getCreatedTimestamp());
+        assertTrue(testTime <= event.getCreatedTimestamp());
         assertEquals(errorMessage, event.getErrorMessage());
         assertTrue(event.getStackTrace().isEmpty());
     }

--- a/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessEventTest.java
+++ b/api-distribution/src/test/java/com/synopsys/integration/alert/api/distribution/audit/AuditSuccessEventTest.java
@@ -1,8 +1,9 @@
 package com.synopsys.integration.alert.api.distribution.audit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Instant;
 import java.util.Set;
 import java.util.UUID;
 
@@ -12,6 +13,7 @@ class AuditSuccessEventTest {
 
     @Test
     void constructorTest() {
+        long testTime = Instant.now().toEpochMilli();
         UUID jobId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
@@ -21,6 +23,6 @@ class AuditSuccessEventTest {
         assertEquals(jobExecutionId, event.getJobExecutionId());
         assertEquals(jobId, event.getJobConfigId());
         assertEquals(notificationIds, event.getNotificationIds());
-        assertNotNull(event.getCreatedTimestamp());
+        assertTrue(testTime <= event.getCreatedTimestamp());
     }
 }


### PR DESCRIPTION
Replace null checks on primitive types.