### PR TITLE
IALERT-3418 - Specify object name to Jackson via JsonProperty annotation

### DIFF
--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/model/LDAPConfigModel.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/model/LDAPConfigModel.java
@@ -10,6 +10,8 @@ import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.rest.model.ConfigWithMetadata;
 
 public class LDAPConfigModel extends ConfigWithMetadata implements Obfuscated<LDAPConfigModel> {
+    private static final long serialVersionUID = -3340739050525348445L;
+
     private Boolean enabled;
     private String serverName;
     private String managerDn;

--- a/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/model/LDAPConfigTestModel.java
+++ b/authentication-ldap/src/main/java/com/synopsys/integration/alert/authentication/ldap/model/LDAPConfigTestModel.java
@@ -1,6 +1,12 @@
 package com.synopsys.integration.alert.authentication.ldap.model;
 
-public class LDAPConfigTestModel {
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.synopsys.integration.alert.api.common.model.AlertSerializableModel;
+
+public class LDAPConfigTestModel extends AlertSerializableModel {
+    private static final long serialVersionUID = 6421872579523951087L;
+
+    @JsonProperty("ldapConfigModel")
     private LDAPConfigModel ldapConfigModel;
     private String testLDAPUsername;
     private String testLDAPPassword;


### PR DESCRIPTION
During DEV of 6.13.1, the get method name was changed. This caused Jackson to not be able to map the object name to the getter. As we want to refer to LDAP objects as all caps, leverage using JsonProperty to instruct Jackson how to map the object.

Also add serialVersionUID to both Data models.