### PR TITLE
Fix PoP scan failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ plugins {
 }
 
 ext {
+    commitHash = 'UNKNOWN'
+
     // Copied from src/test/java - com.synopsys.integration.alert.TestTags
     junitPlatformCustomTestTags = 'BlackDuckConnection, DatabaseConnection, ExternalConnection'
 

--- a/buildSrc/buildTasks.gradle
+++ b/buildSrc/buildTasks.gradle
@@ -30,14 +30,21 @@ task cleanBundles(type: Delete) {
 
 tasks.clean.finalizedBy(cleanBundles)
 
-task createAboutText(type: Task) {
+task getCommitHash(type: Task) {
     def stdout = new ByteArrayOutputStream()
     exec {
+        ignoreExitValue = true
         commandLine 'git', 'rev-parse', '--short', 'HEAD'
         standardOutput = stdout
     }
-    def commitHash = stdout.toString().trim()
+    if (stdout.toString()?.trim()) {
+        project.ext.commitHash = stdout.toString().trim()
+    } else {
+        logger.lifecycle("Unable to determine current git commit hash, using default:" + rootProject.ext.commitHash)
+    }
+}
 
+task createAboutText(type: Task, dependsOn: 'getCommitHash') {
     final def aboutFile = new File("${projectDir}/src/main/resources/about.txt")
     aboutFile.delete()
 
@@ -55,7 +62,7 @@ task createAboutText(type: Task) {
     def time = new Date().format('yyyy-MM-dd\'T\'HH:mm:ss.SSSSSS\'Z\'');
     def year = new Date().format('yyyy');
 
-    final def aboutJson = JsonOutput.toJson([version: version, projectUrl: gitUrl, description: description, created: time, copyrightYear: year, commitHash: commitHash])
+    final def aboutJson = JsonOutput.toJson([version: version, projectUrl: gitUrl, description: description, created: time, copyrightYear: year, commitHash: rootProject.ext.commitHash])
     logger.lifecycle("\nAbout text file: {} content: {}\n", aboutFile, aboutJson)
     aboutFile << aboutJson
 }

--- a/buildSrc/docker.gradle
+++ b/buildSrc/docker.gradle
@@ -121,6 +121,18 @@ dockerImagesToBuild.each { imageName ->
                 }
             }
         }
+
+        onlyIf("Docker executable does not exist in environment") {
+            try {
+                def result = exec {
+                    ignoreExitValue = true
+                    commandLine 'docker', 'version'
+                }
+                result.exitValue != 0
+            } catch (Exception ignored) {
+                return false
+            }
+        }
     }
     project.tasks.findByName(dockerRemoveAllImages).dependsOn dockerImageRemoveTaskName
 


### PR DESCRIPTION
One of the PoP scans is failing for 2 reasons:

- The build is launched within a Docker image, as root. The source files are owned by the build account. When trying to run git, git fails as it detect files owned by multiple users
- The docker exec is not present within the Docker image where the build is being run.

Fixes:
* Create new project variable commitHash, with a default value.
* Create new Gradle task (getCommitHash). If it **can** run successfully, update the project variable to the commitHash.
* Update Gradle task createAboutText to use the new project variable for commitHash and not try to get it itself
* Add onlyIf logic to the Docker clean stages so it only runs if the Docker exec is found