### PR TITLE
IALERT-3437: Jira Server model updates

### DIFF
--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/JiraServerPropertiesFactory.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/JiraServerPropertiesFactory.java
@@ -40,7 +40,8 @@ public class JiraServerPropertiesFactory {
     }
 
     public JiraServerProperties createJiraPropertiesWithJobId(UUID jiraServerJobId) throws AlertConfigurationException {
-        DistributionJobModel jiraServerDistributionJobConfiguration = jobAccessor.getJobById(jiraServerJobId).orElseThrow(() -> new AlertConfigurationException("Missing Jira Server distribution configuration"));
+        DistributionJobModel jiraServerDistributionJobConfiguration = jobAccessor.getJobById(jiraServerJobId)
+            .orElseThrow(() -> new AlertConfigurationException("Missing Jira Server distribution configuration"));
         return createJiraProperties(jiraServerDistributionJobConfiguration.getChannelGlobalConfigId());
     }
 
@@ -48,7 +49,7 @@ public class JiraServerPropertiesFactory {
         return createJiraProperties(
             jiraServerGlobalConfigModel.getUrl(),
             jiraServerGlobalConfigModel.getPassword().orElse(null),
-            jiraServerGlobalConfigModel.getUserName(),
+            jiraServerGlobalConfigModel.getUserName().orElse(null),
             jiraServerGlobalConfigModel.getDisablePluginCheck().orElse(false)
         );
     }

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/convert/JiraServerGlobalConfigurationModelConverter.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/convert/JiraServerGlobalConfigurationModelConverter.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
+import com.synopsys.integration.alert.channel.jira.server.model.enumeration.JiraServerAuthorizationMethod;
 import com.synopsys.integration.alert.channel.jira.server.validator.JiraServerGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.action.api.GlobalConfigurationModelToConcreteConverter;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
@@ -59,7 +60,14 @@ public class JiraServerGlobalConfigurationModelConverter extends GlobalConfigura
             .flatMap(ConfigurationFieldModel::getFieldValue)
             .orElse(null);
 
-        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, url, username, password);
+        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(
+            null,
+            AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
+            url,
+            JiraServerAuthorizationMethod.BASIC
+        );
+        model.setUserName(username);
+        model.setPassword(password);
 
         globalConfigurationModel.getField(DISABLE_PLUGIN_CHECK_KEY)
             .flatMap(ConfigurationFieldModel::getFieldValue)

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/database/accessor/JiraServerGlobalConfigAccessor.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/database/accessor/JiraServerGlobalConfigAccessor.java
@@ -27,6 +27,7 @@ import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurat
 import com.synopsys.integration.alert.channel.jira.server.database.configuration.JiraServerConfigurationEntity;
 import com.synopsys.integration.alert.channel.jira.server.database.configuration.JiraServerConfigurationRepository;
 import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
+import com.synopsys.integration.alert.channel.jira.server.model.enumeration.JiraServerAuthorizationMethod;
 import com.synopsys.integration.alert.common.persistence.accessor.ConfigurationAccessor;
 import com.synopsys.integration.alert.common.rest.model.AlertPagedModel;
 import com.synopsys.integration.alert.common.security.EncryptionUtility;
@@ -142,7 +143,7 @@ public class JiraServerGlobalConfigAccessor implements ConfigurationAccessor<Jir
             createdTime,
             lastUpdated,
             configuration.getUrl(),
-            configuration.getUserName(),
+            configuration.getUserName().orElse(null),
             password,
             disablePluginCheck
         );
@@ -165,6 +166,20 @@ public class JiraServerGlobalConfigAccessor implements ConfigurationAccessor<Jir
         if (doesPasswordExist) {
             password = encryptionUtility.decrypt(password);
         }
-        return new JiraServerGlobalConfigModel(id, name, createdAtFormatted, lastUpdatedFormatted, url, username, password, doesPasswordExist, disablePluginCheck);
+        // TODO: Implement access token and AuthorizationMethod
+        return new JiraServerGlobalConfigModel(
+            id,
+            name,
+            createdAtFormatted,
+            lastUpdatedFormatted,
+            url,
+            JiraServerAuthorizationMethod.BASIC,
+            username,
+            password,
+            doesPasswordExist,
+            null,
+            null,
+            disablePluginCheck
+        );
     }
 }

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/model/JiraServerGlobalConfigModel.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/model/JiraServerGlobalConfigModel.java
@@ -12,29 +12,50 @@ import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 
 import com.synopsys.integration.alert.api.common.model.Obfuscated;
+import com.synopsys.integration.alert.channel.jira.server.model.enumeration.JiraServerAuthorizationMethod;
 import com.synopsys.integration.alert.common.rest.model.ConfigWithMetadata;
 
 public class JiraServerGlobalConfigModel extends ConfigWithMetadata implements Obfuscated<JiraServerGlobalConfigModel> {
     private String url;
+    private JiraServerAuthorizationMethod authorizationMethod;
     private String userName;
     private Boolean isPasswordSet;
     private String password;
+    private String accessToken;
+    private Boolean isAccessTokenSet;
     private Boolean disablePluginCheck;
 
     public JiraServerGlobalConfigModel() {
         // For serialization
     }
 
-    public JiraServerGlobalConfigModel(String id, String name, String url, String userName, String password) {
+    public JiraServerGlobalConfigModel(String id, String name, String url, JiraServerAuthorizationMethod authorizationMethod) {
         super(id, name);
         this.url = url;
-        this.userName = userName;
-        this.password = password;
+        this.authorizationMethod = authorizationMethod;
     }
 
-    public JiraServerGlobalConfigModel(String id, String name, String createdAt, String lastUpdated, String url, String userName, String password, Boolean isPasswordSet, Boolean disablePluginCheck) {
-        this(id, name, url, userName, password);
+    public JiraServerGlobalConfigModel(
+        String id,
+        String name,
+        String createdAt,
+        String lastUpdated,
+        String url,
+        JiraServerAuthorizationMethod authorizationMethod,
+        String userName,
+        String password,
+        Boolean isPasswordSet,
+        String accessToken,
+        Boolean isAccessTokenSet,
+        Boolean disablePluginCheck
+    ) {
+        this(id, name, url, authorizationMethod);
+        this.authorizationMethod = authorizationMethod;
+        this.userName = userName;
+        this.password = password;
         this.isPasswordSet = isPasswordSet;
+        this.accessToken = accessToken;
+        this.isAccessTokenSet = isAccessTokenSet;
         this.disablePluginCheck = disablePluginCheck;
         setCreatedAt(createdAt);
         setLastUpdated(lastUpdated);
@@ -48,9 +69,12 @@ public class JiraServerGlobalConfigModel extends ConfigWithMetadata implements O
             getCreatedAt(),
             getLastUpdated(),
             url,
+            authorizationMethod,
             userName,
             null,
             StringUtils.isNotBlank(password),
+            null,
+            StringUtils.isNotBlank(accessToken),
             disablePluginCheck
         );
     }
@@ -59,8 +83,20 @@ public class JiraServerGlobalConfigModel extends ConfigWithMetadata implements O
         return url;
     }
 
-    public String getUserName() {
-        return userName;
+    public JiraServerAuthorizationMethod getAuthorizationMethod() {
+        return authorizationMethod;
+    }
+
+    public void setAuthorizationMethod(JiraServerAuthorizationMethod authorizationMethod) {
+        this.authorizationMethod = authorizationMethod;
+    }
+
+    public Optional<String> getUserName() {
+        return Optional.ofNullable(userName);
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
     }
 
     public Optional<Boolean> getIsPasswordSet() {
@@ -77,6 +113,22 @@ public class JiraServerGlobalConfigModel extends ConfigWithMetadata implements O
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public Optional<Boolean> getIsAccessTokenSet() {
+        return Optional.ofNullable(isAccessTokenSet);
+    }
+
+    public void setIsAccessTokenSet(Boolean accessTokenSet) {
+        isAccessTokenSet = accessTokenSet;
+    }
+
+    public Optional<String> getAccessToken() {
+        return Optional.ofNullable(accessToken);
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
     }
 
     public Optional<Boolean> getDisablePluginCheck() {

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/model/enumeration/JiraServerAuthorizationMethod.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/model/enumeration/JiraServerAuthorizationMethod.java
@@ -1,0 +1,16 @@
+package com.synopsys.integration.alert.channel.jira.server.model.enumeration;
+
+public enum JiraServerAuthorizationMethod {
+    BASIC("Basic"),
+    PERSONAL_ACCESS_TOKEN("Personal Access Token");
+
+    private final String displayName;
+
+    JiraServerAuthorizationMethod(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/validator/JiraServerGlobalConfigurationValidator.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/validator/JiraServerGlobalConfigurationValidator.java
@@ -22,6 +22,7 @@ import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatus;
 import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatusMessages;
 import com.synopsys.integration.alert.channel.jira.server.database.accessor.JiraServerGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
+import com.synopsys.integration.alert.channel.jira.server.model.enumeration.JiraServerAuthorizationMethod;
 
 @Component
 public class JiraServerGlobalConfigurationValidator {
@@ -51,12 +52,15 @@ public class JiraServerGlobalConfigurationValidator {
                 statuses.add(AlertFieldStatus.error("url", e.getMessage()));
             }
         }
-        if (model.getUserName().isEmpty() || StringUtils.isBlank(model.getUserName().get())) {
-            statuses.add(AlertFieldStatus.error("userName", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
-        }
+        // TODO: Add branching validation depending on AuthorizationMethod using BASIC or BEARER
+        if (model.getAuthorizationMethod() == JiraServerAuthorizationMethod.BASIC) {
+            if (model.getUserName().isEmpty() || StringUtils.isBlank(model.getUserName().get())) {
+                statuses.add(AlertFieldStatus.error("userName", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
+            }
 
-        if (model.getPassword().isEmpty() && !model.getIsPasswordSet().orElse(Boolean.FALSE)) {
-            statuses.add(AlertFieldStatus.error("password", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
+            if (model.getPassword().isEmpty() && !model.getIsPasswordSet().orElse(Boolean.FALSE)) {
+                statuses.add(AlertFieldStatus.error("password", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
+            }
         }
 
         if (!statuses.isEmpty()) {

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/validator/JiraServerGlobalConfigurationValidator.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/validator/JiraServerGlobalConfigurationValidator.java
@@ -35,6 +35,7 @@ public class JiraServerGlobalConfigurationValidator {
     public ValidationResponseModel validate(JiraServerGlobalConfigModel model, String id) {
         Set<AlertFieldStatus> statuses = new HashSet<>();
 
+        // TODO: Implement access token and AuthorizationMethod
         if (StringUtils.isBlank(model.getName())) {
             statuses.add(AlertFieldStatus.error("name", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
         } else if (doesNameExist(model.getName(), id)) {
@@ -50,7 +51,7 @@ public class JiraServerGlobalConfigurationValidator {
                 statuses.add(AlertFieldStatus.error("url", e.getMessage()));
             }
         }
-        if (StringUtils.isBlank(model.getUserName())) {
+        if (model.getUserName().isEmpty() || StringUtils.isBlank(model.getUserName().get())) {
             statuses.add(AlertFieldStatus.error("userName", AlertFieldStatusMessages.REQUIRED_FIELD_MISSING));
         }
 

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/JiraServerExternalConnectionTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/JiraServerExternalConnectionTest.java
@@ -28,6 +28,7 @@ import com.synopsys.integration.alert.channel.jira.server.database.accessor.Jira
 import com.synopsys.integration.alert.channel.jira.server.distribution.JiraServerMessageSenderFactory;
 import com.synopsys.integration.alert.channel.jira.server.distribution.JiraServerProcessorFactory;
 import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
+import com.synopsys.integration.alert.channel.jira.server.model.enumeration.JiraServerAuthorizationMethod;
 import com.synopsys.integration.alert.common.enumeration.FrequencyType;
 import com.synopsys.integration.alert.common.enumeration.ProcessingType;
 import com.synopsys.integration.alert.common.message.model.LinkableItem;
@@ -104,13 +105,16 @@ class JiraServerExternalConnectionTest {
     }
 
     private JiraServerGlobalConfigModel createJiraServerConfigModel() {
-        return new JiraServerGlobalConfigModel(
+        // TODO: Implement access token and AuthorizationMethod
+        JiraServerGlobalConfigModel configModel = new JiraServerGlobalConfigModel(
             UUID.randomUUID().toString(),
             "name",
             testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_URL),
-            testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_USERNAME),
-            testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_PASSWORD)
+            JiraServerAuthorizationMethod.BASIC
         );
+        configModel.setUserName(testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_USERNAME));
+        configModel.setPassword(testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_PASSWORD));
+        return configModel;
     }
 
     private DistributionJobModel createDistributionJobModel() {
@@ -132,7 +136,8 @@ class JiraServerExternalConnectionTest {
         //This test requires that the JIRA server has 2 components associated with the project: "component1" and "component2"
         customFields.add(new JiraJobCustomFieldModel("Component/s", "component1 component2"));
 
-        return new JiraServerJobDetailsModel(uuid,
+        return new JiraServerJobDetailsModel(
+            uuid,
             Boolean.parseBoolean(testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_ADD_COMMENTS)),
             testProperties.getOptionalProperty(TestPropertyKey.TEST_JIRA_SERVER_ISSUE_CREATOR).orElse(null),
             testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_PROJECT_NAME),

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/action/JiraServerGlobalCrudActionsTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/action/JiraServerGlobalCrudActionsTest.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpStatus;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.channel.jira.server.database.accessor.JiraServerGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
+import com.synopsys.integration.alert.channel.jira.server.model.enumeration.JiraServerAuthorizationMethod;
 import com.synopsys.integration.alert.channel.jira.server.validator.JiraServerGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
@@ -137,9 +138,12 @@ class JiraServerGlobalCrudActionsTest {
             CREATED_AT,
             UPDATED_AT,
             URL,
+            JiraServerAuthorizationMethod.BASIC,
             USER_NAME,
             PASSWORD,
             Boolean.TRUE,
+            null,
+            Boolean.FALSE,
             Boolean.TRUE
         );
         AlertPagedModel<JiraServerGlobalConfigModel> alertPagedModel = new AlertPagedModel<>(
@@ -176,15 +180,19 @@ class JiraServerGlobalCrudActionsTest {
     @Test
     void getPagedSortDescendingTest() {
         JiraServerGlobalConfigModel jiraServerGlobalConfigModel = createJiraServerGlobalConfigModel(id);
+        // TODO: Implement access token and AuthorizationMethod
         JiraServerGlobalConfigModel jiraServerGlobalConfigModel2 = new JiraServerGlobalConfigModel(
             String.valueOf(UUID.randomUUID()),
             "Another Job",
             CREATED_AT,
             UPDATED_AT,
             URL,
+            JiraServerAuthorizationMethod.BASIC,
             USER_NAME,
             PASSWORD,
             Boolean.TRUE,
+            null,
+            Boolean.FALSE,
             Boolean.TRUE
         );
         AlertPagedModel<JiraServerGlobalConfigModel> alertPagedModel = new AlertPagedModel<>(
@@ -285,15 +293,19 @@ class JiraServerGlobalCrudActionsTest {
     }
 
     private JiraServerGlobalConfigModel createJiraServerGlobalConfigModel(UUID id) {
+        // TODO: Implement access token and AuthorizationMethod
         return new JiraServerGlobalConfigModel(
             String.valueOf(id),
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             CREATED_AT,
             UPDATED_AT,
             URL,
+            JiraServerAuthorizationMethod.BASIC,
             USER_NAME,
             PASSWORD,
             Boolean.TRUE,
+            null,
+            Boolean.FALSE,
             Boolean.TRUE
         );
     }
@@ -309,7 +321,7 @@ class JiraServerGlobalCrudActionsTest {
         assertEquals(CREATED_AT, jiraServerGlobalConfigModel.getCreatedAt());
         assertEquals(UPDATED_AT, jiraServerGlobalConfigModel.getLastUpdated());
         assertEquals(URL, jiraServerGlobalConfigModel.getUrl());
-        assertEquals(USER_NAME, jiraServerGlobalConfigModel.getUserName());
+        assertEquals(USER_NAME, jiraServerGlobalConfigModel.getUserName().orElse("Username missing"));
 
         assertTrue(jiraServerGlobalConfigModel.getPassword().isEmpty());
         assertTrue(jiraServerGlobalConfigModel.getIsPasswordSet().isPresent());

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/action/JiraServerGlobalTestActionTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/action/JiraServerGlobalTestActionTest.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.channel.jira.server.database.accessor.JiraServerGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
+import com.synopsys.integration.alert.channel.jira.server.model.enumeration.JiraServerAuthorizationMethod;
 import com.synopsys.integration.alert.channel.jira.server.validator.JiraServerGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.channel.issuetracker.exception.IssueTrackerException;
@@ -69,15 +70,19 @@ class JiraServerGlobalTestActionTest {
         Mockito.when(testActionWrapper.isAppMissing()).thenReturn(false);
         Mockito.when(configurationAccessor.getConfiguration(Mockito.any())).thenReturn(Optional.of(jiraServerGlobalConfigModel));
 
+        // TODO: Implement access token and AuthorizationMethod
         JiraServerGlobalConfigModel configurationModel = new JiraServerGlobalConfigModel(
             jiraServerGlobalConfigModel.getId(),
             jiraServerGlobalConfigModel.getName(),
             jiraServerGlobalConfigModel.getCreatedAt(),
             jiraServerGlobalConfigModel.getLastUpdated(),
             jiraServerGlobalConfigModel.getUrl(),
-            jiraServerGlobalConfigModel.getUserName(),
+            JiraServerAuthorizationMethod.BASIC,
+            jiraServerGlobalConfigModel.getUserName().orElse(null),
             null,
             Boolean.TRUE,
+            null,
+            Boolean.FALSE,
             Boolean.FALSE
         );
 
@@ -229,14 +234,18 @@ class JiraServerGlobalTestActionTest {
     }
 
     private JiraServerGlobalConfigModel createValidJiraServerGlobalConfigModel() {
+        // TODO: Implement access token and AuthorizationMethod
         return new JiraServerGlobalConfigModel(
             UUID.randomUUID().toString(),
             "jiraServerConfigName",
             "createdAtTest",
             "lastUpdatedTest",
             "https://jiraServer",
+            JiraServerAuthorizationMethod.BASIC,
             "jiraUser",
             "jiraPassword",
+            Boolean.FALSE,
+            null,
             Boolean.FALSE,
             Boolean.FALSE
         );

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/convert/JiraServerGlobalConfigurationModelConverterTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/convert/JiraServerGlobalConfigurationModelConverterTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mockito;
 
 import com.synopsys.integration.alert.channel.jira.server.database.accessor.JiraServerGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
+import com.synopsys.integration.alert.channel.jira.server.model.enumeration.JiraServerAuthorizationMethod;
 import com.synopsys.integration.alert.channel.jira.server.validator.JiraServerGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
 import com.synopsys.integration.alert.common.persistence.model.ConfigurationFieldModel;
@@ -46,7 +47,7 @@ class JiraServerGlobalConfigurationModelConverterTest {
 
         assertNull(jiraModel.getId());
         assertEquals(TEST_URL, jiraModel.getUrl());
-        assertEquals(TEST_USERNAME, jiraModel.getUserName());
+        assertEquals(TEST_USERNAME, jiraModel.getUserName().orElse("Username missing"));
         assertEquals(TEST_PASSWORD, jiraModel.getPassword().orElse("Password value is missing"));
         assertTrue(jiraModel.getDisablePluginCheck().orElse(Boolean.FALSE));
 
@@ -61,9 +62,10 @@ class JiraServerGlobalConfigurationModelConverterTest {
             uuid,
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             TEST_URL,
-            TEST_USERNAME,
-            TEST_PASSWORD
+            JiraServerAuthorizationMethod.BASIC
         );
+        jiraServerGlobalConfigModelSaved.setUserName(TEST_USERNAME);
+        jiraServerGlobalConfigModelSaved.setPassword(TEST_PASSWORD);
         JiraServerGlobalConfigAccessor jiraServerGlobalConfigAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
         Mockito.when(jiraServerGlobalConfigAccessor.getConfigurationByName(Mockito.anyString())).thenReturn(Optional.of(jiraServerGlobalConfigModelSaved));
         validator = new JiraServerGlobalConfigurationValidator(jiraServerGlobalConfigAccessor);
@@ -75,7 +77,7 @@ class JiraServerGlobalConfigurationModelConverterTest {
         JiraServerGlobalConfigModel jiraModel = model.get();
 
         assertEquals(TEST_URL, jiraModel.getUrl());
-        assertEquals(TEST_USERNAME, jiraModel.getUserName());
+        assertEquals(TEST_USERNAME, jiraModel.getUserName().orElse("Username missing"));
         assertEquals(TEST_PASSWORD, jiraModel.getPassword().orElse("Password value is missing"));
         assertTrue(jiraModel.getDisablePluginCheck().orElse(Boolean.FALSE));
     }
@@ -93,7 +95,7 @@ class JiraServerGlobalConfigurationModelConverterTest {
 
         assertNull(jiraModel.getId());
         assertEquals(TEST_URL, jiraModel.getUrl());
-        assertEquals(TEST_USERNAME, jiraModel.getUserName());
+        assertEquals(TEST_USERNAME, jiraModel.getUserName().orElse("Username missing"));
         assertEquals(TEST_PASSWORD, jiraModel.getPassword().orElse("Password value is missing"));
         assertTrue(jiraModel.getDisablePluginCheck().isEmpty());
 

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/database/accessor/JiraServerGlobalConfigAccessorTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/database/accessor/JiraServerGlobalConfigAccessorTest.java
@@ -23,6 +23,7 @@ import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurat
 import com.synopsys.integration.alert.channel.jira.server.database.configuration.JiraServerConfigurationEntity;
 import com.synopsys.integration.alert.channel.jira.server.database.configuration.JiraServerConfigurationRepository;
 import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
+import com.synopsys.integration.alert.channel.jira.server.model.enumeration.JiraServerAuthorizationMethod;
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.persistence.util.FilePersistenceUtil;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
@@ -64,7 +65,7 @@ class JiraServerGlobalConfigAccessorTest {
             .orElseThrow(() -> new AlertConfigurationException("Cannot find expected configuration"));
         assertEquals(id.toString(), configModel.getId());
         assertEquals(TEST_URL, configModel.getUrl());
-        assertEquals(TEST_USERNAME, configModel.getUserName());
+        assertEquals(TEST_USERNAME, configModel.getUserName().orElse("Username missing"));
         assertTrue(configModel.getIsPasswordSet().orElse(Boolean.FALSE));
         assertEquals(TEST_PASSWORD, configModel.getPassword().orElse(null));
         assertTrue(configModel.getDisablePluginCheck().orElse(Boolean.FALSE));
@@ -88,7 +89,7 @@ class JiraServerGlobalConfigAccessorTest {
             .orElseThrow(() -> new AlertConfigurationException("Cannot find expected configuration"));
         assertEquals(id.toString(), configModel.getId());
         assertEquals(TEST_URL, configModel.getUrl());
-        assertEquals(TEST_USERNAME, configModel.getUserName());
+        assertEquals(TEST_USERNAME, configModel.getUserName().orElse("Username missing"));
         assertTrue(configModel.getIsPasswordSet().orElse(Boolean.FALSE));
         assertEquals(TEST_PASSWORD, configModel.getPassword().orElse(null));
         assertTrue(configModel.getDisablePluginCheck().orElse(Boolean.FALSE));
@@ -211,14 +212,18 @@ class JiraServerGlobalConfigAccessorTest {
     void createConfigurationTest() throws AlertConfigurationException {
         UUID id = UUID.randomUUID();
         JiraServerConfigurationEntity entity = createEntity(id, OffsetDateTime.now(), OffsetDateTime.now());
+        // TODO: Implement access token and AuthorizationMethod
         JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(
             null,
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             DateUtils.formatDate(entity.getCreatedAt(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
             DateUtils.formatDate(entity.getLastUpdated(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
             TEST_URL,
+            JiraServerAuthorizationMethod.BASIC,
             TEST_USERNAME,
             TEST_PASSWORD,
+            false,
+            null,
             false,
             true
         );
@@ -228,7 +233,7 @@ class JiraServerGlobalConfigAccessorTest {
         JiraServerGlobalConfigModel createdModel = jiraServerGlobalConfigAccessor.createConfiguration(model);
         assertEquals(entity.getConfigurationId().toString(), createdModel.getId());
         assertEquals(entity.getUrl(), createdModel.getUrl());
-        assertEquals(entity.getUsername(), createdModel.getUserName());
+        assertEquals(entity.getUsername(), createdModel.getUserName().orElse("Username missing"));
         assertTrue(createdModel.getIsPasswordSet().orElse(Boolean.FALSE));
         assertEquals(TEST_PASSWORD, createdModel.getPassword().orElse(null));
         assertEquals(entity.getDisablePluginCheck(), createdModel.getDisablePluginCheck().orElse(null));
@@ -240,7 +245,8 @@ class JiraServerGlobalConfigAccessorTest {
         String updatedName = "updatedName";
         String newUrl = "https://updated.example.com";
         JiraServerConfigurationEntity entity = createEntity(id, OffsetDateTime.now(), OffsetDateTime.now());
-        JiraServerConfigurationEntity updatedEntity = new JiraServerConfigurationEntity(entity.getConfigurationId(),
+        JiraServerConfigurationEntity updatedEntity = new JiraServerConfigurationEntity(
+            entity.getConfigurationId(),
             updatedName,
             entity.getCreatedAt(),
             entity.getLastUpdated(),
@@ -249,14 +255,18 @@ class JiraServerGlobalConfigAccessorTest {
             entity.getPassword(),
             entity.getDisablePluginCheck()
         );
+        // TODO: Implement access token and AuthorizationMethod
         JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(
             null,
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             DateUtils.formatDate(entity.getCreatedAt(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
             DateUtils.formatDate(entity.getLastUpdated(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
             TEST_URL,
+            JiraServerAuthorizationMethod.BASIC,
             TEST_USERNAME,
             TEST_PASSWORD,
+            false,
+            null,
             false,
             true
         );
@@ -266,7 +276,7 @@ class JiraServerGlobalConfigAccessorTest {
         JiraServerGlobalConfigModel updatedModel = jiraServerGlobalConfigAccessor.updateConfiguration(id, model);
         assertEquals(updatedEntity.getConfigurationId().toString(), updatedModel.getId());
         assertEquals(updatedEntity.getUrl(), updatedModel.getUrl());
-        assertEquals(updatedEntity.getUsername(), updatedModel.getUserName());
+        assertEquals(updatedEntity.getUsername(), updatedModel.getUserName().orElse("Username missing"));
         assertTrue(updatedModel.getIsPasswordSet().orElse(Boolean.FALSE));
         assertEquals(TEST_PASSWORD, updatedModel.getPassword().orElse(null));
         assertEquals(updatedEntity.getDisablePluginCheck(), updatedModel.getDisablePluginCheck().orElse(null));
@@ -278,7 +288,8 @@ class JiraServerGlobalConfigAccessorTest {
         String updatedName = "updatedName";
         String newUrl = "https://updated.example.com";
         JiraServerConfigurationEntity entity = createEntity(id, OffsetDateTime.now(), OffsetDateTime.now());
-        JiraServerConfigurationEntity updatedEntity = new JiraServerConfigurationEntity(entity.getConfigurationId(),
+        JiraServerConfigurationEntity updatedEntity = new JiraServerConfigurationEntity(
+            entity.getConfigurationId(),
             updatedName,
             entity.getCreatedAt(),
             entity.getLastUpdated(),
@@ -287,15 +298,19 @@ class JiraServerGlobalConfigAccessorTest {
             entity.getPassword(),
             entity.getDisablePluginCheck()
         );
+        // TODO: Implement access token and AuthorizationMethod
         JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(
             null,
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             DateUtils.formatDate(entity.getCreatedAt(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
             DateUtils.formatDate(entity.getLastUpdated(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
             TEST_URL,
+            JiraServerAuthorizationMethod.BASIC,
             TEST_USERNAME,
             null,
             true,
+            null,
+            false,
             true
         );
         Mockito.when(jiraServerConfigurationRepository.findById(id)).thenReturn(Optional.of(entity));
@@ -304,7 +319,7 @@ class JiraServerGlobalConfigAccessorTest {
         JiraServerGlobalConfigModel updatedModel = jiraServerGlobalConfigAccessor.updateConfiguration(id, model);
         assertEquals(updatedEntity.getConfigurationId().toString(), updatedModel.getId());
         assertEquals(updatedEntity.getUrl(), updatedModel.getUrl());
-        assertEquals(updatedEntity.getUsername(), updatedModel.getUserName());
+        assertEquals(updatedEntity.getUsername(), updatedModel.getUserName().orElse("Username missing"));
         assertTrue(updatedModel.getIsPasswordSet().orElse(Boolean.FALSE));
         assertEquals(TEST_PASSWORD, updatedModel.getPassword().orElse(null));
         assertEquals(updatedEntity.getDisablePluginCheck(), updatedModel.getDisablePluginCheck().orElse(null));
@@ -321,8 +336,11 @@ class JiraServerGlobalConfigAccessorTest {
             DateUtils.formatDate(entity.getCreatedAt(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
             DateUtils.formatDate(entity.getLastUpdated(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE),
             TEST_URL,
+            JiraServerAuthorizationMethod.BASIC,
             TEST_USERNAME,
             TEST_PASSWORD,
+            false,
+            null,
             false,
             true
         );

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/validator/JiraServerGlobalConfigurationValidatorTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/validator/JiraServerGlobalConfigurationValidatorTest.java
@@ -63,7 +63,7 @@ class JiraServerGlobalConfigurationValidatorTest {
 
         ValidationResponseModel validationResponseModel = validator.validate(model, null);
         Collection<AlertFieldStatus> alertFieldStatuses = validationResponseModel.getErrors().values();
-        assertEquals(4, alertFieldStatuses.size(), "There were errors in the configuration when none were expected.");
+        assertEquals(2, alertFieldStatuses.size(), "There were errors in the configuration when none were expected.");
         for (AlertFieldStatus status : alertFieldStatuses) {
             assertEquals(ConfigurationFieldValidator.REQUIRED_FIELD_MISSING_MESSAGE, status.getFieldMessage(), "Validation had unexpected field message.");
         }

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/validator/JiraServerGlobalConfigurationValidatorTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/validator/JiraServerGlobalConfigurationValidatorTest.java
@@ -13,6 +13,7 @@ import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatus;
 import com.synopsys.integration.alert.channel.jira.server.database.accessor.JiraServerGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
+import com.synopsys.integration.alert.channel.jira.server.model.enumeration.JiraServerAuthorizationMethod;
 import com.synopsys.integration.alert.common.descriptor.validator.ConfigurationFieldValidator;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.util.DateUtils;
@@ -26,12 +27,27 @@ class JiraServerGlobalConfigurationValidatorTest {
     private final String USER_NAME = "username";
     private final String PASSWORD = "password";
 
+    // TODO: Implement access token and AuthorizationMethod
+    //  New set of validation should be implemented to support both Auth methods
     @Test
     void verifyValidConfig() {
         JiraServerGlobalConfigAccessor jiraServerGlobalConfigAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
         Mockito.when(jiraServerGlobalConfigAccessor.getConfigurationByName(Mockito.anyString())).thenReturn(Optional.empty());
         JiraServerGlobalConfigurationValidator validator = new JiraServerGlobalConfigurationValidator(jiraServerGlobalConfigAccessor);
-        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(ID, NAME, CREATED_AT, LAST_UPDATED, URL, USER_NAME, PASSWORD, Boolean.FALSE, Boolean.FALSE);
+        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(
+            ID,
+            NAME,
+            CREATED_AT,
+            LAST_UPDATED,
+            URL,
+            JiraServerAuthorizationMethod.BASIC,
+            USER_NAME,
+            PASSWORD,
+            Boolean.FALSE,
+            null,
+            Boolean.FALSE,
+            Boolean.FALSE
+        );
 
         ValidationResponseModel validationResponseModel = validator.validate(model, null);
         Collection<AlertFieldStatus> alertFieldStatuses = validationResponseModel.getErrors().values();
@@ -59,7 +75,20 @@ class JiraServerGlobalConfigurationValidatorTest {
         Mockito.when(jiraServerGlobalConfigAccessor.getConfigurationByName(Mockito.anyString())).thenReturn(Optional.empty());
         String badUrl = "notAValidUrl";
         JiraServerGlobalConfigurationValidator validator = new JiraServerGlobalConfigurationValidator(jiraServerGlobalConfigAccessor);
-        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(ID, NAME, CREATED_AT, LAST_UPDATED, badUrl, USER_NAME, PASSWORD, Boolean.FALSE, Boolean.FALSE);
+        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(
+            ID,
+            NAME,
+            CREATED_AT,
+            LAST_UPDATED,
+            badUrl,
+            JiraServerAuthorizationMethod.BASIC,
+            USER_NAME,
+            PASSWORD,
+            Boolean.FALSE,
+            null,
+            Boolean.FALSE,
+            Boolean.FALSE
+        );
 
         ValidationResponseModel validationResponseModel = validator.validate(model, null);
         Collection<AlertFieldStatus> alertFieldStatuses = validationResponseModel.getErrors().values();
@@ -74,7 +103,20 @@ class JiraServerGlobalConfigurationValidatorTest {
         JiraServerGlobalConfigAccessor jiraServerGlobalConfigAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
         Mockito.when(jiraServerGlobalConfigAccessor.getConfigurationByName(Mockito.anyString())).thenReturn(Optional.empty());
         JiraServerGlobalConfigurationValidator validator = new JiraServerGlobalConfigurationValidator(jiraServerGlobalConfigAccessor);
-        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(ID, NAME, CREATED_AT, LAST_UPDATED, URL, USER_NAME, null, Boolean.TRUE, Boolean.FALSE);
+        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(
+            ID,
+            NAME,
+            CREATED_AT,
+            LAST_UPDATED,
+            URL,
+            JiraServerAuthorizationMethod.BASIC,
+            USER_NAME,
+            null,
+            Boolean.TRUE,
+            null,
+            Boolean.FALSE,
+            Boolean.FALSE
+        );
 
         ValidationResponseModel validationResponseModel = validator.validate(model, null);
         Collection<AlertFieldStatus> alertFieldStatuses = validationResponseModel.getErrors().values();
@@ -86,7 +128,8 @@ class JiraServerGlobalConfigurationValidatorTest {
         JiraServerGlobalConfigAccessor jiraServerGlobalConfigAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
         Mockito.when(jiraServerGlobalConfigAccessor.getConfigurationByName(Mockito.anyString())).thenReturn(Optional.empty());
         JiraServerGlobalConfigurationValidator validator = new JiraServerGlobalConfigurationValidator(jiraServerGlobalConfigAccessor);
-        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(ID, NAME, URL, USER_NAME, null);
+        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(ID, NAME, URL, JiraServerAuthorizationMethod.BASIC);
+        model.setUserName(USER_NAME);
 
         ValidationResponseModel validationResponseModel = validator.validate(model, null);
         Collection<AlertFieldStatus> alertFieldStatuses = validationResponseModel.getErrors().values();
@@ -105,14 +148,30 @@ class JiraServerGlobalConfigurationValidatorTest {
             CREATED_AT,
             LAST_UPDATED,
             URL,
+            JiraServerAuthorizationMethod.BASIC,
             USER_NAME,
             PASSWORD,
+            Boolean.FALSE,
+            null,
             Boolean.FALSE,
             Boolean.FALSE
         );
         Mockito.when(jiraServerGlobalConfigAccessor.getConfigurationByName(NAME)).thenReturn(Optional.of(existingModel));
         JiraServerGlobalConfigurationValidator validator = new JiraServerGlobalConfigurationValidator(jiraServerGlobalConfigAccessor);
-        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(null, NAME, CREATED_AT, LAST_UPDATED, URL, USER_NAME, PASSWORD, Boolean.FALSE, Boolean.FALSE);
+        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(
+            null,
+            NAME,
+            CREATED_AT,
+            LAST_UPDATED,
+            URL,
+            JiraServerAuthorizationMethod.BASIC,
+            USER_NAME,
+            PASSWORD,
+            Boolean.FALSE,
+            null,
+            Boolean.FALSE,
+            Boolean.FALSE
+        );
 
         ValidationResponseModel validationResponseModel = validator.validate(model, null);
         Collection<AlertFieldStatus> alertFieldStatuses = validationResponseModel.getErrors().values();
@@ -131,14 +190,30 @@ class JiraServerGlobalConfigurationValidatorTest {
             CREATED_AT,
             LAST_UPDATED,
             URL,
+            JiraServerAuthorizationMethod.BASIC,
             USER_NAME,
             PASSWORD,
+            Boolean.FALSE,
+            null,
             Boolean.FALSE,
             Boolean.FALSE
         );
         Mockito.when(jiraServerGlobalConfigAccessor.getConfigurationByName(NAME)).thenReturn(Optional.of(existingModel));
         JiraServerGlobalConfigurationValidator validator = new JiraServerGlobalConfigurationValidator(jiraServerGlobalConfigAccessor);
-        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(ID, NAME, CREATED_AT, LAST_UPDATED, URL, "new" + USER_NAME, PASSWORD, Boolean.FALSE, Boolean.FALSE);
+        JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(
+            ID,
+            NAME,
+            CREATED_AT,
+            LAST_UPDATED,
+            URL,
+            JiraServerAuthorizationMethod.BASIC,
+            "new" + USER_NAME,
+            PASSWORD,
+            Boolean.FALSE,
+            null,
+            Boolean.FALSE,
+            Boolean.FALSE
+        );
 
         ValidationResponseModel validationResponseModel = validator.validate(model, ID);
         Collection<AlertFieldStatus> alertFieldStatuses = validationResponseModel.getErrors().values();
@@ -148,7 +223,20 @@ class JiraServerGlobalConfigurationValidatorTest {
     @Test
     void nameIsUniqueValidTest() {
         JiraServerGlobalConfigAccessor jiraServerGlobalConfigAccessor = Mockito.mock(JiraServerGlobalConfigAccessor.class);
-        JiraServerGlobalConfigModel existingModel = new JiraServerGlobalConfigModel(ID, NAME, CREATED_AT, LAST_UPDATED, URL, USER_NAME, PASSWORD, Boolean.FALSE, Boolean.FALSE);
+        JiraServerGlobalConfigModel existingModel = new JiraServerGlobalConfigModel(
+            ID,
+            NAME,
+            CREATED_AT,
+            LAST_UPDATED,
+            URL,
+            JiraServerAuthorizationMethod.BASIC,
+            USER_NAME,
+            PASSWORD,
+            Boolean.FALSE,
+            null,
+            Boolean.FALSE,
+            Boolean.FALSE
+        );
         Mockito.when(jiraServerGlobalConfigAccessor.getConfigurationByName(NAME)).thenReturn(Optional.of(existingModel));
         JiraServerGlobalConfigurationValidator validator = new JiraServerGlobalConfigurationValidator(jiraServerGlobalConfigAccessor);
         JiraServerGlobalConfigModel model = new JiraServerGlobalConfigModel(
@@ -157,8 +245,11 @@ class JiraServerGlobalConfigurationValidatorTest {
             CREATED_AT,
             LAST_UPDATED,
             URL,
+            JiraServerAuthorizationMethod.BASIC,
             USER_NAME,
             PASSWORD,
+            Boolean.FALSE,
+            null,
             Boolean.FALSE,
             Boolean.FALSE
         );

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerCustomFunctionActionTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerCustomFunctionActionTest.java
@@ -20,6 +20,7 @@ import com.synopsys.integration.alert.channel.jira.server.JiraServerPropertiesFa
 import com.synopsys.integration.alert.channel.jira.server.database.accessor.JiraServerGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.jira.server.descriptor.JiraServerDescriptor;
 import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
+import com.synopsys.integration.alert.channel.jira.server.model.enumeration.JiraServerAuthorizationMethod;
 import com.synopsys.integration.alert.channel.jira.server.validator.JiraServerGlobalConfigurationFieldModelValidator;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
@@ -65,9 +66,10 @@ class JiraServerCustomFunctionActionTest {
             jiraGlobalConfigId.toString(),
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             "http://jira.server.example.com/jira",
-            "user",
-            "password"
+            JiraServerAuthorizationMethod.BASIC
         );
+        configModel.setUserName("user");
+        configModel.setPassword("password");
         DistributionJobModel jobModel = DistributionJobModel.builder()
             .jobId(UUID.randomUUID())
             .enabled(true)
@@ -119,9 +121,10 @@ class JiraServerCustomFunctionActionTest {
             jiraGlobalConfigId.toString(),
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             "http://jira.server.example.com/jira",
-            "user",
-            "password"
+            JiraServerAuthorizationMethod.BASIC
         );
+        configModel.setUserName("user");
+        configModel.setPassword("password");
         DistributionJobModel jobModel = DistributionJobModel.builder()
             .jobId(UUID.randomUUID())
             .enabled(true)
@@ -174,9 +177,10 @@ class JiraServerCustomFunctionActionTest {
             jiraGlobalConfigId.toString(),
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             "http://jira.server.example.com/jira",
-            "user",
-            "password"
+            JiraServerAuthorizationMethod.BASIC
         );
+        configModel.setUserName("user");
+        configModel.setPassword("password");
         DistributionJobModel jobModel = DistributionJobModel.builder()
             .jobId(UUID.randomUUID())
             .enabled(true)
@@ -229,9 +233,10 @@ class JiraServerCustomFunctionActionTest {
             jiraGlobalConfigId.toString(),
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             "http://jira.server.example.com/jira",
-            "user",
-            "password"
+            JiraServerAuthorizationMethod.BASIC
         );
+        configModel.setUserName("user");
+        configModel.setPassword("password");
         DistributionJobModel jobModel = DistributionJobModel.builder()
             .jobId(UUID.randomUUID())
             .enabled(true)
@@ -285,9 +290,10 @@ class JiraServerCustomFunctionActionTest {
             jiraGlobalConfigId.toString(),
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             "http://jira.server.example.com/jira",
-            "user",
-            "password"
+            JiraServerAuthorizationMethod.BASIC
         );
+        configModel.setUserName("user");
+        configModel.setPassword("password");
         DistributionJobModel jobModel = DistributionJobModel.builder()
             .jobId(UUID.randomUUID())
             .enabled(true)
@@ -341,9 +347,10 @@ class JiraServerCustomFunctionActionTest {
             jiraGlobalConfigId.toString(),
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             "http://jira.server.example.com/jira",
-            "user",
-            "password"
+            JiraServerAuthorizationMethod.BASIC
         );
+        configModel.setUserName("user");
+        configModel.setPassword("password");
         DistributionJobModel jobModel = DistributionJobModel.builder()
             .jobId(UUID.randomUUID())
             .enabled(true)

--- a/src/test/java/com/synopsys/integration/alert/channel/jira/server/action/JiraServerGlobalCrudActionsTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/jira/server/action/JiraServerGlobalCrudActionsTestIT.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpStatus;
 
 import com.synopsys.integration.alert.channel.jira.server.database.accessor.JiraServerGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
+import com.synopsys.integration.alert.channel.jira.server.model.enumeration.JiraServerAuthorizationMethod;
 import com.synopsys.integration.alert.channel.jira.server.validator.JiraServerGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.action.ActionResponse;
 import com.synopsys.integration.alert.common.enumeration.ConfigContextEnum;
@@ -234,13 +235,15 @@ class JiraServerGlobalCrudActionsTestIT {
         assertTrue(createActionResponse.getContent().isPresent());
 
         UUID uuid = UUID.fromString(createActionResponse.getContent().get().getId());
+        // TODO: Implement access token and AuthorizationMethod
         JiraServerGlobalConfigModel updatedJiraServerGlobalConfigModel = new JiraServerGlobalConfigModel(
             uuid.toString(),
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             "https://aNewURL",
-            "a-different-username",
-            "newPassword"
+            JiraServerAuthorizationMethod.BASIC
         );
+        updatedJiraServerGlobalConfigModel.setUserName("a-different-username");
+        updatedJiraServerGlobalConfigModel.setPassword("newPassword");
         ActionResponse<JiraServerGlobalConfigModel> actionResponse = crudActions.update(uuid, updatedJiraServerGlobalConfigModel);
 
         assertTrue(createActionResponse.isSuccessful());
@@ -271,13 +274,14 @@ class JiraServerGlobalCrudActionsTestIT {
         assertTrue(createActionResponse.getContent().isPresent());
 
         UUID uuid = UUID.fromString(createActionResponse.getContent().get().getId());
+        // TODO: Implement access token and AuthorizationMethod
         JiraServerGlobalConfigModel updatedJiraServerGlobalConfigModel = new JiraServerGlobalConfigModel(
             null,
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             "https://aNewURL",
-            "a-different-username",
-            null
+            JiraServerAuthorizationMethod.BASIC
         );
+        updatedJiraServerGlobalConfigModel.setUserName("a-different-username");
         ActionResponse<JiraServerGlobalConfigModel> actionResponse = crudActions.update(uuid, updatedJiraServerGlobalConfigModel);
 
         assertTrue(actionResponse.isError());
@@ -318,18 +322,27 @@ class JiraServerGlobalCrudActionsTestIT {
     }
 
     private JiraServerGlobalConfigModel createBasicJiraModel() {
+        // TODO: Implement access token and AuthorizationMethod
         JiraServerGlobalConfigModel jiraServerGlobalConfigModel = new JiraServerGlobalConfigModel(
             null,
             AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
             "https://url",
-            "name",
-            "password"
+            JiraServerAuthorizationMethod.BASIC
         );
+        jiraServerGlobalConfigModel.setUserName("name");
+        jiraServerGlobalConfigModel.setPassword("password");
         return jiraServerGlobalConfigModel;
     }
 
     private JiraServerGlobalConfigModel createJiraModelWithName(String name) {
-        JiraServerGlobalConfigModel jiraServerGlobalConfigModel = new JiraServerGlobalConfigModel(null, name, "https://url", "name", "password");
+        JiraServerGlobalConfigModel jiraServerGlobalConfigModel = new JiraServerGlobalConfigModel(
+            null,
+            name,
+            "https://url",
+            JiraServerAuthorizationMethod.BASIC
+        );
+        jiraServerGlobalConfigModel.setUserName("name");
+        jiraServerGlobalConfigModel.setPassword("password");
         return jiraServerGlobalConfigModel;
     }
 

--- a/src/test/java/com/synopsys/integration/alert/channel/jira/server/environment/JiraServerEnvironmentVariableHandlerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/jira/server/environment/JiraServerEnvironmentVariableHandlerTestIT.java
@@ -18,6 +18,7 @@ import com.synopsys.integration.alert.api.common.model.AlertConstants;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.channel.jira.server.database.accessor.JiraServerGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
+import com.synopsys.integration.alert.channel.jira.server.model.enumeration.JiraServerAuthorizationMethod;
 import com.synopsys.integration.alert.channel.jira.server.validator.JiraServerGlobalConfigurationValidator;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.common.rest.model.Config;
@@ -53,7 +54,11 @@ class JiraServerEnvironmentVariableHandlerTestIT {
     void testCleanEnvironment() {
         Environment environment = setupMockedEnvironment();
         EnvironmentVariableUtility environmentVariableUtility = new EnvironmentVariableUtility(environment);
-        JiraServerEnvironmentVariableHandler jiraServerEnvironmentVariableHandler = new JiraServerEnvironmentVariableHandler(jiraGlobalConfigAccessor, environmentVariableUtility, validator);
+        JiraServerEnvironmentVariableHandler jiraServerEnvironmentVariableHandler = new JiraServerEnvironmentVariableHandler(
+            jiraGlobalConfigAccessor,
+            environmentVariableUtility,
+            validator
+        );
         EnvironmentProcessingResult result = jiraServerEnvironmentVariableHandler.updateFromEnvironment();
         assertEquals(ChannelKeys.JIRA_SERVER.getDisplayName(), jiraServerEnvironmentVariableHandler.getName());
         assertTrue(result.hasValues());
@@ -67,13 +72,31 @@ class JiraServerEnvironmentVariableHandlerTestIT {
     @Test
     void testExistingConfig() throws AlertConfigurationException {
         String createdAt = DateUtils.formatDate(DateUtils.createCurrentDateTimestamp(), DateUtils.UTC_DATE_FORMAT_TO_MINUTE);
-        JiraServerGlobalConfigModel jiraServerGlobalConfigModel = new JiraServerGlobalConfigModel(null, AlertRestConstants.DEFAULT_CONFIGURATION_NAME, createdAt, createdAt, TEST_URL, TEST_USER, TEST_PASSWORD, false, true);
+        // TODO: Implement access token and AuthorizationMethod
+        JiraServerGlobalConfigModel jiraServerGlobalConfigModel = new JiraServerGlobalConfigModel(
+            null,
+            AlertRestConstants.DEFAULT_CONFIGURATION_NAME,
+            createdAt,
+            createdAt,
+            TEST_URL,
+            JiraServerAuthorizationMethod.BASIC,
+            TEST_USER,
+            TEST_PASSWORD,
+            false,
+            null,
+            false,
+            true
+        );
 
         jiraGlobalConfigAccessor.createConfiguration(jiraServerGlobalConfigModel);
 
         Environment environment = setupMockedEnvironment();
         EnvironmentVariableUtility environmentVariableUtility = new EnvironmentVariableUtility(environment);
-        JiraServerEnvironmentVariableHandler jiraServerEnvironmentVariableHandler = new JiraServerEnvironmentVariableHandler(jiraGlobalConfigAccessor, environmentVariableUtility, validator);
+        JiraServerEnvironmentVariableHandler jiraServerEnvironmentVariableHandler = new JiraServerEnvironmentVariableHandler(
+            jiraGlobalConfigAccessor,
+            environmentVariableUtility,
+            validator
+        );
         EnvironmentProcessingResult result = jiraServerEnvironmentVariableHandler.updateFromEnvironment();
         assertEquals(ChannelKeys.JIRA_SERVER.getDisplayName(), jiraServerEnvironmentVariableHandler.getName());
         assertFalse(result.hasValues());
@@ -82,7 +105,12 @@ class JiraServerEnvironmentVariableHandlerTestIT {
     private Environment setupMockedEnvironment() {
         Environment environment = Mockito.mock(Environment.class);
         Predicate<String> hasEnvVarCheck = (variableName) -> !JiraServerEnvironmentVariableHandler.VARIABLE_NAMES.contains(variableName);
-        EnvironmentVariableMockingUtil.addEnvironmentVariableValueToMock(environment, hasEnvVarCheck, JiraServerEnvironmentVariableHandler.DISABLE_PLUGIN_KEY, TEST_DISABLE_PLUGIN_CHECK);
+        EnvironmentVariableMockingUtil.addEnvironmentVariableValueToMock(
+            environment,
+            hasEnvVarCheck,
+            JiraServerEnvironmentVariableHandler.DISABLE_PLUGIN_KEY,
+            TEST_DISABLE_PLUGIN_CHECK
+        );
         EnvironmentVariableMockingUtil.addEnvironmentVariableValueToMock(environment, hasEnvVarCheck, JiraServerEnvironmentVariableHandler.URL_KEY, TEST_URL);
         EnvironmentVariableMockingUtil.addEnvironmentVariableValueToMock(environment, hasEnvVarCheck, JiraServerEnvironmentVariableHandler.PASSWORD_KEY, TEST_PASSWORD);
         EnvironmentVariableMockingUtil.addEnvironmentVariableValueToMock(environment, hasEnvVarCheck, JiraServerEnvironmentVariableHandler.USERNAME_KEY, TEST_USER);

--- a/src/test/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerGlobalConfigControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerGlobalConfigControllerTestIT.java
@@ -23,6 +23,7 @@ import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.channel.jira.server.database.accessor.JiraServerGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
+import com.synopsys.integration.alert.channel.jira.server.model.enumeration.JiraServerAuthorizationMethod;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 import com.synopsys.integration.alert.util.AlertIntegrationTest;
 import com.synopsys.integration.alert.util.AlertIntegrationTestConstants;
@@ -221,13 +222,15 @@ class JiraServerGlobalConfigControllerTestIT {
     }
 
     private JiraServerGlobalConfigModel createConfigModel(UUID uuid, String url) {
+        // TODO: Implement access token and AuthorizationMethod
         JiraServerGlobalConfigModel jiraServerGlobalConfigModel = new JiraServerGlobalConfigModel(
             (null != uuid) ? uuid.toString() : null,
             "Configuration name",
             url,
-            "username",
-            "password"
+            JiraServerAuthorizationMethod.BASIC
         );
+        jiraServerGlobalConfigModel.setUserName("username");
+        jiraServerGlobalConfigModel.setPassword("password");
         return jiraServerGlobalConfigModel;
     }
 

--- a/src/test/java/com/synopsys/integration/alert/performance/utility/jira/server/JiraServerPerformanceUtility.java
+++ b/src/test/java/com/synopsys/integration/alert/performance/utility/jira/server/JiraServerPerformanceUtility.java
@@ -18,6 +18,7 @@ import com.google.gson.Gson;
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.channel.jira.server.descriptor.JiraServerDescriptor;
 import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
+import com.synopsys.integration.alert.channel.jira.server.model.enumeration.JiraServerAuthorizationMethod;
 import com.synopsys.integration.alert.common.descriptor.ChannelDescriptor;
 import com.synopsys.integration.alert.common.enumeration.FrequencyType;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
@@ -63,8 +64,11 @@ public class JiraServerPerformanceUtility {
             createdAt,
             createdAt,
             url,
+            JiraServerAuthorizationMethod.BASIC,
             userName,
             password,
+            Boolean.FALSE,
+            null,
             Boolean.FALSE,
             disablePluginCheck
         );
@@ -137,8 +141,11 @@ public class JiraServerPerformanceUtility {
             createdAt,
             createdAt,
             url,
+            JiraServerAuthorizationMethod.BASIC,
             userName,
             password,
+            Boolean.FALSE,
+            null,
             Boolean.FALSE,
             disablePluginCheck
         );


### PR DESCRIPTION
The purpose of this PR is to implement three new fields into JiraServerGlobalConfigModel in order to support Bearer authorization in the future. To support this we've added the JiraServerAuthorizationMethod enum, accessToken, and isAccessToken set fields into the model.

The remainder of the changes are refactoring the implementation of this model and updating broken tests.