### PR TITLE
Resolve IALERT-3429

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,4 @@ All releases are on the GitHub release page. https://github.com/blackducksoftwar
 <!-- project-url-text-end -->
 
 ## Documentation ##
-Our public documentation is located here: https://community.synopsys.com/s/document-item?bundleId=synopsys-alert&topicId=topics%2Fgeneral%2Fsynopsys-alert-overview.html&_LANG=enus
-
-Installation Documentation available for the following:
- - [Docker Compose](https://github.com/blackducksoftware/blackduck-alert/blob/master/deployment/docker-compose/README.md) 
- - [Docker Swarm](https://github.com/blackducksoftware/blackduck-alert/blob/master/deployment/docker-swarm/README.md)
- - [Kubernetes](https://synopsys.atlassian.net/wiki/spaces/BDLM/pages/153583626/Synopsys+Alert+Installation+Guide+for+Synopsys+Operator)
+Our public documentation, including installation instructions, is located here: https://sig-product-docs.synopsys.com/bundle/synopsys-alert/page/topics/general/synopsys-alert-overview.html


### PR DESCRIPTION
Update documentation URL to point to the new Doc Portal. 
Remove broken link to Docker Compose README file.
Remove link to Docker Swarm README and indicate that install instructions are available on the Portal. 
Remove link to synopsysctrl install wiki.
(https://jira-sig.internal.synopsys.com/browse/IALERT-3429)