### PR TITLE
IALERT-3454 SAML grant preexisting roles

### DIFF
--- a/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/security/SAMLGroupConverter.java
+++ b/authentication-saml/src/main/java/com/synopsys/integration/alert/authentication/saml/security/SAMLGroupConverter.java
@@ -8,6 +8,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.saml2.provider.service.authentication.OpenSaml4AuthenticationProvider;
 import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticatedPrincipal;
 import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication;
@@ -20,9 +23,11 @@ import com.synopsys.integration.alert.common.persistence.model.UserModel;
 @Component
 public class SAMLGroupConverter {
     private final AuthenticationEventManager authenticationEventManager;
+    private UserDetailsService userDetailsService;
 
-    public SAMLGroupConverter(AuthenticationEventManager authenticationEventManager) {
+    public SAMLGroupConverter(UserDetailsService userDetailsService, AuthenticationEventManager authenticationEventManager) {
         this.authenticationEventManager = authenticationEventManager;
+        this.userDetailsService = userDetailsService;
     }
 
     public Converter<OpenSaml4AuthenticationProvider.ResponseToken, Saml2Authentication> groupsConverter() {
@@ -32,22 +37,7 @@ public class SAMLGroupConverter {
         return responseToken -> {
             Saml2Authentication authentication = delegate.convert(responseToken);
             Saml2AuthenticatedPrincipal principal = (Saml2AuthenticatedPrincipal) authentication.getPrincipal();
-            List<String> groups = principal.getAttribute("groups");
-            Set<GrantedAuthority> authorities = new HashSet<>();
-            List<String> alertRoles = principal.getAttribute("AlertRoles");
-
-            if (alertRoles != null) {
-                alertRoles.stream()
-                    .map(attr -> StringUtils.join(UserModel.ROLE_PREFIX, attr))
-                    .map(SimpleGrantedAuthority::new)
-                    .forEach(authorities::add);
-            }
-            if (groups != null) {
-                groups.stream().map(SimpleGrantedAuthority::new).forEach(authorities::add);
-            }
-            if (alertRoles == null && groups == null){
-                authorities.addAll(authentication.getAuthorities());
-            }
+            Set<GrantedAuthority> authorities = createGrantedAuthoritiesSet(authentication, principal);
 
             Saml2Authentication saml2Authentication = new Saml2Authentication(principal, authentication.getSaml2Response(), authorities);
 
@@ -56,5 +46,34 @@ public class SAMLGroupConverter {
             }
             return saml2Authentication;
         };
+    }
+
+    private Set<GrantedAuthority> createGrantedAuthoritiesSet(Saml2Authentication authentication, Saml2AuthenticatedPrincipal principal) {
+        List<String> groups = principal.getAttribute("groups");
+        Set<GrantedAuthority> authorities = new HashSet<>();
+        List<String> alertRoles = principal.getAttribute("AlertRoles");
+
+        // Grant the user its existing authorities as well
+        try {
+            UserDetails userDetails = userDetailsService.loadUserByUsername(principal.getName());
+            authorities.addAll(userDetails.getAuthorities());
+        } catch (UsernameNotFoundException ignored) {
+            // username not found means it has not been previously granted authorities which is ok
+        }
+
+        if (alertRoles != null) {
+            alertRoles.stream()
+                .map(attr -> StringUtils.join(UserModel.ROLE_PREFIX, attr))
+                .map(SimpleGrantedAuthority::new)
+                .forEach(authorities::add);
+        }
+        if (groups != null) {
+            groups.stream().map(SimpleGrantedAuthority::new).forEach(authorities::add);
+        }
+        if (alertRoles == null && groups == null) {
+            authorities.addAll(authentication.getAuthorities());
+        }
+
+        return authorities;
     }
 }


### PR DESCRIPTION
 When granting authorities to user, get the preexisting ones to include as well if exists. This mimics the behavior of SAML pre-6.13.0 where added roles to a SAML user stay. However; if roles were removed, they will be regranted by SAML again upon log in (same behavior pre-6.13.0).