### PR TITLE
Revert "Adjusting liquibase files to work properly when re-run"

### DIFF
--- a/alert-database/src/main/resources/liquibase/6.13.0/concrete-saml-configuration-table.xml
+++ b/alert-database/src/main/resources/liquibase/6.13.0/concrete-saml-configuration-table.xml
@@ -81,7 +81,7 @@
     <changeSet author="mau" id="add_saml_metadata_mode_fk">
         <preConditions onFail="MARK_RAN">
             <not>
-                <foreignKeyConstraintExists schemaName="alert" foreignKeyTableName="configuration_saml" foreignKeyName="saml_metadata_mode_id_fk"/>
+                <foreignKeyConstraintExists schemaName="alert" foreignKeyName="saml_metadata_mode_id_fk"/>
             </not>
         </preConditions>
         <addForeignKeyConstraint
@@ -92,7 +92,6 @@
                 referencedColumnNames="id"
                 referencedTableSchemaName="alert"
                 referencedTableName="saml_metadata_mode"
-                onDelete="CASCADE"
         />
     </changeSet>
 </databaseChangeLog>

--- a/alert-database/src/main/resources/liquibase/6.13.0/job-completion-status.xml
+++ b/alert-database/src/main/resources/liquibase/6.13.0/job-completion-status.xml
@@ -50,9 +50,9 @@
         </createTable>
     </changeSet>
     <changeSet author="psantos" id="create-completion-tables-foreign-key">
-        <preConditions onFail="MARK_RAN">
+        <preConditions>
             <not>
-                <foreignKeyConstraintExists schemaName="alert" foreignKeyTableName="job_completion_durations" foreignKeyName="job-completion-config-id-fk"/>
+                <foreignKeyConstraintExists schemaName="alert" foreignKeyName="job-completion-config-id-fk"/>
             </not>
         </preConditions>
         <addForeignKeyConstraint
@@ -67,9 +67,9 @@
         />
     </changeSet>
     <changeSet author="psantos" id="create-job-config-completion-tables-foreign-key">
-        <preConditions onFail="MARK_RAN">
+        <preConditions>
             <not>
-                <foreignKeyConstraintExists schemaName="alert" foreignKeyTableName="job_completion_status" foreignKeyName="job-config-completion-status-fk"/>
+                <foreignKeyConstraintExists schemaName="alert" foreignKeyName="job-config-completion-status-fk"/>
             </not>
         </preConditions>
         <addForeignKeyConstraint


### PR DESCRIPTION
Liquibase throws an error if you changed files that had previously been run:

```
2023-04-28 18:51:02.427  WARN 1 --- [           main] ConfigServletWebServerApplicationContext : Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'liquibase' defined in class path resource [org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration$LiquibaseConfiguration.class]: Invocation of init method failed; nested exception is liquibase.exception.ValidationFailedException: Validation Failed:
     1 change sets check sum
          liquibase/6.13.0/concrete-saml-configuration-table.xml::add_saml_metadata_mode_fk::mau was: 8:655766efe026e9689e2527913fe7a252 but is now: 8:e13f295c7ef8e2d3c6b4903188ac0500

2023-04-28 18:51:02.428  INFO 1 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...
2023-04-28 18:51:02.452  INFO 1 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.
2023-04-28 18:51:02.456  INFO 1 --- [           main] o.apache.catalina.core.StandardService   : Stopping service [Tomcat]
2023-04-28 18:51:02.474  INFO 1 --- [           main] ConditionEvaluationReportLoggingListener : 

Error starting ApplicationContext. To display the conditions report re-run your application with 'debug' enabled.
2023-04-28 18:51:02.522 ERROR 1 --- [           main] o.s.boot.SpringApplication               : Application run failed

org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'liquibase' defined in class path resource [org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration$LiquibaseConfiguration.class]: Invocation of init method failed; nested exception is liquibase.exception.ValidationFailedException: Validation Failed:
     1 change sets check sum
          liquibase/6.13.0/concrete-saml-configuration-table.xml::add_saml_metadata_mode_fk::mau was: 8:655766efe026e9689e2527913fe7a252 but is now: 8:e13f295c7ef8e2d3c6b4903188ac0500


```