### PR TITLE
IALERT-3467 jira accessor persistance changes

### DIFF
--- a/src/test/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerGlobalConfigControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerGlobalConfigControllerTestIT.java
@@ -125,12 +125,26 @@ class JiraServerGlobalConfigControllerTestIT {
     @Test
     @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
     void verifyCreateEndpointTest() throws Exception {
-        String urlPath = REQUEST_URL;
-        MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(urlPath)
+        MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(REQUEST_URL)
             .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTestConstants.ROLE_ALERT_ADMIN))
             .with(SecurityMockMvcRequestPostProcessors.csrf());
 
         JiraServerGlobalConfigModel configModel = createConfigModel(null);
+        request.content(gson.toJson(configModel));
+        request.contentType(MEDIA_TYPE);
+
+        ResultActions resultActions = mockMvc.perform(request);
+        resultActions.andExpect(MockMvcResultMatchers.status().isCreated());
+    }
+
+    @Test
+    @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
+    void verifyCreateEndpointWithPersonalAccessTokenTest() throws Exception {
+        MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post(REQUEST_URL)
+            .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTestConstants.ROLE_ALERT_ADMIN))
+            .with(SecurityMockMvcRequestPostProcessors.csrf());
+
+        JiraServerGlobalConfigModel configModel = createPersonalAccessTokenConfigModel(null, "https://synopsys.com");
         request.content(gson.toJson(configModel));
         request.contentType(MEDIA_TYPE);
 
@@ -222,7 +236,6 @@ class JiraServerGlobalConfigControllerTestIT {
     }
 
     private JiraServerGlobalConfigModel createConfigModel(UUID uuid, String url) {
-        // TODO: Implement access token and AuthorizationMethod
         JiraServerGlobalConfigModel jiraServerGlobalConfigModel = new JiraServerGlobalConfigModel(
             (null != uuid) ? uuid.toString() : null,
             "Configuration name",
@@ -231,6 +244,17 @@ class JiraServerGlobalConfigControllerTestIT {
         );
         jiraServerGlobalConfigModel.setUserName("username");
         jiraServerGlobalConfigModel.setPassword("password");
+        return jiraServerGlobalConfigModel;
+    }
+
+    private JiraServerGlobalConfigModel createPersonalAccessTokenConfigModel(UUID uuid, String url) {
+        JiraServerGlobalConfigModel jiraServerGlobalConfigModel = new JiraServerGlobalConfigModel(
+            (null != uuid) ? uuid.toString() : null,
+            "Configuration name",
+            url,
+            JiraServerAuthorizationMethod.PERSONAL_ACCESS_TOKEN
+        );
+        jiraServerGlobalConfigModel.setAccessToken("accessToken");
         return jiraServerGlobalConfigModel;
     }
 


### PR DESCRIPTION
Jira Server global configurations will only persist one set of credentials. Either username/password or access token. The end user can flip between the two but by doing so will be required to re-authenticate as a result.
The following cases should be noted:

- If using JiraServerAuthorizationMethod = BASIC, then access token is ignored and not persisted to the database on a save/update.
- If using JiraServerAuthorizationMethod = PERSONAL_ACCESS_TOKEN, then username & password are ignored and not persisted to the database on a save/update.
- Using the REST API a user can populate ALL authentication fields, but whatever the value is set for JiraServerAuthorizationMethod will determine which values are actually persisted. Ex. providing user/password/and accessToken but setting JiraServerAuthorizationMethod to BASIC will only persist user/password.