### PR TITLE
IALERT_3493: Fix audit failures page not rendering

### DIFF
--- a/ui/src/main/js/page/audit/AuditFailureTable.js
+++ b/ui/src/main/js/page/audit/AuditFailureTable.js
@@ -37,7 +37,7 @@ const AuditFailureTable = () => {
         localStorage.setItem('AUDIT_FAILURE_REFRESH_STATUS', JSON.stringify(autoRefresh));
 
         if (autoRefresh) {
-            const refreshIntervalId = setInterval(() => dispatch(fetchAuditData()), 30000);
+            const refreshIntervalId = setInterval(() => dispatch(fetchAuditData(paramsConfig)), 30000);
             return function clearRefreshInterval() {
                 clearInterval(refreshIntervalId);
             };
@@ -47,11 +47,13 @@ const AuditFailureTable = () => {
     }, [autoRefresh]);
 
     const handleSearchChange = (e) => {
-        setParamsConfig({ ...paramsConfig,
+        setParamsConfig({
+            ...paramsConfig,
             mutatorData: {
                 ...paramsConfig.mutatorData,
                 searchTerm: e.target.value
-            } });
+            }
+        });
     };
 
     function handleToggle() {
@@ -66,31 +68,37 @@ const AuditFailureTable = () => {
         const { sortName, sortOrder } = paramsConfig.mutatorData;
         if (name !== sortName) {
             setSortConfig({ name, direction: 'ASC' });
-            return setParamsConfig({ ...paramsConfig,
+            return setParamsConfig({
+                ...paramsConfig,
                 mutatorData: {
                     ...paramsConfig.mutatorData,
                     sortName: name,
                     sortOrder: 'asc'
-                } });
+                }
+            });
         }
 
         if (name === sortName && sortOrder !== 'desc') {
             setSortConfig({ name, direction: 'DESC' });
-            return setParamsConfig({ ...paramsConfig,
+            return setParamsConfig({
+                ...paramsConfig,
                 mutatorData: {
                     ...paramsConfig.mutatorData,
                     sortName: name,
                     sortOrder: 'desc'
-                } });
+                }
+            });
         }
 
         setSortConfig();
-        return setParamsConfig({ ...paramsConfig,
+        return setParamsConfig({
+            ...paramsConfig,
             mutatorData: {
                 ...paramsConfig.mutatorData,
                 sortName: '',
                 sortOrder: ''
-            } });
+            }
+        });
     };
 
     const COLUMNS = [{

--- a/ui/src/main/js/page/audit/RefreshFailureCell.js
+++ b/ui/src/main/js/page/audit/RefreshFailureCell.js
@@ -9,7 +9,7 @@ const RefreshFailureCell = ({ data, settings }) => {
     const dispatch = useDispatch();
     const [statusMessage, setStatusMessage] = useState();
     const { error, hasError, refreshNotificationSuccess, refreshJobSuccess } = useSelector((state) => state.audit);
-    useEffect(() => {s
+    useEffect(() => {
         if (hasError) {
             setStatusMessage({
                 message: `${error.status}: ${error.statusText}`,
@@ -45,7 +45,7 @@ const RefreshFailureCell = ({ data, settings }) => {
 
     return (
         <>
-            { statusMessage && (
+            {statusMessage && (
                 <StatusMessage
                     actionMessage={statusMessage.type === 'success' ? statusMessage.message : null}
                     errorMessage={statusMessage.type === 'error' ? statusMessage.message : null}


### PR DESCRIPTION
The issue occurred only when the audit failures table was populated with values thereby displaying the RefreshFailureCell. There was a typo in this component leading to an error rendering the page.

Secondly, while investigating this fix I discovered the auto-refresh was also causing the page to error out. The cause of this issue was missing parameter configuration in the auto-refresh fetchAuditData function. Any time the page refreshed, undefined data was sent and led to an issue rendering the page as well.