### PR TITLE
IALERT-3476: Plugin error logging fix

### DIFF
--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerInstallPluginAction.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerInstallPluginAction.java
@@ -125,8 +125,8 @@ public class JiraServerInstallPluginAction {
 
     private ActionResponse<ValidationResponseModel> createBadRequestIntegrationException(IntegrationException error) {
         logger.error("There was an issue connecting to Jira server", error);
-        ValidationResponseModel validationResponseModel = ValidationResponseModel.generalError(
-            "The following error occurred when connecting to Jira server: " + error.getMessage());
-        return new ActionResponse<>(HttpStatus.BAD_REQUEST, validationResponseModel);
+        String validationErrorMessage = String.format("The following error occurred when connecting to Jira server: %s", error.getMessage());
+        ValidationResponseModel validationResponseModel = ValidationResponseModel.generalError(validationErrorMessage);
+        return new ActionResponse<>(HttpStatus.BAD_REQUEST, validationErrorMessage, validationResponseModel);
     }
 }

--- a/ui/src/main/js/store/actions/jira-server.js
+++ b/ui/src/main/js/store/actions/jira-server.js
@@ -137,9 +137,11 @@ function sendJiraServerPluginSuccess(message) {
     };
 }
 
-function sendJiraServerPluginError() {
+function sendJiraServerPluginError(message, errors) {
     return {
-        type: JIRA_SERVER_PLUGIN_FAIL
+        type: JIRA_SERVER_PLUGIN_FAIL,
+        message,
+        errors
     };
 }
 
@@ -314,7 +316,7 @@ export function installJiraServerPlugin(jiraServerModel) {
                     if (response.ok) {
                         dispatch(sendJiraServerPluginSuccess(responseData.message));
                     } else {
-                        const defaultHandler = () => sendJiraServerPluginError(responseData);
+                        const defaultHandler = () => sendJiraServerPluginError(responseData.message, responseData.error);
                         errorHandlers.push(HTTPErrorUtils.createBadRequestHandler(defaultHandler));
                         errorHandlers.push(HTTPErrorUtils.createDefaultHandler(defaultHandler));
                         const handler = HTTPErrorUtils.createHttpErrorHandler(errorHandlers);


### PR DESCRIPTION
When returning a message from the Jira Install Plugin endpoint we would print only the general message but miss any additional information from the log message as well as the exception. This PR covers the back end fix as well as redux changes to support both message and errors fields. 