### PR TITLE
IALERT-3510: Fix navigation on audit page

### DIFF
--- a/ui/src/main/js/page/about/AboutChannelCell.js
+++ b/ui/src/main/js/page/about/AboutChannelCell.js
@@ -6,6 +6,7 @@ import { JIRA_CLOUD_URLS } from 'page/channel/jira/cloud/JiraCloudModel';
 import { JIRA_SERVER_URLS } from 'page/channel/jira/server/JiraServerModel';
 import { MSTEAMS_URLS } from 'page/channel/msteams/MSTeamsModel';
 import { SLACK_URLS } from 'page/channel/slack/SlackModels';
+import { NavLink } from 'react-router-dom';
 
 function getUrl(channel) {
     switch (channel) {
@@ -27,11 +28,10 @@ function getUrl(channel) {
 }
 
 const AboutChannelCell = ({ data }) => (
-    <a href={getUrl(data.urlName)}>
+    <NavLink to={getUrl(data.urlName)} id={data.urlName}>
         {data.name}
-    </a>
+    </NavLink>
 );
-
 AboutChannelCell.propTypes = {
     data: PropTypes.shape({
         name: PropTypes.string,

--- a/ui/src/main/js/page/about/AboutProviderCell.js
+++ b/ui/src/main/js/page/about/AboutProviderCell.js
@@ -1,16 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { BLACKDUCK_URLS } from 'page/provider/blackduck/BlackDuckModel';
+import { NavLink } from 'react-router-dom';
 
 const AboutProviderCell = ({ data }) => (
-    <a href={BLACKDUCK_URLS.blackDuckTableUrl}>
+    <NavLink to={BLACKDUCK_URLS.blackDuckTableUrl} id={data.urlName}>
         {data.name}
-    </a>
+    </NavLink>
 );
 
 AboutProviderCell.propTypes = {
     data: PropTypes.shape({
-        name: PropTypes.string
+        name: PropTypes.string,
+        urlName: PropTypes.string
     })
 };
 

--- a/ui/src/main/js/store/actions/session.js
+++ b/ui/src/main/js/store/actions/session.js
@@ -98,7 +98,6 @@ export function verifyLogin() {
                     dispatch(loggedOut());
                 } else {
                     verifyResponse.json().then((verifyData) => {
-                        console.log("Verify Result: {}", verifyData);
                         if (verifyData.authenticated) {
                             dispatch(loggedIn({ csrfToken: csrfData.token }));
                         } else {


### PR DESCRIPTION
Navigation from the about page uses a different system of navigation via a-tags rather than NavLinks. As a result, pressing any of these to navigate essentially reloads the page but at the new URL. 

The change here is to bring navigation more in line with how we navigate on the left side navigation menu.