### PR TITLE
IALERT-3515: Add Table Capability - Change Amount of Rows Shown in Table

### DIFF
--- a/ui/src/main/js/common/component/input/DropdownField.js
+++ b/ui/src/main/js/common/component/input/DropdownField.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { createUseStyles } from 'react-jss';
+
+const useStyles = createUseStyles({
+    dropdownField: {
+        padding: ['4px', '10px'],
+        borderColor: '#c8c8dd',
+        borderRadius: '2px'
+    }
+});
+
+const DropdownField = ({ id, isDisabled = false, onChange, options }) => {
+    const classes = useStyles();
+
+    function handleChange(e) {
+        onChange(e.target.value)
+    }
+
+    return (
+        <select
+            className={classes.dropdownField}
+            onChange={handleChange}
+            disabled={isDisabled}
+            id={id}
+        >
+            { options.map((option) =>
+                <option value={option.value} id={option.value}>
+                    {option.label}
+                </option>
+            )}
+        </select>
+    )
+};
+
+DropdownField.propTypes = {
+    options: PropTypes.arrayOf(
+        PropTypes.shape({
+            label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+            value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+        })
+    ),
+    onChange: PropTypes.func,
+    isDisabled: PropTypes.bool,
+    id: PropTypes.string
+};
+
+export default DropdownField;

--- a/ui/src/main/js/common/component/table/SearchFilter.js
+++ b/ui/src/main/js/common/component/table/SearchFilter.js
@@ -15,7 +15,6 @@ const useStyles = createUseStyles({
     },
     inputStyle: {
         border: 'solid .5px',
-        maxWidth: '150px',
         padding: ['4px', '20px', '4px', '10px'],
         font: 'inherit',
         cursor: 'text',

--- a/ui/src/main/js/common/component/table/Table.js
+++ b/ui/src/main/js/common/component/table/Table.js
@@ -5,8 +5,8 @@ import SearchFilter from 'common/component/table/SearchFilter';
 import TableBody from 'common/component/table/TableBody';
 import TableHeader from 'common/component/table/TableHeader';
 import ToggleSwitch from 'common/component/input/ToggleSwitch';
-import Pagination from 'common/component/navigation/Pagination';
 import EmptyTableView from 'common/component/table/EmptyTableView';
+import TableFooter from 'common/component/table/TableFooter';
 
 const useStyles = createUseStyles({
     table: {
@@ -24,7 +24,9 @@ const useStyles = createUseStyles({
 });
 
 const Table = ({ columns, multiSelect, selected, onSelected, disableSelectOptions, tableData, handleSearchChange,
-    searchBarPlaceholder, tableActions, onToggle, active, onSort, sortConfig, data, onPage, emptyTableConfig, defaultSearchValue }) => {
+    searchBarPlaceholder, tableActions, onToggle, active, onSort, sortConfig, data, onPage, emptyTableConfig, 
+    defaultSearchValue, onPageSize, showPageSize
+ }) => {
     const classes = useStyles();
 
     return (
@@ -76,9 +78,7 @@ const Table = ({ columns, multiSelect, selected, onSelected, disableSelectOption
                 </table>
             )}
 
-            { data?.totalPages > 1 && (
-                <Pagination data={data} onPage={onPage} />
-            )}
+            <TableFooter data={data} onPage={onPage} onPageSize={onPageSize} showPageSize={showPageSize} />
         </>
     );
 };
@@ -105,9 +105,9 @@ Table.propTypes = {
         direction: PropTypes.string
     }),
     onPage: PropTypes.func,
-    data: PropTypes.shape({
-        totalPages: PropTypes.number
-    }),
+    onPageSize: PropTypes.func,
+    showPageSize: PropTypes.bool,
+    data: PropTypes.object,
     emptyTableConfig: PropTypes.shape({
         message: PropTypes.string
     })

--- a/ui/src/main/js/common/component/table/TableFooter.js
+++ b/ui/src/main/js/common/component/table/TableFooter.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { createUseStyles } from 'react-jss';
+import Pagination from 'common/component/navigation/Pagination';
+import DropdownField from 'common/component/input/DropdownField';
+
+const useStyles = createUseStyles({
+    tableFooter: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'baseline',
+        paddingBottom: '50px'
+    },
+    rowCountSelector: {
+        marginLeft: 'auto',
+        marginRight: 0
+    }
+});
+
+const TableFooter = ({ data, onPage, onPageSize, showPageSize }) => {
+    const classes = useStyles();
+
+    // Default table row amounts are 10, 25, 30, and 50 - these were collected from legacy code
+    const onPageOptions = [{label: '10 Rows', value: 10}, {label: '25 Rows', value: 25}, {label: '30 Rows', value: 30}, {label: '50 Rows', value: 50}];
+
+    return (
+            <div className={classes.tableFooter}>
+                { data?.totalPages > 1 && (
+                    <div>
+                        <Pagination data={data} onPage={onPage} />
+                    </div>
+                )}
+                {/* Until all endpoints are converted to HATEOAS, we need to use showPageSize prop to determine which tables should have this capability */}
+                { (data?.totalPages > 1 && showPageSize) && (
+                    <div className={classes.rowCountSelector}>
+                        <DropdownField options={onPageOptions} onChange={onPageSize}/>
+                    </div>
+                )}
+            </div>
+    )
+}
+
+TableFooter.defaultProps = {
+    showPageSize: false
+}
+
+TableFooter.propTypes = {
+    data: PropTypes.object,
+    onPage: PropTypes.func,
+    onPageSize: PropTypes.func,
+    showPageSize: PropTypes.bool
+};
+
+export default TableFooter;

--- a/ui/src/main/js/page/audit/AuditFailureTable.js
+++ b/ui/src/main/js/page/audit/AuditFailureTable.js
@@ -65,6 +65,10 @@ const AuditFailureTable = () => {
         setParamsConfig({ ...paramsConfig, pageNumber: page });
     }
 
+    function handlePageSize(count) {
+        setParamsConfig({ ...paramsConfig, pageSize: count });
+    }
+
     function handleRefresh() {
         dispatch(fetchAuditData(paramsConfig));
     }
@@ -160,6 +164,8 @@ const AuditFailureTable = () => {
             onSort={onSort}
             sortConfig={sortConfig}
             onPage={handlePagination}
+            onPageSize={handlePageSize}
+            showPageSize
             data={data}
             emptyTableConfig={emptyTableConfig}
             tableActions={() => <Button onClick={handleRefresh} type="button" text="Refresh" isDisabled={fetching} showLoader={fetching} />}

--- a/ui/src/main/js/page/channel/azure/AzureBoardsTable.js
+++ b/ui/src/main/js/page/channel/azure/AzureBoardsTable.js
@@ -121,6 +121,10 @@ const AzureBoardsTable = ({ readonly, allowDelete }) => {
         setParamsConfig({ ...paramsConfig, pageNumber: page });
     }
 
+    function handlePageSize(count) {
+        setParamsConfig({ ...paramsConfig, pageSize: count });
+    }
+
     const onSort = (name) => {
         const { sortName, sortOrder } = paramsConfig.mutatorData;
         if (name !== sortName) {
@@ -171,6 +175,8 @@ const AzureBoardsTable = ({ readonly, allowDelete }) => {
                 selected={selected}
                 onSelected={onSelected}
                 onPage={handlePagination}
+                onPageSize={handlePageSize}
+                showPageSize
                 data={data}
                 emptyTableConfig={emptyTableConfig}
                 tableActions={() => <AzureBoardsTableActions data={data} readonly={readonly} allowDelete={allowDelete} selected={selected} setSelected={setSelected} />}

--- a/ui/src/main/js/page/channel/jira/server/JiraServerTable.js
+++ b/ui/src/main/js/page/channel/jira/server/JiraServerTable.js
@@ -99,6 +99,10 @@ const JiraServerTable = ({ readonly, allowDelete }) => {
         setParamsConfig({ ...paramsConfig, pageNumber: page });
     }
 
+    function handlePageSize(count) {
+        setParamsConfig({ ...paramsConfig, pageSize: count });
+    }
+
     const onSort = (name) => {
         const { sortName, sortOrder } = paramsConfig.mutatorData;
         if (name !== sortName) {
@@ -148,6 +152,8 @@ const JiraServerTable = ({ readonly, allowDelete }) => {
             selected={selected}
             onSelected={onSelected}
             onPage={handlePagination}
+            onPageSize={handlePageSize}
+            showPageSize
             data={data}
             emptyTableConfig={emptyTableConfig}
             tableActions={() => <JiraServerTableActions data={data} readonly={readonly} allowDelete={allowDelete} selected={selected} setSelected={setSelected} />}

--- a/ui/src/main/js/page/distribution/DistributionTable.js
+++ b/ui/src/main/js/page/distribution/DistributionTable.js
@@ -113,6 +113,10 @@ const DistributionTable = ({ readonly }) => {
         setParamsConfig({ ...paramsConfig, pageNumber: page });
     }
 
+    function handlePageSize(count) {
+        setParamsConfig({ ...paramsConfig, pageSize: count });
+    }
+
     const onSort = (name) => {
         const { sortBy, sortOrder } = paramsConfig.mutatorData;
         if (name !== sortBy) {
@@ -168,6 +172,8 @@ const DistributionTable = ({ readonly }) => {
             selected={selected}
             onSelected={onSelected}
             onPage={handlePagination}
+            onPageSize={handlePageSize}
+            showPageSize
             data={data}
             emptyTableConfig={emptyTableConfig}
             tableActions={() => <DistributionTableActions data={data} readonly={readonly} selected={selected} setSelected={setSelected} />}


### PR DESCRIPTION
Adding the ability to update a table's page size.  What this does is allows the user to switch between 10, 25, 30, and 50 rows shown in a table.  These numbers came from legacy code, and can easily be updated in the TableFooter component.  A screenshot below shows where this can be found in a table.  
  
<img width="1728" alt="Screen Shot 2023-06-27 at 4 40 37 PM" src="https://github.com/blackducksoftware/blackduck-alert/assets/28878577/519e7f28-99fb-4f57-8241-c8595ae53d36">
