### PR TITLE
IALERT-3526 Remove @Lob annotation

### DIFF
--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/audit/AuditEntryEntity.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/audit/AuditEntryEntity.java
@@ -19,7 +19,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
@@ -49,8 +48,7 @@ public class AuditEntryEntity extends BaseEntity implements DatabaseEntity {
 
     @Column(name = "error_message")
     private String errorMessage;
-
-    @Lob
+    
     @Column(name = "error_stack_trace", length = STACK_TRACE_CHAR_LIMIT)
     private String errorStackTrace;
 

--- a/alert-database/src/main/java/com/synopsys/integration/alert/database/audit/AuditFailedEntity.java
+++ b/alert-database/src/main/java/com/synopsys/integration/alert/database/audit/AuditFailedEntity.java
@@ -10,7 +10,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
@@ -41,8 +40,7 @@ public class AuditFailedEntity extends BaseEntity {
 
     @Column(name = "error_message")
     private String errorMessage;
-
-    @Lob
+    
     @Column(name = "error_stack_trace", length = STACK_TRACE_CHAR_LIMIT)
     private String errorStackTrace;
 


### PR DESCRIPTION
It seems we removed annotation that specified error_stack_track as a text column in https://github.com/blackducksoftware/blackduck-alert/commit/eabb415fd92f66afe412b9613e04fa08b7e109b4

Resources online indicate that @Lob annotation does not work with postgres and will convert it to an id and store the contents in another table: https://stackoverflow.com/questions/67261808/jpa-with-postgres-anomalously-writes-text-in-lob-column-as-a-number

Since it is expecting a long and received text instead (pre-PR mentioned earlier will store it as text), the error throws. Fix is to remove @Lob annotation and monitor if the same upgrade results in audit page failures again.