### PR TITLE
IALERT-3513: Edit & Copy user page improvements 

### DIFF
--- a/ui/src/main/js/common/component/button/Button.js
+++ b/ui/src/main/js/common/component/button/Button.js
@@ -86,7 +86,7 @@ const Button = ({ id, icon, type, isDisabled, onClick, role, buttonStyle = 'defa
             title={title}
             disabled={isDisabled}
         >
-            { icon && (
+            {icon && (
                 <FontAwesomeIcon icon={icon} size="sm" />
             )}
             <div>
@@ -94,7 +94,7 @@ const Button = ({ id, icon, type, isDisabled, onClick, role, buttonStyle = 'defa
             </div>
             {showLoader && (
                 <div className={classes.loader}>
-                    <FontAwesomeIcon icon="spinner" size="md" spin />
+                    <FontAwesomeIcon icon="spinner" size="sm" spin />
                 </div>
             )}
         </button>

--- a/ui/src/main/js/common/component/button/IconButton.js
+++ b/ui/src/main/js/common/component/button/IconButton.js
@@ -21,7 +21,7 @@ const useStyles = createUseStyles({
     }
 });
 
-const IconButton = ({ id, type, onClick, role, title, icon }) => {
+const IconButton = ({ id, type, onClick, role, title, icon, disabled }) => {
     const classes = useStyles();
     return (
         <button
@@ -31,6 +31,7 @@ const IconButton = ({ id, type, onClick, role, title, icon }) => {
             type={type}
             onClick={onClick}
             title={title}
+            disabled={disabled}
         >
             <FontAwesomeIcon icon={icon} />
         </button>
@@ -47,7 +48,8 @@ IconButton.propTypes = {
     role: PropTypes.string,
     title: PropTypes.string,
     type: PropTypes.string,
-    icon: PropTypes.string.isRequired
+    icon: PropTypes.string.isRequired,
+    disabled: PropTypes.bool
 };
 
 export default IconButton;

--- a/ui/src/main/js/page/usermgmt/user/UserCopyCell.js
+++ b/ui/src/main/js/page/usermgmt/user/UserCopyCell.js
@@ -18,8 +18,6 @@ const UserCopyCell = ({ data }) => {
     };
 
     function handleClick() {
-        console.log(data);
-        console.log(data.authenticationType);
         setStatusMessage();
         setShowModal(true);
         setSelectedData((userData) => ({
@@ -46,7 +44,7 @@ const UserCopyCell = ({ data }) => {
                 icon="copy"
                 onClick={() => handleClick()}
                 disabled={isExternalUser}
-                title={isExternalUser ? 'Cannot copy an externally managed user' : undefined}
+                title={isExternalUser ? 'Cannot copy an externally managed user' : 'Copy'}
             />
 
             {showModal ? (

--- a/ui/src/main/js/page/usermgmt/user/UserCopyCell.js
+++ b/ui/src/main/js/page/usermgmt/user/UserCopyCell.js
@@ -8,6 +8,7 @@ const UserCopyCell = ({ data }) => {
     const [showModal, setShowModal] = useState(false);
     const [selectedData, setSelectedData] = useState(data);
     const [statusMessage, setStatusMessage] = useState();
+    const isExternalUser = data.authenticationType !== 'DATABASE';
 
     const modalOptions = {
         type: 'COPY',
@@ -17,6 +18,8 @@ const UserCopyCell = ({ data }) => {
     };
 
     function handleClick() {
+        console.log(data);
+        console.log(data.authenticationType);
         setStatusMessage();
         setShowModal(true);
         setSelectedData((userData) => ({
@@ -32,16 +35,21 @@ const UserCopyCell = ({ data }) => {
 
     return (
         <>
-            { statusMessage && (
+            {statusMessage && (
                 <StatusMessage
                     actionMessage={statusMessage.type === 'success' ? statusMessage.message : null}
                     errorMessage={statusMessage.type === 'error' ? statusMessage.message : null}
                 />
             )}
 
-            <IconButton icon="copy" onClick={() => handleClick()} />
+            <IconButton
+                icon="copy"
+                onClick={() => handleClick()}
+                disabled={isExternalUser}
+                title={isExternalUser ? 'Cannot copy an externally managed user' : undefined}
+            />
 
-            { showModal ? (
+            {showModal ? (
                 <UserModal
                     data={selectedData}
                     isOpen={showModal}
@@ -50,7 +58,7 @@ const UserCopyCell = ({ data }) => {
                     setStatusMessage={setStatusMessage}
                     successMessage="Successfully created one new user."
                 />
-            ) : null }
+            ) : null}
         </>
 
     );

--- a/ui/src/main/js/page/usermgmt/user/UserEditCell.js
+++ b/ui/src/main/js/page/usermgmt/user/UserEditCell.js
@@ -24,16 +24,20 @@ const UserEditCell = ({ data }) => {
 
     return (
         <>
-            { statusMessage && (
+            {statusMessage && (
                 <StatusMessage
                     actionMessage={statusMessage.type === 'success' ? statusMessage.message : null}
                     errorMessage={statusMessage.type === 'error' ? statusMessage.message : null}
                 />
             )}
 
-            <IconButton icon="pencil-alt" onClick={() => handleClick()} />
+            <IconButton
+                icon="pencil-alt"
+                onClick={() => handleClick()}
+                title="Edit"
+            />
 
-            { showModal && (
+            {showModal && (
                 <UserModal
                     data={selectedData}
                     isOpen={showModal}

--- a/ui/src/main/js/page/usermgmt/user/UserModal.js
+++ b/ui/src/main/js/page/usermgmt/user/UserModal.js
@@ -3,19 +3,24 @@ import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { createUseStyles } from 'react-jss';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { saveUser, validateUser, fetchUsers, clearUserFieldErrors } from 'store/actions/users';
+import { clearUserFieldErrors, fetchUsers, saveUser, validateUser } from 'store/actions/users';
 import DynamicSelectInput from 'common/component/input/DynamicSelectInput';
 import Modal from 'common/component/modal/Modal';
 import PasswordInput from 'common/component/input/PasswordInput';
 import TextInput from 'common/component/input/TextInput';
 import * as HTTPErrorUtils from 'common/util/httpErrorUtilities';
 import { USER_INPUT_FIELD_KEYS } from 'page/usermgmt/user/UserModel';
+import classNames from 'classnames';
 
-const useStyles = createUseStyles({
-    descriptorContainer: {
+const useStyles = createUseStyles((theme) => ({
+    messageContainer: {
         display: 'flex',
         alignItems: 'center',
-        padding: [0, 0, '20px', '60px']
+        padding: [0, 0, '20px', '70px'],
+        justifyContent: 'center'
+    },
+    warningStyle: {
+        color: theme.colors.warning
     },
     descriptor: {
         fontSize: '14px',
@@ -24,7 +29,7 @@ const useStyles = createUseStyles({
     userModalContent: {
         margin: ['30px', 0, '60px']
     }
-});
+}));
 
 const UserModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, successMessage }) => {
     const classes = useStyles();
@@ -33,6 +38,9 @@ const UserModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
     const { copyDescription, submitText, title, type } = modalOptions;
     const [userModel, setUserModel] = useState(type === 'CREATE' ? {} : data);
     const [showLoader, setShowLoader] = useState(false);
+    const messageContainerClass = classNames(classes.messageContainer, {
+        [classes.warningStyle]: type === 'EDIT'
+    });
 
     const fieldErrors = useSelector((state) => state.users.error.fieldErrors);
     const roles = useSelector((state) => state.roles.data);
@@ -125,15 +133,23 @@ const UserModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
             submitText={submitText}
             showLoader={showLoader}
         >
-            { type === 'COPY' && (
-                <div className={classes.descriptorContainer}>
-                    <FontAwesomeIcon icon="exclamation-circle" size="2x" />
-                    <span className={classes.descriptor}>
-                        {copyDescription}
-                    </span>
-                </div>
-            )}
             <div className={classes.userModalContent}>
+                {type === 'COPY' && (
+                    <div className={messageContainerClass}>
+                        <FontAwesomeIcon icon="exclamation-circle" size="2x" />
+                        <span className={classes.descriptor}>
+                            {copyDescription}
+                        </span>
+                    </div>
+                )}
+                {type === 'EDIT' && external && (
+                    <div className={messageContainerClass}>
+                        <FontAwesomeIcon icon="exclamation-circle" size="2x" />
+                        <span className={classes.descriptor}>
+                            This user is managed by a system external to Alert. Only roles can be assigned.
+                        </span>
+                    </div>
+                )}
                 <TextInput
                     id={USER_INPUT_FIELD_KEYS.USERNAME_KEY}
                     name={USER_INPUT_FIELD_KEYS.USERNAME_KEY}
@@ -161,20 +177,22 @@ const UserModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
                     errorName={USER_INPUT_FIELD_KEYS.PASSWORD_KEY}
                     errorValue={fieldErrors[USER_INPUT_FIELD_KEYS.PASSWORD_KEY]}
                 />
-                <PasswordInput
-                    id={USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_KEY}
-                    name={USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_KEY}
-                    label="Confirm Password"
-                    customDescription="The user's password."
-                    placeholder="Confirm password..."
-                    readOnly={false}
-                    required
-                    isSet={userModel[USER_INPUT_FIELD_KEYS.IS_PASSWORD_SET]}
-                    onChange={handleOnChange(USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_KEY)}
-                    value={userModel[USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_KEY] || undefined}
-                    errorName={USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_KEY}
-                    errorValue={userModel[USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_ERROR_KEY]}
-                />
+                {!external && (
+                    <PasswordInput
+                        id={USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_KEY}
+                        name={USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_KEY}
+                        label="Confirm Password"
+                        customDescription="The user's password."
+                        placeholder="Confirm password..."
+                        readOnly={false}
+                        required
+                        isSet={userModel[USER_INPUT_FIELD_KEYS.IS_PASSWORD_SET]}
+                        onChange={handleOnChange(USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_KEY)}
+                        value={userModel[USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_KEY] || undefined}
+                        errorName={USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_KEY}
+                        errorValue={userModel[USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_ERROR_KEY]}
+                    />
+                )}
                 <TextInput
                     id={USER_INPUT_FIELD_KEYS.EMAIL_KEY}
                     name={USER_INPUT_FIELD_KEYS.EMAIL_KEY}


### PR DESCRIPTION
Several improvements for the user page
- Disable copying externally managed users
- Add warning logging when editing externally managed users
- Fix console logging some errors when using incorrect props for the loading icon