### PR TITLE
IALERT-3518: Show Error Message with No Password Setup

### DIFF
--- a/ui/src/main/js/page/provider/ProviderModal.js
+++ b/ui/src/main/js/page/provider/ProviderModal.js
@@ -115,7 +115,7 @@ const ProviderModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessa
             });
         }
 
-        if (testStatus === 'ERROR' && requestType === 'test') {
+        if (testStatus === 'ERROR' || saveStatus === 'ERROR') {
             setShowLoader();
             setNotificationConfig({
                 title: 'Provider Test Unsuccessful.',
@@ -134,10 +134,6 @@ const ProviderModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessa
             });
             setShowNotification(true);
             dispatch(clearProviderFieldErrors());
-        }
-
-        if (saveStatus === 'ERROR') {
-            setShowLoader();
         }
     }, [saveStatus, testStatus]);
 

--- a/ui/src/main/js/store/reducers/provider.js
+++ b/ui/src/main/js/store/reducers/provider.js
@@ -113,6 +113,7 @@ const provider = (state = initialState, action) => {
                 ...state,
                 fetching: false,
                 saveStatus: 'ERROR',
+                testStatus: 'ERROR',
                 error: HTTPErrorUtils.createErrorObject(action)
             };
         case PROVIDER_VALIDATE_SUCCESS:


### PR DESCRIPTION
In the Provider modal, if a user doest not have the encryption settings set, then testing or saving a provider model will fail.  We did not properly show a message before.  This should fix that.  HUGE props to @ChomickiM for solving the root of this.  
  
<img width="1091" alt="Screen Shot 2023-06-30 at 4 04 08 PM" src="https://github.com/blackducksoftware/blackduck-alert/assets/28878577/be4f01a1-5f81-449d-96e2-db167c427e9d">
