### PR TITLE
IALERT-3519: Update Email Test Config Popup

### DIFF
--- a/ui/src/main/js/page/channel/email/EmailGlobalConfiguration.js
+++ b/ui/src/main/js/page/channel/email/EmailGlobalConfiguration.js
@@ -27,7 +27,7 @@ const EmailGlobalConfiguration = ({
             id={EMAIL_TEST_FIELD.key}
             name={EMAIL_TEST_FIELD.key}
             label={EMAIL_TEST_FIELD.label}
-            description={EMAIL_TEST_FIELD.description}
+            customDescription={EMAIL_TEST_FIELD.description}
             onChange={({ target }) => setTestEmailAddress(target.value)}
             value={testEmailAddress}
         />


### PR DESCRIPTION
Popup on the help dialog for the only field in the Email Test Configuration Modal wasn't showing properly.  It should have been updated to use 'customDescription' prop.