### PR TITLE
IALERT-3524: Modal Body Overflow

### DIFF
--- a/ui/src/main/js/common/component/modal/Modal.js
+++ b/ui/src/main/js/common/component/modal/Modal.js
@@ -43,7 +43,7 @@ const useStyles = createUseStyles((theme) => ({
         position: 'relative'
     },
     modalBody: {
-        overflowY: 'visible',
+        overflowY: 'auto',
         maxHeight: 'calc(100vh - 355px)',
         padding: ['16px', 0]
     }


### PR DESCRIPTION
**Bug:**  
When a users viewport was small enough to make enable a modal scroll, the modal footer would be locked in place (relative to the position it initially was placed).  To fix this, I've just enabled overflow on the y axis of the modal body to automatically correct for itself.  This should allow the modal to scroll, locking the header/footer in place.