### PR TITLE
IALERT-3528: Persist API Params on Table Refresh

### DIFF
--- a/ui/src/main/js/page/channel/azure/AzureBoardsTable.js
+++ b/ui/src/main/js/page/channel/azure/AzureBoardsTable.js
@@ -179,7 +179,16 @@ const AzureBoardsTable = ({ readonly, allowDelete }) => {
                 showPageSize
                 data={data}
                 emptyTableConfig={emptyTableConfig}
-                tableActions={() => <AzureBoardsTableActions data={data} readonly={readonly} allowDelete={allowDelete} selected={selected} setSelected={setSelected} />}
+                tableActions={() => 
+                    <AzureBoardsTableActions
+                        data={data}
+                        readonly={readonly}
+                        allowDelete={allowDelete}
+                        selected={selected}
+                        setSelected={setSelected}
+                        paramsConfig={paramsConfig}
+                    />
+                }
             />
             {statusMessage && (
                 <StatusMessage

--- a/ui/src/main/js/page/channel/azure/AzureBoardsTableActions.js
+++ b/ui/src/main/js/page/channel/azure/AzureBoardsTableActions.js
@@ -7,7 +7,7 @@ import AzureBoardsDeleteModal from 'page/channel/azure/AzureBoardsDeleteModal';
 import { fetchAzureBoards } from 'store/actions/azure-boards';
 import { useDispatch, useSelector } from 'react-redux';
 
-const AzureBoardsTableActions = ({ data, readonly, allowDelete, selected, setSelected }) => {
+const AzureBoardsTableActions = ({ data, readonly, allowDelete, selected, setSelected, paramsConfig }) => {
     const modalOptions = {
         type: 'CREATE',
         submitText: 'Create',
@@ -31,7 +31,7 @@ const AzureBoardsTableActions = ({ data, readonly, allowDelete, selected, setSel
     }
 
     function handleRefresh() {
-        dispatch(fetchAzureBoards());
+        dispatch(fetchAzureBoards(paramsConfig));
     }
 
     return (
@@ -88,7 +88,8 @@ AzureBoardsTableActions.propTypes = {
     selected: PropTypes.array,
     readonly: PropTypes.bool,
     allowDelete: PropTypes.bool,
-    setSelected: PropTypes.func
+    setSelected: PropTypes.func,
+    paramsConfig: PropTypes.object
 };
 
 export default AzureBoardsTableActions;

--- a/ui/src/main/js/page/channel/jira/server/JiraServerTable.js
+++ b/ui/src/main/js/page/channel/jira/server/JiraServerTable.js
@@ -156,7 +156,16 @@ const JiraServerTable = ({ readonly, allowDelete }) => {
             showPageSize
             data={data}
             emptyTableConfig={emptyTableConfig}
-            tableActions={() => <JiraServerTableActions data={data} readonly={readonly} allowDelete={allowDelete} selected={selected} setSelected={setSelected} />}
+            tableActions={() => 
+                <JiraServerTableActions 
+                    data={data}
+                    readonly={readonly}
+                    allowDelete={allowDelete}
+                    selected={selected}
+                    setSelected={setSelected}
+                    paramsConfig={paramsConfig}
+                />
+            }
         />
     );
 };

--- a/ui/src/main/js/page/channel/jira/server/JiraServerTableActions.js
+++ b/ui/src/main/js/page/channel/jira/server/JiraServerTableActions.js
@@ -7,7 +7,7 @@ import Button from 'common/component/button/Button';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchJiraServer } from 'store/actions/jira-server';
 
-const JiraServerTableActions = ({ data, readonly, allowDelete, selected, setSelected }) => {
+const JiraServerTableActions = ({ data, readonly, allowDelete, selected, setSelected, paramsConfig }) => {
     const modalOptions = {
         type: 'CREATE',
         submitText: 'Create',
@@ -31,7 +31,7 @@ const JiraServerTableActions = ({ data, readonly, allowDelete, selected, setSele
     }
 
     function handleRefresh() {
-        dispatch(fetchJiraServer());
+        dispatch(fetchJiraServer(paramsConfig));
     }
 
     return (
@@ -88,7 +88,8 @@ JiraServerTableActions.propTypes = {
     allowDelete: PropTypes.bool,
     data: PropTypes.object,
     selected: PropTypes.array,
-    setSelected: PropTypes.func
+    setSelected: PropTypes.func,
+    paramsConfig: PropTypes.object
 };
 
 export default JiraServerTableActions;

--- a/ui/src/main/js/page/distribution/DistributionTable.js
+++ b/ui/src/main/js/page/distribution/DistributionTable.js
@@ -176,7 +176,15 @@ const DistributionTable = ({ readonly }) => {
             showPageSize
             data={data}
             emptyTableConfig={emptyTableConfig}
-            tableActions={() => <DistributionTableActions data={data} readonly={readonly} selected={selected} setSelected={setSelected} />}
+            tableActions={() =>
+                <DistributionTableActions
+                    data={data}
+                    readonly={readonly}
+                    selected={selected}
+                    setSelected={setSelected}
+                    paramsConfig={paramsConfig} 
+                />
+            }
         />
     );
 };

--- a/ui/src/main/js/page/distribution/DistributionTableActions.js
+++ b/ui/src/main/js/page/distribution/DistributionTableActions.js
@@ -67,7 +67,8 @@ const DistributionTableActions = ({ data, selected, setSelected, paramsConfig })
 DistributionTableActions.propTypes = {
     data: PropTypes.arrayOf(PropTypes.object),
     selected: PropTypes.array,
-    setSelected: PropTypes.func
+    setSelected: PropTypes.func,
+    paramsConfig: PropTypes.object
 };
 
 export default DistributionTableActions;

--- a/ui/src/main/js/page/distribution/DistributionTableActions.js
+++ b/ui/src/main/js/page/distribution/DistributionTableActions.js
@@ -8,7 +8,7 @@ import { useHistory } from 'react-router-dom/cjs/react-router-dom';
 import { fetchDistribution } from 'store/actions/distribution';
 import { useDispatch, useSelector } from 'react-redux';
 
-const DistributionTableActions = ({ data, selected, setSelected }) => {
+const DistributionTableActions = ({ data, selected, setSelected, paramsConfig }) => {
     const dispatch = useDispatch();
     const history = useHistory();
     const { fetching } = useSelector((state) => state.distribution);
@@ -25,7 +25,7 @@ const DistributionTableActions = ({ data, selected, setSelected }) => {
     }
 
     function handleRefresh() {
-        dispatch(fetchDistribution());
+        dispatch(fetchDistribution(paramsConfig));
     }
 
     return (


### PR DESCRIPTION
This MR should persist the search query, page number,  page length, and sort direction for a refresh on the updated 'concrete model' tables.  This also solves, IALERT-3496