### PR TITLE
IALERT-3529: Update UI for Audit Status Cell

### DIFF
--- a/ui/src/main/js/_theme.js
+++ b/ui/src/main/js/_theme.js
@@ -18,6 +18,9 @@ const colors = {
     },
     defaultAlertColor: '#2E3B4E',
     darkGreyAlertColor: '#646E81',
+    statusFailure: '#E15241',
+    statusPending: '#F0AD4E',
+    statusSuccess: '#509D51',
     warning: '#E07C05'
 };
 

--- a/ui/src/main/js/page/distribution/DistributionStatusCell.js
+++ b/ui/src/main/js/page/distribution/DistributionStatusCell.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { createUseStyles } from 'react-jss';
-import IconButton from 'common/component/button/IconButton';
-import { DISTRIBUTION_URLS } from 'page/distribution/DistributionModel';
-import { useHistory } from 'react-router-dom/cjs/react-router-dom';
 import classNames from 'classnames';
 
 const useStyles = createUseStyles((theme) => ({

--- a/ui/src/main/js/page/distribution/DistributionStatusCell.js
+++ b/ui/src/main/js/page/distribution/DistributionStatusCell.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { createUseStyles } from 'react-jss';
+import IconButton from 'common/component/button/IconButton';
+import { DISTRIBUTION_URLS } from 'page/distribution/DistributionModel';
+import { useHistory } from 'react-router-dom/cjs/react-router-dom';
+import classNames from 'classnames';
+
+const useStyles = createUseStyles((theme) => ({
+    badge: {
+        padding: ['1px', '4px'],
+        fontSize: '0.9em',
+        textAlign: 'center',
+        borderRadius: '2px'
+    },
+    fail: {
+        backgroundColor: theme.colors.statusFailure,
+        color: theme.colors.white.default
+    },
+    pending: {
+        backgroundColor: theme.colors.statusPending,
+        border: '1px solid #F2B560'
+    },
+    success: {
+        backgroundColor: theme.colors.statusSuccess,
+        color: theme.colors.white.default
+    }
+}));
+
+const DistributionEditCell = ({ data }) => {
+    const classes = useStyles();
+    const { auditStatus } = data;
+
+    const statusClass = classNames(classes.badge, {
+        [classes.fail]: auditStatus === 'FAILURE',
+        [classes.pending]: auditStatus === 'PENDING',
+        [classes.success]: auditStatus === 'SUCCESS',
+    });
+    
+    function getStatus(status) {
+        if (status === 'FAILURE') {
+            return 'Failure'
+        } else if (status === 'SUCCESS') {
+            return 'Success'
+        } else if (status === 'PENDING') {
+            return 'Pending'
+        } else {
+            return '\u2014'
+        }
+    }
+    
+    return (
+        <div className={statusClass}>
+            {getStatus(auditStatus)}
+        </div>
+    )
+};
+
+DistributionEditCell.propTypes = {
+    data: PropTypes.shape({
+        auditStatus: PropTypes.string
+    })
+};
+
+export default DistributionEditCell;

--- a/ui/src/main/js/page/distribution/DistributionTable.js
+++ b/ui/src/main/js/page/distribution/DistributionTable.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Table from 'common/component/table/Table';
 import DistributionTableActions from 'page/distribution/DistributionTableActions';
 import DistributionActionCell from 'page/distribution/DistributionActionCell';
+import DistributionStatusCell from 'page/distribution/DistributionStatusCell';
 import ChannelCell from 'page/distribution/ChannelCell';
 import ProviderCell from 'page/distribution/ProviderCell';
 import FrequencyCell from 'page/distribution/FrequencyCell';
@@ -36,7 +37,8 @@ const COLUMNS = [{
 }, {
     key: 'auditStatus',
     label: 'Status',
-    sortable: false
+    sortable: false,
+    customCell: DistributionStatusCell
 }, {
     key: 'enabled',
     label: 'Enabled',


### PR DESCRIPTION
Simple update to the ui of the audit status.  Here's the new look:  
<img width="941" alt="Screen Shot 2023-07-07 at 3 44 47 PM" src="https://github.com/blackducksoftware/blackduck-alert/assets/28878577/7d10a621-128d-4ceb-94c9-e4f46cdee4a5">
