### PR TITLE
IALERT-3528: Ensure Autorefresh Utilizes API Params

### DIFF
--- a/ui/src/main/js/page/audit/AuditFailureTable.js
+++ b/ui/src/main/js/page/audit/AuditFailureTable.js
@@ -45,7 +45,7 @@ const AuditFailureTable = () => {
         }
 
         return undefined;
-    }, [autoRefresh]);
+    }, [autoRefresh, paramsConfig]);
 
     const handleSearchChange = (searchValue) => {
         setParamsConfig({

--- a/ui/src/main/js/page/channel/azure/AzureBoardsTable.js
+++ b/ui/src/main/js/page/channel/azure/AzureBoardsTable.js
@@ -101,7 +101,7 @@ const AzureBoardsTable = ({ readonly, allowDelete }) => {
         }
 
         return undefined;
-    }, [autoRefresh]);
+    }, [autoRefresh, paramsConfig]);
 
     const handleSearchChange = (searchValue) => {
         setParamsConfig({

--- a/ui/src/main/js/page/channel/jira/server/JiraServerTable.js
+++ b/ui/src/main/js/page/channel/jira/server/JiraServerTable.js
@@ -79,7 +79,7 @@ const JiraServerTable = ({ readonly, allowDelete }) => {
         }
 
         return undefined;
-    }, [autoRefresh]);
+    }, [autoRefresh, paramsConfig]);
 
     const handleSearchChange = (searchValue) => {
         setParamsConfig({

--- a/ui/src/main/js/page/distribution/DistributionTable.js
+++ b/ui/src/main/js/page/distribution/DistributionTable.js
@@ -95,7 +95,7 @@ const DistributionTable = ({ readonly }) => {
         }
 
         return undefined;
-    }, [autoRefresh]);
+    }, [autoRefresh, paramsConfig]);
 
     const handleSearchChange = (searchValue) => {
         setParamsConfig({


### PR DESCRIPTION
Weird bug where the autorefresh would not use the params passed in by the user.  Solution was to provide the params for the api inside of the useEffect parameters array to ensure that the autorefresh is accepting the updated params.  Steps to reproduce bug can be seen in the comments of the ticket.