### PR TITLE
IALERT-3611 - Add timezone to DB column

### DIFF
--- a/alert-database-job/src/main/java/com/synopsys/integration/alert/database/api/DefaultDistributionAccessor.java
+++ b/alert-database-job/src/main/java/com/synopsys/integration/alert/database/api/DefaultDistributionAccessor.java
@@ -7,7 +7,7 @@
  */
 package com.synopsys.integration.alert.database.api;
 
-import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -76,11 +76,11 @@ public class DefaultDistributionAccessor implements DistributionAccessor {
         );
     }
 
-    private String formatAuditDate(Timestamp dateTime) {
+    private String formatAuditDate(Instant dateTime) {
         if (dateTime == null) {
             return null;
         }
 
-        return DateUtils.formatDate(DateUtils.fromInstantUTC(dateTime.toInstant()), DateUtils.AUDIT_DATE_FORMAT);
+        return DateUtils.formatDate(DateUtils.fromInstantUTC(dateTime), DateUtils.AUDIT_DATE_FORMAT);
     }
 }

--- a/alert-database-job/src/main/java/com/synopsys/integration/alert/database/distribution/DistributionRepository.java
+++ b/alert-database-job/src/main/java/com/synopsys/integration/alert/database/distribution/DistributionRepository.java
@@ -7,7 +7,7 @@
  */
 package com.synopsys.integration.alert.database.distribution;
 
-import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.UUID;
 
@@ -60,7 +60,7 @@ public interface DistributionRepository extends JpaRepository<DistributionJobEnt
 
         String getDistribution_Frequency();
 
-        Timestamp getTime_Last_Sent();
+        Instant getTime_Last_Sent();
 
         String getStatus();
 

--- a/alert-database/src/main/resources/liquibase/7.1.0/changelog.xml
+++ b/alert-database/src/main/resources/liquibase/7.1.0/changelog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+    <include file="update_timestamp_columns.xml" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/alert-database/src/main/resources/liquibase/7.1.0/update_timestamp_columns.xml
+++ b/alert-database/src/main/resources/liquibase/7.1.0/update_timestamp_columns.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+    <changeSet author="dmaxfield" id="update-job-completion-status-timestamp">
+        <sql dbms="postgresql" stripComments="true">
+            alter table alert.job_completion_status alter column last_run type timestamp with time zone;
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/alert-database/src/main/resources/liquibase/changelog-postgres-master.xml
+++ b/alert-database/src/main/resources/liquibase/changelog-postgres-master.xml
@@ -27,4 +27,5 @@
     <include file="6.13.0/changelog.xml" relativeToChangelogFile="true"/>
     <include file="6.13.1/changelog.xml" relativeToChangelogFile="true"/>
     <include file="7.0.0/changelog.xml" relativeToChangelogFile="true"/>
+    <include file="7.1.0/changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/buildSrc/src/main/resources/init_test_db.sql
+++ b/buildSrc/src/main/resources/init_test_db.sql
@@ -8,5 +8,6 @@ $$
         -- create role and database if there are errors they will be logged.
         PERFORM dblink('user=test dbname=postgres', 'CREATE ROLE sa WITH SUPERUSER LOGIN ENCRYPTED PASSWORD ''blackduck'' ', FALSE);
         PERFORM dblink('user=sa dbname=postgres', 'CREATE DATABASE alertdb WITH OWNER sa', FALSE);
+        ALTER DATABASE alertdb SET timezone TO 'Etc/UTC';
     END
 $$

--- a/src/test/java/com/synopsys/integration/alert/database/api/DefaultDistributionAccessorTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/database/api/DefaultDistributionAccessorTestIT.java
@@ -52,7 +52,6 @@ class DefaultDistributionAccessorTestIT {
     private final int TOTAL_NUMBER_OF_RECORDS = 6;
 
     public static final String SORT_LAST_SENT = "time_last_sent";
-    public static final String SORT_STATUS = "status";
     public static final String SORT_CHANNEL = "channel_descriptor_name";
     public static final String SORT_FREQUENCY = "distribution_frequency";
     public static final String SORT_NAME = "name";
@@ -119,58 +118,58 @@ class DefaultDistributionAccessorTestIT {
     }
 
     @Test
-    void verifyValidityOfQueryTest() throws ParseException {
+    void verifyValidityOfQueryTest() {
         assertValidQueryFunctionality(TOTAL_NUMBER_OF_RECORDS, () -> distributionAccessor.getDistributionWithAuditInfo(0, 100, "name", Direction.ASC, getAllDescriptorNames()));
     }
 
     @Test
-    void verifyValidityOfQueryWithNullsTest() throws ParseException {
+    void verifyValidityOfQueryWithNullsTest() {
         assertValidQueryFunctionality(TOTAL_NUMBER_OF_RECORDS, () -> distributionAccessor.getDistributionWithAuditInfo(0, 100, null, null, getAllDescriptorNames()));
     }
 
     @Test
-    void sortByNameDESCLowPageSizeTest() throws ParseException {
+    void sortByNameDESCLowPageSizeTest() {
         assertSorted(3, 3, SORT_NAME, Direction.DESC, DistributionWithAuditInfo::getJobName);
     }
 
     @Test
-    void sortByNameDESCTest() throws ParseException {
+    void sortByNameDESCTest() {
         assertSorted(TOTAL_NUMBER_OF_RECORDS, 100, SORT_NAME, Direction.DESC, DistributionWithAuditInfo::getJobName);
     }
 
     @Test
-    void sortByNameASCTest() throws ParseException {
+    void sortByNameASCTest() {
         assertSorted(TOTAL_NUMBER_OF_RECORDS, 100, SORT_NAME, Direction.ASC, DistributionWithAuditInfo::getJobName);
     }
 
     @Test
-    void sortByFrequencyASCTest() throws ParseException {
+    void sortByFrequencyASCTest() {
         assertSorted(TOTAL_NUMBER_OF_RECORDS, 100, SORT_FREQUENCY, Direction.ASC, DistributionWithAuditInfo::getFrequencyType);
     }
 
     @Test
-    void sortByFrequencyDESCTest() throws ParseException {
+    void sortByFrequencyDESCTest() {
         assertSorted(TOTAL_NUMBER_OF_RECORDS, 100, SORT_FREQUENCY, Direction.DESC, DistributionWithAuditInfo::getFrequencyType);
     }
 
     @Test
     @Disabled("This feature is not currently supported due to limitations in hibernate")
-    void sortByAuditLastTimeSentDESCTest() throws ParseException {
+    void sortByAuditLastTimeSentDESCTest() {
         assertAuditLastTimeSent(Direction.DESC);
     }
 
     @Test
     @Disabled("This feature is not currently supported due to limitations in hibernate")
-    void sortByAuditLastTimeSentASCTest() throws ParseException {
+    void sortByAuditLastTimeSentASCTest() {
         assertAuditLastTimeSent(Direction.ASC);
     }
 
     @Test
-    void sortByChannelNameDESCTest() throws ParseException {
+    void sortByChannelNameDESCTest() {
         assertSorted(TOTAL_NUMBER_OF_RECORDS, 100, SORT_CHANNEL, Direction.DESC, DistributionWithAuditInfo::getChannelName);
     }
 
-    private AlertPagedModel<DistributionWithAuditInfo> assertAuditLastTimeSent(Direction sortDirection) throws ParseException {
+    private AlertPagedModel<DistributionWithAuditInfo> assertAuditLastTimeSent(Direction sortDirection) {
         return assertSorted(TOTAL_NUMBER_OF_RECORDS, 100, SORT_LAST_SENT, sortDirection,
             info -> {
                 String auditTimeLastSent = info.getAuditTimeLastSent();
@@ -186,8 +185,7 @@ class DefaultDistributionAccessorTestIT {
         );
     }
 
-    private <T extends Comparable> AlertPagedModel<DistributionWithAuditInfo> assertSorted(int expectedTotal, int pageSize, String sortName, Direction sortDirection, Function<DistributionWithAuditInfo, T> getNullableValue)
-        throws ParseException {
+    private <T extends Comparable> AlertPagedModel<DistributionWithAuditInfo> assertSorted(int expectedTotal, int pageSize, String sortName, Direction sortDirection, Function<DistributionWithAuditInfo, T> getNullableValue) {
         AlertPagedModel<DistributionWithAuditInfo> distributionWithAuditInfoSorted = assertValidQueryFunctionality(
             expectedTotal,
             () -> distributionAccessor.getDistributionWithAuditInfo(0, pageSize, sortName, sortDirection, getAllDescriptorNames())
@@ -215,7 +213,7 @@ class DefaultDistributionAccessorTestIT {
         return descriptorMap.getDescriptorKeys().stream().map(DescriptorKey::getUniversalKey).collect(Collectors.toSet());
     }
 
-    private AlertPagedModel<DistributionWithAuditInfo> assertValidQueryFunctionality(int expectedNumberOfResults, Supplier<AlertPagedModel<DistributionWithAuditInfo>> dBQuery) throws ParseException {
+    private AlertPagedModel<DistributionWithAuditInfo> assertValidQueryFunctionality(int expectedNumberOfResults, Supplier<AlertPagedModel<DistributionWithAuditInfo>> dBQuery) {
         Map<UUID, DistributionJobModel> jobAndAuditData = createAndSave6JobAndAudit();
         assertEquals(TOTAL_NUMBER_OF_RECORDS, jobAndAuditData.keySet().size());
 


### PR DESCRIPTION
This is a fix to the issue that came up from updating spring boot.

The column last_run for table job_completion_status did not include 'with timezone' for the type. This PR adds in a liquibase file to alter the table, as well as data type changes to handle the data returned from PG including the timezone.