### PR TITLE
IALERT-3618 - Fix endpoint called when resend a failed notification

### DIFF
--- a/ui/src/main/js/store/actions/audit.js
+++ b/ui/src/main/js/store/actions/audit.js
@@ -155,7 +155,7 @@ export function sendNotification(notificationId, requestParams) {
 export function sendJob(notificationId, jobId) {
     return (dispatch, getState) => {
         dispatch(sendJobRequest());
-        const resendUrl = `${AUDIT_URLS.resend}${notificationId}/job/${jobId}/`;
+        const resendUrl = `${AUDIT_URLS.resend}${notificationId}/job/${jobId}`;
         const { csrfToken } = getState().session;
         const errorHandlers = [];
         errorHandlers.push(HTTPErrorUtils.createUnauthorizedHandler(unauthorized));


### PR DESCRIPTION
When ending with a slash, we throw a 404.