### PR TITLE
IALERT-3584: Create SSLContext from client keystore and truststore

### DIFF
--- a/component/src/main/java/com/synopsys/integration/alert/component/certificates/AlertClientCertificateManager.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/certificates/AlertClientCertificateManager.java
@@ -21,14 +21,13 @@ public class AlertClientCertificateManager {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private PemSslStoreBundle clientSslStoreBundle;
-    private String clientKeyPassword;
 
     public synchronized void importCertificate(ClientCertificateModel clientCertificateModel, ClientCertificateKeyModel clientCertificateKeyModel)
         throws AlertException {
         logger.debug("Importing certificate into key store.");
         validateClientCertificateHasValues(clientCertificateModel);
         validateCertificateKeyHasValues(clientCertificateKeyModel);
-        clientKeyPassword = clientCertificateKeyModel.getPassword()
+        String clientKeyPassword = clientCertificateKeyModel.getPassword()
             .orElseThrow(() -> new AlertException("Missing private key password for client certificate"));
         PemSslStoreDetails keyStoreDetails = PemSslStoreDetails.forCertificate(clientCertificateModel.getCertificateContent())
             .withPrivateKey(clientCertificateKeyModel.getKeyContent())
@@ -51,20 +50,15 @@ public class AlertClientCertificateManager {
         }
         // clean up the reference
         clientSslStoreBundle = null;
-        clientKeyPassword = null;
     }
 
     public boolean containsClientCertificate() {
-        return null != clientSslStoreBundle && null != clientKeyPassword;
+        return null != clientSslStoreBundle;
     }
 
     public Optional<KeyStore> getClientKeyStore() {
         return Optional.ofNullable(clientSslStoreBundle)
             .map(PemSslStoreBundle::getKeyStore);
-    }
-
-    public Optional<String> getClientKeyPassword() {
-        return Optional.ofNullable(clientKeyPassword);
     }
 
     private void validateClientCertificateHasValues(ClientCertificateModel clientCertificateModel) throws AlertException {

--- a/component/src/main/java/com/synopsys/integration/alert/component/certificates/AlertClientCertificateManager.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/certificates/AlertClientCertificateManager.java
@@ -54,6 +54,10 @@ public class AlertClientCertificateManager {
         clientKeyPassword = null;
     }
 
+    public boolean containsClientCertificate() {
+        return null != clientSslStoreBundle && null != clientKeyPassword;
+    }
+
     public Optional<KeyStore> getClientKeyStore() {
         return Optional.ofNullable(clientSslStoreBundle)
             .map(PemSslStoreBundle::getKeyStore);

--- a/component/src/main/java/com/synopsys/integration/alert/component/certificates/AlertSSLContextManager.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/certificates/AlertSSLContextManager.java
@@ -44,8 +44,7 @@ public class AlertSSLContextManager {
 
     private Optional<SslManagerBundle> getSslManagerBundle() {
         Optional<KeyStore> trustStore = trustStoreManager.getTrustStore();
-        if (clientCertificateManager.getClientKeyStore().isPresent() && clientCertificateManager.getClientKeyPassword().isPresent()
-            && trustStore.isPresent()) {
+        if (clientCertificateManager.containsClientCertificate() && trustStore.isPresent()) {
             // when the client keystore is created the password is changed to null by the implementation class used to read the certificate and key data.
             // pass null in order to create the manager bundle.
             KeyStore clientKeystore = clientCertificateManager.getClientKeyStore().orElse(null);

--- a/component/src/main/java/com/synopsys/integration/alert/component/certificates/AlertSSLContextManager.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/certificates/AlertSSLContextManager.java
@@ -1,11 +1,20 @@
 package com.synopsys.integration.alert.component.certificates;
 
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.util.Optional;
 
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
+import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 
 @Component
 public class AlertSSLContextManager {
@@ -19,10 +28,21 @@ public class AlertSSLContextManager {
         this.clientCertificateManager = clientCertificateManager;
     }
 
-    public void initialize() {
+    public void initialize() throws AlertConfigurationException {
     }
 
-    public SSLContext buildSslContext() throws NoSuchAlgorithmException {
-        return SSLContext.getDefault();
+    public Optional<SSLContext> buildSslContext() throws AlertConfigurationException {
+        SSLContext sslContext;
+        try {
+            sslContext = SSLContext.getInstance("TLS");
+            KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            keyManagerFactory.init(clientCertificateManager.getClientKeyStore().orElseThrow(), "".toCharArray());
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(trustStoreManager.getTrustStore());
+            sslContext.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);
+        } catch (AlertException | KeyManagementException | KeyStoreException | NoSuchAlgorithmException | UnrecoverableKeyException ex) {
+            throw new AlertConfigurationException(ex);
+        }
+        return Optional.ofNullable(sslContext);
     }
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/certificates/AlertSSLContextManager.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/certificates/AlertSSLContextManager.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 
 import javax.net.ssl.SSLContext;
 
-import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ssl.SslBundleKey;
 import org.springframework.boot.ssl.SslManagerBundle;
@@ -14,7 +13,6 @@ import org.springframework.boot.ssl.SslStoreBundle;
 import org.springframework.stereotype.Component;
 
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
-import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 
 @Component
@@ -29,32 +27,33 @@ public class AlertSSLContextManager {
         this.clientCertificateManager = clientCertificateManager;
     }
 
-    public void initialize() throws AlertConfigurationException {
-    }
-
     public Optional<SSLContext> buildSslContext() throws AlertConfigurationException {
         SSLContext sslContext;
         try {
-            if (clientCertificateManager.getClientKeyStore().isPresent() && clientCertificateManager.getClientKeyPassword().isPresent()) {
-                SslManagerBundle sslManagerBundle = getSslManagerBundle();
-                sslContext = sslManagerBundle.createSslContext("TLS");
+            Optional<SslManagerBundle> sslManagerBundle = getSslManagerBundle();
+            if (sslManagerBundle.isPresent()) {
+                sslContext = sslManagerBundle.get().createSslContext("TLS");
             } else {
                 sslContext = SSLContext.getDefault();
             }
-        } catch (AlertException | NoSuchAlgorithmException ex) {
+        } catch (NoSuchAlgorithmException ex) {
             throw new AlertConfigurationException(ex);
         }
         return Optional.ofNullable(sslContext);
     }
 
-    @NotNull
-    private SslManagerBundle getSslManagerBundle() throws AlertException {
-        KeyStore trustStore = trustStoreManager.getTrustStore();
-        // when the client keystore is created the password is changed to null by the implementation class used to read the certificate and key data.
-        // pass null in order to create the manager bundle.
-        KeyStore clientKeystore = clientCertificateManager.getClientKeyStore().orElse(null);
-        SslBundleKey sslBundleKey = SslBundleKey.of(null, AlertRestConstants.DEFAULT_CLIENT_CERTIFICATE_ALIAS);
-        SslStoreBundle sslStoreBundle = SslStoreBundle.of(clientKeystore, null, trustStore);
-        return SslManagerBundle.from(sslStoreBundle, sslBundleKey);
+    private Optional<SslManagerBundle> getSslManagerBundle() {
+        Optional<KeyStore> trustStore = trustStoreManager.getTrustStore();
+        if (clientCertificateManager.getClientKeyStore().isPresent() && clientCertificateManager.getClientKeyPassword().isPresent()
+            && trustStore.isPresent()) {
+            // when the client keystore is created the password is changed to null by the implementation class used to read the certificate and key data.
+            // pass null in order to create the manager bundle.
+            KeyStore clientKeystore = clientCertificateManager.getClientKeyStore().orElse(null);
+            SslBundleKey sslBundleKey = SslBundleKey.of(null, AlertRestConstants.DEFAULT_CLIENT_CERTIFICATE_ALIAS);
+            SslStoreBundle sslStoreBundle = SslStoreBundle.of(clientKeystore, null, trustStore.orElse(null));
+            return Optional.of(SslManagerBundle.from(sslStoreBundle, sslBundleKey));
+        } else {
+            return Optional.empty();
+        }
     }
 }

--- a/component/src/main/java/com/synopsys/integration/alert/component/certificates/AlertTrustStoreManager.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/certificates/AlertTrustStoreManager.java
@@ -65,6 +65,16 @@ public class AlertTrustStoreManager {
         }
     }
 
+    public synchronized KeyStore getTrustStore() throws AlertException {
+        Optional<String> optionalTrustStoreFileName = alertProperties.getTrustStoreFile();
+        if (optionalTrustStoreFileName.isPresent()) {
+            return keyStoreManager.getAsKeyStore(keyStoreManager.getAndValidateKeyStoreFile(optionalTrustStoreFileName.get()), getTrustStorePassword());
+        } else {
+            throw new AlertConfigurationException("No trust store file has been provided.");
+        }
+
+    }
+
     public synchronized void validateCertificateContent(CustomCertificateModel customCertificateModel) throws AlertException {
         // Result is ignored, but we continue to throw an AlertException if one occurs
         getAsJavaCertificate(customCertificateModel);

--- a/component/src/main/java/com/synopsys/integration/alert/component/certificates/AlertTrustStoreManager.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/certificates/AlertTrustStoreManager.java
@@ -65,12 +65,17 @@ public class AlertTrustStoreManager {
         }
     }
 
-    public synchronized KeyStore getTrustStore() throws AlertException {
+    public synchronized Optional<KeyStore> getTrustStore() {
         Optional<String> optionalTrustStoreFileName = alertProperties.getTrustStoreFile();
         if (optionalTrustStoreFileName.isPresent()) {
-            return keyStoreManager.getAsKeyStore(keyStoreManager.getAndValidateKeyStoreFile(optionalTrustStoreFileName.get()), getTrustStorePassword());
+            try {
+                return Optional.of(keyStoreManager.getAsKeyStore(keyStoreManager.getAndValidateKeyStoreFile(optionalTrustStoreFileName.get()), getTrustStorePassword()));
+            } catch (AlertException ex) {
+                logger.error("Error getting trust store", ex);
+                return Optional.empty();
+            }
         } else {
-            throw new AlertConfigurationException("No trust store file has been provided.");
+            return Optional.empty();
         }
 
     }

--- a/src/test/java/com/synopsys/integration/alert/component/certificates/AlertClientCertificateManagerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/certificates/AlertClientCertificateManagerTestIT.java
@@ -178,7 +178,6 @@ class AlertClientCertificateManagerTestIT {
         KeyStore clientKeystore = clientCertificateManager.getClientKeyStore().orElseThrow(() -> new AssertionError("Keystore missing when it should exist"));
 
         assertTrue(clientCertificateManager.containsClientCertificate());
-        assertEquals(keyModel.getPassword(), clientCertificateManager.getClientKeyPassword());
         assertTrue(clientKeystore.containsAlias(AlertRestConstants.DEFAULT_CLIENT_CERTIFICATE_ALIAS));
         Certificate clientCertificate = clientKeystore.getCertificate(AlertRestConstants.DEFAULT_CLIENT_CERTIFICATE_ALIAS);
 
@@ -197,16 +196,13 @@ class AlertClientCertificateManagerTestIT {
         clientCertificateManager.removeCertificate();
         assertFalse(clientCertificateManager.containsClientCertificate());
         assertTrue(clientCertificateManager.getClientKeyStore().isEmpty());
-        assertTrue(clientCertificateManager.getClientKeyPassword().isEmpty());
     }
 
     @Test
     void clientCertificateNotSetTest() {
         clientCertificateManager = new AlertClientCertificateManager();
         Optional<KeyStore> keystore = clientCertificateManager.getClientKeyStore();
-        Optional<String> password = clientCertificateManager.getClientKeyPassword();
         assertFalse(clientCertificateManager.containsClientCertificate());
         assertTrue(keystore.isEmpty());
-        assertTrue(password.isEmpty());
     }
 }

--- a/src/test/java/com/synopsys/integration/alert/component/certificates/AlertClientCertificateManagerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/certificates/AlertClientCertificateManagerTestIT.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.AfterEach;
@@ -167,6 +168,7 @@ class AlertClientCertificateManagerTestIT {
         Certificate validationCertificate = certTestUtil.loadCertificate(model.getCertificateContent());
         clientCertificateManager.importCertificate(model, keyModel);
         KeyStore clientKeystore = clientCertificateManager.getClientKeyStore().orElseThrow(() -> new AssertionError("Keystore missing when it should exist"));
+        assertEquals(keyModel.getPassword(), clientCertificateManager.getClientKeyPassword());
         assertTrue(clientKeystore.containsAlias(AlertRestConstants.DEFAULT_CLIENT_CERTIFICATE_ALIAS));
         Certificate clientCertificate = clientKeystore.getCertificate(AlertRestConstants.DEFAULT_CLIENT_CERTIFICATE_ALIAS);
 
@@ -184,5 +186,15 @@ class AlertClientCertificateManagerTestIT {
         clientCertificateManager.importCertificate(model, keyModel);
         clientCertificateManager.removeCertificate();
         assertTrue(clientCertificateManager.getClientKeyStore().isEmpty());
+        assertTrue(clientCertificateManager.getClientKeyPassword().isEmpty());
+    }
+
+    @Test
+    void clientCertificateNotSetTest() {
+        clientCertificateManager = new AlertClientCertificateManager();
+        Optional<KeyStore> keystore = clientCertificateManager.getClientKeyStore();
+        Optional<String> password = clientCertificateManager.getClientKeyPassword();
+        assertTrue(keystore.isEmpty());
+        assertTrue(password.isEmpty());
     }
 }

--- a/src/test/java/com/synopsys/integration/alert/component/certificates/AlertClientCertificateManagerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/certificates/AlertClientCertificateManagerTestIT.java
@@ -2,6 +2,7 @@ package com.synopsys.integration.alert.component.certificates;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -76,6 +77,7 @@ class AlertClientCertificateManagerTestIT {
         clientCertificateManager = new AlertClientCertificateManager();
         ClientCertificateKeyModel keyModel = createClientKeyModel();
         assertThrows(AlertException.class, () -> clientCertificateManager.importCertificate(null, keyModel));
+        assertFalse(clientCertificateManager.containsClientCertificate());
     }
 
     @Test
@@ -90,6 +92,7 @@ class AlertClientCertificateManagerTestIT {
             DateUtils.createCurrentDateString(DateUtils.UTC_DATE_FORMAT_TO_MINUTE)
         );
         assertThrows(AlertException.class, () -> clientCertificateManager.importCertificate(model, keyModel));
+        assertFalse(clientCertificateManager.containsClientCertificate());
     }
 
     @Test
@@ -104,6 +107,7 @@ class AlertClientCertificateManagerTestIT {
             DateUtils.createCurrentDateString(DateUtils.UTC_DATE_FORMAT_TO_MINUTE)
         );
         assertThrows(AlertException.class, () -> clientCertificateManager.importCertificate(model, keyModel));
+        assertFalse(clientCertificateManager.containsClientCertificate());
     }
 
     @Test
@@ -112,6 +116,7 @@ class AlertClientCertificateManagerTestIT {
         ClientCertificateKeyModel keyModel = createClientKeyModel();
         ClientCertificateModel model = createClientModel(keyModel);
         assertThrows(AlertException.class, () -> clientCertificateManager.importCertificate(model, null));
+        assertFalse(clientCertificateManager.containsClientCertificate());
     }
 
     @Test
@@ -127,6 +132,7 @@ class AlertClientCertificateManagerTestIT {
         );
         ClientCertificateModel model = createClientModel(keyModel);
         assertThrows(AlertException.class, () -> clientCertificateManager.importCertificate(model, keyModel));
+        assertFalse(clientCertificateManager.containsClientCertificate());
     }
 
     @Test
@@ -142,6 +148,7 @@ class AlertClientCertificateManagerTestIT {
         );
         ClientCertificateModel model = createClientModel(keyModel);
         assertThrows(AlertException.class, () -> clientCertificateManager.importCertificate(model, keyModel));
+        assertFalse(clientCertificateManager.containsClientCertificate());
     }
 
     @Test
@@ -158,6 +165,7 @@ class AlertClientCertificateManagerTestIT {
         );
         ClientCertificateModel model = createClientModel(keyModel);
         assertThrows(AlertException.class, () -> clientCertificateManager.importCertificate(model, keyModel));
+        assertFalse(clientCertificateManager.containsClientCertificate());
     }
 
     @Test
@@ -168,6 +176,8 @@ class AlertClientCertificateManagerTestIT {
         Certificate validationCertificate = certTestUtil.loadCertificate(model.getCertificateContent());
         clientCertificateManager.importCertificate(model, keyModel);
         KeyStore clientKeystore = clientCertificateManager.getClientKeyStore().orElseThrow(() -> new AssertionError("Keystore missing when it should exist"));
+
+        assertTrue(clientCertificateManager.containsClientCertificate());
         assertEquals(keyModel.getPassword(), clientCertificateManager.getClientKeyPassword());
         assertTrue(clientKeystore.containsAlias(AlertRestConstants.DEFAULT_CLIENT_CERTIFICATE_ALIAS));
         Certificate clientCertificate = clientKeystore.getCertificate(AlertRestConstants.DEFAULT_CLIENT_CERTIFICATE_ALIAS);
@@ -185,6 +195,7 @@ class AlertClientCertificateManagerTestIT {
         ClientCertificateModel model = createClientModel(keyModel);
         clientCertificateManager.importCertificate(model, keyModel);
         clientCertificateManager.removeCertificate();
+        assertFalse(clientCertificateManager.containsClientCertificate());
         assertTrue(clientCertificateManager.getClientKeyStore().isEmpty());
         assertTrue(clientCertificateManager.getClientKeyPassword().isEmpty());
     }
@@ -194,6 +205,7 @@ class AlertClientCertificateManagerTestIT {
         clientCertificateManager = new AlertClientCertificateManager();
         Optional<KeyStore> keystore = clientCertificateManager.getClientKeyStore();
         Optional<String> password = clientCertificateManager.getClientKeyPassword();
+        assertFalse(clientCertificateManager.containsClientCertificate());
         assertTrue(keystore.isEmpty());
         assertTrue(password.isEmpty());
     }

--- a/src/test/java/com/synopsys/integration/alert/component/certificates/AlertSSLContextManagerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/certificates/AlertSSLContextManagerTestIT.java
@@ -22,6 +22,7 @@ import com.synopsys.integration.alert.common.persistence.model.ClientCertificate
 import com.synopsys.integration.alert.common.persistence.model.CustomCertificateModel;
 import com.synopsys.integration.alert.common.util.DateUtils;
 import com.synopsys.integration.alert.component.certificates.web.CertificateTestUtil;
+import com.synopsys.integration.alert.test.common.MockAlertProperties;
 import com.synopsys.integration.alert.util.AlertIntegrationTest;
 
 @AlertIntegrationTest
@@ -50,7 +51,7 @@ class AlertSSLContextManagerTestIT {
             trustStoreManager.removeCertificate(SERVER_CERTIFICATE_ALIAS);
             clientCertificateManager.removeCertificate();
         } catch (AlertException e) {
-
+            // ignore the exception and just continue to clean up.
         }
         certTestUtil.cleanup();
     }
@@ -111,5 +112,16 @@ class AlertSSLContextManagerTestIT {
         assertTrue(sslContext.isPresent());
         assertEquals(SSLContext.getDefault(), sslContext.get());
     }
+
+    @Test
+    void createDefaultSSLContextFromMissingTrustStoreTest() throws Exception {
+        AlertTrustStoreManager missingFileTrustStoreManager = new AlertTrustStoreManager(new MockAlertProperties());
+        AlertSSLContextManager sslContextManager = new AlertSSLContextManager(missingFileTrustStoreManager, clientCertificateManager);
+
+        Optional<SSLContext> sslContext = sslContextManager.buildSslContext();
+        assertTrue(sslContext.isPresent());
+        assertEquals(SSLContext.getDefault(), sslContext.get());
+    }
+
 
 }

--- a/src/test/java/com/synopsys/integration/alert/component/certificates/AlertSSLContextManagerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/certificates/AlertSSLContextManagerTestIT.java
@@ -1,0 +1,115 @@
+package com.synopsys.integration.alert.component.certificates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.net.ssl.SSLContext;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import com.synopsys.integration.alert.api.common.model.exception.AlertException;
+import com.synopsys.integration.alert.common.AlertProperties;
+import com.synopsys.integration.alert.common.persistence.model.ClientCertificateKeyModel;
+import com.synopsys.integration.alert.common.persistence.model.ClientCertificateModel;
+import com.synopsys.integration.alert.common.persistence.model.CustomCertificateModel;
+import com.synopsys.integration.alert.common.util.DateUtils;
+import com.synopsys.integration.alert.component.certificates.web.CertificateTestUtil;
+import com.synopsys.integration.alert.util.AlertIntegrationTest;
+
+@AlertIntegrationTest
+@TestPropertySource(locations = "classpath:certificates/spring-certificate-test.properties")
+class AlertSSLContextManagerTestIT {
+    public static final String ROOT_CERTIFICATE_ALIAS = "root-certificate";
+    public static final String SERVER_CERTIFICATE_ALIAS = "server-certificate";
+    @Autowired
+    private AlertProperties alertProperties;
+    @Autowired
+    private AlertTrustStoreManager trustStoreManager;
+    @Autowired
+    private AlertClientCertificateManager clientCertificateManager;
+
+    private final CertificateTestUtil certTestUtil = new CertificateTestUtil();
+
+    @BeforeEach
+    void initTest() throws Exception {
+        certTestUtil.init(alertProperties);
+    }
+
+    @AfterEach
+    void cleanup() {
+        try {
+            trustStoreManager.removeCertificate(ROOT_CERTIFICATE_ALIAS);
+            trustStoreManager.removeCertificate(SERVER_CERTIFICATE_ALIAS);
+            clientCertificateManager.removeCertificate();
+        } catch (AlertException e) {
+
+        }
+        certTestUtil.cleanup();
+    }
+
+    private ClientCertificateKeyModel createClientKeyModel() throws IOException {
+        UUID id = UUID.randomUUID();
+        String content = certTestUtil.readCertificateOrKeyContents(CertificateTestUtil.KEY_MTLS_CLIENT_FILE_PATH);
+        ClientCertificateKeyModel keyModel = new ClientCertificateKeyModel(
+            id,
+            CertificateTestUtil.MTLS_CERTIFICATE_PASSWORD,
+            false,
+            content,
+            DateUtils.createCurrentDateString(DateUtils.UTC_DATE_FORMAT_TO_MINUTE)
+        );
+
+        return keyModel;
+    }
+
+    private ClientCertificateModel createClientModel(ClientCertificateKeyModel keyModel) throws IOException {
+        UUID id = UUID.randomUUID();
+        String content = certTestUtil.readCertificateOrKeyContents(CertificateTestUtil.CERTIFICATE_MTLS_CLIENT_FILE_PATH);
+        ClientCertificateModel certificateModel = new ClientCertificateModel(
+            id,
+            keyModel.getId(),
+            content,
+            DateUtils.createCurrentDateString(DateUtils.UTC_DATE_FORMAT_TO_MINUTE)
+        );
+        return certificateModel;
+    }
+
+    private CustomCertificateModel createTrustStoreCertificate(String alias, String certificateFilePath) throws IOException {
+        String content = certTestUtil.readCertificateOrKeyContents(certificateFilePath);
+        return new CustomCertificateModel(alias, content, DateUtils.createCurrentDateString(DateUtils.UTC_DATE_FORMAT_TO_MINUTE));
+    }
+
+    @Test
+    void createValidSSLContextTest() throws Exception {
+        AlertSSLContextManager sslContextManager = new AlertSSLContextManager(trustStoreManager, clientCertificateManager);
+        // load certificate data.
+        ClientCertificateKeyModel keyModel = createClientKeyModel();
+        ClientCertificateModel model = createClientModel(keyModel);
+        CustomCertificateModel rootCertificate = createTrustStoreCertificate(ROOT_CERTIFICATE_ALIAS, CertificateTestUtil.CERTIFICATE_MTLS_ROOT_CA_FILE_PATH);
+        CustomCertificateModel serverCertificate = createTrustStoreCertificate(SERVER_CERTIFICATE_ALIAS, CertificateTestUtil.CERTIFICATE_MTLS_SERVER_FILE_PATH);
+
+        trustStoreManager.importCertificate(rootCertificate);
+        trustStoreManager.importCertificate(serverCertificate);
+        clientCertificateManager.importCertificate(model, keyModel);
+
+        Optional<SSLContext> sslContext = sslContextManager.buildSslContext();
+        assertTrue(sslContext.isPresent());
+    }
+
+    @Test
+    void createDefaultSSLContextTest() throws Exception {
+        AlertSSLContextManager sslContextManager = new AlertSSLContextManager(trustStoreManager, clientCertificateManager);
+
+        Optional<SSLContext> sslContext = sslContextManager.buildSslContext();
+        assertTrue(sslContext.isPresent());
+        assertEquals(SSLContext.getDefault(), sslContext.get());
+    }
+
+}

--- a/src/test/java/com/synopsys/integration/alert/component/certificates/AlertTrustStoreManagerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/certificates/AlertTrustStoreManagerTestIT.java
@@ -1,0 +1,169 @@
+package com.synopsys.integration.alert.component.certificates;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
+import com.synopsys.integration.alert.api.common.model.exception.AlertException;
+import com.synopsys.integration.alert.common.AlertProperties;
+import com.synopsys.integration.alert.common.persistence.accessor.CustomCertificateAccessor;
+import com.synopsys.integration.alert.common.persistence.model.CustomCertificateModel;
+import com.synopsys.integration.alert.common.util.DateUtils;
+import com.synopsys.integration.alert.component.certificates.web.CertificateTestUtil;
+import com.synopsys.integration.alert.test.common.MockAlertProperties;
+import com.synopsys.integration.alert.util.AlertIntegrationTest;
+
+@AlertIntegrationTest
+@TestPropertySource(locations = "classpath:certificates/spring-certificate-test.properties")
+class AlertTrustStoreManagerTestIT {
+    public static final String CERTIFICATE_ALIAS = "certificate-alias";
+    public static final String EMPTY_STRING_CONTENT = " \n\t\r  \n\t\r  \n";
+    @Autowired
+    private AlertProperties alertProperties;
+
+    @Autowired
+    private CustomCertificateAccessor certificateAccessor;
+
+    private final CertificateTestUtil certTestUtil = new CertificateTestUtil();
+
+    @BeforeEach
+    void init() throws Exception {
+        certTestUtil.init(alertProperties);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        certTestUtil.cleanup();
+    }
+
+    private CustomCertificateModel createCertificateModel() throws Exception {
+        String certificateContent = certTestUtil.readCertificateOrKeyContents(CertificateTestUtil.CERTIFICATE_FILE_PATH);
+        return new CustomCertificateModel(CERTIFICATE_ALIAS, certificateContent, DateUtils.createCurrentDateString(DateUtils.UTC_DATE_FORMAT_TO_MINUTE));
+    }
+
+    @Test
+    void importCertificateTest() throws Exception {
+        CustomCertificateModel customCertificateModel = createCertificateModel();
+        AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(alertProperties);
+        trustStoreManager.importCertificate(customCertificateModel);
+        KeyStore trustStore = trustStoreManager.getTrustStore().orElseThrow(() -> new AssertionError("Trust strore file should exist"));
+        Certificate certificate = trustStore.getCertificate(CERTIFICATE_ALIAS);
+
+        assertTrue(trustStoreManager.getTrustStore().isPresent());
+        assertTrue(trustStoreManager.getAndValidateTrustStoreFile().exists());
+        assertNotNull(certificate);
+    }
+
+    @Test
+    void importNullCertificateTest() {
+        AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(alertProperties);
+        assertThrows(AlertException.class, () -> trustStoreManager.importCertificate(null));
+
+    }
+
+    @Test
+    void importNullCertificateAliasTest() throws Exception {
+        String certificateContent = certTestUtil.readCertificateOrKeyContents(CertificateTestUtil.CERTIFICATE_FILE_PATH);
+        CustomCertificateModel customCertificateModel = new CustomCertificateModel(
+            null,
+            certificateContent,
+            DateUtils.createCurrentDateString(DateUtils.UTC_DATE_FORMAT_TO_MINUTE)
+        );
+        AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(alertProperties);
+        assertThrows(AlertException.class, () -> trustStoreManager.importCertificate(customCertificateModel));
+    }
+
+    @Test
+    void importNullCertificateContentTest() {
+        CustomCertificateModel customCertificateModel = new CustomCertificateModel(CERTIFICATE_ALIAS, null, DateUtils.createCurrentDateString(DateUtils.UTC_DATE_FORMAT_TO_MINUTE));
+        AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(alertProperties);
+        assertThrows(AlertException.class, () -> trustStoreManager.importCertificate(customCertificateModel));
+    }
+
+    @Test
+    void importEmptyCertificateAliasTest() throws Exception {
+        String certificateContent = certTestUtil.readCertificateOrKeyContents(CertificateTestUtil.CERTIFICATE_FILE_PATH);
+        CustomCertificateModel customCertificateModel = new CustomCertificateModel(
+            EMPTY_STRING_CONTENT,
+            certificateContent,
+            DateUtils.createCurrentDateString(DateUtils.UTC_DATE_FORMAT_TO_MINUTE)
+        );
+        AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(alertProperties);
+        assertThrows(AlertException.class, () -> trustStoreManager.importCertificate(customCertificateModel));
+    }
+
+    @Test
+    void importEmptyCertificateContentTest() {
+        CustomCertificateModel customCertificateModel = new CustomCertificateModel(
+            CERTIFICATE_ALIAS,
+            EMPTY_STRING_CONTENT,
+            DateUtils.createCurrentDateString(DateUtils.UTC_DATE_FORMAT_TO_MINUTE)
+        );
+        AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(alertProperties);
+        assertThrows(AlertException.class, () -> trustStoreManager.importCertificate(customCertificateModel));
+    }
+
+    @Test
+    void removeCertificateByAliasTest() throws Exception {
+        CustomCertificateModel customCertificateModel = createCertificateModel();
+        AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(alertProperties);
+        trustStoreManager.importCertificate(customCertificateModel);
+        trustStoreManager.removeCertificate(CERTIFICATE_ALIAS);
+        KeyStore trustStore = trustStoreManager.getTrustStore().orElseThrow(() -> new AssertionError("Trust strore file should exist"));
+
+        Certificate certificate = trustStore.getCertificate(CERTIFICATE_ALIAS);
+        assertNull(certificate);
+    }
+
+    @Test
+    void removeCertificateByModelContentTest() throws Exception {
+        CustomCertificateModel customCertificateModel = createCertificateModel();
+        AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(alertProperties);
+        trustStoreManager.importCertificate(customCertificateModel);
+        trustStoreManager.removeCertificate(customCertificateModel);
+        KeyStore trustStore = trustStoreManager.getTrustStore().orElseThrow(() -> new AssertionError("Trust strore file should exist"));
+
+        Certificate certificate = trustStore.getCertificate(CERTIFICATE_ALIAS);
+        assertNull(certificate);
+    }
+
+    @Test
+    void removeNullCertificateModelTest() {
+        CustomCertificateModel customCertificateModel = null;
+        AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(alertProperties);
+        assertThrows(AlertException.class, () -> trustStoreManager.removeCertificate(customCertificateModel));
+    }
+
+    @Test
+    void removeTrustStoreFileMissingTest() {
+        AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(new MockAlertProperties());
+        assertThrows(AlertConfigurationException.class, () -> trustStoreManager.removeCertificate(CERTIFICATE_ALIAS));
+    }
+
+    @Test
+    void getTrustStoreWithFileMissingTest() {
+        AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(new MockAlertProperties());
+        assertTrue(trustStoreManager.getTrustStore().isEmpty());
+    }
+
+    @Test
+    void validateCertificateContent() throws Exception {
+        CustomCertificateModel customCertificateModel = createCertificateModel();
+        AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(alertProperties);
+
+        assertDoesNotThrow(() -> trustStoreManager.validateCertificateContent(customCertificateModel));
+    }
+}
+

--- a/src/test/java/com/synopsys/integration/alert/component/certificates/AlertTrustStoreManagerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/certificates/AlertTrustStoreManagerTestIT.java
@@ -18,7 +18,6 @@ import org.springframework.test.context.TestPropertySource;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.common.AlertProperties;
-import com.synopsys.integration.alert.common.persistence.accessor.CustomCertificateAccessor;
 import com.synopsys.integration.alert.common.persistence.model.CustomCertificateModel;
 import com.synopsys.integration.alert.common.util.DateUtils;
 import com.synopsys.integration.alert.component.certificates.web.CertificateTestUtil;
@@ -32,9 +31,6 @@ class AlertTrustStoreManagerTestIT {
     public static final String EMPTY_STRING_CONTENT = " \n\t\r  \n\t\r  \n";
     @Autowired
     private AlertProperties alertProperties;
-
-    @Autowired
-    private CustomCertificateAccessor certificateAccessor;
 
     private final CertificateTestUtil certTestUtil = new CertificateTestUtil();
 
@@ -179,13 +175,13 @@ class AlertTrustStoreManagerTestIT {
         MockAlertProperties mockAlertProperties = new MockAlertProperties();
         mockAlertProperties.setTrustStoreFile("badprotocol:a_file-that-does-not-exist");
         AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(mockAlertProperties);
-        assertThrows(AlertConfigurationException.class, () -> trustStoreManager.getAndValidateTrustStoreFile());
+        assertThrows(AlertConfigurationException.class, trustStoreManager::getAndValidateTrustStoreFile);
     }
 
     @Test
     void getAndValidateFileMissingTest() {
         AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(new MockAlertProperties());
-        assertThrows(AlertConfigurationException.class, () -> trustStoreManager.getAndValidateTrustStoreFile());
+        assertThrows(AlertConfigurationException.class, trustStoreManager::getAndValidateTrustStoreFile);
     }
 }
 

--- a/src/test/java/com/synopsys/integration/alert/component/certificates/AlertTrustStoreManagerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/certificates/AlertTrustStoreManagerTestIT.java
@@ -159,11 +159,33 @@ class AlertTrustStoreManagerTestIT {
     }
 
     @Test
-    void validateCertificateContent() throws Exception {
+    void getTrustStoreWithInvalidFilePathTest() {
+        MockAlertProperties mockAlertProperties = new MockAlertProperties();
+        mockAlertProperties.setTrustStoreFile("badprotocol:a_file-that-does-not-exist");
+        AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(mockAlertProperties);
+        assertTrue(trustStoreManager.getTrustStore().isEmpty());
+    }
+
+    @Test
+    void validateCertificateContentTest() throws Exception {
         CustomCertificateModel customCertificateModel = createCertificateModel();
         AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(alertProperties);
 
         assertDoesNotThrow(() -> trustStoreManager.validateCertificateContent(customCertificateModel));
+    }
+
+    @Test
+    void getAndValidateFileThrowsExceptionTest() {
+        MockAlertProperties mockAlertProperties = new MockAlertProperties();
+        mockAlertProperties.setTrustStoreFile("badprotocol:a_file-that-does-not-exist");
+        AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(mockAlertProperties);
+        assertThrows(AlertConfigurationException.class, () -> trustStoreManager.getAndValidateTrustStoreFile());
+    }
+
+    @Test
+    void getAndValidateFileMissingTest() {
+        AlertTrustStoreManager trustStoreManager = new AlertTrustStoreManager(new MockAlertProperties());
+        assertThrows(AlertConfigurationException.class, () -> trustStoreManager.getAndValidateTrustStoreFile());
     }
 }
 

--- a/src/test/java/com/synopsys/integration/alert/component/certificates/web/CertificateTestUtil.java
+++ b/src/test/java/com/synopsys/integration/alert/component/certificates/web/CertificateTestUtil.java
@@ -28,6 +28,8 @@ public class CertificateTestUtil {
     // server.pem = "server-cert-test.xxx.blackduck.alert.example.com"
     // client.pem = "client-cert-test.xxx.blackduck.alert.example.com"
     public static final String CERTIFICATE_MTLS_CLIENT_FILE_PATH = "certificates/mtls/client.pem";
+    public static final String CERTIFICATE_MTLS_SERVER_FILE_PATH = "certificates/mtls/server.pem";
+    public static final String CERTIFICATE_MTLS_ROOT_CA_FILE_PATH = "certificates/mtls/rootCA.pem";
     public static final String KEY_MTLS_CLIENT_FILE_PATH = "certificates/mtls/client.key";
     public static final String TEST_ALIAS = "test-alias";
     public static final String TRUSTSTORE_FILE_PATH = "./build/certs/blackduck-alert-test.truststore";

--- a/test-common/src/main/java/com/synopsys/integration/alert/test/common/MockAlertProperties.java
+++ b/test-common/src/main/java/com/synopsys/integration/alert/test/common/MockAlertProperties.java
@@ -36,6 +36,8 @@ public class MockAlertProperties extends AlertProperties {
     private String encryptionSalt;
     private String alertEmailAttachmentsDir;
 
+    private String alertTrustStoreFile;
+
     public MockAlertProperties() {
         alertImagesDir = computeImagesDirPath().toString();
 
@@ -123,6 +125,18 @@ public class MockAlertProperties extends AlertProperties {
 
     public void setAlertEmailAttachmentsDir(String alertEmailAttachmentsDir) {
         this.alertEmailAttachmentsDir = alertEmailAttachmentsDir;
+    }
+
+    @Override
+    public Optional<String> getTrustStoreFile() {
+        if (alertTrustStoreFile == null) {
+            return super.getTrustStoreFile();
+        }
+        return Optional.ofNullable(alertTrustStoreFile);
+    }
+
+    public void setTrustStoreFile(String trustStoreFile) {
+        this.alertTrustStoreFile = trustStoreFile;
     }
 
     private Path computeImagesDirPath() {


### PR DESCRIPTION
- Update the AlertSSLContextManager to create an SSL Context from the client certificate and the trust store file.
- Use the AlertClientCertificateManager to get the keystore for the client certificate data.  
- Use the AlertTrustStoreManager to get the keystore containing all the trusted certificates.  
- Use Spring Boot SSLBundle objects to load the keystores and create an SSLContext object to be used with HTTP requests in the future.
- Add additional tests to increase code coverage for the AlertTrustStoreManager class.
- Add additional tests to increase code coverage for the AlertClientCertificateManager class.