### PR TITLE
IALERT-3588: mtls certificate startup

### DIFF
--- a/component/src/main/java/com/synopsys/integration/alert/component/certificates/AlertSSLContextManager.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/certificates/AlertSSLContextManager.java
@@ -19,9 +19,6 @@ public class AlertSSLContextManager {
         this.clientCertificateManager = clientCertificateManager;
     }
 
-    public void initialize() {
-    }
-
     public SSLContext buildSslContext() throws NoSuchAlgorithmException {
         return SSLContext.getDefault();
     }

--- a/src/main/java/com/synopsys/integration/alert/startup/component/AlertClientCertificateManagerStartupComponent.java
+++ b/src/main/java/com/synopsys/integration/alert/startup/component/AlertClientCertificateManagerStartupComponent.java
@@ -1,0 +1,57 @@
+package com.synopsys.integration.alert.startup.component;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import com.synopsys.integration.alert.api.common.model.exception.AlertException;
+import com.synopsys.integration.alert.common.persistence.model.ClientCertificateKeyModel;
+import com.synopsys.integration.alert.common.persistence.model.ClientCertificateModel;
+import com.synopsys.integration.alert.component.certificates.AlertClientCertificateManager;
+import com.synopsys.integration.alert.database.api.DefaultClientCertificateAccessor;
+import com.synopsys.integration.alert.database.api.DefaultClientCertificateKeyAccessor;
+
+@Component
+@Order(42)
+public class AlertClientCertificateManagerStartupComponent extends StartupComponent {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final AlertClientCertificateManager alertClientCertificateManager;
+    private final DefaultClientCertificateKeyAccessor clientCertificateKeyAccessor;
+    private final DefaultClientCertificateAccessor clientCertificateAccessor;
+
+    @Autowired
+    public AlertClientCertificateManagerStartupComponent(
+        AlertClientCertificateManager alertClientCertificateManager,
+        DefaultClientCertificateKeyAccessor clientCertificateKeyAccessor,
+        DefaultClientCertificateAccessor clientCertificateAccessor
+    ) {
+        this.alertClientCertificateManager = alertClientCertificateManager;
+        this.clientCertificateKeyAccessor = clientCertificateKeyAccessor;
+        this.clientCertificateAccessor = clientCertificateAccessor;
+    }
+
+    @Override
+    protected void initialize() {
+        logger.info("Alert client certificate initialization running.");
+        Optional<ClientCertificateKeyModel> clientCertificateKeyModel = clientCertificateKeyAccessor.getConfiguration();
+        if (clientCertificateKeyModel.isEmpty()) {
+            logger.info("No client certificate key has been supplied at this time. Skipping client certificate initialization.");
+            return;
+        }
+        Optional<ClientCertificateModel> clientCertificateModel = clientCertificateAccessor.getConfiguration();
+        if (clientCertificateModel.isEmpty()) {
+            logger.info("No client certificate has been supplied at this time. Skipping client certificate initialization.");
+            return;
+        }
+        try {
+            alertClientCertificateManager.importCertificate(clientCertificateModel.get(), clientCertificateKeyModel.get());
+            logger.info("Client certificate successfully imported.");
+        } catch (AlertException e) {
+            logger.error("Failed to import client certificate.", e);
+        }
+    }
+}

--- a/src/test/java/com/synopsys/integration/alert/component/certificates/web/CertificateTestUtil.java
+++ b/src/test/java/com/synopsys/integration/alert/component/certificates/web/CertificateTestUtil.java
@@ -10,6 +10,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.apache.commons.io.FileUtils;
 import org.springframework.core.io.ClassPathResource;
@@ -17,6 +18,8 @@ import org.springframework.core.io.ClassPathResource;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.common.AlertProperties;
 import com.synopsys.integration.alert.common.action.ActionResponse;
+import com.synopsys.integration.alert.common.persistence.model.ClientCertificateKeyModel;
+import com.synopsys.integration.alert.common.persistence.model.ClientCertificateModel;
 import com.synopsys.integration.alert.common.util.DateUtils;
 
 import io.micrometer.common.util.StringUtils;
@@ -33,6 +36,7 @@ public class CertificateTestUtil {
     public static final String TRUSTSTORE_FILE_PATH = "./build/certs/blackduck-alert-test.truststore";
     public static final String TRUSTSTORE_PASSWORD = "changeit";
     public static final String MTLS_CERTIFICATE_PASSWORD = "changeit";
+    public static final String EMPTY_STRING_CONTENT = " \n\t\r  \n\t\r  \n";
 
     protected File trustStoreFile;
 
@@ -85,6 +89,29 @@ public class CertificateTestUtil {
         } catch (CertificateException | IOException e) {
             throw new AlertException("The custom certificate could not be read.", e);
         }
+    }
+
+    public ClientCertificateKeyModel createClientKeyModel() throws IOException {
+        UUID id = UUID.randomUUID();
+        String content = readCertificateOrKeyContents(CertificateTestUtil.KEY_MTLS_CLIENT_FILE_PATH);
+        return new ClientCertificateKeyModel(
+            id,
+            CertificateTestUtil.MTLS_CERTIFICATE_PASSWORD,
+            false,
+            content,
+            DateUtils.createCurrentDateString(DateUtils.UTC_DATE_FORMAT_TO_MINUTE)
+        );
+    }
+
+    public ClientCertificateModel createClientModel(ClientCertificateKeyModel keyModel) throws IOException {
+        UUID id = UUID.randomUUID();
+        String content = readCertificateOrKeyContents(CertificateTestUtil.CERTIFICATE_MTLS_CLIENT_FILE_PATH);
+        return new ClientCertificateModel(
+            id,
+            keyModel.getId(),
+            content,
+            DateUtils.createCurrentDateString(DateUtils.UTC_DATE_FORMAT_TO_MINUTE)
+        );
     }
 
 }

--- a/src/test/java/com/synopsys/integration/alert/startup/component/AlertClientCertificateManagerStartupComponentTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/startup/component/AlertClientCertificateManagerStartupComponentTestIT.java
@@ -1,0 +1,108 @@
+package com.synopsys.integration.alert.startup.component;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import com.synopsys.integration.alert.api.common.model.exception.AlertException;
+import com.synopsys.integration.alert.common.AlertProperties;
+import com.synopsys.integration.alert.common.persistence.model.ClientCertificateKeyModel;
+import com.synopsys.integration.alert.common.persistence.model.ClientCertificateModel;
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
+import com.synopsys.integration.alert.common.util.DateUtils;
+import com.synopsys.integration.alert.component.certificates.AlertClientCertificateManager;
+import com.synopsys.integration.alert.component.certificates.web.CertificateTestUtil;
+import com.synopsys.integration.alert.database.api.DefaultClientCertificateAccessor;
+import com.synopsys.integration.alert.database.api.DefaultClientCertificateKeyAccessor;
+import com.synopsys.integration.alert.util.AlertIntegrationTest;
+
+@AlertIntegrationTest
+@TestPropertySource(locations = "classpath:certificates/spring-certificate-test.properties")
+class AlertClientCertificateManagerStartupComponentTestIT {
+    @Autowired
+    private AlertProperties alertProperties;
+    @Autowired
+    private AlertClientCertificateManagerStartupComponent alertClientCertificateManagerStartupComponent;
+    @Autowired
+    private AlertClientCertificateManager alertClientCertificateManager;
+    @Autowired
+    private DefaultClientCertificateKeyAccessor clientCertificateKeyAccessor;
+    @Autowired
+    private DefaultClientCertificateAccessor clientCertificateAccessor;
+    private final CertificateTestUtil certTestUtil = new CertificateTestUtil();
+
+    @BeforeEach
+    void initTest() throws Exception {
+        certTestUtil.init(alertProperties);
+    }
+
+    @AfterEach
+    void cleanup() throws AlertException {
+        certTestUtil.cleanup();
+        clientCertificateKeyAccessor.deleteConfiguration();
+        clientCertificateAccessor.deleteConfiguration();
+        alertClientCertificateManager.removeCertificate();
+    }
+
+    @Test
+    void initializeWithClientCertificatePersistedTest() throws Exception {
+        ClientCertificateKeyModel clientCertificateKeyModel = clientCertificateKeyAccessor.createConfiguration(certTestUtil.createClientKeyModel());
+        ClientCertificateModel clientCertificateModel = clientCertificateAccessor.createConfiguration(certTestUtil.createClientModel(clientCertificateKeyModel));
+        assertTrue(alertClientCertificateManager.getClientKeyStore().isEmpty());
+
+        alertClientCertificateManagerStartupComponent.initialize();
+        KeyStore clientKeystore = alertClientCertificateManager.getClientKeyStore().orElseThrow(() -> new AssertionError("Keystore missing when it should exist"));
+        assertTrue(clientKeystore.containsAlias(AlertRestConstants.DEFAULT_CLIENT_CERTIFICATE_ALIAS));
+        Certificate clientCertificate = clientKeystore.getCertificate(AlertRestConstants.DEFAULT_CLIENT_CERTIFICATE_ALIAS);
+        Certificate validationCertificate = certTestUtil.loadCertificate(clientCertificateModel.getCertificateContent());
+
+        assertEquals(validationCertificate.getType(), clientCertificate.getType());
+        assertEquals(validationCertificate.getPublicKey().getAlgorithm(), clientCertificate.getPublicKey().getAlgorithm());
+        assertEquals(validationCertificate.getPublicKey().getFormat(), clientCertificate.getPublicKey().getFormat());
+        assertArrayEquals(validationCertificate.getPublicKey().getEncoded(), clientCertificate.getPublicKey().getEncoded());
+    }
+
+    @Test
+    void initializeWithoutCertificateOrKeyPersistedTest() {
+        assertTrue(alertClientCertificateManager.getClientKeyStore().isEmpty());
+        alertClientCertificateManagerStartupComponent.initialize();
+        assertTrue(alertClientCertificateManager.getClientKeyStore().isEmpty());
+    }
+
+    @Test
+    void initializeWithoutCertificatePersistedTest() throws Exception {
+        clientCertificateKeyAccessor.createConfiguration(certTestUtil.createClientKeyModel());
+        assertTrue(alertClientCertificateManager.getClientKeyStore().isEmpty());
+        alertClientCertificateManagerStartupComponent.initialize();
+        assertTrue(alertClientCertificateManager.getClientKeyStore().isEmpty());
+    }
+
+    @Test
+    void certificateManagerThrowsExceptionTest() throws Exception {
+        UUID id = UUID.randomUUID();
+        ClientCertificateKeyModel keyModelWithoutPassword = new ClientCertificateKeyModel(
+            id,
+            CertificateTestUtil.MTLS_CERTIFICATE_PASSWORD,
+            false,
+            CertificateTestUtil.EMPTY_STRING_CONTENT,
+            DateUtils.createCurrentDateString(DateUtils.UTC_DATE_FORMAT_TO_MINUTE)
+        );
+
+        ClientCertificateKeyModel clientCertificateKeyModel = clientCertificateKeyAccessor.createConfiguration(keyModelWithoutPassword);
+        clientCertificateAccessor.createConfiguration(certTestUtil.createClientModel(clientCertificateKeyModel));
+        assertTrue(alertClientCertificateManager.getClientKeyStore().isEmpty());
+
+        alertClientCertificateManagerStartupComponent.initialize();
+        assertTrue(alertClientCertificateManager.getClientKeyStore().isEmpty());
+    }
+}


### PR DESCRIPTION
Adding a startup component to import the client certificate into memory from the database if one exists. 

Additionally to this, we've added some integration test coverage.