### PR TITLE
IALERT-3585: Update ChannelRestConnectionFactory to use SSLContext.

### DIFF
--- a/api-certificates/src/main/java/com/synopsys/integration/alert/api/certificates/AlertSSLContextManager.java
+++ b/api-certificates/src/main/java/com/synopsys/integration/alert/api/certificates/AlertSSLContextManager.java
@@ -1,7 +1,6 @@
 package com.synopsys.integration.alert.api.certificates;
 
 import java.security.KeyStore;
-import java.security.NoSuchAlgorithmException;
 import java.util.Optional;
 
 import javax.net.ssl.SSLContext;
@@ -12,7 +11,6 @@ import org.springframework.boot.ssl.SslManagerBundle;
 import org.springframework.boot.ssl.SslStoreBundle;
 import org.springframework.stereotype.Component;
 
-import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.common.rest.AlertRestConstants;
 
 @Component
@@ -27,19 +25,9 @@ public class AlertSSLContextManager {
         this.clientCertificateManager = clientCertificateManager;
     }
 
-    public Optional<SSLContext> buildSslContext() throws AlertConfigurationException {
-        SSLContext sslContext;
-        try {
-            Optional<SslManagerBundle> sslManagerBundle = getSslManagerBundle();
-            if (sslManagerBundle.isPresent()) {
-                sslContext = sslManagerBundle.get().createSslContext("TLS");
-            } else {
-                sslContext = SSLContext.getDefault();
-            }
-        } catch (NoSuchAlgorithmException ex) {
-            throw new AlertConfigurationException(ex);
-        }
-        return Optional.ofNullable(sslContext);
+    public Optional<SSLContext> buildWithClientCertificate() {
+        Optional<SslManagerBundle> sslManagerBundle = getSslManagerBundle();
+        return sslManagerBundle.map(bundle -> bundle.createSslContext("TLS"));
     }
 
     private Optional<SslManagerBundle> getSslManagerBundle() {

--- a/api-channel/build.gradle
+++ b/api-channel/build.gradle
@@ -1,6 +1,7 @@
 ext.moduleName = 'com.synopsys.integration.alert.api-channel'
 
 dependencies {
+    api project(':api-certificates')
     api project(':api-distribution')
     api project(':api-environment')
     api project(':api-event')

--- a/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/rest/ChannelRestConnectionFactoryTest.java
+++ b/api-channel/src/test/java/com/synopsys/integration/alert/api/channel/rest/ChannelRestConnectionFactoryTest.java
@@ -3,10 +3,13 @@ package com.synopsys.integration.alert.api.channel.rest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.certificates.AlertSSLContextManager;
 import com.synopsys.integration.alert.common.rest.proxy.ProxyManager;
 import com.synopsys.integration.alert.test.common.MockAlertProperties;
 import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
@@ -40,8 +43,10 @@ class ChannelRestConnectionFactoryTest {
         MockAlertProperties testAlertProperties = new MockAlertProperties();
         testAlertProperties.setAlertTrustCertificate(true);
         ProxyManager proxyManager = Mockito.mock(ProxyManager.class);
-        Mockito.when(proxyManager.createProxyInfoForHost(baseUrl)).thenReturn(expectedProxyInfo);
-        ChannelRestConnectionFactory channelRestConnectionFactory = new ChannelRestConnectionFactory(testAlertProperties, proxyManager, gson);
+        AlertSSLContextManager alertSSLContextManager = Mockito.mock(AlertSSLContextManager.class);
+        Mockito.when(proxyManager.createProxyInfoForHost(Mockito.anyString())).thenReturn(expectedProxyInfo);
+        Mockito.when(alertSSLContextManager.buildWithClientCertificate()).thenReturn(Optional.empty());
+        ChannelRestConnectionFactory channelRestConnectionFactory = new ChannelRestConnectionFactory(testAlertProperties, proxyManager, gson, alertSSLContextManager);
 
         IntHttpClient intHttpClient = channelRestConnectionFactory.createIntHttpClient(baseUrl);
 

--- a/channel-msteams/src/test/java/com/synopsys/integration/alert/channel/msteams/distribution/MsTeamsChannelTest.java
+++ b/channel-msteams/src/test/java/com/synopsys/integration/alert/channel/msteams/distribution/MsTeamsChannelTest.java
@@ -1,6 +1,7 @@
 package com.synopsys.integration.alert.channel.msteams.distribution;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.certificates.AlertSSLContextManager;
 import com.synopsys.integration.alert.api.channel.rest.ChannelRestConnectionFactory;
 import com.synopsys.integration.alert.api.common.model.exception.AlertException;
 import com.synopsys.integration.alert.api.distribution.execution.ExecutingJobManager;
@@ -92,8 +94,10 @@ class MsTeamsChannelTest {
     private ChannelRestConnectionFactory createConnectionFactory() {
         MockAlertProperties testAlertProperties = new MockAlertProperties();
         ProxyManager proxyManager = Mockito.mock(ProxyManager.class);
+        AlertSSLContextManager alertSSLContextManager = Mockito.mock(AlertSSLContextManager.class);
         Mockito.when(proxyManager.createProxyInfoForHost(Mockito.anyString())).thenReturn(ProxyInfo.NO_PROXY_INFO);
-        return new ChannelRestConnectionFactory(testAlertProperties, proxyManager, gson);
+        Mockito.when(alertSSLContextManager.buildWithClientCertificate()).thenReturn(Optional.empty());
+        return new ChannelRestConnectionFactory(testAlertProperties, proxyManager, gson, alertSSLContextManager);
     }
 
 }

--- a/channel-slack/src/test/java/com/synopsys/integration/alert/channel/slack/distribution/SlackChannelTestIT.java
+++ b/channel-slack/src/test/java/com/synopsys/integration/alert/channel/slack/distribution/SlackChannelTestIT.java
@@ -11,12 +11,15 @@
  */
 package com.synopsys.integration.alert.channel.slack.distribution;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.certificates.AlertSSLContextManager;
 import com.synopsys.integration.alert.api.channel.rest.ChannelRestConnectionFactory;
 import com.synopsys.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.synopsys.integration.alert.api.event.EventManager;
@@ -72,8 +75,10 @@ class SlackChannelTestIT {
     private ChannelRestConnectionFactory createConnectionFactory() {
         MockAlertProperties testAlertProperties = new MockAlertProperties();
         ProxyManager proxyManager = Mockito.mock(ProxyManager.class);
+        AlertSSLContextManager alertSSLContextManager = Mockito.mock(AlertSSLContextManager.class);
         Mockito.when(proxyManager.createProxyInfoForHost(Mockito.anyString())).thenReturn(ProxyInfo.NO_PROXY_INFO);
-        return new ChannelRestConnectionFactory(testAlertProperties, proxyManager, gson);
+        Mockito.when(alertSSLContextManager.buildWithClientCertificate()).thenReturn(Optional.empty());
+        return new ChannelRestConnectionFactory(testAlertProperties, proxyManager, gson, alertSSLContextManager);
     }
 
 }

--- a/channel-slack/src/test/java/com/synopsys/integration/alert/channel/slack/distribution/SlackDistributionEventHandlerTest.java
+++ b/channel-slack/src/test/java/com/synopsys/integration/alert/channel/slack/distribution/SlackDistributionEventHandlerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.google.gson.Gson;
+import com.synopsys.integration.alert.api.certificates.AlertSSLContextManager;
 import com.synopsys.integration.alert.api.channel.rest.ChannelRestConnectionFactory;
 import com.synopsys.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.synopsys.integration.alert.api.distribution.audit.AuditSuccessEvent;
@@ -108,8 +109,10 @@ class SlackDistributionEventHandlerTest {
     private ChannelRestConnectionFactory createConnectionFactory() {
         MockAlertProperties testAlertProperties = new MockAlertProperties();
         ProxyManager proxyManager = Mockito.mock(ProxyManager.class);
+        AlertSSLContextManager alertSSLContextManager = Mockito.mock(AlertSSLContextManager.class);
         Mockito.when(proxyManager.createProxyInfoForHost(Mockito.anyString())).thenReturn(ProxyInfo.NO_PROXY_INFO);
-        return new ChannelRestConnectionFactory(testAlertProperties, proxyManager, gson);
+        Mockito.when(alertSSLContextManager.buildWithClientCertificate()).thenReturn(Optional.empty());
+        return new ChannelRestConnectionFactory(testAlertProperties, proxyManager, gson, alertSSLContextManager);
     }
 
     private ProviderMessageHolder createTwoMessages() {

--- a/src/test/java/com/synopsys/integration/alert/component/certificates/AlertSSLContextManagerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/certificates/AlertSSLContextManagerTestIT.java
@@ -1,6 +1,5 @@
 package com.synopsys.integration.alert.component.certificates;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -103,17 +102,8 @@ class AlertSSLContextManagerTestIT {
         trustStoreManager.importCertificate(serverCertificate);
         clientCertificateManager.importCertificate(model, keyModel);
 
-        Optional<SSLContext> sslContext = sslContextManager.buildSslContext();
+        Optional<SSLContext> sslContext = sslContextManager.buildWithClientCertificate();
         assertTrue(sslContext.isPresent());
-    }
-
-    @Test
-    void createDefaultSSLContextTest() throws Exception {
-        AlertSSLContextManager sslContextManager = new AlertSSLContextManager(trustStoreManager, clientCertificateManager);
-
-        Optional<SSLContext> sslContext = sslContextManager.buildSslContext();
-        assertTrue(sslContext.isPresent());
-        assertEquals(SSLContext.getDefault(), sslContext.get());
     }
 
     @Test
@@ -121,9 +111,8 @@ class AlertSSLContextManagerTestIT {
         AlertTrustStoreManager missingFileTrustStoreManager = new AlertTrustStoreManager(new MockAlertProperties());
         AlertSSLContextManager sslContextManager = new AlertSSLContextManager(missingFileTrustStoreManager, clientCertificateManager);
 
-        Optional<SSLContext> sslContext = sslContextManager.buildSslContext();
-        assertTrue(sslContext.isPresent());
-        assertEquals(SSLContext.getDefault(), sslContext.get());
+        Optional<SSLContext> sslContext = sslContextManager.buildWithClientCertificate();
+        assertTrue(sslContext.isEmpty());
     }
 
 


### PR DESCRIPTION
- Change AlertSSLContextManager to return the SSL Context only if client certificates are used.
- Change ChannelRestConnectionFactory to use the AlertSSLContextManager to utilize client certificates if they are configured.