### PR TITLE
IALERT-3587: Add SSLContext support for jira server properties

### DIFF
--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/JiraServerProperties.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/JiraServerProperties.java
@@ -9,6 +9,9 @@ package com.synopsys.integration.alert.channel.jira.server;
 
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLContext;
+
 import org.slf4j.Logger;
 
 import com.google.gson.Gson;
@@ -30,6 +33,7 @@ public class JiraServerProperties {
     private final String accessToken;
     private final boolean pluginCheckDisabled;
     private final ProxyInfo proxyInfo;
+    private final SSLContext sslContext;
 
     public JiraServerProperties(
         String url,
@@ -38,7 +42,8 @@ public class JiraServerProperties {
         String username,
         String accessToken,
         boolean pluginCheckDisabled,
-        ProxyInfo proxyInfo
+        ProxyInfo proxyInfo,
+        @Nullable SSLContext sslContext
     ) {
         this.url = url;
         this.authorizationMethod = authorizationMethod;
@@ -47,6 +52,7 @@ public class JiraServerProperties {
         this.accessToken = accessToken;
         this.pluginCheckDisabled = pluginCheckDisabled;
         this.proxyInfo = proxyInfo;
+        this.sslContext = sslContext;
     }
 
     public JiraServerRestConfig createJiraServerConfig() throws IssueTrackerException {
@@ -77,6 +83,9 @@ public class JiraServerProperties {
             .setAuthPassword(password)
             .setAuthUsername(username)
             .setProxyInfo(proxyInfo);
+        if (sslContext != null) {
+            builder.setSslContext(sslContext);
+        }
 
         return builder.build();
     }
@@ -86,6 +95,9 @@ public class JiraServerProperties {
         builder.setUrl(url)
             .setAccessToken(accessToken)
             .setProxyInfo(proxyInfo);
+        if (sslContext != null) {
+            builder.setSslContext(sslContext);
+        }
 
         return builder.build();
     }

--- a/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/JiraServerPropertiesFactory.java
+++ b/channel-jira-server/src/main/java/com/synopsys/integration/alert/channel/jira/server/JiraServerPropertiesFactory.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.synopsys.integration.alert.api.certificates.AlertSSLContextManager;
 import com.synopsys.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.synopsys.integration.alert.channel.jira.server.database.accessor.JiraServerGlobalConfigAccessor;
 import com.synopsys.integration.alert.channel.jira.server.model.JiraServerGlobalConfigModel;
@@ -25,12 +26,19 @@ public class JiraServerPropertiesFactory {
     private final ProxyManager proxyManager;
     private final JiraServerGlobalConfigAccessor jiraServerGlobalConfigAccessor;
     private final JobAccessor jobAccessor;
+    private final AlertSSLContextManager alertSSLContextManager;
 
     @Autowired
-    public JiraServerPropertiesFactory(ProxyManager proxyManager, JiraServerGlobalConfigAccessor jiraServerGlobalConfigAccessor, JobAccessor jobAccessor) {
+    public JiraServerPropertiesFactory(
+        ProxyManager proxyManager,
+        JiraServerGlobalConfigAccessor jiraServerGlobalConfigAccessor,
+        JobAccessor jobAccessor,
+        AlertSSLContextManager alertSSLContextManager
+    ) {
         this.proxyManager = proxyManager;
         this.jiraServerGlobalConfigAccessor = jiraServerGlobalConfigAccessor;
         this.jobAccessor = jobAccessor;
+        this.alertSSLContextManager = alertSSLContextManager;
     }
 
     public JiraServerProperties createJiraProperties(UUID jiraServerConfigId) throws AlertConfigurationException {
@@ -65,6 +73,15 @@ public class JiraServerPropertiesFactory {
         String accessToken,
         boolean pluginCheckDisabled
     ) {
-        return new JiraServerProperties(url, authorizationMethod, password, username, accessToken, pluginCheckDisabled, proxyManager.createProxyInfoForHost(url));
+        return new JiraServerProperties(
+            url,
+            authorizationMethod,
+            password,
+            username,
+            accessToken,
+            pluginCheckDisabled,
+            proxyManager.createProxyInfoForHost(url),
+            alertSSLContextManager.buildWithClientCertificate().orElse(null)
+        );
     }
 }

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/JiraServerExternalConnectionTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/JiraServerExternalConnectionTest.java
@@ -68,7 +68,7 @@ class JiraServerExternalConnectionTest {
         Mockito.when(proxyManager.createProxyInfoForHost(Mockito.anyString())).thenReturn(null);
         JobAccessor jobAccessor = Mockito.mock(JobAccessor.class);
         Mockito.when(jobAccessor.getJobById(Mockito.any())).thenReturn(Optional.of(createDistributionJobModel()));
-        JiraServerPropertiesFactory jiraServerPropertiesFactory = new JiraServerPropertiesFactory(proxyManager, jiraServerGlobalConfigAccessor, jobAccessor);
+        JiraServerPropertiesFactory jiraServerPropertiesFactory = new JiraServerPropertiesFactory(proxyManager, jiraServerGlobalConfigAccessor, jobAccessor, null);
 
         IssueTrackerCallbackInfoCreator issueTrackerCallbackInfoCreator = new IssueTrackerCallbackInfoCreator();
         IssueCategoryRetriever issueCategoryRetriever = new IssueCategoryRetriever();

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/JiraServerSummaryFieldLengthTestIT.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/JiraServerSummaryFieldLengthTestIT.java
@@ -104,7 +104,16 @@ public class JiraServerSummaryFieldLengthTestIT {
         String password = testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_PASSWORD);
 
         JiraServerPropertiesFactory jiraServerPropertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
-        JiraServerProperties jiraServerProperties = new JiraServerProperties(url, JiraServerAuthorizationMethod.BASIC, password, username, null, true, ProxyInfo.NO_PROXY_INFO);
+        JiraServerProperties jiraServerProperties = new JiraServerProperties(
+            url,
+            JiraServerAuthorizationMethod.BASIC,
+            password,
+            username,
+            null,
+            true,
+            ProxyInfo.NO_PROXY_INFO,
+            null
+        );
         Mockito.when(jiraServerPropertiesFactory.createJiraProperties(Mockito.any(UUID.class))).thenReturn(jiraServerProperties);
 
         return jiraServerPropertiesFactory;

--- a/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerCustomFunctionActionTest.java
+++ b/channel-jira-server/src/test/java/com/synopsys/integration/alert/channel/jira/server/web/JiraServerCustomFunctionActionTest.java
@@ -404,7 +404,7 @@ class JiraServerCustomFunctionActionTest {
         JobAccessor jobAccessor = Mockito.mock(JobAccessor.class);
         Mockito.when(jobAccessor.getJobById(Mockito.any())).thenReturn(Optional.empty());
 
-        JiraServerPropertiesFactory jiraServerPropertiesFactory = new JiraServerPropertiesFactory(proxyManager, globalConfigAccessor, jobAccessor);
+        JiraServerPropertiesFactory jiraServerPropertiesFactory = new JiraServerPropertiesFactory(proxyManager, globalConfigAccessor, jobAccessor, null);
         JiraServerCustomFunctionAction action = new JiraServerCustomFunctionAction(
             authorizationManager,
             jiraServerGlobalConfigurationFieldModelValidator,


### PR DESCRIPTION
Added SSLContext to the JiraServerProperties and updated JiraServerPropertiesFactory to use the the SSLContextManager to build an SSL context from the persisted client certificate. 