### PR TITLE
IALERT-3627: Generate unique operation ids

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,6 +28,9 @@ spring.liquibase.change-log=classpath:liquibase/changelog-postgres-master.xml
 # Swagger
 spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
 springdoc.swagger-ui.path=/swagger-ui
+springdoc.swagger-ui.displayOperationId=true
+springdoc.swagger-ui.tags-sorter=alpha
+springdoc.swagger-ui.operations-sorter=alpha
 # JMS
 spring.jms.template.qos-enabled=true
 spring.jms.template.time-to-live=14400000ms

--- a/web/src/main/java/com/synopsys/integration/alert/web/documentation/CustomOperationNameGenerator.java
+++ b/web/src/main/java/com/synopsys/integration/alert/web/documentation/CustomOperationNameGenerator.java
@@ -1,0 +1,40 @@
+package com.synopsys.integration.alert.web.documentation;
+
+import java.util.Arrays;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springdoc.core.customizers.GlobalOperationCustomizer;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.method.HandlerMethod;
+
+import io.swagger.v3.oas.models.Operation;
+
+public class CustomOperationNameGenerator implements GlobalOperationCustomizer {
+    public static final String TAG_KEYWORD_CONTROLLER = "controller";
+    public static final String TAG_NAME_COMPONENT_DELIMETER = "-";
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+        Class<?> beanType = handlerMethod.getBeanType();
+        boolean isControllerClass = beanType.isAnnotationPresent(Controller.class) || beanType.isAnnotationPresent(RestController.class);
+        logger.debug("Processing Open API doc for type: {} controller:{}", beanType, isControllerClass);
+        if (isControllerClass && !operation.getTags().isEmpty()) {
+            logger.debug("Tags for operation: {}", operation.getTags());
+            String[] tagNameSplit = StringUtils.split(operation.getTags().get(0), TAG_NAME_COMPONENT_DELIMETER);
+            //remove the controller keyword from the tag name
+            String tagNameAbbreviated = Arrays.stream(tagNameSplit)
+                .filter(subString -> !subString.equalsIgnoreCase(TAG_KEYWORD_CONTROLLER))
+                .map(StringUtils::capitalize)
+                .reduce("", String::concat);
+            String methodName = handlerMethod.getMethod().getName();
+            String operationId = String.format("api%s%s", tagNameAbbreviated, StringUtils.capitalize(methodName));
+            logger.debug("Operation Id old: {} new: {}", operation.getOperationId(), operationId);
+            operation.setOperationId(operationId);
+        }
+        return operation;
+    }
+}

--- a/web/src/main/java/com/synopsys/integration/alert/web/documentation/SwaggerConfiguration.java
+++ b/web/src/main/java/com/synopsys/integration/alert/web/documentation/SwaggerConfiguration.java
@@ -7,6 +7,7 @@
  */
 package com.synopsys.integration.alert.web.documentation;
 
+import org.springdoc.core.customizers.GlobalOperationCustomizer;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,6 +36,11 @@ public class SwaggerConfiguration {
                     + " Currently, these are all subject to change between versions."
                     + " A stable, versioned API is coming soon.")
                 .version("preview"));
+    }
+
+    @Bean
+    public GlobalOperationCustomizer operationCustomizer() {
+        return new CustomOperationNameGenerator();
     }
 
 }


### PR DESCRIPTION
The Open API generator can generate postman scripts from Alert's Open API specification created by SpringDoc.  While using the generator tool there were some issues uncovered that needed some updates in Alert.

The issues were:

- The REST API is not shown in alphabetical order in the Swagger UI
- The operation IDs aren't shown in the swagger UI
- The operation IDs generated although unique are in a naming convention that lacks context when the generator is used
   - The operation IDs are getOne, getOne1, getOne12, getPage, getPage2, getPage12 which doesn't provide much context
   - Use a bean that implements GlobalOperationCustomizer to update the operation IDs via a custom algorithm
   - The algorithm creates a string from a prefix, context, and suffix string
      - Prefix: api
      - Context: abbreviated controller name
      - Suffix: original method name
      - Examples:
         - apiCertificatesGetOne
         - apiConfigGetOne
         - apiCertificatesCreate
         - apiConfigCreate
   - The algorithm change generates unique operation names for Alert without having to change every controller to no longer implement the interfaces that ensure a consistent API contract for both developers and users.
 - These changes were also made because the generator can produce a java client library project for the REST API
    - This includes models
    - This includes classes that make HTTP requests to the REST API
    - The method names for the client library use the operation IDs
       - The generated code has more context than getOne1
       - If a controller is added that changes the ordering of the generated code then the current method named getOne1 may change to getOne2 when the code is generated again.