### PR TITLE
IALERT-3632 - Add logic to generate Swagger API spec file

### DIFF
--- a/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/AlertRestConstants.java
+++ b/alert-common/src/main/java/com/synopsys/integration/alert/common/rest/AlertRestConstants.java
@@ -33,6 +33,8 @@ public final class AlertRestConstants {
     public static final String DEFAULT_CONFIGURATION_NAME = "default-configuration";
     public static final String DEFAULT_CLIENT_CERTIFICATE_ALIAS = "default-alert-client-certificate";
 
+    public static final String SWAGGER_PATH = "/v3/api-docs/production";
+
     private AlertRestConstants() {
         // This class should not be instantiated
     }

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     commitHash = 'UNKNOWN'
 
     // Copied from src/test/java - com.synopsys.integration.alert.TestTags
-    junitPlatformCustomTestTags = 'BlackDuckConnection, DatabaseConnection, ExternalConnection'
+    junitPlatformCustomTestTags = 'BlackDuckConnection, DatabaseConnection, ExternalConnection, Swagger'
 
     javaSourceCompatibility = JavaVersion.VERSION_17
     javaTargetCompatibility = JavaVersion.VERSION_17
@@ -273,3 +273,10 @@ tasks.getByName(ext.dockerBuildAllImagesStageName).mustRunAfter(buildAll)
 tasks.getByName(ext.dockerBuildAllImagesStageName).mustRunAfter(tasks.getByName(ext.dockerSetupStagingAreaDirectoryStageName))
 tasks.getByName(ext.dockerSetupStagingAreaDirectoryStageName).mustRunAfter(buildAll)
 tasks.getByName(ext.dockerPublishAllImages_DHStageName).mustRunAfter(buildAll)
+
+task swaggerApiSpec(type: Test) {
+    useJUnitPlatform {
+        includeTags "Swagger"
+    }
+    testLogging.showStandardStreams = true
+}

--- a/src/test/java/com/synopsys/integration/alert/swagger/SwaggerGenerateDocTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/swagger/SwaggerGenerateDocTestIT.java
@@ -1,0 +1,71 @@
+package com.synopsys.integration.alert.swagger;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.synopsys.integration.alert.common.rest.AlertRestConstants;
+import com.synopsys.integration.alert.test.common.TestResourceUtils;
+import com.synopsys.integration.alert.test.common.TestTags;
+import com.synopsys.integration.alert.util.AlertIntegrationTest;
+import com.synopsys.integration.alert.util.AlertIntegrationTestConstants;
+import com.synopsys.integration.alert.web.documentation.SwaggerConfiguration;
+
+@AlertIntegrationTest
+public class SwaggerGenerateDocTestIT {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).apply(SecurityMockMvcConfigurers.springSecurity()).build();
+    }
+
+    @Test
+    @Tag(TestTags.CUSTOM_SWAGGER)
+    @WithMockUser(roles = AlertIntegrationTestConstants.ROLE_ALERT_ADMIN)
+    void testGenerateSwaggerAPISpec() {
+        MockHttpServletRequestBuilder request = MockMvcRequestBuilders.get(AlertRestConstants.SWAGGER_PATH)
+            .with(SecurityMockMvcRequestPostProcessors.user("admin").roles(AlertIntegrationTestConstants.ROLE_ALERT_ADMIN))
+            .with(SecurityMockMvcRequestPostProcessors.csrf());
+        String swaggerAPISpecContent = assertDoesNotThrow(() -> mockMvc.perform(request)
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString()
+        );
+
+        Assertions.assertTrue(swaggerAPISpecContent.contains(SwaggerConfiguration.SWAGGER_DESCRIPTION));
+
+        Path swaggerAPISpecPath = assertDoesNotThrow(TestResourceUtils::createSwaggerAPISpecCanonicalFilePath);
+        assertDoesNotThrow(() -> FileUtils.write(swaggerAPISpecPath.toFile(), swaggerAPISpecContent, Charset.defaultCharset(), false));
+        assertTrue(swaggerAPISpecPath.toFile().exists() && swaggerAPISpecPath.toFile().isFile());
+
+        logger.info("Swagger API spec file successfully created");
+        logger.info("  --> " + swaggerAPISpecPath);
+    }
+}

--- a/test-common/src/main/java/com/synopsys/integration/alert/test/common/TestResourceUtils.java
+++ b/test-common/src/main/java/com/synopsys/integration/alert/test/common/TestResourceUtils.java
@@ -21,9 +21,23 @@ import org.springframework.core.io.ClassPathResource;
 
 public final class TestResourceUtils {
     public static final String DEFAULT_PROPERTIES_FILE_NAME = "test.properties";
+    public static final String DEFAULT_SWAGGER_API_SPEC_FILE_NAME = "swagger.api-spec";
 
     private static final String SUB_PROJECT_NAME = "test-common";
-    private static final File EXPECTED_BASE_TEST_RESOURCE_DIR = new File(TestResourceUtils.class.getProtectionDomain().getCodeSource().getLocation().getPath(), "../../../../src/main/resources/");
+    private static final File EXPECTED_BASE_TEST_RESOURCE_DIR = new File(
+        TestResourceUtils.class.getProtectionDomain().getCodeSource().getLocation().getPath(),
+        "../../../../"
+    );
+    private static final File EXPECTED_ROOT_DIR = new File(
+        TestResourceUtils.class.getProtectionDomain().getCodeSource().getLocation().getPath(),
+        "../../../../../"
+    );
+
+    public static Path createSwaggerAPISpecCanonicalFilePath() throws IOException {
+        File buildOutputDir = new File(TestResourceUtils.class.getProtectionDomain().getCodeSource().getLocation().getPath()).getCanonicalFile();
+        File baseDirectory = findAncestorDirectory(buildOutputDir, SUB_PROJECT_NAME).orElse(EXPECTED_ROOT_DIR);
+        return Path.of(baseDirectory.getAbsolutePath(), "build", "swagger", TestResourceUtils.DEFAULT_SWAGGER_API_SPEC_FILE_NAME);
+    }
 
     public static Path createTestPropertiesCanonicalFilePath() throws IOException {
         File buildOutputDir = new File(TestResourceUtils.class.getProtectionDomain().getCodeSource().getLocation().getPath()).getCanonicalFile();

--- a/test-common/src/main/java/com/synopsys/integration/alert/test/common/TestTags.java
+++ b/test-common/src/main/java/com/synopsys/integration/alert/test/common/TestTags.java
@@ -15,5 +15,5 @@ public class TestTags {
     public static final String CUSTOM_BLACKDUCK_CONNECTION = "BlackDuckConnection";
     public static final String CUSTOM_DATABASE_CONNECTION = "DatabaseConnection";
     public static final String CUSTOM_EXTERNAL_CONNECTION = "ExternalConnection";
-
+    public static final String CUSTOM_SWAGGER = "Swagger";
 }

--- a/web/src/main/java/com/synopsys/integration/alert/web/documentation/SwaggerConfiguration.java
+++ b/web/src/main/java/com/synopsys/integration/alert/web/documentation/SwaggerConfiguration.java
@@ -18,6 +18,9 @@ import io.swagger.v3.oas.models.info.Info;
 @Configuration
 public class SwaggerConfiguration {
     public static final String SWAGGER_DEFAULT_PATH_SPEC = "swagger-ui";
+    public static final String SWAGGER_DESCRIPTION = "The production REST endpoints used by the Alert UI."
+        + " Currently, these are all subject to change between versions."
+        + " A stable, versioned API is coming soon.";
 
     @Bean
     public GroupedOpenApi api() {
@@ -32,9 +35,7 @@ public class SwaggerConfiguration {
     public OpenAPI springShopOpenAPI() {
         return new OpenAPI()
             .info(new Info().title("Synopsys Alert - REST API")
-                .description("The production REST endpoints used by the Alert UI."
-                    + " Currently, these are all subject to change between versions."
-                    + " A stable, versioned API is coming soon.")
+                .description(SWAGGER_DESCRIPTION)
                 .version("preview"));
     }
 


### PR DESCRIPTION
* Create new test, SwaggerGenerateDocTestIT.testGenerateSwaggerAPISpec(), to create the needed Swagger API Spec file
* Create new test tag to allow targeting of this specific test
* Add new gradle task, swaggerApiSpec, to allow running this test directly