### PR TITLE
IALERT-3631 - Add gradle tasks to generate postman collection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ apply from: 'buildSrc/buildTasks.gradle'
 apply from: 'buildSrc/runTasks.gradle'
 apply from: 'buildSrc/deploymentTasks.gradle'
 apply from: 'buildSrc/docker.gradle'
-apply from: 'buildSrc/swagger.gradle'
+apply from: 'buildSrc/postman.gradle'
 
 subprojects {
     if (project.name != 'alert-platform') {

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ apply from: 'buildSrc/buildTasks.gradle'
 apply from: 'buildSrc/runTasks.gradle'
 apply from: 'buildSrc/deploymentTasks.gradle'
 apply from: 'buildSrc/docker.gradle'
+apply from: 'buildSrc/swagger.gradle'
 
 subprojects {
     if (project.name != 'alert-platform') {
@@ -273,10 +274,3 @@ tasks.getByName(ext.dockerBuildAllImagesStageName).mustRunAfter(buildAll)
 tasks.getByName(ext.dockerBuildAllImagesStageName).mustRunAfter(tasks.getByName(ext.dockerSetupStagingAreaDirectoryStageName))
 tasks.getByName(ext.dockerSetupStagingAreaDirectoryStageName).mustRunAfter(buildAll)
 tasks.getByName(ext.dockerPublishAllImages_DHStageName).mustRunAfter(buildAll)
-
-task swaggerApiSpec(type: Test) {
-    useJUnitPlatform {
-        includeTags "Swagger"
-    }
-    testLogging.showStandardStreams = true
-}

--- a/buildSrc/postman.gradle
+++ b/buildSrc/postman.gradle
@@ -1,0 +1,69 @@
+String openapiGeneratorImageName = 'openapitools/openapi-generator-cli'
+String runDirectory = project(':test-common').buildDir.toString() + '/swagger'
+String dockerRunDirectory = '/local'
+String baseFileName = 'postman.json'
+String openAPIGeneratorOutputFile = runDirectory + '/' + baseFileName
+String finalOutputFile = runDirectory + '/' + project.name + '-' + project.version + '-' + baseFileName
+
+project.tasks.create(name: 'createSwaggerAPISpec', type: Test, group: 'Postman', description: 'Runs the test which generates the input to create Postman collection. <sub-task>') {
+    useJUnitPlatform {
+        includeTags 'Swagger'
+    }
+    testLogging.showStandardStreams = true
+
+    doFirst {
+        logger.lifecycle('Running all tests tagged as --> Swagger')
+    }
+}
+
+project.tasks.create(name: 'pullOpenApiGeneratorImage', type: Exec, dependsOn: 'createSwaggerAPISpec', group: 'Postman', description: 'Pulls Docker image needed to create Postman collection. <sub-task>') {
+    outputs.upToDateWhen { false }
+
+    def buildCommand = ['docker', 'pull', openapiGeneratorImageName]
+
+    doFirst {
+        logger.lifecycle('Running command:: ' + buildCommand.join(" "))
+    }
+
+    commandLine buildCommand
+}
+
+project.tasks.create(name: 'runOpenAPIGenerator', type: Exec, dependsOn: 'pullOpenApiGeneratorImage', group: 'Postman', description: 'Create the Postman collection. <sub-task>') {
+    outputs.upToDateWhen { false }
+
+    def buildCommand = ['docker', 'run', '--rm', '-v', "${runDirectory}:${dockerRunDirectory}",
+                        openapiGeneratorImageName, 'generate', '-i', "${dockerRunDirectory}/swagger.api-spec",
+                        '-g', 'postman-collection', '-o', dockerRunDirectory, '--additional-properties=folderStrategy=Tags']
+
+    doFirst {
+        logger.lifecycle('Running command:: ' + buildCommand.join(" "))
+    }
+
+    doLast {
+        if (!file(openAPIGeneratorOutputFile).exists()) {
+            throw new GradleException('Output file not found:: ' + openAPIGeneratorOutputFile)
+        } else {
+            logger.lifecycle('Expected output file found:: ' + openAPIGeneratorOutputFile)
+        }
+    }
+
+    workingDir runDirectory
+    commandLine buildCommand
+}
+
+project.tasks.create(name: 'renamePostmanCollection', dependsOn: 'runOpenAPIGenerator', group: 'Postman', description: 'Rename Postman collection. <sub-task>') {
+    outputs.upToDateWhen { false }
+
+    doLast {
+        logger.lifecycle('Renaming file to --> ' + finalOutputFile)
+
+        project.file(finalOutputFile).delete()
+        project.file(openAPIGeneratorOutputFile).renameTo(finalOutputFile)
+
+        if (!file(finalOutputFile).exists()) {
+            throw new GradleException('Final output file not found:: ' + finalOutputFile)
+        }
+    }
+}
+
+project.tasks.create(name: 'createPostmanCollection', dependsOn: 'renamePostmanCollection', group: 'Postman', description: 'All tasks to create Postman collection. <primary task>') {}


### PR DESCRIPTION
Add necessary tasks to create the input to the OpenAPI postman collection generator, and execute the generate. The final task listed, createPostmanCollection, is what will be called by the build.  Comprehensive build run successfully

Postman tasks
-------------
createPostmanCollection - All tasks to create Postman collection. <primary task>
createSwaggerAPISpec - Runs the test which generates the input to create Postman collection. <sub-task>
pullOpenApiGeneratorImage - Pulls Docker image needed to create Postman collection. <sub-task>
renamePostmanCollection - Rename Postman collection. <sub-task>
runOpenAPIGenerator - Create the Postman collection. <sub-task>