### PR TITLE
IALERT-3631 - Run Docker container as user running build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,9 @@ plugins {
 }
 
 ext {
+    userID = 'id -u'.execute().text.trim()
+    groupID = 'id -g'.execute().text.trim()
+
     commitHash = 'UNKNOWN'
 
     // Copied from src/test/java - com.synopsys.integration.alert.TestTags

--- a/buildSrc/postman.gradle
+++ b/buildSrc/postman.gradle
@@ -31,9 +31,10 @@ project.tasks.create(name: 'pullOpenApiGeneratorImage', type: Exec, dependsOn: '
 project.tasks.create(name: 'runOpenAPIGenerator', type: Exec, dependsOn: 'pullOpenApiGeneratorImage', group: 'Postman', description: 'Create the Postman collection. <sub-task>') {
     outputs.upToDateWhen { false }
 
-    def buildCommand = ['docker', 'run', '--rm', '-v', "${runDirectory}:${dockerRunDirectory}",
-                        openapiGeneratorImageName, 'generate', '-i', "${dockerRunDirectory}/swagger.api-spec",
-                        '-g', 'postman-collection', '-o', dockerRunDirectory, '--additional-properties=folderStrategy=Tags']
+    def buildCommand = ['docker', 'run', '--rm', '--user', rootProject.ext.userID + ':' + rootProject.ext.groupID,
+                        '-v', "${runDirectory}:${dockerRunDirectory}", openapiGeneratorImageName, 'generate', '-i',
+                        "${dockerRunDirectory}/swagger.api-spec", '-g', 'postman-collection', '-o', dockerRunDirectory,
+                        '--additional-properties=folderStrategy=Tags']
 
     doFirst {
         logger.lifecycle('Running command:: ' + buildCommand.join(" "))


### PR DESCRIPTION
Default ID in openapitools/openapi-generator-cli container is root. So all files created when running the container are owned by root. Within the build environment, the build ID is not able to clean up files owned by root.

Edit the build to run the Docker container as the same ID as the ID which launched gradle.