### PR TITLE
IALERT-3637: Add additional validation for client certificates

### DIFF
--- a/api-certificates/src/main/java/com/synopsys/integration/alert/api/certificates/AlertClientCertificateManager.java
+++ b/api-certificates/src/main/java/com/synopsys/integration/alert/api/certificates/AlertClientCertificateManager.java
@@ -21,15 +21,31 @@ public class AlertClientCertificateManager {
 
     private PemSslStoreBundle clientSslStoreBundle;
 
-    public synchronized void importCertificate(ClientCertificateModel clientCertificateModel)
-        throws AlertException {
+    public synchronized void importCertificate(ClientCertificateModel clientCertificateModel) throws AlertException {
         logger.debug("Importing certificate into key store.");
+        clientSslStoreBundle = createPemSslStoreBundle(clientCertificateModel);
+    }
+
+    public synchronized boolean validateCertificate(ClientCertificateModel clientCertificateModel) {
+        try {
+            logger.debug("Validating client certificate.");
+            // Validate a PemSslStoreBundle can be created. If an exception is thrown, the certificate is invalid.
+            // The returned result is ignored and not saved to the clientSslStoreBundle.
+            createPemSslStoreBundle(clientCertificateModel);
+            return true;
+        } catch (Exception e) {
+            logger.error(e.getMessage());
+            return false;
+        }
+    }
+
+    private PemSslStoreBundle createPemSslStoreBundle(ClientCertificateModel clientCertificateModel) throws AlertException {
         validateClientCertificateHasValues(clientCertificateModel);
         PemSslStoreDetails keyStoreDetails = PemSslStoreDetails.forCertificate(clientCertificateModel.getClientCertificateContent())
             .withPrivateKey(clientCertificateModel.getKeyContent())
             .withPrivateKeyPassword(clientCertificateModel.getKeyPassword());
         PemSslStoreDetails trustStoreDetails = PemSslStoreDetails.forCertificate(null);
-        clientSslStoreBundle = new PemSslStoreBundle(keyStoreDetails, trustStoreDetails, AlertRestConstants.DEFAULT_CLIENT_CERTIFICATE_ALIAS);
+        return new PemSslStoreBundle(keyStoreDetails, trustStoreDetails, AlertRestConstants.DEFAULT_CLIENT_CERTIFICATE_ALIAS);
     }
 
     public synchronized void removeCertificate() throws AlertException {

--- a/component/src/main/java/com/synopsys/integration/alert/component/certificates/web/ClientCertificateConfigurationValidator.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/certificates/web/ClientCertificateConfigurationValidator.java
@@ -4,8 +4,10 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.synopsys.integration.alert.api.certificates.AlertClientCertificateManager;
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatus;
 import com.synopsys.integration.alert.common.persistence.model.ClientCertificateModel;
@@ -13,6 +15,14 @@ import com.synopsys.integration.alert.component.certificates.CertificatesDescrip
 
 @Component
 public class ClientCertificateConfigurationValidator {
+    public static final String CERTIFICATE_VALIDATE_ERROR_MESSAGE = "Error creating config: Error reading certificate or key.";
+    private final AlertClientCertificateManager alertClientCertificateManager;
+
+    @Autowired
+    ClientCertificateConfigurationValidator(AlertClientCertificateManager alertClientCertificateManager) {
+        this.alertClientCertificateManager = alertClientCertificateManager;
+    }
+
     public ValidationResponseModel validate(ClientCertificateModel model) {
         Set<AlertFieldStatus> statuses = new HashSet<>();
 
@@ -28,6 +38,10 @@ public class ClientCertificateConfigurationValidator {
 
         if (!statuses.isEmpty()) {
             return ValidationResponseModel.fromStatusCollection(statuses);
+        }
+
+        if (!alertClientCertificateManager.validateCertificate(model)) {
+            return ValidationResponseModel.generalError(CERTIFICATE_VALIDATE_ERROR_MESSAGE);
         }
 
         return ValidationResponseModel.success();

--- a/component/src/test/java/com/synopsys/integration/alert/component/certificates/web/ClientCertificateConfigurationValidatorTest.java
+++ b/component/src/test/java/com/synopsys/integration/alert/component/certificates/web/ClientCertificateConfigurationValidatorTest.java
@@ -1,14 +1,19 @@
 package com.synopsys.integration.alert.component.certificates.web;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import com.synopsys.integration.alert.api.certificates.AlertClientCertificateManager;
 import com.synopsys.integration.alert.api.common.model.ValidationResponseModel;
 import com.synopsys.integration.alert.api.common.model.errors.AlertFieldStatus;
 import com.synopsys.integration.alert.common.persistence.model.ClientCertificateModel;
@@ -17,21 +22,28 @@ import com.synopsys.integration.alert.common.persistence.model.ClientCertificate
 class ClientCertificateConfigurationValidatorTest {
     private ClientCertificateConfigurationValidator validator;
 
+    @Mock
+    private AlertClientCertificateManager alertClientCertificateManager;
+
     @BeforeEach
     void setUp() {
-        validator = new ClientCertificateConfigurationValidator();
+        validator = new ClientCertificateConfigurationValidator(alertClientCertificateManager);
     }
 
     @Test
     void validate() {
+        Mockito.when(alertClientCertificateManager.validateCertificate(Mockito.any())).thenReturn(true);
         ValidationResponseModel responseModel = validator.validate(new ClientCertificateModel("key_password", "key_content", "certificate_content"));
+        assertFalse(responseModel.hasErrors());
         Collection<AlertFieldStatus> alertFieldStatuses = responseModel.getErrors().values();
         assertEquals(0, alertFieldStatuses.size());
     }
 
     @Test
     void validateEmptyKeyPassword() {
+        Mockito.when(alertClientCertificateManager.validateCertificate(Mockito.any())).thenReturn(false);
         ValidationResponseModel responseModel = validator.validate(new ClientCertificateModel(null, "key_content", "certificate_content"));
+        assertTrue(responseModel.hasErrors());
         Collection<AlertFieldStatus> alertFieldStatuses = responseModel.getErrors().values();
         assertEquals(1, alertFieldStatuses.size());
 
@@ -42,7 +54,9 @@ class ClientCertificateConfigurationValidatorTest {
 
     @Test
     void validateEmptyKeyContent() {
+        Mockito.when(alertClientCertificateManager.validateCertificate(Mockito.any())).thenReturn(false);
         ValidationResponseModel responseModel = validator.validate(new ClientCertificateModel("key_password", null, "certificate_content"));
+        assertTrue(responseModel.hasErrors());
         Collection<AlertFieldStatus> alertFieldStatuses = responseModel.getErrors().values();
         assertEquals(1, alertFieldStatuses.size());
 
@@ -53,23 +67,37 @@ class ClientCertificateConfigurationValidatorTest {
 
     @Test
     void validateEmptyCertificateContent() {
+        Mockito.when(alertClientCertificateManager.validateCertificate(Mockito.any())).thenReturn(false);
         ValidationResponseModel responseModel = validator.validate(new ClientCertificateModel("key_password", "key_content", null));
+        assertTrue(responseModel.hasErrors());
         Collection<AlertFieldStatus> alertFieldStatuses = responseModel.getErrors().values();
         assertEquals(1, alertFieldStatuses.size());
 
         ValidationResponseModel responseModel1 = validator.validate(new ClientCertificateModel("key_password", "key_content", ""));
+        assertTrue(responseModel.hasErrors());
         Collection<AlertFieldStatus> alertFieldStatuses1 = responseModel1.getErrors().values();
         assertEquals(1, alertFieldStatuses1.size());
     }
 
     @Test
     void validateEmptyAllFields() {
+        Mockito.when(alertClientCertificateManager.validateCertificate(Mockito.any())).thenReturn(false);
         ValidationResponseModel responseModel = validator.validate(new ClientCertificateModel(null, null, null));
+        assertTrue(responseModel.hasErrors());
         Collection<AlertFieldStatus> alertFieldStatuses = responseModel.getErrors().values();
         assertEquals(3, alertFieldStatuses.size());
 
         ValidationResponseModel responseModel1 = validator.validate(new ClientCertificateModel("", "", ""));
         Collection<AlertFieldStatus> alertFieldStatuses1 = responseModel1.getErrors().values();
         assertEquals(3, alertFieldStatuses1.size());
+    }
+
+    @Test
+    void validateInvalidCertificate() {
+        Mockito.when(alertClientCertificateManager.validateCertificate(Mockito.any())).thenReturn(false);
+        ValidationResponseModel responseModel = validator.validate(new ClientCertificateModel("key_password", "key_content", "certificate_content"));
+        assertTrue(responseModel.hasErrors());
+        Collection<AlertFieldStatus> alertFieldStatuses = responseModel.getErrors().values();
+        assertEquals(0, alertFieldStatuses.size());
     }
 }

--- a/src/test/java/com/synopsys/integration/alert/component/certificates/AlertClientCertificateManagerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/certificates/AlertClientCertificateManagerTestIT.java
@@ -139,6 +139,29 @@ class AlertClientCertificateManagerTestIT {
     }
 
     @Test
+    void validateCertificateNullContentTest() {
+        clientCertificateManager = new AlertClientCertificateManager();
+        ClientCertificateModel model = certTestUtil.createClientModel(
+            CertificateTestUtil.MTLS_CERTIFICATE_PASSWORD,
+            null,
+            CertificateTestUtil.EMPTY_STRING_CONTENT
+        );
+
+        assertFalse(clientCertificateManager.validateCertificate(model));
+        assertFalse(clientCertificateManager.containsClientCertificate());
+    }
+
+    @Test
+    void validateCertificateTest() throws Exception {
+        clientCertificateManager = new AlertClientCertificateManager();
+        ClientCertificateModel model = certTestUtil.createClientModel();
+
+        assertTrue(clientCertificateManager.validateCertificate(model));
+        assertFalse(clientCertificateManager.containsClientCertificate());
+        assertTrue(clientCertificateManager.getClientKeyStore().isEmpty());
+    }
+
+    @Test
     void removeCertificateTest() throws Exception {
         clientCertificateManager = new AlertClientCertificateManager();
         ClientCertificateModel model = certTestUtil.createClientModel();

--- a/src/test/java/com/synopsys/integration/alert/component/certificates/web/ClientCertificateControllerTestIT.java
+++ b/src/test/java/com/synopsys/integration/alert/component/certificates/web/ClientCertificateControllerTestIT.java
@@ -177,7 +177,7 @@ class ClientCertificateControllerTestIT {
 
         request.content(gson.toJson(model));
         request.contentType(MEDIA_TYPE);
-        mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isInternalServerError());
+        mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isBadRequest());
     }
 
     @Test


### PR DESCRIPTION
It was discovered that if importing the certificate fails, the configuration remained persisted. The goal of this change is to remove the persisted certificate on a failure to import the certificate when the AlertClientCertificateManager cannot import the values.

To better prevent this issue I've enhanced the validation to also attempt creating the PemSslStoreBundle. This would do a dry-run without saving the bundle in memory but would test all the inputs of the model. To facilitate that behavior I've also slightly refactored the AlertClientCertificateManager to remove duplicate code for import and validation.