### PR TITLE
IALERT-3559 - Correct value for volumeName check

### DIFF
--- a/deployment/helm/synopsys-alert/templates/postgres.yaml
+++ b/deployment/helm/synopsys-alert/templates/postgres.yaml
@@ -35,7 +35,7 @@ spec:
   {{- else if .Values.storageClass }}
   storageClassName: {{ .Values.storageClass }}
   {{- end}}
-  {{ if .Values.alert.volumeName -}}
+  {{ if .Values.postgres.volumeName -}}
   volumeName: {{ .Values.postgres.volumeName }}
   {{ end -}}
   accessModes:

--- a/deployment/helm/synopsys-alert/templates/rabbitmq.yaml
+++ b/deployment/helm/synopsys-alert/templates/rabbitmq.yaml
@@ -35,7 +35,7 @@ spec:
   {{- else if .Values.storageClass }}
   storageClassName: {{ .Values.storageClass }}
   {{- end}}
-  {{ if .Values.alert.volumeName -}}
+  {{ if .Values.rabbitmq.volumeName -}}
   volumeName: {{ .Values.rabbitmq.volumeName }}
   {{ end -}}
   accessModes:

--- a/src/test/resources/database/helm-test-postgres/templates/postgres.yaml
+++ b/src/test/resources/database/helm-test-postgres/templates/postgres.yaml
@@ -35,7 +35,7 @@ spec:
   {{- else if .Values.storageClass }}
   storageClassName: {{ .Values.storageClass }}
   {{- end}}
-  {{ if .Values.alert.volumeName -}}
+  {{ if .Values.postgres.volumeName -}}
   volumeName: {{ .Values.postgres.volumeName }}
   {{ end -}}
   accessModes:


### PR DESCRIPTION
It was requested to include this in the current release. The if check is performed against .Values.alert, and not against the pod associated with the yaml.