### PR TITLE
IALERT-3643 - Force version of snakeyaml to be version from runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,12 @@ jacoco {
     toolVersion = "0.8.9"
 }
 
+configurations.all {
+  resolutionStrategy {
+    force 'org.yaml:snakeyaml:2.1'
+  }
+}
+
 dependencies {
     implementation platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES)
 


### PR DESCRIPTION
Since we don’t use yaml within liquibase, this dependency isn’t really needed. Force the version of snakeyaml in compile time to be the same as the version coming in for runtime.

Comprehensive build was successful

**output of gradle task `dependencies` for snakeyaml BEFORE edit**
```
|    +--- org.yaml:snakeyaml:1.33 (c)  <--- HERE
|    |    \--- org.yaml:snakeyaml:1.33  <--- HERE
|    +--- org.yaml:snakeyaml:1.33 -> 2.1 (c)
|    |    +--- org.yaml:snakeyaml:1.33 -> 2.1
|    |    |    |    \--- org.yaml:snakeyaml:1.33 -> 2.1
|         |    |         +--- org.yaml:snakeyaml:1.33 -> 2.1
|         |    |         |    +--- org.yaml:snakeyaml:2.1
|    +--- org.yaml:snakeyaml:1.33 -> 2.1 (c)
|    |    +--- org.yaml:snakeyaml:1.33 -> 2.1
|    |    |    |    \--- org.yaml:snakeyaml:1.33 -> 2.1
|         |    |         +--- org.yaml:snakeyaml:1.33 -> 2.1
|         |    |         |    +--- org.yaml:snakeyaml:2.1
|    +--- org.yaml:snakeyaml:1.33 (c)  <--- HERE
|    |    \--- org.yaml:snakeyaml:1.33  <--- HERE
|    +--- org.yaml:snakeyaml:1.33 -> 2.1 (c)
|    |    +--- org.yaml:snakeyaml:1.33 -> 2.1
|    |    |    |    \--- org.yaml:snakeyaml:1.33 -> 2.1
|         |    |         +--- org.yaml:snakeyaml:1.33 -> 2.1
|         |    |         |    +--- org.yaml:snakeyaml:2.1
```

**output of gradle task `dependencies` for snakeyaml AFTER edit**
```
|    +--- org.yaml:snakeyaml:1.33 -> 2.1 (c)  <--- HERE
|    |    \--- org.yaml:snakeyaml:1.33 -> 2.1  <--- HERE
|    +--- org.yaml:snakeyaml:1.33 -> 2.1 (c)
|    |    +--- org.yaml:snakeyaml:1.33 -> 2.1
|    |    |    |    \--- org.yaml:snakeyaml:1.33 -> 2.1
|         |    |         +--- org.yaml:snakeyaml:1.33 -> 2.1
|         |    |         |    +--- org.yaml:snakeyaml:2.1
|    +--- org.yaml:snakeyaml:1.33 -> 2.1 (c)
|    |    +--- org.yaml:snakeyaml:1.33 -> 2.1
|    |    |    |    \--- org.yaml:snakeyaml:1.33 -> 2.1
|         |    |         +--- org.yaml:snakeyaml:1.33 -> 2.1
|         |    |         |    +--- org.yaml:snakeyaml:2.1
|    +--- org.yaml:snakeyaml:1.33 -> 2.1 (c)  <--- HERE
|    |    \--- org.yaml:snakeyaml:1.33 -> 2.1  <--- HERE
|    +--- org.yaml:snakeyaml:1.33 -> 2.1 (c)
|    |    +--- org.yaml:snakeyaml:1.33 -> 2.1
|    |    |    |    \--- org.yaml:snakeyaml:1.33 -> 2.1
|         |    |         +--- org.yaml:snakeyaml:1.33 -> 2.1
|         |    |         |    +--- org.yaml:snakeyaml:2.1
```