### PR TITLE
IALERT-3643 - Exclude snakeyaml from buildscript

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         classpath "com.synopsys.integration:common-gradle-plugin:${managedCgpVersion}"
     }
 
+    // In Alert 7.2 we plan to upgrade spring-boot, which should make this exclude unnecessary
     configurations {
         classpath {
             resolutionStrategy {
@@ -106,6 +107,7 @@ subprojects {
 }
 
 allprojects {
+    // In Alert 7.2 we plan to upgrade spring-boot, which should make this force unnecessary
     configurations {
         all {
             resolutionStrategy {


### PR DESCRIPTION
Because snakeyaml is coming in via a Gradle plugin AND Detect gets the dependencies from each subproject individually, we need to exclude snakeyaml from buildscript.

Because we also pull in other spring dependencies directly, we still need to perform the force of the version to 2.1. I moved the force to be in section of build.gradle that already existed for subprojects, purely for clarity and consistency.

This has been run via PoP job and results confirm snakeyaml 1.33 is no longer present.

