### PR TITLE
IALERT-3651: Fix certificate data being overwritten while editing the certificate content

### DIFF
--- a/ui/src/main/js/page/certificates/CertificateModal.js
+++ b/ui/src/main/js/page/certificates/CertificateModal.js
@@ -9,14 +9,10 @@ import TextInput from 'common/component/input/TextInput';
 
 const CertificateModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, successMessage }) => {
     const dispatch = useDispatch();
-    const [certificateData, setCertificateData] = useState();
+    const [certificateData, setCertificateData] = useState(data);
     const [showLoader, setShowLoader] = useState(false);
     const { submitText, title } = modalOptions;
     const { saveStatus, error } = useSelector((state) => state.certificates);
-
-    useEffect(() => {
-        setCertificateData(data);
-    }, [data]);
 
     function handleClose() {
         toggleModal(false);
@@ -78,7 +74,7 @@ const CertificateModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMe
             handleSubmit={handleSubmit}
             showLoader={showLoader}
         >
-            { certificateData?.lastUpdated ? (
+            {certificateData?.lastUpdated ? (
                 <ReadOnlyField
                     id="lastUpdated-readOnlyFieldId"
                     label="Last Updated"


### PR DESCRIPTION
Each time the auto-refresh runs (30s) it updates the state of "data" in the front end from the values we have persisted. This then means that whenever your in the modal, it would clear the values that you've input with whatever was saved previously if you are updating.

Now, we only get the data in the initial state when you open the modal, and no longer re-check the state of the data. This resolves the issue where the server certificate was still working for Jira Server even when an invalid value was provided as it was getting reset before the user saved it.