### PR TITLE
IALERT-3600 Reconfigure BlackDuck Project Selection For Distribution Job Form

### DIFF
--- a/ui/src/main/js/common/component/table/SearchFilter.js
+++ b/ui/src/main/js/common/component/table/SearchFilter.js
@@ -48,7 +48,7 @@ const useStyles = createUseStyles({
     }
 });
 
-const SearchFilter = ({ searchBarPlaceholder, handleSearchChange, defaultSearchValue }) => {
+const SearchFilter = ({ searchBarPlaceholder, handleSearchChange, defaultSearchValue, isDisabled }) => {
     const classes = useStyles();
     const [searchValue, setSearchValue] = useState(null);
 
@@ -81,9 +81,10 @@ const SearchFilter = ({ searchBarPlaceholder, handleSearchChange, defaultSearchV
                     value={searchValue === null ? '' : searchValue}
                     onChange={handleChange}
                     onKeyDown={handleKeyDown}
+                    disabled={isDisabled}
                 />
                 { searchValue && (
-                    <button className={classes.clearInputIcon} onClick={handleClearSearchField} role="button" >
+                    <button className={classes.clearInputIcon} onClick={handleClearSearchField} role="button" disabled={isDisabled} >
                         <FontAwesomeIcon icon="times" size='sm' />
                     </button>
                 ) }

--- a/ui/src/main/js/common/component/table/SearchFilter.js
+++ b/ui/src/main/js/common/component/table/SearchFilter.js
@@ -100,7 +100,8 @@ const SearchFilter = ({ searchBarPlaceholder, handleSearchChange, defaultSearchV
 SearchFilter.propTypes = {
     searchBarPlaceholder: PropTypes.string,
     handleSearchChange: PropTypes.func,
-    defaultSearchValue: PropTypes.string
+    defaultSearchValue: PropTypes.string,
+    isDisabled: PropTypes.bool
 };
 
 export default SearchFilter;

--- a/ui/src/main/js/common/component/table/Table.js
+++ b/ui/src/main/js/common/component/table/Table.js
@@ -7,6 +7,7 @@ import TableHeader from 'common/component/table/TableHeader';
 import ToggleSwitch from 'common/component/input/ToggleSwitch';
 import EmptyTableView from 'common/component/table/EmptyTableView';
 import TableFooter from 'common/component/table/TableFooter';
+import TableSkeleton from 'common/component/table/TableSkeleton';
 
 const useStyles = createUseStyles({
     table: {
@@ -29,7 +30,7 @@ const useStyles = createUseStyles({
 const Table = ({
     columns, multiSelect, selected, onSelected, disableSelectOptions, tableData, handleSearchChange,
     searchBarPlaceholder, tableActions, onToggle, active, onSort, sortConfig, data, onPage, emptyTableConfig,
-    defaultSearchValue, onPageSize, showPageSize, pageSize, cellId
+    defaultSearchValue, onPageSize, showPageSize, pageSize, cellId, isLoading
 }) => {
     const classes = useStyles();
 
@@ -43,6 +44,7 @@ const Table = ({
                             handleSearchChange={handleSearchChange}
                             searchBarPlaceholder={searchBarPlaceholder}
                             defaultSearchValue={defaultSearchValue}
+                            isDisabled={isLoading}
                         />
                     )}
 
@@ -55,36 +57,42 @@ const Table = ({
                 </div>
             ) }
 
-            { (!tableData || tableData.length === 0) && (
+            { isLoading && (
+                <TableSkeleton />
+            )}
+
+            { (!isLoading && !tableData || tableData?.length === 0) && (
                 <EmptyTableView emptyTableConfig={emptyTableConfig} />
             )}
 
-            { tableData && tableData.length !== 0 && (
-                <table className={classes.table}>
-                    <TableHeader
-                        columns={columns}
-                        tableData={tableData}
-                        multiSelect={multiSelect}
-                        selected={selected}
-                        onSelected={onSelected}
-                        onSort={onSort}
-                        sortConfig={sortConfig}
-                        disableSelectOptions={disableSelectOptions}
-                        cellId={cellId}
-                    />
-                    <TableBody
-                        columns={columns}
-                        multiSelect={multiSelect}
-                        tableData={tableData}
-                        selected={selected}
-                        onSelected={onSelected}
-                        disableSelectOptions={disableSelectOptions}
-                        cellId={cellId}
-                    />
-                </table>
-            )}
+            { (!isLoading && tableData && tableData.length !== 0) && (
+                <>
+                    <table className={classes.table}>
+                        <TableHeader
+                            columns={columns}
+                            tableData={tableData}
+                            multiSelect={multiSelect}
+                            selected={selected}
+                            onSelected={onSelected}
+                            onSort={onSort}
+                            sortConfig={sortConfig}
+                            disableSelectOptions={disableSelectOptions}
+                            cellId={cellId}
+                        />
+                        <TableBody
+                            columns={columns}
+                            multiSelect={multiSelect}
+                            tableData={tableData}
+                            selected={selected}
+                            onSelected={onSelected}
+                            disableSelectOptions={disableSelectOptions}
+                            cellId={cellId}
+                        />
+                    </table>
 
-            <TableFooter data={data} onPage={onPage} onPageSize={onPageSize} showPageSize={showPageSize} pageSize={pageSize} />
+                    <TableFooter data={data} onPage={onPage} onPageSize={onPageSize} showPageSize={showPageSize} pageSize={pageSize} />
+                </>
+            )}
         </>
     );
 };
@@ -119,7 +127,8 @@ Table.propTypes = {
     }),
     defaultSearchValue: PropTypes.string,
     pageSize: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    cellId: PropTypes.string
+    cellId: PropTypes.string,
+    isLoading: PropTypes.bool
 };
 
 export default Table;

--- a/ui/src/main/js/common/component/table/TableSkeleton.js
+++ b/ui/src/main/js/common/component/table/TableSkeleton.js
@@ -30,10 +30,6 @@ const useStyles = createUseStyles(theme => ({
         `,
         gridTemplateRows: '45px 35px 35px 35px'
     },
-    headerContainer: {
-        width: '100%',
-        height: '45px'
-    },
     headerItem: {
         height: '25px',
         width: '75px',
@@ -67,28 +63,9 @@ const useStyles = createUseStyles(theme => ({
         )`
     },
     col1: {
-        gridArea: 'col1',
         marginLeft: '10px'
     },
-    row1col1: {
-        gridArea: 'row1col1',
-        marginLeft: '10px'
-    },
-    row2col1: {
-        gridArea: 'row2col1',
-        marginLeft: '10px'
-    },
-    row3col1: {
-        gridArea: 'row3col1',
-        marginLeft: '10px'
-    },
-    row1col2: {
-        width: '200px'
-    }, 
-    row2col2: {
-        width: '200px'
-    }, 
-    row3col2: {
+    col2: {
         width: '200px'
     }
 }));
@@ -99,20 +76,20 @@ export default function TableSkeleton() {
     return (
         <div className={classes.skeletonTableContainer}>
             <div className={classNames(classes.headerItem, classes.col1)} />
-            <div className={classNames(classes.headerItem, classes.col2)} />
-            <div className={classNames(classes.headerItem, classes.col3)} />
+            <div className={classes.headerItem} />
+            <div className={classes.headerItem} />
 
-            <div className={classNames(classes.rowItem, classes.row1col1)} />
-            <div className={classNames(classes.rowItem, classes.row1col2)} />
-            <div className={classNames(classes.rowItem, classes.row1col3)} />
+            <div className={classNames(classes.rowItem, classes.col1)} />
+            <div className={classNames(classes.rowItem, classes.col2)} />
+            <div className={classes.rowItem} />
 
-            <div className={classNames(classes.rowItem, classes.row2col1)} />
-            <div className={classNames(classes.rowItem, classes.row2col2)} />
-            <div className={classNames(classes.rowItem, classes.row2col3)} />
+            <div className={classNames(classes.rowItem, classes.col1)} />
+            <div className={classNames(classes.rowItem, classes.col2)} />
+            <div className={classes.rowItem} />
 
-            <div className={classNames(classes.rowItem, classes.row3col1)} />
-            <div className={classNames(classes.rowItem, classes.row3col2)} />
-            <div className={classNames(classes.rowItem, classes.row3col3)} />
+            <div className={classNames(classes.rowItem, classes.col1)} />
+            <div className={classNames(classes.rowItem, classes.col2)} />
+            <div className={classes.rowItem} />
         </div>
     );
 };

--- a/ui/src/main/js/common/component/table/TableSkeleton.js
+++ b/ui/src/main/js/common/component/table/TableSkeleton.js
@@ -1,0 +1,118 @@
+import React from 'react';
+import { createUseStyles } from 'react-jss';
+import classNames from 'classnames';
+
+const useStyles = createUseStyles(theme => ({
+    '@keyframes loading': {
+        from: {
+            backgroundPosition: '-200px 0'
+        },
+        to: {
+            backgroundPosition: 'calc(200px + 100%) 0'
+        }
+    },
+    '@media (prefers-reduced-motion)': {
+        skeleton: {
+            animation: 'none'
+        }
+    },
+    skeletonTableContainer: {
+        width: '100%',
+        paddingBottom: '12px',
+        background: '#fafafa',
+        borderRadius: '3px',
+        display: 'grid',
+        gridTemplateAreas: `
+            "col1     col2     col3"
+            "row1col1 row1col2 row1col3"
+            "row2col1 row2col2 row2col3"
+            "row3col1 row3col2 row3col3"
+        `,
+        gridTemplateRows: '45px 35px 35px 35px'
+    },
+    headerContainer: {
+        width: '100%',
+        height: '45px'
+    },
+    headerItem: {
+        height: '25px',
+        width: '75px',
+        borderRadius: '5px',
+        marginTop: '16px',
+        animation: '$loading 1.5s ease-in-out infinite',
+        backgroundSize: '200px 100%',
+        backgroundRepeat: 'no-repeat',
+        backgroundColor: '#ececec',
+        backgroundImage: `linear-gradient(
+            90deg,
+            #ececec,
+            #fbfbfb,
+            #ececec
+        )`
+    },
+    rowItem: {
+        height: '20px',
+        width: '125px',
+        borderRadius: '5px',
+        marginTop: '8px',
+        animation: '$loading 1.5s ease-in-out infinite',
+        backgroundSize: '200px 100%',
+        backgroundRepeat: 'no-repeat',
+        backgroundColor: '#ececec',
+        backgroundImage: `linear-gradient(
+            90deg,
+            #ececec,
+            #fbfbfb,
+            #ececec
+        )`
+    },
+    col1: {
+        gridArea: 'col1',
+        marginLeft: '10px'
+    },
+    row1col1: {
+        gridArea: 'row1col1',
+        marginLeft: '10px'
+    },
+    row2col1: {
+        gridArea: 'row2col1',
+        marginLeft: '10px'
+    },
+    row3col1: {
+        gridArea: 'row3col1',
+        marginLeft: '10px'
+    },
+    row1col2: {
+        width: '200px'
+    }, 
+    row2col2: {
+        width: '200px'
+    }, 
+    row3col2: {
+        width: '200px'
+    }
+}));
+
+export default function TableSkeleton() {
+    const classes = useStyles();
+
+    return (
+        <div className={classes.skeletonTableContainer}>
+            <div className={classNames(classes.headerItem, classes.col1)} />
+            <div className={classNames(classes.headerItem, classes.col2)} />
+            <div className={classNames(classes.headerItem, classes.col3)} />
+
+            <div className={classNames(classes.rowItem, classes.row1col1)} />
+            <div className={classNames(classes.rowItem, classes.row1col2)} />
+            <div className={classNames(classes.rowItem, classes.row1col3)} />
+
+            <div className={classNames(classes.rowItem, classes.row2col1)} />
+            <div className={classNames(classes.rowItem, classes.row2col2)} />
+            <div className={classNames(classes.rowItem, classes.row2col3)} />
+
+            <div className={classNames(classes.rowItem, classes.row3col1)} />
+            <div className={classNames(classes.rowItem, classes.row3col2)} />
+            <div className={classNames(classes.rowItem, classes.row3col3)} />
+        </div>
+    );
+};

--- a/ui/src/main/js/common/component/table/cell/MultiSelectCell.js
+++ b/ui/src/main/js/common/component/table/cell/MultiSelectCell.js
@@ -26,9 +26,9 @@ const MultiSelectCell = ({ selected, onSelected, data, disableSelectOptions, cel
 
     const toggleSelect = useCallback((evt) => {
         if (evt.target.checked) {
-            onSelected(selected.concat(identifier));
+            onSelected(selected.concat(identifier), data);
         } else {
-            onSelected(selected.filter((item) => item !== identifier));
+            onSelected(selected.filter((item) => item !== identifier), data);
         }
     }, [onSelected, selected]);
 

--- a/ui/src/main/js/page/distribution/ProjectSelectModal.js
+++ b/ui/src/main/js/page/distribution/ProjectSelectModal.js
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import Modal from 'common/component/modal/Modal';
+import Table from 'common/component/table/Table';
+import { createNewConfigurationRequest } from 'common/util/configurationRequestBuilder';
+import * as FieldModelUtilities from 'common/util/fieldModelUtilities';
+import { DISTRIBUTION_COMMON_FIELD_KEYS, DISTRIBUTION_URLS } from './DistributionModel';
+
+const KEY_CELL = "name"
+
+const COLUMNS = [{
+    key: KEY_CELL,
+    label: 'Project Name',
+    sortable: false
+}];
+
+// Note: this Modal is near identical to <AdditionalEmailAddressesModal>.  Consider consolidation as a future IMPROVEMENT
+export default function ProjectSelectModal({ isOpen, handleClose, csrfToken, projectRequestBody, handleSubmit, formData }) {
+    const [data, setData] = useState({});
+    const [pageNumber, setPageNumber] = useState(0);
+    const [pageSize, setPageSize] = useState(25);
+    const [searchTerm, setSearchTerm] = useState('');
+    const [selected, setSelected] = useState((FieldModelUtilities.getFieldModelValues(formData, DISTRIBUTION_COMMON_FIELD_KEYS.configuredProjects)));
+    const [showLoader, setShowLoader] = useState(false);
+    const [errorMessage, setErrorMessage] = useState({ message: 'No Projects Available' });
+    const selectedProjectNames = selected.map((project) => project.label);
+
+    function handleFieldValueChange(option) {
+        const name = DISTRIBUTION_COMMON_FIELD_KEYS.configuredProjects;
+        handleSubmit({
+            target: {
+                name,
+                value: option
+            }
+        });
+        handleClose();
+    }
+
+    useEffect(() => {
+        function fetchProjectList() {
+            const apiUrl = `${DISTRIBUTION_URLS.distributionSelectTableUrl}?pageNumber=${pageNumber}&pageSize=${pageSize}&searchTerm=${searchTerm}`;
+            const request = createNewConfigurationRequest(apiUrl, csrfToken, projectRequestBody());
+            setShowLoader(true);
+            request.then((response) => {
+                if (response.ok) {
+                    response.json().then((resJson) => {
+                        setData(resJson);
+                        setShowLoader(false);
+                    });
+                } else {
+                    response.json().then((resJson) => {
+                        setErrorMessage(resJson);
+                        setShowLoader(false);
+                    });
+                }
+            });
+        }
+
+        fetchProjectList();
+    }, [pageNumber, pageSize, searchTerm, csrfToken, projectRequestBody]);
+
+    return (
+        <>
+            <Modal
+                isOpen={isOpen}
+                size="lg"
+                title="Projects"
+                closeModal={handleClose}
+                handleSubmit={() => { handleFieldValueChange(selected); }}
+                submitText="Save"
+            >
+                <div style={{ paddingLeft: 15, paddingRight: 15 }}>
+                    <Table
+                        tableData={data?.models}
+                        columns={COLUMNS}
+                        multiSelect
+                        searchBarPlaceholder="Filter Projects..."
+                        handleSearchChange={(newSearchTerm) => {
+                            setSearchTerm(newSearchTerm);
+                        }}
+                        selected={selectedProjectNames}
+                        onSelected={(rowID, rowData) => {
+                            if (selectedProjectNames.includes(rowData.name)) {
+                                setSelected(selected.filter((project) => project.value !== rowData.href));
+                            } else {
+                                setSelected([...selected, { label: rowData.name, value: rowData.href }]);
+                            }
+                        }}
+                        onPage={(newPageNumber) => {
+                            setPageNumber(newPageNumber);
+                        }}
+                        onPageSize={(newPageSize) => {
+                            setPageNumber(0);
+                            setPageSize(newPageSize);
+                        }}
+                        pageSize={pageSize}
+                        showPageSize
+                        data={data}
+                        emptyTableConfig={errorMessage}
+                        cellId={KEY_CELL}
+                        defaultSearchValue=""
+                        isLoading={showLoader}
+                    />
+                </div>
+            </Modal>
+        </>
+    );
+}
+
+ProjectSelectModal.propTypes = {
+    isOpen: PropTypes.bool,
+    handleClose: PropTypes.func,
+    csrfToken: PropTypes.string,
+    projectRequestBody: PropTypes.func,
+    handleSubmit: PropTypes.func,
+    formData: PropTypes.object
+};


### PR DESCRIPTION
# IALERT-3600

**Overview:**  
Client has requested the Project selection field, found in the Distribution Job Form, to be restructured.  Their request included that the dropdown field was not able to update the search, limit, or paging of the request that populates the data in that dropdown.  After review, I discovered that the request was hardcoded with searchQuery, limit, and pagination.  
  
**Fix Overview:**  
To fix this I reworked the field to do the following:

- A user can click on the field which will open a modal
- Inside the modal, a table will render where the user can select any or all projects
- Once the user has selected and pressed 'Save', the modal will disappear and the field will render the selected projects, to which the user can unselect a project(s) directly from the field, or they can reopen the modal and unselect/select more.