### PR TITLE
IALERT-3624 Display HelpText Popover in Test LDAP Config Modal

### DIFF
--- a/ui/src/main/js/application/auth/LdapForm.js
+++ b/ui/src/main/js/application/auth/LdapForm.js
@@ -110,7 +110,7 @@ const LdapForm = ({ csrfToken, errorHandler, readonly, displayTest }) => {
                 id={AUTHENTICATION_LDAP_GLOBAL_TEST_FIELD_KEYS.testLDAPUsername}
                 name={AUTHENTICATION_LDAP_GLOBAL_TEST_FIELD_KEYS.testLDAPUsername}
                 label="User Name"
-                description="The user name to test LDAP authentication; if LDAP authentication is enabled."
+                customDescription="The user name to test LDAP authentication; if LDAP authentication is enabled."
                 readOnly={false}
                 onChange={FieldModelUtilities.handleConcreteModelChange(testFormData, setTestFormData)}
                 value={testFormData[AUTHENTICATION_LDAP_GLOBAL_TEST_FIELD_KEYS.testLDAPUsername]}
@@ -119,7 +119,7 @@ const LdapForm = ({ csrfToken, errorHandler, readonly, displayTest }) => {
                 id={AUTHENTICATION_LDAP_GLOBAL_TEST_FIELD_KEYS.testLDAPPassword}
                 name={AUTHENTICATION_LDAP_GLOBAL_TEST_FIELD_KEYS.testLDAPPassword}
                 label="Password"
-                description="The password to test LDAP authentication; if LDAP authentication is enabled."
+                customDescription="The password to test LDAP authentication; if LDAP authentication is enabled."
                 readOnly={false}
                 onChange={FieldModelUtilities.handleConcreteModelChange(testFormData, setTestFormData)}
                 value={testFormData[AUTHENTICATION_LDAP_GLOBAL_TEST_FIELD_KEYS.testLDAPPassword]}


### PR DESCRIPTION
**Overview:**  
When the LDAP Test Configuration Modal was rendered on screen, the help text tooltips were on showing up on user click. 
  
**Fix Overview:**  
The fix was simple, switch the prop from `description` to `customDescription`.  `customDescription` was implemented in our UI changes in 7.0.0 specifically for tooltip/popovers in modals.