### PR TITLE
IALERT-3625 Do not retain test form data on fetch

### DIFF
--- a/ui/src/main/js/application/auth/AuthenticationModel.js
+++ b/ui/src/main/js/application/auth/AuthenticationModel.js
@@ -36,5 +36,5 @@ export const AUTHENTICATION_SAML_GLOBAL_FIELD_KEYS = {
     name: 'name',
     signingCertFileName: 'signingCertFileName',
     signingPrivateKeyFileName: 'signingPrivateKeyFileName',
-    verificationCertFileName: 'verificationCertFileName',
+    verificationCertFileName: 'verificationCertFileName'
 };

--- a/ui/src/main/js/application/auth/LdapForm.js
+++ b/ui/src/main/js/application/auth/LdapForm.js
@@ -88,7 +88,7 @@ const LdapForm = ({ csrfToken, errorHandler, readonly, displayTest }) => {
 
     function testButtonClicked() {
         processFormData();
-        setTestFormData({ ...testFormData, ldapConfigModel: formData });
+        setTestFormData({ ldapConfigModel: formData });
     }
 
     function handleValidation() {


### PR DESCRIPTION
Matches 6.12.0 LDAP test modal where data was not retained for the LDAP test modal.

Rebased to v7.1.2