### PR TITLE
IALERT-3600: Reset Page Number on Search

### DIFF
--- a/ui/src/main/js/page/distribution/ProjectSelectModal.js
+++ b/ui/src/main/js/page/distribution/ProjectSelectModal.js
@@ -76,6 +76,7 @@ export default function ProjectSelectModal({ isOpen, handleClose, csrfToken, pro
                         multiSelect
                         searchBarPlaceholder="Filter Projects..."
                         handleSearchChange={(newSearchTerm) => {
+                            setPageNumber(0);
                             setSearchTerm(newSearchTerm);
                         }}
                         selected={selectedProjectNames}


### PR DESCRIPTION
# Bug Overview
When a user is creating a distribution job and they are have selected a Black Duck provider, they have the ability to filter by project.  With the project selection modal open, if they navigate to any page other than 1 on the table and attempt to search/filter, the request returns no results.  This is due to the request containing the page number.  To fix this, I have reset the page number to 0 whenever a user searches/filters.  