### PR TITLE
IALERT-3610: upgrade sprint boot dependency

### DIFF
--- a/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/LDAPAuthenticationPerformerTest.java
+++ b/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/LDAPAuthenticationPerformerTest.java
@@ -2,6 +2,7 @@ package com.synopsys.integration.alert.authentication.ldap;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -63,6 +64,7 @@ class LDAPAuthenticationPerformerTest {
 
         Authentication returnAuthentication = ldapAuthenticationPerformer.authenticateWithProvider(inputAuthentication);
         assertEquals(inputAuthentication.getPrincipal(), returnAuthentication.getPrincipal());
+        assertFalse(returnAuthentication.isAuthenticated());
     }
 
     @Test
@@ -72,6 +74,7 @@ class LDAPAuthenticationPerformerTest {
 
         Authentication returnAuthentication = ldapAuthenticationPerformer.authenticateWithProvider(inputAuthentication);
         assertEquals(inputAuthentication.getPrincipal(), returnAuthentication.getPrincipal());
+        assertFalse(returnAuthentication.isAuthenticated());
     }
 
     @Test
@@ -80,6 +83,7 @@ class LDAPAuthenticationPerformerTest {
 
         Authentication returnAuthentication = ldapAuthenticationPerformer.authenticateWithProvider(inputAuthentication);
         assertEquals(inputAuthentication.getPrincipal(), returnAuthentication.getPrincipal());
+        assertFalse(returnAuthentication.isAuthenticated());
     }
 
     @Test
@@ -94,6 +98,7 @@ class LDAPAuthenticationPerformerTest {
 
         Authentication returnAuthentication = ldapAuthenticationPerformer.authenticateWithProvider(inputAuthentication);
         assertEquals(inputAuthentication.getPrincipal(), returnAuthentication.getPrincipal());
+        assertFalse(returnAuthentication.isAuthenticated());
     }
 
     @Test
@@ -102,16 +107,15 @@ class LDAPAuthenticationPerformerTest {
 
         LDAPManager spiedLDAPManager = Mockito.spy(ldapManager);
         LdapAuthenticationProvider ldapAuthenticationProvider = Mockito.mock(LdapAuthenticationProvider.class);
-        LdapAuthenticationProvider spiedLdapAuthenticationProvider = Mockito.spy(ldapAuthenticationProvider);
-        assertDoesNotThrow(() -> Mockito.doReturn(Optional.of(spiedLdapAuthenticationProvider)).when(spiedLDAPManager).createAuthProvider(Mockito.any(LDAPConfigModel.class)));
+        assertDoesNotThrow(() -> Mockito.doReturn(Optional.of(ldapAuthenticationProvider)).when(spiedLDAPManager).createAuthProvider(Mockito.any(LDAPConfigModel.class)));
 
         // Return an authenticated token when authenticate() is called
         SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority("ROLE_AUTH");
         TestingAuthenticationToken authenticatedToken = new TestingAuthenticationToken("foo", "bar", List.of(simpleGrantedAuthority));
-        Mockito.doReturn(authenticatedToken).when(spiedLdapAuthenticationProvider).authenticate(inputAuthentication);
+        Mockito.doReturn(authenticatedToken).when(ldapAuthenticationProvider).authenticate(inputAuthentication);
 
-        LDAPAuthenticationPerformer ldapAuthenticationPerformer = new LDAPAuthenticationPerformer(mockAuthenticationEventManager, mockRoleAccessor, spiedLDAPManager);
-        Authentication returnAuthentication = ldapAuthenticationPerformer.authenticateWithProvider(inputAuthentication);
+        LDAPAuthenticationPerformer testLdapAuthenticationPerformer = new LDAPAuthenticationPerformer(mockAuthenticationEventManager, mockRoleAccessor, spiedLDAPManager);
+        Authentication returnAuthentication = testLdapAuthenticationPerformer.authenticateWithProvider(inputAuthentication);
         assertTrue(returnAuthentication.isAuthenticated());
         assertEquals("foo", returnAuthentication.getPrincipal());
     }

--- a/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/action/LDAPTestActionTest.java
+++ b/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/action/LDAPTestActionTest.java
@@ -140,11 +140,10 @@ class LDAPTestActionTest {
         LDAPConfigTestModel ldapConfigTestModel = new LDAPConfigTestModel(validLDAPConfigModel, testUser, testPass);
         LDAPManager spiedLDAPManager = Mockito.spy(ldapManager);
         LdapAuthenticationProvider mockLdapAuthenticationProvider = Mockito.mock(LdapAuthenticationProvider.class);
-        LdapAuthenticationProvider spiedLdapAuthenticationProvider = Mockito.spy(mockLdapAuthenticationProvider);
-        assertDoesNotThrow(() -> Mockito.doReturn(Optional.of(spiedLdapAuthenticationProvider)).when(spiedLDAPManager).createAuthProvider(validLDAPConfigModel));
+        assertDoesNotThrow(() -> Mockito.doReturn(Optional.of(mockLdapAuthenticationProvider)).when(spiedLDAPManager).createAuthProvider(validLDAPConfigModel));
 
         Authentication authentication = new UsernamePasswordAuthenticationToken("testLDAPUsername", "testLDAPPassword");
-        Mockito.doReturn(authentication).when(spiedLdapAuthenticationProvider).authenticate(Mockito.any(Authentication.class));
+        Mockito.doReturn(authentication).when(mockLdapAuthenticationProvider).authenticate(Mockito.any(Authentication.class));
 
         ldapTestAction = new LDAPTestAction(authorizationManager, authenticationDescriptorKey, ldapConfigurationValidator, spiedLDAPManager, ldapConfigAccessor);
         ActionResponse<ValidationResponseModel> validationResponseModelActionResponse = ldapTestAction.testAuthentication(ldapConfigTestModel);
@@ -160,13 +159,12 @@ class LDAPTestActionTest {
         LDAPConfigTestModel ldapConfigTestModel = new LDAPConfigTestModel(validLDAPConfigModel, testUser, testPass);
         LDAPManager spiedLDAPManager = Mockito.spy(ldapManager);
         LdapAuthenticationProvider mockLdapAuthenticationProvider = Mockito.mock(LdapAuthenticationProvider.class);
-        LdapAuthenticationProvider spiedLdapAuthenticationProvider = Mockito.spy(mockLdapAuthenticationProvider);
-        assertDoesNotThrow(() -> Mockito.doReturn(Optional.of(spiedLdapAuthenticationProvider)).when(spiedLDAPManager).createAuthProvider(validLDAPConfigModel));
+        assertDoesNotThrow(() -> Mockito.doReturn(Optional.of(mockLdapAuthenticationProvider)).when(spiedLDAPManager).createAuthProvider(validLDAPConfigModel));
 
         // Create an instance of an implementation of Authentication that will return true for isAuthenticated()
         SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority("ROLE_AUTH");
         TestingAuthenticationToken authenticatedToken = new TestingAuthenticationToken("foo", "bar", List.of(simpleGrantedAuthority));
-        Mockito.doReturn(authenticatedToken).when(spiedLdapAuthenticationProvider).authenticate(Mockito.any(Authentication.class));
+        Mockito.doReturn(authenticatedToken).when(mockLdapAuthenticationProvider).authenticate(Mockito.any(Authentication.class));
 
         ldapTestAction = new LDAPTestAction(authorizationManager, authenticationDescriptorKey, ldapConfigurationValidator, spiedLDAPManager, ldapConfigAccessor);
         ActionResponse<ValidationResponseModel> validationResponseModelActionResponse = ldapTestAction.testAuthentication(ldapConfigTestModel);

--- a/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/web/LDAPConfigControllerTest.java
+++ b/authentication-ldap/src/test/java/com/synopsys/integration/alert/authentication/ldap/web/LDAPConfigControllerTest.java
@@ -166,19 +166,18 @@ class LDAPConfigControllerTest {
     void testTestValidModel() {
         LDAPManager spiedLDAPManager = Mockito.spy(ldapManager);
         LdapAuthenticationProvider mockLdapAuthenticationProvider = Mockito.mock(LdapAuthenticationProvider.class);
-        LdapAuthenticationProvider spiedLdapAuthenticationProvider = Mockito.spy(mockLdapAuthenticationProvider);
-        assertDoesNotThrow(() -> Mockito.doReturn(Optional.of(spiedLdapAuthenticationProvider)).when(spiedLDAPManager).createAuthProvider(validLDAPConfigModel));
+        assertDoesNotThrow(() -> Mockito.doReturn(Optional.of(mockLdapAuthenticationProvider)).when(spiedLDAPManager).createAuthProvider(validLDAPConfigModel));
 
         // Create an instance of an implementation of Authentication that will return true for isAuthenticated()
         SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority("ROLE_AUTH");
         TestingAuthenticationToken authenticatedToken = new TestingAuthenticationToken("foo", "bar", List.of(simpleGrantedAuthority));
-        Mockito.doReturn(authenticatedToken).when(spiedLdapAuthenticationProvider).authenticate(Mockito.any(Authentication.class));
+        Mockito.doReturn(authenticatedToken).when(mockLdapAuthenticationProvider).authenticate(Mockito.any(Authentication.class));
 
         LDAPTestAction ldapTestAction = new LDAPTestAction(authorizationManager, authenticationDescriptorKey, ldapConfigurationValidator, spiedLDAPManager, ldapConfigAccessor);
-        LDAPConfigController ldapConfigController = new LDAPConfigController(ldapCrudActions, ldapValidationAction, ldapTestAction);
+        LDAPConfigController testLdapConfigController = new LDAPConfigController(ldapCrudActions, ldapValidationAction, ldapTestAction);
 
         LDAPConfigTestModel ldapConfigTestModel = new LDAPConfigTestModel(validLDAPConfigModel, "User", "Pass");
-        ValidationResponseModel validationResponseModel = assertDoesNotThrow(() -> ldapConfigController.test(ldapConfigTestModel));
+        ValidationResponseModel validationResponseModel = assertDoesNotThrow(() -> testLdapConfigController.test(ldapConfigTestModel));
         assertEquals("LDAP Test Configuration successful.", validationResponseModel.getMessage());
         assertFalse(validationResponseModel.hasErrors());
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '3.1.8'
+        springBootVersion = '3.2.9'
     }
 
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-repositories.gradle', to: buildscript
@@ -10,15 +10,6 @@ buildscript {
     dependencies {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
         classpath "com.synopsys.integration:common-gradle-plugin:${managedCgpVersion}"
-    }
-
-    // In Alert 7.2 we plan to upgrade spring-boot, which should make this exclude unnecessary
-    configurations {
-        classpath {
-            resolutionStrategy {
-                exclude group: 'org.yaml', module: 'snakeyaml'
-            }
-        }
     }
 }
 
@@ -107,15 +98,6 @@ subprojects {
 }
 
 allprojects {
-    // In Alert 7.2 we plan to upgrade spring-boot, which should make this force unnecessary
-    configurations {
-        all {
-            resolutionStrategy {
-                force 'org.yaml:snakeyaml:2.1'
-            }
-        }
-    }
-
     configurations {
         all {
             exclude group: 'com.blackducksoftware.bdio', module: 'bdio2'

--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,10 @@ allprojects {
         }
     }
 
+    tasks.withType(JavaCompile) {
+        options.compilerArgs << '-parameters'
+    }
+
     repositories {
         // Need this repository to resolve the opensaml dependencies
         maven {

--- a/buildSrc/src/main/resources/init_test_db.sql
+++ b/buildSrc/src/main/resources/init_test_db.sql
@@ -10,4 +10,4 @@ $$
         PERFORM dblink('user=sa dbname=postgres', 'CREATE DATABASE alertdb WITH OWNER sa', FALSE);
         ALTER DATABASE alertdb SET timezone TO 'Etc/UTC';
     END
-$$
+$$;

--- a/src/test/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckAccumulatorTest.java
+++ b/src/test/java/com/synopsys/integration/alert/provider/blackduck/task/accumulator/BlackDuckAccumulatorTest.java
@@ -2,7 +2,6 @@ package com.synopsys.integration.alert.provider.blackduck.task.accumulator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.mockito.Mockito.spy;
 
 import java.util.Date;
 import java.util.List;
@@ -58,6 +57,7 @@ class BlackDuckAccumulatorTest {
         accumulator.run();
 
         Mockito.verify(notificationAccessor, Mockito.times(1)).saveAllNotifications(Mockito.anyList());
+        Mockito.verify(eventManager, Mockito.times(1)).sendEvent(Mockito.any(NotificationReceivedEvent.class));
     }
 
     @Test
@@ -165,9 +165,8 @@ class BlackDuckAccumulatorTest {
     private BlackDuckSystemValidator createBlackDuckValidator(BlackDuckProperties blackDuckProperties, boolean validationResult) {
         BlackDuckSystemValidator blackDuckSystemValidator = Mockito.mock(BlackDuckSystemValidator.class);
         Mockito.when(blackDuckSystemValidator.validate(blackDuckProperties)).thenReturn(validationResult);
-        BlackDuckSystemValidator spiedBlackDuckSystemValidator = spy(blackDuckSystemValidator);
-        Mockito.doReturn(validationResult).when(spiedBlackDuckSystemValidator).canConnect(Mockito.eq(blackDuckProperties), Mockito.any(BlackDuckApiTokenValidator.class));
-        return spiedBlackDuckSystemValidator;
+        Mockito.doReturn(validationResult).when(blackDuckSystemValidator).canConnect(Mockito.eq(blackDuckProperties), Mockito.any(BlackDuckApiTokenValidator.class));
+        return blackDuckSystemValidator;
     }
 
     private BlackDuckNotificationRetrieverFactory createBlackDuckNotificationRetrieverFactory(BlackDuckProperties blackDuckProperties, @Nullable BlackDuckNotificationRetriever notificationRetriever) {


### PR DESCRIPTION
Upgrade the Spring Boot dependency to version 3.2.9.

To support this new version, the following additional changes needed to be made:
- Mockito spy can no longer be performed on a mocked object and will therefore error at test time. Refactored the tests to use mockito when without passing the spied object
- Added a missing semi-colon in causing failures after upgrade in init_test_db.sql
- Passing in the java compiler argument '-parameters' to resolve runtime errors with parameter matching in Spring 3.2
- Remove snakeyaml resolution strategy