### PR TITLE
IALERT-3554: Support Azure Flexible server

### DIFF
--- a/deployment/helm/synopsys-alert/templates/alert.yaml
+++ b/deployment/helm/synopsys-alert/templates/alert.yaml
@@ -74,12 +74,22 @@ spec:
               name: {{ .Release.Name }}-db-creds
         {{- end }}
         {{- if (eq .Values.postgres.sslUseFiles true) }}
+        {{- if (eq .Values.postgres.isAzure false)}}
         - name: ALERT_DB_SSL_KEY_PATH
           value: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslKeyKey }}
         - name: ALERT_DB_SSL_CERT_PATH
           value: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslCertKey }}
         - name: ALERT_DB_SSL_ROOT_CERT_PATH
           value: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslRootCertKey }}
+        {{- else }}
+        # if we only have a CA cert, ignore the client cert and key
+        - name: ALERT_DB_SSL_KEY_PATH
+          value: ""
+        - name: ALERT_DB_SSL_CERT_PATH
+          value: ""
+        - name: ALERT_DB_SSL_ROOT_CERT_PATH
+          value: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslRootCertKey }}
+        {{- end }}
         {{- end }}
         {{- if .Values.rabbitmq.credential.secretName }}
         - name: ALERT_RABBITMQ_USER
@@ -131,6 +141,11 @@ spec:
         - mountPath: /opt/blackduck/alert/alert-config
           name: dir-alert
         {{- if .Values.postgres.sslUseFiles }}
+        {{- if (eq .Values.postgres.isAzure true) }}
+        - mountPath: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslRootCertKey }}
+          name: dbcert
+          subPath: {{ .Values.postgres.sslSecrets.sslRootCertKey }}
+        {{- else }}
         - mountPath: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslKeyKey }}
           name: dbcert
           subPath: {{ .Values.postgres.sslSecrets.sslKeyKey }}
@@ -140,6 +155,7 @@ spec:
         - mountPath: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslRootCertKey }}
           name: dbcert
           subPath: {{ .Values.postgres.sslSecrets.sslRootCertKey }}
+        {{- end }}
         {{- end }}
         {{- if .Values.webserverCustomCertificatesSecretName }}
         - mountPath: {{ .Values.secretsDirectory }}/WEBSERVER_CUSTOM_CERT_FILE

--- a/deployment/helm/synopsys-alert/values.yaml
+++ b/deployment/helm/synopsys-alert/values.yaml
@@ -49,12 +49,13 @@ postgres:
   imageTag: ALERT_VERSION_TOKEN
   registry: "" # override the docker registry at container level
   isExternal: false # false for running Postgres as a container and true for using External Postgres database
+  isAzure: false # should only be true if your external database is running on azure
   ssl: false # If true, Alert uses SSL for external Postgres connection
   sslUseFiles: false # If true, Alert will expect to find ssl certs for communicating with the External Postgres database
   sslSecrets: # Secret that contains all the ssl file paths
     secretName: ""
-    sslKeyKey: "ALERT_DB_SSL_KEY_PATH"
-    sslCertKey: "ALERT_DB_SSL_CERT_PATH"
+    sslKeyKey: "ALERT_DB_SSL_KEY_PATH" # not required for azure
+    sslCertKey: "ALERT_DB_SSL_CERT_PATH" # not required for azure
     sslRootCertKey: "ALERT_DB_SSL_ROOT_CERT_PATH"
   host: "" # required only for external postgres, for postgres as a container, it will point to <name>-postgres
   port: 5432


### PR DESCRIPTION
Fixes IALERT-3554

Changes:

- adds `isAzure` boolean to values along with some comments
- alert.yaml template has a few conditional blocks to either include or omit the full certificate chain based on the value of `isAzure` in values

Tested against:

- Azure Flexible server (PG 14)
- GCP Postgres (PG 14) with `Require trusted client certificates` enabled 