### PR TITLE
IALERT-3676: add content-security-policy header

### DIFF
--- a/component/src/main/java/com/synopsys/integration/alert/component/authentication/security/AuthenticationHandler.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/authentication/security/AuthenticationHandler.java
@@ -96,7 +96,8 @@ public class AuthenticationHandler {
             .headers(customizer -> {
                 customizer.contentSecurityPolicy(cspCustomizer -> {
                     cspCustomizer.policyDirectives(
-                        "form-action 'self'; default-src 'self' 'https://www.synopsys.com'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' 'https://www.synopsys.com';");
+                        "form-action 'self'; default-src 'none'; connect-src 'self'; object-src 'self'; script-src 'self' 'unsafe-eval'; img-src 'self' https://www.synopsys.com/ https://images.synopsys.com/; style-src 'self' 'unsafe-inline'; font-src 'self';"
+                    );
                 });
             })
             .csrf(customizer -> {

--- a/component/src/main/java/com/synopsys/integration/alert/component/authentication/security/AuthenticationHandler.java
+++ b/component/src/main/java/com/synopsys/integration/alert/component/authentication/security/AuthenticationHandler.java
@@ -88,15 +88,16 @@ public class AuthenticationHandler {
                 securityContext.requireExplicitSave(true);
                 securityContext.securityContextRepository(securityContextRepository);
             })
-            //            .headers(customizer -> {
-            //                customizer.contentSecurityPolicy(cspCustomizer -> {
-            //                    cspCustomizer.policyDirectives("form-action 'self'; default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' 'www.synopsys.com';");
-            //                });
-            //            })
             .authenticationProvider(authenticationProvider)
             .authorizeHttpRequests(customizer -> {
                 customizer.requestMatchers(allowedRequestMatchers).permitAll();
                 customizer.anyRequest().authenticated();
+            })
+            .headers(customizer -> {
+                customizer.contentSecurityPolicy(cspCustomizer -> {
+                    cspCustomizer.policyDirectives(
+                        "form-action 'self'; default-src 'self' 'https://www.synopsys.com'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' 'https://www.synopsys.com';");
+                });
             })
             .csrf(customizer -> {
                 customizer.csrfTokenRequestHandler(csrfRequestHandler);

--- a/ui/src/main/js/page/about/AboutInfoFooter.js
+++ b/ui/src/main/js/page/about/AboutInfoFooter.js
@@ -157,12 +157,13 @@ class AboutInfoFooter extends React.Component {
         return (
             <div className="footer">
                 <span className="synopsysLogoSpan">
-                    <img
-                        className="synopsysFooterLogo"
-                        src="https://www.synopsys.com/content/dam/synopsys/company/about/legal/synopsys-logos/blacklogo/synopsys_blk.png"
-                        alt={projectUrl}
-                        href={projectUrl}
-                    />
+                    <a href={projectUrl}>
+                        <img
+                            className="synopsysFooterLogo"
+                            src="https://www.synopsys.com/content/dam/synopsys/company/about/legal/synopsys-logos/blacklogo/synopsys_blk.png"
+                            alt={projectUrl}
+                        />
+                    </a>
                     <span className="synopsysFooterLogoVerticalBarSpace">|</span>
                     ALERT
                 </span>


### PR DESCRIPTION
Update the security context to remove deprecated methods.  
Add the content security policy header to the security context.

Tests performed:

1. Open Alert UI verify the style of the UI and make sure images loaded.
3. Login to the Alert UI.
4. Create a Black Duck provider configuration.
5. Create a Jira Server configuration.
6. Create a distribution job.
7. In Black Duck generate notifications and make sure the Jira Issue is created and transitioned to Done.