### PR TITLE
IALERT-3685 Remove confirm password field key from UI

### DIFF
--- a/ui/src/main/js/page/usermgmt/user/UserModal.js
+++ b/ui/src/main/js/page/usermgmt/user/UserModal.js
@@ -41,6 +41,8 @@ const UserModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
     const messageContainerClass = classNames(classes.messageContainer, {
         [classes.warningStyle]: type === 'EDIT'
     });
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [confirmPasswordError, setConfirmPasswordError] = useState({});
 
     const fieldErrors = useSelector((state) => state.users.error.fieldErrors);
     const roles = useSelector((state) => state.roles.data);
@@ -50,11 +52,11 @@ const UserModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
         let passwordError = {};
         let matching = true;
 
-        if ((user[USER_INPUT_FIELD_KEYS.PASSWORD_KEY] || user[USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_KEY]) && (user[USER_INPUT_FIELD_KEYS.PASSWORD_KEY] !== user[USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_KEY])) {
+        if ((user[USER_INPUT_FIELD_KEYS.PASSWORD_KEY] || confirmPassword) && (user[USER_INPUT_FIELD_KEYS.PASSWORD_KEY] !== confirmPassword)) {
             passwordError = HTTPErrorUtils.createFieldError('Passwords do not match.');
             matching = false;
         }
-        setUserModel(Object.assign(user, { [USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_ERROR_KEY]: passwordError }));
+        setConfirmPasswordError(passwordError);
 
         return matching;
     }
@@ -177,18 +179,18 @@ const UserModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
                 />
                 {!external && (
                     <PasswordInput
-                        id={USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_KEY}
-                        name={USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_KEY}
+                        id="confirmPassword"
+                        name="confirmPassword"
                         label="Confirm Password"
                         customDescription="The user's password."
                         placeholder="Confirm password..."
                         readOnly={false}
                         required
-                        isSet={userModel[USER_INPUT_FIELD_KEYS.IS_PASSWORD_SET]}
-                        onChange={handleOnChange(USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_KEY)}
-                        value={userModel[USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_KEY] || undefined}
-                        errorName={USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_KEY}
-                        errorValue={userModel[USER_INPUT_FIELD_KEYS.CONFIRM_PASSWORD_ERROR_KEY]}
+                        isSet={Boolean(confirmPassword)}
+                        onChange={(e) => setConfirmPassword(e.target.value)}
+                        value={confirmPassword || undefined}
+                        errorName="confirmPasswordError"
+                        errorValue={confirmPasswordError}
                     />
                 )}
                 <TextInput

--- a/ui/src/main/js/page/usermgmt/user/UserModel.js
+++ b/ui/src/main/js/page/usermgmt/user/UserModel.js
@@ -1,6 +1,4 @@
 export const USER_INPUT_FIELD_KEYS = {
-    CONFIRM_PASSWORD_KEY: 'confirmPassword',
-    CONFIRM_PASSWORD_ERROR_KEY: 'confirmPasswordError',
     EMAIL_KEY: 'emailAddress',
     PASSWORD_KEY: 'password',
     IS_PASSWORD_SET: 'passwordSet',


### PR DESCRIPTION
Test steps:

1. Verified "Passwords do not match." error message appears in UI for non-matching passwords
2. Verified create and update of user succeeds on matching password
3. Verified create and update payload do not have confirmPassword field

Following HUB; copy of password fields is disallowed but paste is allowed.

Create payload:
<img width="558" alt="Screenshot 2024-09-24 at 1 59 44 PM" src="https://github.com/user-attachments/assets/5f4047cd-a382-4c5c-923d-7cf3c740cb0a">
Update payload:
<img width="637" alt="Screenshot 2024-09-24 at 2 53 56 PM" src="https://github.com/user-attachments/assets/26d1bfd7-20b4-45a2-8438-d83819353183">
