### PR TITLE
IALERT-3746: Ensure Modals Fit Content

### DIFF
--- a/ui/src/main/js/common/component/modal/Modal.js
+++ b/ui/src/main/js/common/component/modal/Modal.js
@@ -44,12 +44,12 @@ const useStyles = createUseStyles((theme) => ({
     },
     modalBody: {
         maxHeight: 'calc(100vh - 355px)',
-        padding: ['16px', 0],
+        padding: ['16px', '32px'],
         overflowY: 'auto'
     },
     noOverflowModalBody: {
         maxHeight: 'calc(100vh - 355px)',
-        padding: ['16px', 0]
+        padding: ['16px', '32px']
     }
 }));
 


### PR DESCRIPTION
For some reason the modals were not fitting the content within them.  This was likely due to one of our dependabot updates.  The fix for this was just to add left/right padding, as there was none prior to this.  This will ensure that content fits within the given space of our Modals.