### PR TITLE
IALERT-3554 - Update SSL to better control SSL secrets and sslmode

### DIFF
--- a/deployment/docker-swarm/external-db/docker-compose.local-overrides.yml
+++ b/deployment/docker-swarm/external-db/docker-compose.local-overrides.yml
@@ -26,7 +26,8 @@ services:
 #      - ALERT_DB_HOST=alertdb
 #      - ALERT_DB_PORT=5432
 #      - ALERT_DB_NAME=alertdb
-#      - ALERT_DB_SSL_MODE=require
+#     # See https://jdbc.postgresql.org/documentation/ssl/ for valid Postgres sslmode values
+#      - ALERT_DB_SSL_MODE=disable
 #
 #     # -- RabbitMQ Settings
 #      - ALERT_RABBITMQ_HOST=alert-rabbitmq

--- a/deployment/helm/synopsys-alert/templates/_helpers.tpl
+++ b/deployment/helm/synopsys-alert/templates/_helpers.tpl
@@ -37,8 +37,8 @@ Environs for Alert Config Map
 Enable SSL for External Postgres
 */}}
 {{- define "enablePostgresSSL" -}}
-{{- if .Values.postgres.sslSecrets.sslMode }}
-ALERT_DB_SSL_MODE: {{ .Values.postgres.sslSecrets.sslMode }}
+{{- if .Values.postgres.sslMode }}
+ALERT_DB_SSL_MODE: {{ .Values.postgres.sslMode }}
 {{- else -}}
 ALERT_DB_SSL_MODE: "disable"
 {{- end -}}

--- a/deployment/helm/synopsys-alert/templates/_helpers.tpl
+++ b/deployment/helm/synopsys-alert/templates/_helpers.tpl
@@ -37,12 +37,8 @@ Environs for Alert Config Map
 Enable SSL for External Postgres
 */}}
 {{- define "enablePostgresSSL" -}}
-{{- if and (eq .Values.postgres.isExternal true) (eq .Values.postgres.ssl true) -}}
-{{- if (eq .Values.postgres.sslUseFiles true) -}}
-ALERT_DB_SSL_MODE: "verify-ca"
-{{- else -}}
-ALERT_DB_SSL_MODE: "require"
-{{- end -}}
+{{- if .Values.postgres.sslSecrets.sslMode }}
+ALERT_DB_SSL_MODE: {{ .Values.postgres.sslSecrets.sslMode }}
 {{- else -}}
 ALERT_DB_SSL_MODE: "disable"
 {{- end -}}

--- a/deployment/helm/synopsys-alert/templates/alert.yaml
+++ b/deployment/helm/synopsys-alert/templates/alert.yaml
@@ -74,12 +74,18 @@ spec:
               name: {{ .Release.Name }}-db-creds
         {{- end }}
         {{- if (eq .Values.postgres.sslUseFiles true) }}
+        {{- if .Values.postgres.sslSecrets.sslKeyKey }}
         - name: ALERT_DB_SSL_KEY_PATH
           value: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslKeyKey }}
+        {{- end }}
+        {{- if .Values.postgres.sslSecrets.sslCertKey }}
         - name: ALERT_DB_SSL_CERT_PATH
           value: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslCertKey }}
+        {{- end }}
+        {{- if .Values.postgres.sslSecrets.sslRootCertKey }}
         - name: ALERT_DB_SSL_ROOT_CERT_PATH
           value: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslRootCertKey }}
+        {{- end }}
         {{- end }}
         {{- if .Values.rabbitmq.credential.secretName }}
         - name: ALERT_RABBITMQ_USER
@@ -131,15 +137,21 @@ spec:
         - mountPath: /opt/blackduck/alert/alert-config
           name: dir-alert
         {{- if .Values.postgres.sslUseFiles }}
+        {{- if .Values.postgres.sslSecrets.sslKeyKey }}
         - mountPath: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslKeyKey }}
           name: dbcert
           subPath: {{ .Values.postgres.sslSecrets.sslKeyKey }}
+        {{- end }}
+        {{- if .Values.postgres.sslSecrets.sslCertKey }}
         - mountPath: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslCertKey }}
           name: dbcert
           subPath: {{ .Values.postgres.sslSecrets.sslCertKey }}
+        {{- end }}
+        {{- if .Values.postgres.sslSecrets.sslRootCertKey }}
         - mountPath: {{ .Values.secretsDirectory }}/{{ .Values.postgres.sslSecrets.sslRootCertKey }}
           name: dbcert
           subPath: {{ .Values.postgres.sslSecrets.sslRootCertKey }}
+        {{- end }}
         {{- end }}
         {{- if .Values.webserverCustomCertificatesSecretName }}
         - mountPath: {{ .Values.secretsDirectory }}/WEBSERVER_CUSTOM_CERT_FILE

--- a/deployment/helm/synopsys-alert/values.yaml
+++ b/deployment/helm/synopsys-alert/values.yaml
@@ -50,12 +50,13 @@ postgres:
   registry: "" # override the docker registry at container level
   isExternal: false # false for running Postgres as a container and true for using External Postgres database
   ssl: false # If true, Alert uses SSL for external Postgres connection
+  sslMode: "disable" # See https://jdbc.postgresql.org/documentation/ssl/ for valid Postgres sslmode values
   sslUseFiles: false # If true, Alert will expect to find ssl certs for communicating with the External Postgres database
   sslSecrets: # Secret that contains all the ssl file paths
     secretName: ""
-    sslKeyKey: "ALERT_DB_SSL_KEY_PATH"
-    sslCertKey: "ALERT_DB_SSL_CERT_PATH"
-    sslRootCertKey: "ALERT_DB_SSL_ROOT_CERT_PATH"
+    sslKeyKey: "ALERT_DB_SSL_KEY_PATH" # If sslUseFiles is true, but not using a key, set to empty string
+    sslCertKey: "ALERT_DB_SSL_CERT_PATH" # If sslUseFiles is true, but not using a cert, set to empty string
+    sslRootCertKey: "ALERT_DB_SSL_ROOT_CERT_PATH" # If sslUseFiles is true, but not using a root cert, set to empty string
   host: "" # required only for external postgres, for postgres as a container, it will point to <name>-postgres
   port: 5432
   # NOTE: do not change usernames when using postgres as a container; only configure if using external database

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,8 +19,8 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.id.optimizer.pooled.preferred=pooled-lo
 # Datasource
 spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.url=jdbc:postgresql://${ALERT_DB_HOST:alertdb}:${ALERT_DB_PORT:5432}/${ALERT_DB_NAME:alertdb}?sslmode=${ALERT_DB_SSL_MODE:allow}&sslkey=${ALERT_DB_SSL_KEY_PATH:#{null}}&sslcert=${ALERT_DB_SSL_CERT_PATH:#{null}}&sslrootcert=${ALERT_DB_SSL_ROOT_CERT_PATH:#{null}}
-spring.datasource.hikari.jdbc-url=jdbc:postgresql://${ALERT_DB_HOST:alertdb}:${ALERT_DB_PORT:5432}/${ALERT_DB_NAME:alertdb}?sslmode=${ALERT_DB_SSL_MODE:allow}&sslkey=${ALERT_DB_SSL_KEY_PATH:#{null}}&sslcert=${ALERT_DB_SSL_CERT_PATH:#{null}}&sslrootcert=${ALERT_DB_SSL_ROOT_CERT_PATH:#{null}}
+spring.datasource.url=jdbc:postgresql://${ALERT_DB_HOST:alertdb}:${ALERT_DB_PORT:5432}/${ALERT_DB_NAME:alertdb}?sslmode=${ALERT_DB_SSL_MODE:disable}&sslkey=${ALERT_DB_SSL_KEY_PATH:#{null}}&sslcert=${ALERT_DB_SSL_CERT_PATH:#{null}}&sslrootcert=${ALERT_DB_SSL_ROOT_CERT_PATH:#{null}}
+spring.datasource.hikari.jdbc-url=jdbc:postgresql://${ALERT_DB_HOST:alertdb}:${ALERT_DB_PORT:5432}/${ALERT_DB_NAME:alertdb}?sslmode=${ALERT_DB_SSL_MODE:disable}&sslkey=${ALERT_DB_SSL_KEY_PATH:#{null}}&sslcert=${ALERT_DB_SSL_CERT_PATH:#{null}}&sslrootcert=${ALERT_DB_SSL_ROOT_CERT_PATH:#{null}}
 spring.datasource.username=${ALERT_DB_USERNAME:sa}
 spring.datasource.password=${ALERT_DB_PASSWORD:blackduck}
 spring.datasource.initialization-mode=never


### PR DESCRIPTION
* Add new configuration option to values.yaml for Postgres named sslMode. --> [sslmode](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION)
* Update logic in alert.yaml to only include Postgres secrets if sslUseFiles is true AND the individual secrets are configured.
* Update values.yaml to put comments on the Postgres secrets
* Update docker-entrypoint.sh for the following
  * Default sslmode to disable as it is elsewhere
  * New function setDatabaseConnectionDetails. 
    * If root cert is configured, include it in connection
    * If sslkey & sslcert are configured, include it in connection
    * Define new value for spring datasource URL
  * Pass new spring datasource URL to Alert exec, overriding default spring configuration value.