### PR TITLE
IALERT-3761: Fix field alignment issues

### DIFF
--- a/ui/src/main/css/field.scss
+++ b/ui/src/main/css/field.scss
@@ -4,6 +4,8 @@ label {
   display: inline-block;
   max-width: 100%;
   font-weight: bold;
+  text-align: right;
+  padding-right: 15px;
 }
 
 input {


### PR DESCRIPTION
After the recent dependabot fixes, it seems like a few UI elements broke including the alignment for fields. The original ticket lists alignment issues on the About page but upon investigation this is widespread in the entire UI impacting fields in both pages as well as modals. Attached are sample screenshots of the issue before and after the alignment and padding changes.

Before changes:
<img width="892" alt="Before" src="https://github.com/user-attachments/assets/3da6138e-dfd9-4b33-9e50-0601ef505960">
After the fix is applied:
<img width="896" alt="After" src="https://github.com/user-attachments/assets/71a41fe5-2a5e-48f9-8fb6-c0adab3f8c28">

Additionally, this solutions resolves as it was impacted by the same changes IALERT-3762
