### PR TITLE
IALERT-3763: Fix missing description in proxy modal

### DIFF
--- a/ui/src/main/js/page/settings/standalone/SettingsProxyConfiguration.js
+++ b/ui/src/main/js/page/settings/standalone/SettingsProxyConfiguration.js
@@ -24,7 +24,7 @@ const SettingsProxyConfiguration = ({
             id={SETTINGS_PROXY_TEST_FIELD.key}
             name={SETTINGS_PROXY_TEST_FIELD.key}
             label={SETTINGS_PROXY_TEST_FIELD.label}
-            description={SETTINGS_PROXY_TEST_FIELD.description}
+            customDescription={SETTINGS_PROXY_TEST_FIELD.description}
             onChange={({ target }) => setTestUrl(target.value)}
             value={testUrl}
         />


### PR DESCRIPTION
The description field in an Input field is for non-modals and instead should be using customDescription field when setting the description inside of a modal.

This PR resolves the bug that was discovered. A separate task will be created to investigate consolidating the descriptions to be the same for both modals and non-modals as it is out of the scope of this bug fix.