### PR TITLE
IALERT-3764: modal tooltip consistency fix

### DIFF
--- a/ui/src/main/js/common/component/input/field/LabeledField.js
+++ b/ui/src/main/js/common/component/input/field/LabeledField.js
@@ -23,7 +23,8 @@ const useStyles = createUseStyles((theme) => ({
         top: '-25px',
         left: '-35px',
         padding: ['2px', '10px'],
-        backgroundColor: theme.colors.grey.darkGrey,
+        backgroundColor: theme.colors.defaultAlertColor,
+        opacity: '0.9',
         width: 'max-content',
         maxWidth: '500px',
         zIndex: 100,
@@ -51,7 +52,7 @@ const LabeledField = ({
             <label id={`${id}-label`} className={labelClasses}>{label}</label>
             { (description || customDescription) && (
                 <div className="d-inline-flex">
-                    
+
                     <span
                         className="descriptionIcon"
                         onClick={() => setShowDescription(!showDescription)}


### PR DESCRIPTION
This change is similar to the previous task regarding the tooltip description between modals and pages. Throughout the Alert app the colors for modal tooltips are also inconsistent as a result of using a custom tooltip.

The change here is to update the style of the custom tooltip to be similar to page tooltips.