### PR TITLE
IALERT-3771: auto refresh button fix

### DIFF
--- a/ui/src/main/js/common/component/input/ToggleSwitch.js
+++ b/ui/src/main/js/common/component/input/ToggleSwitch.js
@@ -20,7 +20,7 @@ const useStyles = createUseStyles({
     },
     switchLabel: {
         display: 'block',
-        width: '40px',
+        width: '24px',
         height: '15px',
         textIndent: '-150%',
         clip: 'rect(0 0 0 0)',


### PR DESCRIPTION
It appears that after the bootstrap update some UI elements have been changed. The toggle switch for auto-refresh appears to have extra padding causing it to look too long compared to 7.2.0 and previous versions. This is a small change to update the padding so that the button is consistent with 7.2.0 and prior again.

<img width="297" alt="ToggleButtonIssue" src="https://github.com/user-attachments/assets/6eae70b2-d9a8-4072-a96e-8f600bb36544">


<img width="300" alt="ToggleButtonFixed" src="https://github.com/user-attachments/assets/6efb0ac1-8dd0-40ee-acb6-6e283fdfb4ae">

