### PR TITLE
IALERT-3656: Fix Jira Server Re-test

### DIFF
--- a/ui/src/main/js/page/channel/jira/server/JiraServerModal.js
+++ b/ui/src/main/js/page/channel/jira/server/JiraServerModal.js
@@ -165,6 +165,7 @@ const JiraServerModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMes
                 type: 'success'
             });
             setShowNotification(true);
+            dispatch(clearJiraServerFieldErrors());
         }
 
         if (saveStatus === 'ERROR') {


### PR DESCRIPTION
Jira Server global configuration has an issue currently in the UI where clicking the test button multiple times will never actually call the test endpoint. The first time testing a validate request will be made, followed by a test assuming validation was successful. Regardless of valid or invalid input, any followup presses of the test config button will only validate, but never call test.

The fix here is a missing dispatch to the clear field errors which was missing from Jira but was present in other channels such as Azure. This resets the state of the for jira-server to re-validate and to re-test as the old test status was never reset.