### PR TITLE
IALERT-3776: Fix status message padding

### DIFF
--- a/ui/src/main/css/field.scss
+++ b/ui/src/main/css/field.scss
@@ -122,8 +122,8 @@ small {
 
 .statusAlert {
   position: fixed;
-  top: 5px;
-  left: 255px;
+  top: 55px;
+  left: 100px;
   right: 20px;
   z-index: 100;
 }


### PR DESCRIPTION
Status message padding was not properly aligned after the side nav and logo changes were made. These padding changes set it to be slightly more centered along the page and extends it to just before the side nav. Additionally, as the logo is now longer we have shifted the status message slightly below the Black Duck Alert logo.

See image for example of new status message.


<img width="1309" alt="StatusMessageFix" src="https://github.com/user-attachments/assets/21665482-218f-4b91-9cfa-5a6ffcc839a3">
