### PR TITLE
IALERT-3775: Fix side nav bugs

### DIFF
--- a/ui/src/main/js/common/component/navigation/SideNavSubmenu.js
+++ b/ui/src/main/js/common/component/navigation/SideNavSubmenu.js
@@ -39,7 +39,7 @@ const useStyles = createUseStyles({
         '&:hover, &:focus, &:active': {
             color: 'white',
             background: '#313944 !important',
-            textDecoration: 'none',
+            textDecoration: 'none'
         },
         '&::after': {
             display: 'none !important'
@@ -74,7 +74,7 @@ const SideNavSubmenu = ({ icon, id, label, subMenuItems }) => {
     const classes = useStyles();
 
     return (
-        <Dropdown drop="right">
+        <Dropdown drop="end">
             <Dropdown.Toggle className={classes.navItem}>
                 <FontAwesomeIcon size="2x" className={classes.icon} icon={icon} fixedWidth />
                 <span id={id} className={classes.navLabel}>{label}</span>
@@ -85,17 +85,16 @@ const SideNavSubmenu = ({ icon, id, label, subMenuItems }) => {
                     if (!item.showOption) {
                         return null;
                     }
-
                     return (
-                        <NavLink to={item.href} className={classes.navMenuItem} key={item.id}>
+                        <Dropdown.Item as={NavLink} to={item.href} className={classes.navMenuItem} key={item.id}>
                             {item.label}
-                        </NavLink>
-                    )
+                        </Dropdown.Item>
+                    );
                 })}
             </Dropdown.Menu>
         </Dropdown>
     );
-}
+};
 
 SideNavSubmenu.propTypes = {
     icon: PropTypes.string,


### PR DESCRIPTION
This PR is intended to fix 2 issues:
1. The alignment of the dropdown was incorrect and was opening the drop down under the nav button covering the other nav options. Shifting the dropdown to start at the end brings it to the right and out of the way.
2. This fixes the dropdown menu persisting after selecting an option and not closing. We continue to use NavLink rather than going directly to the href as going to the href directly would reload Alert between pages.

Alignment Before:
<img width="298" alt="Alignment Before" src="https://github.com/user-attachments/assets/643698f2-7302-479e-9675-d7431afa8cca">


New alignment:
<img width="302" alt="Alignment Changes After" src="https://github.com/user-attachments/assets/cce01711-63cd-4fb6-9fb0-8cf7a0246490">
