### PR TITLE
IALERT-3780 Disable modal overflow

### DIFF
--- a/ui/src/main/js/common/component/modal/Modal.js
+++ b/ui/src/main/js/common/component/modal/Modal.js
@@ -17,7 +17,8 @@ const useStyles = createUseStyles((theme) => ({
         position: 'fixed',
         zIndex: '10000',
         outline: 0,
-        cursor: 'default'
+        cursor: 'default',
+        overflow: 'hidden'
     },
     modalStyle: {
         backgroundColor: theme.colors.white.default,


### PR DESCRIPTION
Disable scrolling for modal background. Note modal is the whole greyed area and modal content is where the actual modal is so scrolling is not affected for it.