### PR TITLE
IALERT-3780 Remove overflow and max height on modal content/area

### DIFF
--- a/ui/src/main/js/common/component/modal/Modal.js
+++ b/ui/src/main/js/common/component/modal/Modal.js
@@ -26,9 +26,7 @@ const useStyles = createUseStyles((theme) => ({
         position: 'relative',
         width: '90%',
         maxWidth: 600,
-        margin: ['100px', 'auto'],
-        maxHeight: '80%',
-        overflow: 'auto'
+        margin: ['100px', 'auto']
     },
     modalStyleLarge: {
         maxWidth: 900


### PR DESCRIPTION
Resolves an issue where the save/edit button were cut off for long modals 