### PR TITLE
IALERT-3563: Fix additional email address search

### DIFF
--- a/ui/src/main/js/page/channel/email/AdditionalEmailAddressesModal.js
+++ b/ui/src/main/js/page/channel/email/AdditionalEmailAddressesModal.js
@@ -68,6 +68,7 @@ export default function AdditionalEmailAddressesModal({ isOpen, handleClose, csr
                         multiSelect
                         searchBarPlaceholder="Search Email Address..."
                         handleSearchChange={(newSearchTerm) => {
+                            setPageNumber(0);
                             setSearchTerm(newSearchTerm);
                         }}
                         selected={selected}


### PR DESCRIPTION
The changes here are to add the a black duck query when fetching emails for the additional email addresses in the distribution job. The issue occurs because in blackduck-common when a page of results is fetched the total count reflects the number of items found prior to the predicate being applied. This means that while a subset of results are returned, the total count reflects the unfiltered set.

By using the query for the email field in Blackduck we can filter down the results at the time we make the request to get an accurate total count.

Secondly, there was a minor UI bug where if you filter from another page that reduces the total number of pages below the current page, the user would be presented with a modal table with no results. By switching it to page 0 every time we ensure that the first page of results is always displayed.