### PR TITLE
IALERT-3733: Deprecate legacy REST API controllers

### DIFF
--- a/channel-azure-boards/src/main/java/com/blackduck/integration/alert/channel/azure/boards/web/AzureBoardsOAuthFunctionController.java
+++ b/channel-azure-boards/src/main/java/com/blackduck/integration/alert/channel/azure/boards/web/AzureBoardsOAuthFunctionController.java
@@ -17,7 +17,7 @@ import com.blackduck.integration.alert.common.rest.api.AbstractFunctionControlle
 
 /**
  * @deprecated This controller is replaced by the oAuthAuthenticate endpoint of AzureBoardsGlobalConfigController.
- * This class should be removed in 8.0.0.
+ * Deprecated in 7.x, To be removed in 9.0.0.
  */
 @Deprecated(forRemoval = true)
 @RestController

--- a/channel-email/src/main/java/com/blackduck/integration/alert/channel/email/web/EmailAddressFunctionController.java
+++ b/channel-email/src/main/java/com/blackduck/integration/alert/channel/email/web/EmailAddressFunctionController.java
@@ -15,8 +15,9 @@ import com.blackduck.integration.alert.channel.email.descriptor.EmailDescriptor;
 import com.blackduck.integration.alert.common.rest.api.AbstractFunctionController;
 
 /**
- * TODO: This class needs to be updated to follow the new model/request paradigm for retrieving additional email addresses
+ * @deprecated Deprecated in 8.x, planned for removed in 10.0.0.
  */
+@Deprecated(forRemoval = true)
 @RestController
 @RequestMapping(EmailAddressFunctionController.EMAIL_ADDRESS_FUNCTION_URL)
 public class EmailAddressFunctionController extends AbstractFunctionController<EmailAddressOptions> {

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/web/JiraServerFunctionController.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/web/JiraServerFunctionController.java
@@ -15,7 +15,8 @@ import com.blackduck.integration.alert.channel.jira.server.descriptor.JiraServer
 import com.blackduck.integration.alert.common.rest.api.AbstractFunctionController;
 
 /**
- * @deprecated This class is unused and part of the old Jira Server REST API. It is set for removal in 8.0.0.
+ * @deprecated This class is unused and part of the old Jira Server REST API.
+ * Deprecated in 7.x, To be removed in 9.0.0.
  */
 @RestController
 @RequestMapping(JiraServerFunctionController.JIRA_SERVER_FUNCTION_URL)

--- a/component/src/main/java/com/blackduck/integration/alert/component/audit/web/AuditEntryControllerLegacy.java
+++ b/component/src/main/java/com/blackduck/integration/alert/component/audit/web/AuditEntryControllerLegacy.java
@@ -30,7 +30,8 @@ import com.blackduck.integration.alert.common.rest.model.AuditJobStatusesModel;
 import com.blackduck.integration.alert.common.rest.model.JobIdsRequestModel;
 
 /**
- * @deprecated Replaced by AuditEntryController. To be removed in 8.0.0.
+ * @deprecated Replaced by AuditEntryController.
+ * Deprecated in 7.x, To be removed in 9.0.0.
  */
 @Deprecated(forRemoval = true)
 @RestController

--- a/component/src/main/java/com/blackduck/integration/alert/component/authentication/web/SAMLMetadataUploadFunctionController.java
+++ b/component/src/main/java/com/blackduck/integration/alert/component/authentication/web/SAMLMetadataUploadFunctionController.java
@@ -15,6 +15,10 @@ import com.blackduck.integration.alert.api.authentication.descriptor.Authenticat
 import com.blackduck.integration.alert.common.action.upload.AbstractUploadAction;
 import com.blackduck.integration.alert.common.rest.api.AbstractUploadFunctionController;
 
+/**
+ * @deprecated Deprecated in 8.x, planned for removed in 9.0.0.
+ */
+@Deprecated(forRemoval = true)
 @Controller
 @RequestMapping(SAMLMetadataUploadFunctionController.SAML_UPLOAD_URL)
 public class SAMLMetadataUploadFunctionController extends AbstractUploadFunctionController {

--- a/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/web/PolicyFilterFunctionController.java
+++ b/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/web/PolicyFilterFunctionController.java
@@ -14,6 +14,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.blackduck.integration.alert.common.rest.api.AbstractFunctionController;
 import com.blackduck.integration.alert.provider.blackduck.descriptor.BlackDuckDescriptor;
 
+/**
+ * @deprecated Deprecated in 8.x, planned for removed in 10.0.0.
+ */
+@Deprecated(forRemoval = true)
 @RestController
 @RequestMapping(PolicyFilterFunctionController.POLICY_FILTER_FUNCTION_URL)
 public class PolicyFilterFunctionController extends AbstractFunctionController<NotificationFilterModelOptions> {

--- a/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/web/VulnerabilityFilterFunctionController.java
+++ b/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/web/VulnerabilityFilterFunctionController.java
@@ -15,6 +15,10 @@ import com.blackduck.integration.alert.common.descriptor.config.field.LabelValue
 import com.blackduck.integration.alert.common.rest.api.AbstractFunctionController;
 import com.blackduck.integration.alert.provider.blackduck.descriptor.BlackDuckDescriptor;
 
+/**
+ * @deprecated Deprecated in 8.x, planned for removed in 10.0.0.
+ */
+@Deprecated(forRemoval = true)
 @RestController
 @RequestMapping(VulnerabilityFilterFunctionController.VULNERABILITY_FILTER_FUNCTION_URL)
 public class VulnerabilityFilterFunctionController extends AbstractFunctionController<LabelValueSelectOptions> {

--- a/web/src/main/java/com/blackduck/integration/alert/web/api/config/ConfigController.java
+++ b/web/src/main/java/com/blackduck/integration/alert/web/api/config/ConfigController.java
@@ -23,6 +23,12 @@ import com.blackduck.integration.alert.common.rest.api.ValidateController;
 import com.blackduck.integration.alert.common.rest.model.FieldModel;
 import com.blackduck.integration.alert.common.rest.model.MultiFieldModel;
 
+/**
+ * @deprecated Further development on endpoints should be done with explicit implementations. This controller is planned for removal
+ * once all Alert functions are migrated to their own endpoints.
+ * Deprecated in 8.x, planned for removed in 10.0.0.
+ */
+@Deprecated(forRemoval = true)
 @RestController
 @RequestMapping(AlertRestConstants.CONFIGURATION_PATH)
 public class ConfigController implements ConfigResourceController, TestController<FieldModel>, ValidateController<FieldModel> {

--- a/web/src/main/java/com/blackduck/integration/alert/web/api/job/JobConfigController.java
+++ b/web/src/main/java/com/blackduck/integration/alert/web/api/job/JobConfigController.java
@@ -28,6 +28,10 @@ import com.blackduck.integration.alert.common.rest.model.JobFieldStatuses;
 import com.blackduck.integration.alert.common.rest.model.JobIdsRequestModel;
 import com.blackduck.integration.alert.common.rest.model.JobPagedModel;
 
+/**
+ * @deprecated Deprecated in 8.x, planned for removed in 10.0.0.
+ */
+@Deprecated(forRemoval = true)
 @RestController
 @RequestMapping(JobConfigController.JOB_CONFIGURATION_PATH)
 public class JobConfigController implements BaseJobResourceController, ReadPageController<JobPagedModel>, TestController<JobFieldModel>, ValidateController<JobFieldModel> {

--- a/web/src/main/java/com/blackduck/integration/alert/web/api/metadata/ContextController.java
+++ b/web/src/main/java/com/blackduck/integration/alert/web/api/metadata/ContextController.java
@@ -15,6 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.blackduck.integration.alert.common.rest.ResponseFactory;
 import com.blackduck.integration.alert.web.api.metadata.model.ConfigContextsResponseModel;
 
+/**
+ * @deprecated Deprecated in 8.x, planned for removed in 9.0.0.
+ */
+@Deprecated(forRemoval = true)
 @RestController
 @RequestMapping(ContextController.CONTEXTS_PATH)
 public class ContextController {

--- a/web/src/main/java/com/blackduck/integration/alert/web/api/metadata/DescriptorController.java
+++ b/web/src/main/java/com/blackduck/integration/alert/web/api/metadata/DescriptorController.java
@@ -16,6 +16,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.blackduck.integration.alert.common.rest.ResponseFactory;
 import com.blackduck.integration.alert.web.api.metadata.model.DescriptorsResponseModel;
 
+/**
+ * @deprecated Deprecated in 8.x, planned for removed in 10.0.0.
+ */
+@Deprecated(forRemoval = true)
 @RestController
 @RequestMapping(DescriptorController.BASE_PATH)
 public class DescriptorController {

--- a/web/src/main/java/com/blackduck/integration/alert/web/api/metadata/DescriptorTypeController.java
+++ b/web/src/main/java/com/blackduck/integration/alert/web/api/metadata/DescriptorTypeController.java
@@ -15,6 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.blackduck.integration.alert.common.rest.ResponseFactory;
 import com.blackduck.integration.alert.web.api.metadata.model.DescriptorTypesResponseModel;
 
+/**
+ * @deprecated Deprecated in 8.x, planned for removed in 10.0.0.
+ */
+@Deprecated(forRemoval = true)
 @RestController
 @RequestMapping(DescriptorTypeController.TYPES_PATH)
 public class DescriptorTypeController {

--- a/web/src/main/java/com/blackduck/integration/alert/web/api/provider/processing/ProcessingTypeFunctionController.java
+++ b/web/src/main/java/com/blackduck/integration/alert/web/api/provider/processing/ProcessingTypeFunctionController.java
@@ -14,6 +14,10 @@ import com.blackduck.integration.alert.api.provider.ProviderDescriptor;
 import com.blackduck.integration.alert.common.descriptor.config.field.LabelValueSelectOptions;
 import com.blackduck.integration.alert.common.rest.api.AbstractFunctionController;
 
+/**
+ * @deprecated Deprecated in 8.x, planned for removed in 10.0.0.
+ */
+@Deprecated(forRemoval = true)
 @RestController
 @RequestMapping(ProcessingTypeFunctionController.PROCESSING_TYPE_FUNCTION_URL)
 public class ProcessingTypeFunctionController extends AbstractFunctionController<LabelValueSelectOptions> {


### PR DESCRIPTION
These controllers will no longer be getting additional features and lowered support. The goal is to migrate all Alert functionality into the new scheme for creating controllers and away from the generic controllers we've used in the past. As such, we want to flag controllers that will eventually be removed and replaced.