### PR TITLE
IALERT-3758: Fix Black Duck logo scaling in the email template

### DIFF
--- a/channel-email/src/main/resources/templates/email/message_content.ftl
+++ b/channel-email/src/main/resources/templates/email/message_content.ftl
@@ -45,7 +45,7 @@
     <br />
 </#if>
 <div style="display:inline-block;width:100%;">
-    <img src="cid:${logo_image}" height="33" width="150" />
+    <img src="cid:${logo_image}" height="33" width="211" />
 </div>
 <br />
 </body>


### PR DESCRIPTION
The freemarker template generating the Black Duck emails had it's height and width scaled for the old Synopsys logo. The scaling change here is to keep the same height as the old logo but switch the width to match the new logo.