### PR TITLE
IALERT-3773: Fix missing error messages on email distribution configuration

### DIFF
--- a/ui/src/main/js/page/channel/email/EmailDistributionConfiguration.js
+++ b/ui/src/main/js/page/channel/email/EmailDistributionConfiguration.js
@@ -49,6 +49,8 @@ const EmailDistributionConfiguration = ({
                 )}
                 onChange={() => {
                 }}
+                errorName={FieldModelUtilities.createFieldModelErrorKey(EMAIL_DISTRIBUTION_FIELD_KEYS.additionalAddresses)}
+                errorValue={errors.fieldErrors[EMAIL_DISTRIBUTION_FIELD_KEYS.additionalAddresses]}
             />
             {showAdditionalEmailAddressesModal && (
                 <AdditionalEmailAddressesModal


### PR DESCRIPTION
If you attempt to save an email distribution job checking off "Additional Email Addresses Only" but do not provide any Additional Email Addresses we would return an error containing an error field and message but would never render it underneath the field. We would just print the banner message of "Invalid Configuration" with no additional context of what is invalid.

The change here is to just take the error name and value that were already correctly received, and pass the prop along to the DynamicSelectInput to correctly render the field error.