### PR TITLE
IALERT-3780 Modal background fits scrolled content

### DIFF
--- a/ui/src/main/js/application/MainPage.js
+++ b/ui/src/main/js/application/MainPage.js
@@ -61,16 +61,17 @@ const useStyles = createUseStyles({
     },
     topnav: {
         gridArea: 'topnav',
-        height: '50px'
+        height: '50px',
+        zIndex: 10001 // above modal gray background
     },
     appSidenav: {
         gridArea: 'sidenav',
         width: '80px'
     },
     main: {
-        gridArea: 'main',
+        gridArea: 'main'
     }
-})
+});
 
 const MainPage = ({
     descriptors, fetching, getDescriptorsRedux, csrfToken, autoRefresh, unauthorizedFunction

--- a/ui/src/main/js/common/component/modal/Modal.js
+++ b/ui/src/main/js/common/component/modal/Modal.js
@@ -13,7 +13,7 @@ const useStyles = createUseStyles((theme) => ({
     modal: {
         backgroundColor: 'rgba(0, 0, 0, 0.5)',
         display: 'block',
-        inset: '50px 0 36px 80px',
+        inset: '0 0 36px 80px',
         position: 'fixed',
         zIndex: '10000',
         outline: 0,


### PR DESCRIPTION
The empty space was taking in to account the nav bar. Since the nav bar and modal have different parent divs on the main page, there isnt an easy to have the modal just fill "content page". Instead just give the top nav bar a higher z index priority than modal.