### PR TITLE
IALERT-3733: Fix deprecated endpoint in Swagger UI

### DIFF
--- a/alert-common/src/main/java/com/blackduck/integration/alert/common/rest/api/AbstractUploadFunctionController.java
+++ b/alert-common/src/main/java/com/blackduck/integration/alert/common/rest/api/AbstractUploadFunctionController.java
@@ -21,6 +21,10 @@ import com.blackduck.integration.alert.common.action.upload.AbstractUploadAction
 import com.blackduck.integration.alert.common.rest.ResponseFactory;
 import com.blackduck.integration.alert.common.rest.model.ExistenceModel;
 
+/**
+ * @deprecated Deprecated in 8.x as a result of deprecation of SAMLMetadataUploadFunctionController, planned for removed in 9.0.0.
+ */
+@Deprecated(forRemoval = true)
 @RestController
 @RequestMapping(AbstractUploadAction.API_FUNCTION_UPLOAD_URL)
 public abstract class AbstractUploadFunctionController {

--- a/component/src/main/java/com/blackduck/integration/alert/component/authentication/web/SAMLMetadataUploadFunctionController.java
+++ b/component/src/main/java/com/blackduck/integration/alert/component/authentication/web/SAMLMetadataUploadFunctionController.java
@@ -8,8 +8,8 @@
 package com.blackduck.integration.alert.component.authentication.web;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.blackduck.integration.alert.api.authentication.descriptor.AuthenticationDescriptor;
 import com.blackduck.integration.alert.common.action.upload.AbstractUploadAction;
@@ -19,7 +19,7 @@ import com.blackduck.integration.alert.common.rest.api.AbstractUploadFunctionCon
  * @deprecated Deprecated in 8.x, planned for removed in 9.0.0.
  */
 @Deprecated(forRemoval = true)
-@Controller
+@RestController
 @RequestMapping(SAMLMetadataUploadFunctionController.SAML_UPLOAD_URL)
 public class SAMLMetadataUploadFunctionController extends AbstractUploadFunctionController {
     public static final String SAML_UPLOAD_URL = AbstractUploadAction.API_FUNCTION_UPLOAD_URL + "/" + AuthenticationDescriptor.KEY_SAML_METADATA_FILE;


### PR DESCRIPTION
During the previous deprecation changes the SAML upload function controller was not getting marked deprecated in Swagger. The change here is to update the controller to use the @RestController annotation which contains the @Controller annotation. Additionally, this deprecates the abstract controller that was only used by the legacy SAML upload controller.