### PR TITLE
IALERT-3774: JQL search string backwards compatability

### DIFF
--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/JiraConstants.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/JiraConstants.java
@@ -14,6 +14,8 @@ public final class JiraConstants {
     public static final String JIRA_ALERT_APP_NAME = "Alert Issue Property Indexer";
     // This String must always match the String found in the atlassian-connect.json file under modules.jiraEntityProperties.key.
     public static final String JIRA_ISSUE_PROPERTY_KEY = "com-blackduck-integration-alert";
+    // This String is used to support backwards compatability prior to rebranding in 8.0.0.
+    public static final String JIRA_ISSUE_PROPERTY_OLD_KEY = "com-synopsys-integration-alert";
 
     public static final String JIRA_SEARCH_KEY_JIRA_PROJECT = "project";
 

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JqlStringCreator.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JqlStringCreator.java
@@ -140,9 +140,9 @@ public final class JqlStringCreator {
     }
 
     private static String createPropertySearchString(String key, String value) {
-        String propertySearchFormat = "issue.property[%s].%s = '%s'";
+        String propertySearchFormat = "(issue.property[%s].%s = '%s' OR issue.property[%s].%s = '%s')";
         String escapedValue = escapeSearchString(value);
-        return String.format(propertySearchFormat, JiraConstants.JIRA_ISSUE_PROPERTY_KEY, key, escapedValue);
+        return String.format(propertySearchFormat, JiraConstants.JIRA_ISSUE_PROPERTY_KEY, key, escapedValue, JiraConstants.JIRA_ISSUE_PROPERTY_OLD_KEY, key, escapedValue);
     }
 
     private static String escapeSearchString(String originalString) {

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JqlStringCreator.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JqlStringCreator.java
@@ -140,6 +140,9 @@ public final class JqlStringCreator {
     }
 
     private static String createPropertySearchString(String key, String value) {
+        // To support backwards compatability of Jira tickets prior to Alert 8.0.0 we check if properties contain either the new blackduck (post 8.0.0)
+        //  OR the old synopsys (pre 8.0.0) property index.
+        //  Ex. "(issue.property[com-blackduck-integration-alert].provider = 'Black Duck' OR issue.property[com-synopsys-integration-alert].provider = 'Black Duck')"
         String propertySearchFormat = "(issue.property[%s].%s = '%s' OR issue.property[%s].%s = '%s')";
         String escapedValue = escapeSearchString(value);
         return String.format(propertySearchFormat, JiraConstants.JIRA_ISSUE_PROPERTY_KEY, key, escapedValue, JiraConstants.JIRA_ISSUE_PROPERTY_OLD_KEY, key, escapedValue);

--- a/api-channel-jira/src/test/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JqlStringCreatorTest.java
+++ b/api-channel-jira/src/test/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JqlStringCreatorTest.java
@@ -51,18 +51,20 @@ class JqlStringCreatorTest {
             ComponentConcernType.POLICY,
             policyName
         );
-        String expectedSearchString = "project = 'TEST' AND issue.property[com-blackduck-integration-alert].provider = 'Black Duck' "
-            + "AND issue.property[com-blackduck-integration-alert].providerUrl = 'http://providerUrl/' "
-            + "AND issue.property[com-blackduck-integration-alert].topicName = 'Project' "
-            + "AND issue.property[com-blackduck-integration-alert].topicValue = 'project_with_single_quote\\'' "
-            + "AND issue.property[com-blackduck-integration-alert].subTopicName = 'Project Version' "
-            + "AND issue.property[com-blackduck-integration-alert].subTopicValue = 'v1.0 \\\\& v2.0' "
-            + "AND issue.property[com-blackduck-integration-alert].componentName = 'Component' "
-            + "AND issue.property[com-blackduck-integration-alert].componentValue = 'myVulnerableComponent' "
-            + "AND issue.property[com-blackduck-integration-alert].subComponentName = 'Component Version' "
-            + "AND issue.property[com-blackduck-integration-alert].subComponentValue = '1.1.2' "
-            + "AND issue.property[com-blackduck-integration-alert].category = 'Policy' "
-            + "AND issue.property[com-blackduck-integration-alert].additionalKey = 'Policy ViolatedMyPolicy' ";
+        String expectedSearchString =
+            "project = 'TEST' "
+                + "AND (issue.property[com-blackduck-integration-alert].provider = 'Black Duck' OR issue.property[com-synopsys-integration-alert].provider = 'Black Duck') "
+                + "AND (issue.property[com-blackduck-integration-alert].providerUrl = 'http://providerUrl/' OR issue.property[com-synopsys-integration-alert].providerUrl = 'http://providerUrl/') "
+                + "AND (issue.property[com-blackduck-integration-alert].topicName = 'Project' OR issue.property[com-synopsys-integration-alert].topicName = 'Project') "
+                + "AND (issue.property[com-blackduck-integration-alert].topicValue = 'project_with_single_quote\\'' OR issue.property[com-synopsys-integration-alert].topicValue = 'project_with_single_quote\\'') "
+                + "AND (issue.property[com-blackduck-integration-alert].subTopicName = 'Project Version' OR issue.property[com-synopsys-integration-alert].subTopicName = 'Project Version') "
+                + "AND (issue.property[com-blackduck-integration-alert].subTopicValue = 'v1.0 \\\\& v2.0' OR issue.property[com-synopsys-integration-alert].subTopicValue = 'v1.0 \\\\& v2.0') "
+                + "AND (issue.property[com-blackduck-integration-alert].componentName = 'Component' OR issue.property[com-synopsys-integration-alert].componentName = 'Component') "
+                + "AND (issue.property[com-blackduck-integration-alert].componentValue = 'myVulnerableComponent' OR issue.property[com-synopsys-integration-alert].componentValue = 'myVulnerableComponent') "
+                + "AND (issue.property[com-blackduck-integration-alert].subComponentName = 'Component Version' OR issue.property[com-synopsys-integration-alert].subComponentName = 'Component Version') "
+                + "AND (issue.property[com-blackduck-integration-alert].subComponentValue = '1.1.2' OR issue.property[com-synopsys-integration-alert].subComponentValue = '1.1.2') "
+                + "AND (issue.property[com-blackduck-integration-alert].category = 'Policy' OR issue.property[com-synopsys-integration-alert].category = 'Policy') "
+                + "AND (issue.property[com-blackduck-integration-alert].additionalKey = 'Policy ViolatedMyPolicy' OR issue.property[com-synopsys-integration-alert].additionalKey = 'Policy ViolatedMyPolicy') ";
 
         assertEquals(expectedSearchString, jqlString);
     }
@@ -79,17 +81,19 @@ class JqlStringCreatorTest {
             ComponentConcernType.VULNERABILITY,
             null
         );
-        String expectedSearchString = "project = 'TEST' AND issue.property[com-blackduck-integration-alert].provider = 'Black Duck' "
-            + "AND issue.property[com-blackduck-integration-alert].providerUrl = 'http://providerUrl/' "
-            + "AND issue.property[com-blackduck-integration-alert].topicName = 'Project' "
-            + "AND issue.property[com-blackduck-integration-alert].topicValue = 'project_with_single_quote\\'' "
-            + "AND issue.property[com-blackduck-integration-alert].subTopicName = 'Project Version' "
-            + "AND issue.property[com-blackduck-integration-alert].subTopicValue = 'v1.0 \\\\& v2.0' "
-            + "AND issue.property[com-blackduck-integration-alert].componentName = 'Component' "
-            + "AND issue.property[com-blackduck-integration-alert].componentValue = 'myVulnerableComponent' "
-            + "AND issue.property[com-blackduck-integration-alert].subComponentName = 'Component Version' "
-            + "AND issue.property[com-blackduck-integration-alert].subComponentValue = '1.1.2' "
-            + "AND issue.property[com-blackduck-integration-alert].category = 'Vulnerability' ";
+        String expectedSearchString =
+            "project = 'TEST' "
+                + "AND (issue.property[com-blackduck-integration-alert].provider = 'Black Duck' OR issue.property[com-synopsys-integration-alert].provider = 'Black Duck') "
+                + "AND (issue.property[com-blackduck-integration-alert].providerUrl = 'http://providerUrl/' OR issue.property[com-synopsys-integration-alert].providerUrl = 'http://providerUrl/') "
+                + "AND (issue.property[com-blackduck-integration-alert].topicName = 'Project' OR issue.property[com-synopsys-integration-alert].topicName = 'Project') "
+                + "AND (issue.property[com-blackduck-integration-alert].topicValue = 'project_with_single_quote\\'' OR issue.property[com-synopsys-integration-alert].topicValue = 'project_with_single_quote\\'') "
+                + "AND (issue.property[com-blackduck-integration-alert].subTopicName = 'Project Version' OR issue.property[com-synopsys-integration-alert].subTopicName = 'Project Version') "
+                + "AND (issue.property[com-blackduck-integration-alert].subTopicValue = 'v1.0 \\\\& v2.0' OR issue.property[com-synopsys-integration-alert].subTopicValue = 'v1.0 \\\\& v2.0') "
+                + "AND (issue.property[com-blackduck-integration-alert].componentName = 'Component' OR issue.property[com-synopsys-integration-alert].componentName = 'Component') "
+                + "AND (issue.property[com-blackduck-integration-alert].componentValue = 'myVulnerableComponent' OR issue.property[com-synopsys-integration-alert].componentValue = 'myVulnerableComponent') "
+                + "AND (issue.property[com-blackduck-integration-alert].subComponentName = 'Component Version' OR issue.property[com-synopsys-integration-alert].subComponentName = 'Component Version') "
+                + "AND (issue.property[com-blackduck-integration-alert].subComponentValue = '1.1.2' OR issue.property[com-synopsys-integration-alert].subComponentValue = '1.1.2') "
+                + "AND (issue.property[com-blackduck-integration-alert].category = 'Vulnerability' OR issue.property[com-synopsys-integration-alert].category = 'Vulnerability') ";
 
         assertEquals(expectedSearchString, jqlString);
     }
@@ -112,17 +116,19 @@ class JqlStringCreatorTest {
             ComponentConcernType.VULNERABILITY,
             null
         );
-        String expectedSearchString = "project = 'TEST' AND issue.property[com-blackduck-integration-alert].provider = 'Black Duck' "
-            + "AND issue.property[com-blackduck-integration-alert].providerUrl = 'http://providerUrl/' "
-            + "AND issue.property[com-blackduck-integration-alert].topicName = 'Project' "
-            + "AND issue.property[com-blackduck-integration-alert].topicValue = 'project_with_single_quote\\'' "
-            + "AND issue.property[com-blackduck-integration-alert].subTopicName = 'Project Version' "
-            + "AND issue.property[com-blackduck-integration-alert].subTopicValue = 'INJECTED\\\\\\' OR project = \"SomeOtherProject\" OR summary ~ 2021-01-01\\\\\\\\\\\\' "
-            + "AND issue.property[com-blackduck-integration-alert].componentName = 'Component' "
-            + "AND issue.property[com-blackduck-integration-alert].componentValue = 'myVulnerableComponent' "
-            + "AND issue.property[com-blackduck-integration-alert].subComponentName = 'Component Version' "
-            + "AND issue.property[com-blackduck-integration-alert].subComponentValue = '1.1.2' "
-            + "AND issue.property[com-blackduck-integration-alert].category = 'Vulnerability' ";
+        String expectedSearchString =
+            "project = 'TEST' "
+                + "AND (issue.property[com-blackduck-integration-alert].provider = 'Black Duck' OR issue.property[com-synopsys-integration-alert].provider = 'Black Duck') "
+                + "AND (issue.property[com-blackduck-integration-alert].providerUrl = 'http://providerUrl/' OR issue.property[com-synopsys-integration-alert].providerUrl = 'http://providerUrl/') "
+                + "AND (issue.property[com-blackduck-integration-alert].topicName = 'Project' OR issue.property[com-synopsys-integration-alert].topicName = 'Project') "
+                + "AND (issue.property[com-blackduck-integration-alert].topicValue = 'project_with_single_quote\\'' OR issue.property[com-synopsys-integration-alert].topicValue = 'project_with_single_quote\\'') "
+                + "AND (issue.property[com-blackduck-integration-alert].subTopicName = 'Project Version' OR issue.property[com-synopsys-integration-alert].subTopicName = 'Project Version') "
+                + "AND (issue.property[com-blackduck-integration-alert].subTopicValue = 'INJECTED\\\\\\' OR project = \"SomeOtherProject\" OR summary ~ 2021-01-01\\\\\\\\\\\\' OR issue.property[com-synopsys-integration-alert].subTopicValue = 'INJECTED\\\\\\' OR project = \"SomeOtherProject\" OR summary ~ 2021-01-01\\\\\\\\\\\\') "
+                + "AND (issue.property[com-blackduck-integration-alert].componentName = 'Component' OR issue.property[com-synopsys-integration-alert].componentName = 'Component') "
+                + "AND (issue.property[com-blackduck-integration-alert].componentValue = 'myVulnerableComponent' OR issue.property[com-synopsys-integration-alert].componentValue = 'myVulnerableComponent') "
+                + "AND (issue.property[com-blackduck-integration-alert].subComponentName = 'Component Version' OR issue.property[com-synopsys-integration-alert].subComponentName = 'Component Version') "
+                + "AND (issue.property[com-blackduck-integration-alert].subComponentValue = '1.1.2' OR issue.property[com-synopsys-integration-alert].subComponentValue = '1.1.2') "
+                + "AND (issue.property[com-blackduck-integration-alert].category = 'Vulnerability' OR issue.property[com-synopsys-integration-alert].category = 'Vulnerability') ";
 
         assertEquals(expectedSearchString, jqlString);
     }


### PR DESCRIPTION
Jira tickets rely on a specific JQL query to find existing issues. As part of the rebranding we have changed in name of the property we used for indexing. In order to support backwards compatibility we are changing the condition we use to check and see if an issue exists, allowing us to find tickets made prior to 8.0.0 that still use the legacy property keys.