### PR TITLE
IALERT-3782: Add empty project validation for disitribution jobs

### DIFF
--- a/web/src/main/java/com/blackduck/integration/alert/web/api/job/JobConfigActions.java
+++ b/web/src/main/java/com/blackduck/integration/alert/web/api/job/JobConfigActions.java
@@ -364,7 +364,7 @@ public class JobConfigActions extends AbstractJobResourceActions {
     private Optional<AlertFieldStatus> validateConfiguredProviderProjects(JobFieldModel jobFieldModel) {
         return jobFieldModel.getConfiguredProviderProjects()
             .stream()
-            .filter(model -> model.getName() == null || model.getHref() == null)
+            .filter(model -> StringUtils.isBlank(model.getName())  || StringUtils.isBlank(model.getHref()))
             .findAny()
             .map(ignored -> AlertFieldStatus.error(ProviderDescriptor.KEY_CONFIGURED_PROJECT, "A Project name or link is invalid"));
     }

--- a/web/src/main/java/com/blackduck/integration/alert/web/api/job/JobConfigActions.java
+++ b/web/src/main/java/com/blackduck/integration/alert/web/api/job/JobConfigActions.java
@@ -34,6 +34,7 @@ import com.blackduck.integration.alert.api.common.model.ValidationResponseModel;
 import com.blackduck.integration.alert.api.common.model.errors.AlertFieldStatus;
 import com.blackduck.integration.alert.api.common.model.exception.AlertException;
 import com.blackduck.integration.alert.api.descriptor.model.DescriptorKey;
+import com.blackduck.integration.alert.api.provider.ProviderDescriptor;
 import com.blackduck.integration.alert.api.provider.ProviderProjectExistencePopulator;
 import com.blackduck.integration.alert.common.action.ActionResponse;
 import com.blackduck.integration.alert.common.action.FieldModelTestAction;
@@ -288,6 +289,8 @@ public class JobConfigActions extends AbstractJobResourceActions {
         List<AlertFieldStatus> descriptorValidationResults = validateDescriptorFields(resource);
         fieldStatuses.addAll(descriptorValidationResults);
 
+        validateConfiguredProviderProjects(resource).ifPresent(fieldStatuses::add);
+
         if (!fieldStatuses.isEmpty()) {
             ValidationResponseModel responseModel = ValidationResponseModel.fromStatusCollection("Invalid Configuration", fieldStatuses);
             return new ValidationActionResponse(HttpStatus.BAD_REQUEST, responseModel);
@@ -356,6 +359,14 @@ public class JobConfigActions extends AbstractJobResourceActions {
             .flatMap(Collection::stream)
             .collect(Collectors.toList());
         return fieldErrors;
+    }
+
+    private Optional<AlertFieldStatus> validateConfiguredProviderProjects(JobFieldModel jobFieldModel) {
+        return jobFieldModel.getConfiguredProviderProjects()
+            .stream()
+            .filter(model -> model.getName() == null || model.getHref() == null)
+            .findAny()
+            .map(ignored -> AlertFieldStatus.error(ProviderDescriptor.KEY_CONFIGURED_PROJECT, "A Project name or link is invalid"));
     }
 
     @Override

--- a/web/src/test/java/com/blackduck/integration/alert/web/api/job/JobConfigActionsTest.java
+++ b/web/src/test/java/com/blackduck/integration/alert/web/api/job/JobConfigActionsTest.java
@@ -474,6 +474,22 @@ class JobConfigActionsTest {
     }
 
     @Test
+    void validateConfiguredProviderProjectsBlankTest() {
+        Descriptor descriptorWithValidator = createDescriptor(Optional::empty, () -> Optional.of(jobFieldModel -> Set.of()));
+        JobConfigActions jobConfigActionsForTest = createJobConfigActions(new DescriptorMap(List.of(descriptorKey), List.of(descriptorWithValidator)), List.of());
+
+        JobProviderProjectFieldModel jobProviderProjectFieldModel = new JobProviderProjectFieldModel("", "", false);
+        JobFieldModel jobWithConfiguredProviderProjects = new JobFieldModel(UUID.randomUUID().toString(), Set.of(fieldModel), List.of(jobProviderProjectFieldModel));
+        ValidationActionResponse validationActionResponse = jobConfigActionsForTest.validate(jobWithConfiguredProviderProjects);
+
+        assertTrue(validationActionResponse.isSuccessful());
+        assertEquals(HttpStatus.OK, validationActionResponse.getHttpStatus());
+        assertTrue(validationActionResponse.hasContent());
+        ValidationResponseModel validationResponseModel = validationActionResponse.getContent().get();
+        assertTrue(validationResponseModel.hasErrors());
+    }
+
+    @Test
     void validateConfiguredProviderProjectsEmptyTest() {
         Descriptor descriptorWithValidator = createDescriptor(Optional::empty, () -> Optional.of(jobFieldModel -> Set.of()));
         JobConfigActions jobConfigActionsForTest = createJobConfigActions(new DescriptorMap(List.of(descriptorKey), List.of(descriptorWithValidator)), List.of());

--- a/web/src/test/java/com/blackduck/integration/alert/web/api/job/JobConfigActionsTest.java
+++ b/web/src/test/java/com/blackduck/integration/alert/web/api/job/JobConfigActionsTest.java
@@ -67,6 +67,7 @@ import com.blackduck.integration.alert.common.rest.model.JobFieldModel;
 import com.blackduck.integration.alert.common.rest.model.JobFieldStatuses;
 import com.blackduck.integration.alert.common.rest.model.JobIdsRequestModel;
 import com.blackduck.integration.alert.common.rest.model.JobPagedModel;
+import com.blackduck.integration.alert.common.rest.model.JobProviderProjectFieldModel;
 import com.blackduck.integration.alert.common.security.authorization.AuthorizationManager;
 import com.blackduck.integration.alert.component.certificates.web.PKIXErrorResponseFactory;
 import com.blackduck.integration.exception.IntegrationException;
@@ -416,6 +417,69 @@ class JobConfigActionsTest {
         JobConfigActions jobConfigActionsForTest = createJobConfigActions(new DescriptorMap(List.of(descriptorKey), List.of(descriptorWithValidator)), List.of());
 
         ValidationActionResponse validationActionResponse = jobConfigActionsForTest.validate(jobFieldModel);
+
+        assertTrue(validationActionResponse.isSuccessful());
+        assertEquals(HttpStatus.OK, validationActionResponse.getHttpStatus());
+        assertTrue(validationActionResponse.hasContent());
+        ValidationResponseModel validationResponseModel = validationActionResponse.getContent().get();
+        assertFalse(validationResponseModel.hasErrors());
+    }
+
+    @Test
+    void validateConfiguredProviderProjects() {
+        Descriptor descriptorWithValidator = createDescriptor(Optional::empty, () -> Optional.of(jobFieldModel -> Set.of()));
+        JobConfigActions jobConfigActionsForTest = createJobConfigActions(new DescriptorMap(List.of(descriptorKey), List.of(descriptorWithValidator)), List.of());
+
+        JobProviderProjectFieldModel jobProviderProjectFieldModel = new JobProviderProjectFieldModel("projectName", "https://href", false);
+        JobFieldModel jobWithConfiguredProviderProjects = new JobFieldModel(UUID.randomUUID().toString(), Set.of(fieldModel), List.of(jobProviderProjectFieldModel));
+        ValidationActionResponse validationActionResponse = jobConfigActionsForTest.validate(jobWithConfiguredProviderProjects);
+
+        assertTrue(validationActionResponse.isSuccessful());
+        assertEquals(HttpStatus.OK, validationActionResponse.getHttpStatus());
+        assertTrue(validationActionResponse.hasContent());
+        ValidationResponseModel validationResponseModel = validationActionResponse.getContent().get();
+        assertFalse(validationResponseModel.hasErrors());
+    }
+
+    @Test
+    void validateConfiguredProviderProjectsNullTest() {
+        Descriptor descriptorWithValidator = createDescriptor(Optional::empty, () -> Optional.of(jobFieldModel -> Set.of()));
+        JobConfigActions jobConfigActionsForTest = createJobConfigActions(new DescriptorMap(List.of(descriptorKey), List.of(descriptorWithValidator)), List.of());
+
+        JobProviderProjectFieldModel jobProviderProjectFieldModel = new JobProviderProjectFieldModel(null, null, false);
+        JobFieldModel jobWithConfiguredProviderProjects = new JobFieldModel(UUID.randomUUID().toString(), Set.of(fieldModel), List.of(jobProviderProjectFieldModel));
+        ValidationActionResponse validationActionResponse = jobConfigActionsForTest.validate(jobWithConfiguredProviderProjects);
+
+        assertTrue(validationActionResponse.isSuccessful());
+        assertEquals(HttpStatus.OK, validationActionResponse.getHttpStatus());
+        assertTrue(validationActionResponse.hasContent());
+        ValidationResponseModel validationResponseModel = validationActionResponse.getContent().get();
+        assertTrue(validationResponseModel.hasErrors());
+    }
+
+    @Test
+    void validateConfiguredProviderProjectsOnlyHrefNullTest() {
+        Descriptor descriptorWithValidator = createDescriptor(Optional::empty, () -> Optional.of(jobFieldModel -> Set.of()));
+        JobConfigActions jobConfigActionsForTest = createJobConfigActions(new DescriptorMap(List.of(descriptorKey), List.of(descriptorWithValidator)), List.of());
+
+        JobProviderProjectFieldModel jobProviderProjectFieldModel = new JobProviderProjectFieldModel("projectName", null, false);
+        JobFieldModel jobWithConfiguredProviderProjects = new JobFieldModel(UUID.randomUUID().toString(), Set.of(fieldModel), List.of(jobProviderProjectFieldModel));
+        ValidationActionResponse validationActionResponse = jobConfigActionsForTest.validate(jobWithConfiguredProviderProjects);
+
+        assertTrue(validationActionResponse.isSuccessful());
+        assertEquals(HttpStatus.OK, validationActionResponse.getHttpStatus());
+        assertTrue(validationActionResponse.hasContent());
+        ValidationResponseModel validationResponseModel = validationActionResponse.getContent().get();
+        assertTrue(validationResponseModel.hasErrors());
+    }
+
+    @Test
+    void validateConfiguredProviderProjectsEmptyTest() {
+        Descriptor descriptorWithValidator = createDescriptor(Optional::empty, () -> Optional.of(jobFieldModel -> Set.of()));
+        JobConfigActions jobConfigActionsForTest = createJobConfigActions(new DescriptorMap(List.of(descriptorKey), List.of(descriptorWithValidator)), List.of());
+
+        JobFieldModel jobWithConfiguredProviderProjects = new JobFieldModel(UUID.randomUUID().toString(), Set.of(fieldModel), List.of());
+        ValidationActionResponse validationActionResponse = jobConfigActionsForTest.validate(jobWithConfiguredProviderProjects);
 
         assertTrue(validationActionResponse.isSuccessful());
         assertEquals(HttpStatus.OK, validationActionResponse.getHttpStatus());


### PR DESCRIPTION
If a distribution job is configured in Alert that filters by Black Duck projects if no projects are selected we throw an error that a project must be selected. However, if an empty project that does not contain a project name or link is instead passed Alert will run into an error attempting to save these. 

The change here is to add additional validation to ensure that empty values cannot be passed in for required fields if project filtering is being used in distribution jobs.