### PR TITLE
IALERT-3765: Project Filter Request

### DIFF
--- a/ui/src/main/js/page/distribution/DistributionConfigurationForm.js
+++ b/ui/src/main/js/page/distribution/DistributionConfigurationForm.js
@@ -66,6 +66,7 @@ const DistributionConfigurationForm = ({
         const providerConfig = JSON.parse(JSON.stringify(providerModelData));
         let configuredProviderProjects = [];
 
+        const fieldConfiguredProjects = FieldModelUtilities.getFieldModelValues(providerConfig, DISTRIBUTION_COMMON_FIELD_KEYS.configuredProjects);
         
         // Determine if fieldConfiguredProjects has shape { label: projectName, href: projectHREF }
         //      If true change shape to { name: projectName, href: projectHREF, missing: false }

--- a/ui/src/main/js/page/distribution/DistributionConfigurationForm.js
+++ b/ui/src/main/js/page/distribution/DistributionConfigurationForm.js
@@ -66,13 +66,18 @@ const DistributionConfigurationForm = ({
         const providerConfig = JSON.parse(JSON.stringify(providerModelData));
         let configuredProviderProjects = [];
 
-        const fieldConfiguredProjects = FieldModelUtilities.getFieldModelValues(providerConfig, DISTRIBUTION_COMMON_FIELD_KEYS.configuredProjects);
-        if (fieldConfiguredProjects && fieldConfiguredProjects.length > 0) {
+        
+        // Determine if fieldConfiguredProjects has shape { label: projectName, href: projectHREF }
+        //      If true change shape to { name: projectName, href: projectHREF, missing: false }
+        //      If false, data shape is OK
+        if (fieldConfiguredProjects.some(project => project.hasOwnProperty('label'))) {
             configuredProviderProjects = fieldConfiguredProjects.map((selectedValue) => ({
                 name: selectedValue.label,
                 href: selectedValue.value,
                 missing: false
             }));
+        } else {
+            configuredProviderProjects = fieldConfiguredProjects;
         }
 
         const providerConfigToSave = FieldModelUtilities.updateFieldModelValues(providerConfig, DISTRIBUTION_COMMON_FIELD_KEYS.configuredProjects, []);


### PR DESCRIPTION
# Bug  
When solving https://github.com/blackducksoftware/blackduck-alert/pull/2634 I introduced a bug that did not send the proper request payload.  A user was able to create a Distribution Job, but when editing that job they were unable to save as the project filter portion of the payload contained an empty list.  This fix checks whether the payload object looks correct, and if not updates it to what it should be.