### PR TITLE
IALERT-3785: Revert changes to jira indexer

### DIFF
--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/JiraConstants.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/JiraConstants.java
@@ -10,7 +10,7 @@ package com.blackduck.integration.alert.api.channel.jira;
 public final class JiraConstants {
     public static final String DEFAULT_ISSUE_TYPE = "Task";
     // This String must always match the String found in the atlassian-connect.json file under key.
-    public static final String JIRA_APP_KEY = "com.blackduck.integration.alert";
+    public static final String JIRA_APP_KEY = "com.synopsys.integration.alert";
     public static final String JIRA_ALERT_APP_NAME = "Alert Issue Property Indexer";
     // This String must always match the String found in the atlassian-connect.json file under modules.jiraEntityProperties.key.
     public static final String JIRA_ISSUE_PROPERTY_KEY = "com-blackduck-integration-alert";

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JiraIssuePropertyKeys.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JiraIssuePropertyKeys.java
@@ -9,7 +9,7 @@ package com.blackduck.integration.alert.api.channel.jira.distribution.search;
 
 public final class JiraIssuePropertyKeys {
     // This String must always match the String found in the atlassian-connect.json file under modules.jiraEntityProperties.key.
-    public static final String JIRA_ISSUE_PROPERTY_KEY = "com-blackduck-integration-alert";
+    public static final String JIRA_ISSUE_PROPERTY_KEY = "com-synopsys-integration-alert";
     // These Strings must always match the Strings found in the atlassian-connect.json file under modules.jiraEntityProperties.keyConfigurations.propertyKey["com-blackduck-integration-alert"].extractions.objectName.
     public static final String JIRA_ISSUE_PROPERTY_OBJECT_KEY_PROVIDER = "provider";
     public static final String JIRA_ISSUE_PROPERTY_OBJECT_KEY_PROVIDER_URL = "providerUrl";

--- a/src/main/resources/jira/atlassian-connect.json
+++ b/src/main/resources/jira/atlassian-connect.json
@@ -14,14 +14,14 @@
   "modules": {
     "jiraEntityProperties": [
       {
-        "key": "com-blackduck-integration-alert",
+        "key": "com-synopsys-integration-alert",
         "name": {
           "value": "Alert Issue Property"
         },
         "entityType": "issue",
         "keyConfigurations": [
           {
-            "propertyKey": "com-blackduck-integration-alert",
+            "propertyKey": "com-synopsys-integration-alert",
             "extractions": [
               {
                 "objectName": "provider",


### PR DESCRIPTION
To support customers transitioning from versions 7.2.x to 8.0.0 this change aims to revert the changes to prevent installing an unreleased version of the plugin as well as attempting to use indices that don't yet exist in Jira.

Once a version of the indexer is publicly available these values should be changed to support the new plugin.