### PR TITLE
IALERT-3790 Removes useCvss3 and include cvssVersion instead

### DIFF
--- a/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreator.java
+++ b/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreator.java
@@ -112,11 +112,13 @@ public class BlackDuckComponentVulnerabilityDetailsCreator {
         String severity = VulnerabilitySeverityType.HIGH.name();
 
         ProjectVersionComponentVersionVulnerabilityRemediationCvss3View cvss3 = vulnerability.getCvss3();
-        if (vulnerability.getCvssVersion().equalsIgnoreCase("cvss3") && (cvss3 != null)) {
-            severity = Optional.ofNullable(cvss3.getSeverity()).map(Enum::name).orElse(VulnerabilitySeverityType.HIGH.name());
-        } else if (vulnerability.getCvssVersion().equalsIgnoreCase("cvss2")) {
-            ProjectVersionComponentVersionVulnerabilityRemediationCvss2View cvss2 = vulnerability.getCvss2();
-            severity = Optional.ofNullable(cvss2.getSeverity()).map(Enum::name).orElse(VulnerabilitySeverityType.HIGH.name());
+        if (vulnerability.getCvssVersion() != null) {
+            if (vulnerability.getCvssVersion().equalsIgnoreCase("cvss3") && (cvss3 != null)) {
+                severity = Optional.ofNullable(cvss3.getSeverity()).map(Enum::name).orElse(VulnerabilitySeverityType.HIGH.name());
+            } else if (vulnerability.getCvssVersion().equalsIgnoreCase("cvss2")) {
+                ProjectVersionComponentVersionVulnerabilityRemediationCvss2View cvss2 = vulnerability.getCvss2();
+                severity = Optional.ofNullable(cvss2.getSeverity()).map(Enum::name).orElse(VulnerabilitySeverityType.HIGH.name());
+            }
         }
 
         VulnerabilitySeverityType vulnSeverity = EnumUtils.getEnum(VulnerabilitySeverityType.class, severity, VulnerabilitySeverityType.HIGH);

--- a/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreator.java
+++ b/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreator.java
@@ -109,12 +109,12 @@ public class BlackDuckComponentVulnerabilityDetailsCreator {
     private AlertVulnerability toAlertVulnerabilityView(BlackDuckProjectVersionComponentVulnerabilitiesView vulnerability) {
         String name = vulnerability.getId();
         String url = vulnerability.getFirstLinkSafely("vulnerability").map(HttpUrl::toString).orElse(null);
-        String severity;
+        String severity = VulnerabilitySeverityType.HIGH.name();
 
         ProjectVersionComponentVersionVulnerabilityRemediationCvss3View cvss3 = vulnerability.getCvss3();
-        if (vulnerability.getUseCvss3() && null != cvss3) {
+        if (vulnerability.getCvssVersion().equalsIgnoreCase("cvss3") && (cvss3 != null)) {
             severity = Optional.ofNullable(cvss3.getSeverity()).map(Enum::name).orElse(VulnerabilitySeverityType.HIGH.name());
-        } else {
+        } else if (vulnerability.getCvssVersion().equalsIgnoreCase("cvss2")) {
             ProjectVersionComponentVersionVulnerabilityRemediationCvss2View cvss2 = vulnerability.getCvss2();
             severity = Optional.ofNullable(cvss2.getSeverity()).map(Enum::name).orElse(VulnerabilitySeverityType.HIGH.name());
         }

--- a/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckProjectVersionComponentVulnerabilitiesView.java
+++ b/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckProjectVersionComponentVulnerabilitiesView.java
@@ -40,7 +40,7 @@ public class BlackDuckProjectVersionComponentVulnerabilitiesView extends BlackDu
     private String title;
     private java.util.Date updatedAt;
     private JsonElement updatedBy;
-    private Boolean useCvss3;
+    private String cvssVersion;
     private Boolean workaroundAvailable;
 
     public String getComment() {
@@ -219,12 +219,12 @@ public class BlackDuckProjectVersionComponentVulnerabilitiesView extends BlackDu
         this.updatedBy = updatedBy;
     }
 
-    public Boolean getUseCvss3() {
-        return useCvss3;
+    public String getCvssVersion() {
+        return cvssVersion;
     }
 
-    public void setUseCvss3(Boolean useCvss3) {
-        this.useCvss3 = useCvss3;
+    public void setCvssVersion(String cvssVersion) {
+        this.cvssVersion = cvssVersion;
     }
 
     public Boolean getWorkaroundAvailable() {

--- a/provider-blackduck/src/test/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreatorTest.java
+++ b/provider-blackduck/src/test/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreatorTest.java
@@ -125,7 +125,7 @@ public class BlackDuckComponentVulnerabilityDetailsCreatorTest {
     @Test
     public void unknownCVSSVersionTest() throws IntegrationException {
         BlackDuckComponentVulnerabilityDetailsCreator vulnerabilityDetailsCreator = new BlackDuckComponentVulnerabilityDetailsCreator();
-        
+
         BlackDuckProjectVersionComponentVulnerabilitiesView cvss4VulnView = new BlackDuckProjectVersionComponentVulnerabilitiesView();
         cvss4VulnView.setCvssVersion("cvss4");
         ResourceMetadata meta = new ResourceMetadata();
@@ -139,6 +139,17 @@ public class BlackDuckComponentVulnerabilityDetailsCreatorTest {
         assertEquals(1, cvss4Vulns.getHigh().size());
         assertEquals(0, cvss4Vulns.getMedium().size());
         assertEquals(0, cvss4Vulns.getLow().size());
+
+        BlackDuckProjectVersionComponentVulnerabilitiesView nullCvssVersionView = new BlackDuckProjectVersionComponentVulnerabilitiesView();
+        nullCvssVersionView.setCvssVersion(null);
+        nullCvssVersionView.setMeta(meta);
+
+        ComponentVulnerabilities nullCvssVulns = vulnerabilityDetailsCreator.toComponentVulnerabilities(List.of(nullCvssVersionView));
+        assertTrue(nullCvssVulns.hasVulnerabilities(), EXPECTED_VULNERABILITIES_MESSAGE);
+        assertEquals(0, nullCvssVulns.getCritical().size());
+        assertEquals(1, nullCvssVulns.getHigh().size());
+        assertEquals(0, nullCvssVulns.getMedium().size());
+        assertEquals(0, nullCvssVulns.getLow().size());
     }
 
     private BlackDuckProjectVersionComponentVulnerabilitiesView createVulnsView(ProjectVersionComponentVersionVulnerabilityRemediationCvss2SeverityType severity) throws IntegrationException {

--- a/provider-blackduck/src/test/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreatorTest.java
+++ b/provider-blackduck/src/test/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreatorTest.java
@@ -122,6 +122,25 @@ public class BlackDuckComponentVulnerabilityDetailsCreatorTest {
         assertFalse(vulnerabilityDetailsCreator.hasSecurityRisk(comp3), UNEXPECTED_RISK_MESSAGE);
     }
 
+    @Test
+    public void unknownCVSSVersionTest() throws IntegrationException {
+        BlackDuckComponentVulnerabilityDetailsCreator vulnerabilityDetailsCreator = new BlackDuckComponentVulnerabilityDetailsCreator();
+        
+        BlackDuckProjectVersionComponentVulnerabilitiesView cvss4VulnView = new BlackDuckProjectVersionComponentVulnerabilitiesView();
+        cvss4VulnView.setCvssVersion("cvss4");
+        ResourceMetadata meta = new ResourceMetadata();
+        meta.setHref(new HttpUrl("https://google.com"));
+        meta.setLinks(List.of());
+        cvss4VulnView.setMeta(meta);
+
+        ComponentVulnerabilities cvss4Vulns = vulnerabilityDetailsCreator.toComponentVulnerabilities(List.of(cvss4VulnView));
+        assertTrue(cvss4Vulns.hasVulnerabilities(), EXPECTED_VULNERABILITIES_MESSAGE);
+        assertEquals(0, cvss4Vulns.getCritical().size());
+        assertEquals(1, cvss4Vulns.getHigh().size());
+        assertEquals(0, cvss4Vulns.getMedium().size());
+        assertEquals(0, cvss4Vulns.getLow().size());
+    }
+
     private BlackDuckProjectVersionComponentVulnerabilitiesView createVulnsView(ProjectVersionComponentVersionVulnerabilityRemediationCvss2SeverityType severity) throws IntegrationException {
         ResourceMetadata meta = new ResourceMetadata();
         meta.setHref(new HttpUrl("https://google.com"));
@@ -132,7 +151,7 @@ public class BlackDuckComponentVulnerabilityDetailsCreatorTest {
 
         BlackDuckProjectVersionComponentVulnerabilitiesView withCriticals = new BlackDuckProjectVersionComponentVulnerabilitiesView();
         withCriticals.setRemediationStatus(VulnerabilityRemediationStatusType.NEW);
-        withCriticals.setUseCvss3(false);
+        withCriticals.setCvssVersion("cvss2");
         withCriticals.setCvss2(cvss2);
         withCriticals.setTitle("VULN-123");
         withCriticals.setMeta(meta);


### PR DESCRIPTION
`useCvss3` was used to differentiate between cvss3 and cvss2. With the addition of cvss4, `useCvss3` was replaced with `cvssVersion`. This PR replaces the old field with the new one and defaults unknown version vul severity to HIGH (existing code defaults to HIGH when severity isnt found).