### PR TITLE
IALERT-3790 Fix for compatibility with cvss 4

### DIFF
--- a/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreator.java
+++ b/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreator.java
@@ -17,8 +17,6 @@ import org.springframework.stereotype.Component;
 
 import com.blackduck.integration.alert.api.processor.extract.model.project.ComponentVulnerabilities;
 import com.blackduck.integration.alert.common.message.model.LinkableItem;
-import com.blackduck.integration.blackduck.api.generated.component.ProjectVersionComponentVersionVulnerabilityRemediationCvss2View;
-import com.blackduck.integration.blackduck.api.generated.component.ProjectVersionComponentVersionVulnerabilityRemediationCvss3View;
 import com.blackduck.integration.blackduck.api.generated.component.RiskProfileCountsView;
 import com.blackduck.integration.blackduck.api.generated.enumeration.VulnerabilityRemediationStatusType;
 import com.blackduck.integration.blackduck.api.generated.enumeration.VulnerabilitySeverityType;
@@ -111,12 +109,27 @@ public class BlackDuckComponentVulnerabilityDetailsCreator {
         String url = vulnerability.getFirstLinkSafely("vulnerability").map(HttpUrl::toString).orElse(null);
         String severity = VulnerabilitySeverityType.HIGH.name();
 
-        ProjectVersionComponentVersionVulnerabilityRemediationCvss3View cvss3 = vulnerability.getCvss3();
         if (vulnerability.getCvssVersion() != null) {
-            if (vulnerability.getCvssVersion().equalsIgnoreCase("cvss3") && (cvss3 != null)) {
+            switch (vulnerability.getCvssVersion()) {
+                case "CVSS4":
+                    ProjectVersionComponentVersionVulnerabilityRemediationCvssView cvss4 = vulnerability.getCvss4();
+                    severity = Optional.ofNullable(cvss4.getSeverity()).map(Enum::name).orElse(VulnerabilitySeverityType.HIGH.name());
+                    break;
+                case "CVSS3":
+                    ProjectVersionComponentVersionVulnerabilityRemediationCvssView cvss3 = vulnerability.getCvss3();
+                    severity = Optional.ofNullable(cvss3.getSeverity()).map(Enum::name).orElse(VulnerabilitySeverityType.HIGH.name());
+                    break;
+                case "CVSS2":
+                    ProjectVersionComponentVersionVulnerabilityRemediationCvssView cvss2 = vulnerability.getCvss2();
+                    severity = Optional.ofNullable(cvss2.getSeverity()).map(Enum::name).orElse(VulnerabilitySeverityType.HIGH.name());
+                    break;
+            }
+        } else {
+            if (Boolean.TRUE.equals(vulnerability.getUseCvss3()) && vulnerability.getCvss3() != null) {
+                ProjectVersionComponentVersionVulnerabilityRemediationCvssView cvss3 = vulnerability.getCvss3();
                 severity = Optional.ofNullable(cvss3.getSeverity()).map(Enum::name).orElse(VulnerabilitySeverityType.HIGH.name());
-            } else if (vulnerability.getCvssVersion().equalsIgnoreCase("cvss2")) {
-                ProjectVersionComponentVersionVulnerabilityRemediationCvss2View cvss2 = vulnerability.getCvss2();
+            } else if (vulnerability.getCvss2() != null) {
+                ProjectVersionComponentVersionVulnerabilityRemediationCvssView cvss2 = vulnerability.getCvss2();
                 severity = Optional.ofNullable(cvss2.getSeverity()).map(Enum::name).orElse(VulnerabilitySeverityType.HIGH.name());
             }
         }

--- a/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreator.java
+++ b/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreator.java
@@ -112,11 +112,13 @@ public class BlackDuckComponentVulnerabilityDetailsCreator {
         String severity = VulnerabilitySeverityType.HIGH.name();
 
         ProjectVersionComponentVersionVulnerabilityRemediationCvss3View cvss3 = vulnerability.getCvss3();
-        if (vulnerability.getCvssVersion().equalsIgnoreCase("cvss3") && (cvss3 != null)) {
-            severity = Optional.ofNullable(cvss3.getSeverity()).map(Enum::name).orElse(VulnerabilitySeverityType.HIGH.name());
-        } else if (vulnerability.getCvssVersion().equalsIgnoreCase("cvss2")) {
-            ProjectVersionComponentVersionVulnerabilityRemediationCvss2View cvss2 = vulnerability.getCvss2();
-            severity = Optional.ofNullable(cvss2.getSeverity()).map(Enum::name).orElse(VulnerabilitySeverityType.HIGH.name());
+        if (vulnerability.getCvssVersion() != null) {
+            if (vulnerability.getCvssVersion().equalsIgnoreCase("cvss3") && (cvss3 != null)) {
+                severity = Optional.ofNullable(cvss3.getSeverity()).map(Enum::name).orElse(VulnerabilitySeverityType.HIGH.name());
+            } else if (vulnerability.getCvssVersion().equalsIgnoreCase("cvss2")) {
+                ProjectVersionComponentVersionVulnerabilityRemediationCvss2View cvss2 = vulnerability.getCvss2();
+                severity = Optional.ofNullable(cvss2.getSeverity()).map(Enum::name).orElse(VulnerabilitySeverityType.HIGH.name());
+            }
         }
 
         VulnerabilitySeverityType vulnSeverity = EnumUtils.getEnum(VulnerabilitySeverityType.class, severity, VulnerabilitySeverityType.HIGH);

--- a/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreator.java
+++ b/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreator.java
@@ -109,12 +109,12 @@ public class BlackDuckComponentVulnerabilityDetailsCreator {
     private AlertVulnerability toAlertVulnerabilityView(BlackDuckProjectVersionComponentVulnerabilitiesView vulnerability) {
         String name = vulnerability.getId();
         String url = vulnerability.getFirstLinkSafely("vulnerability").map(HttpUrl::toString).orElse(null);
-        String severity;
+        String severity = VulnerabilitySeverityType.HIGH.name();
 
         ProjectVersionComponentVersionVulnerabilityRemediationCvss3View cvss3 = vulnerability.getCvss3();
-        if (vulnerability.getUseCvss3() && null != cvss3) {
+        if (vulnerability.getCvssVersion().equalsIgnoreCase("cvss3") && (cvss3 != null)) {
             severity = Optional.ofNullable(cvss3.getSeverity()).map(Enum::name).orElse(VulnerabilitySeverityType.HIGH.name());
-        } else {
+        } else if (vulnerability.getCvssVersion().equalsIgnoreCase("cvss2")) {
             ProjectVersionComponentVersionVulnerabilityRemediationCvss2View cvss2 = vulnerability.getCvss2();
             severity = Optional.ofNullable(cvss2.getSeverity()).map(Enum::name).orElse(VulnerabilitySeverityType.HIGH.name());
         }

--- a/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckProjectVersionComponentVulnerabilitiesView.java
+++ b/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckProjectVersionComponentVulnerabilitiesView.java
@@ -10,8 +10,6 @@ package com.blackduck.integration.alert.provider.blackduck.processor.message.ser
 import java.math.BigDecimal;
 
 import com.blackduck.integration.blackduck.api.core.BlackDuckView;
-import com.blackduck.integration.blackduck.api.generated.component.ProjectVersionComponentVersionVulnerabilityRemediationCvss2View;
-import com.blackduck.integration.blackduck.api.generated.component.ProjectVersionComponentVersionVulnerabilityRemediationCvss3View;
 import com.blackduck.integration.blackduck.api.generated.enumeration.VulnerabilityRemediationStatusType;
 import com.google.gson.JsonElement;
 
@@ -21,8 +19,9 @@ public class BlackDuckProjectVersionComponentVulnerabilitiesView extends BlackDu
     private String comment;
     private java.util.Date createdAt;
     private JsonElement createdBy;
-    private ProjectVersionComponentVersionVulnerabilityRemediationCvss2View cvss2;
-    private ProjectVersionComponentVersionVulnerabilityRemediationCvss3View cvss3;
+    private ProjectVersionComponentVersionVulnerabilityRemediationCvssView cvss2;
+    private ProjectVersionComponentVersionVulnerabilityRemediationCvssView cvss3;
+    private ProjectVersionComponentVersionVulnerabilityRemediationCvssView cvss4;
     private java.util.Date disclosureDate;
     private Boolean exploitAvailable;
     private java.util.Date exploitPublishDate;
@@ -40,6 +39,7 @@ public class BlackDuckProjectVersionComponentVulnerabilitiesView extends BlackDu
     private String title;
     private java.util.Date updatedAt;
     private JsonElement updatedBy;
+    private Boolean useCvss3;   // TODO: For backwards compatability with hub 2024.10.0, remove when version is not supported
     private String cvssVersion;
     private Boolean workaroundAvailable;
 
@@ -67,20 +67,28 @@ public class BlackDuckProjectVersionComponentVulnerabilitiesView extends BlackDu
         this.createdBy = createdBy;
     }
 
-    public ProjectVersionComponentVersionVulnerabilityRemediationCvss2View getCvss2() {
+    public ProjectVersionComponentVersionVulnerabilityRemediationCvssView getCvss2() {
         return cvss2;
     }
 
-    public void setCvss2(ProjectVersionComponentVersionVulnerabilityRemediationCvss2View cvss2) {
+    public void setCvss2(ProjectVersionComponentVersionVulnerabilityRemediationCvssView cvss2) {
         this.cvss2 = cvss2;
     }
 
-    public ProjectVersionComponentVersionVulnerabilityRemediationCvss3View getCvss3() {
+    public ProjectVersionComponentVersionVulnerabilityRemediationCvssView getCvss3() {
         return cvss3;
     }
 
-    public void setCvss3(ProjectVersionComponentVersionVulnerabilityRemediationCvss3View cvss3) {
+    public void setCvss3(ProjectVersionComponentVersionVulnerabilityRemediationCvssView cvss3) {
         this.cvss3 = cvss3;
+    }
+
+    public ProjectVersionComponentVersionVulnerabilityRemediationCvssView getCvss4() {
+        return cvss4;
+    }
+
+    public void setCvss4(ProjectVersionComponentVersionVulnerabilityRemediationCvssView cvss4) {
+        this.cvss4 = cvss4;
     }
 
     public java.util.Date getDisclosureDate() {
@@ -217,6 +225,14 @@ public class BlackDuckProjectVersionComponentVulnerabilitiesView extends BlackDu
 
     public void setUpdatedBy(JsonElement updatedBy) {
         this.updatedBy = updatedBy;
+    }
+
+    public Boolean getUseCvss3() {
+        return useCvss3;
+    }
+
+    public void setUseCvss3(Boolean useCvss3) {
+        this.useCvss3 = useCvss3;
     }
 
     public String getCvssVersion() {

--- a/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckProjectVersionComponentVulnerabilitiesView.java
+++ b/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckProjectVersionComponentVulnerabilitiesView.java
@@ -40,7 +40,7 @@ public class BlackDuckProjectVersionComponentVulnerabilitiesView extends BlackDu
     private String title;
     private java.util.Date updatedAt;
     private JsonElement updatedBy;
-    private Boolean useCvss3;
+    private String cvssVersion;
     private Boolean workaroundAvailable;
 
     public String getComment() {
@@ -219,12 +219,12 @@ public class BlackDuckProjectVersionComponentVulnerabilitiesView extends BlackDu
         this.updatedBy = updatedBy;
     }
 
-    public Boolean getUseCvss3() {
-        return useCvss3;
+    public String getCvssVersion() {
+        return cvssVersion;
     }
 
-    public void setUseCvss3(Boolean useCvss3) {
-        this.useCvss3 = useCvss3;
+    public void setCvssVersion(String cvssVersion) {
+        this.cvssVersion = cvssVersion;
     }
 
     public Boolean getWorkaroundAvailable() {

--- a/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/ProjectVersionComponentVersionVulnerabilityRemediationCvssView.java
+++ b/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/ProjectVersionComponentVersionVulnerabilityRemediationCvssView.java
@@ -1,0 +1,57 @@
+package com.blackduck.integration.alert.provider.blackduck.processor.message.service;
+
+import com.blackduck.integration.blackduck.api.core.BlackDuckComponent;
+import com.blackduck.integration.blackduck.api.generated.enumeration.VulnerabilitySeverityType;
+
+import java.math.BigDecimal;
+
+public class ProjectVersionComponentVersionVulnerabilityRemediationCvssView extends BlackDuckComponent {
+    private BigDecimal baseScore;
+    private BigDecimal exploitabilitySubscore;
+    private BigDecimal impactSubscore;
+    private BigDecimal overallScore;
+    private VulnerabilitySeverityType severity;
+
+    public ProjectVersionComponentVersionVulnerabilityRemediationCvssView() {
+    }
+
+    public BigDecimal getBaseScore() {
+        return this.baseScore;
+    }
+
+    public void setBaseScore(BigDecimal baseScore) {
+        this.baseScore = baseScore;
+    }
+
+    public BigDecimal getExploitabilitySubscore() {
+        return this.exploitabilitySubscore;
+    }
+
+    public void setExploitabilitySubscore(BigDecimal exploitabilitySubscore) {
+        this.exploitabilitySubscore = exploitabilitySubscore;
+    }
+
+    public BigDecimal getImpactSubscore() {
+        return this.impactSubscore;
+    }
+
+    public void setImpactSubscore(BigDecimal impactSubscore) {
+        this.impactSubscore = impactSubscore;
+    }
+
+    public BigDecimal getOverallScore() {
+        return this.overallScore;
+    }
+
+    public void setOverallScore(BigDecimal overallScore) {
+        this.overallScore = overallScore;
+    }
+
+    public VulnerabilitySeverityType getSeverity() {
+        return this.severity;
+    }
+
+    public void setSeverity(VulnerabilitySeverityType severity) {
+        this.severity = severity;
+    }
+}

--- a/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/ProjectVersionComponentVersionVulnerabilityRemediationCvssView.java
+++ b/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/ProjectVersionComponentVersionVulnerabilityRemediationCvssView.java
@@ -3,48 +3,10 @@ package com.blackduck.integration.alert.provider.blackduck.processor.message.ser
 import com.blackduck.integration.blackduck.api.core.BlackDuckComponent;
 import com.blackduck.integration.blackduck.api.generated.enumeration.VulnerabilitySeverityType;
 
-import java.math.BigDecimal;
-
 public class ProjectVersionComponentVersionVulnerabilityRemediationCvssView extends BlackDuckComponent {
-    private BigDecimal baseScore;
-    private BigDecimal exploitabilitySubscore;
-    private BigDecimal impactSubscore;
-    private BigDecimal overallScore;
     private VulnerabilitySeverityType severity;
 
     public ProjectVersionComponentVersionVulnerabilityRemediationCvssView() {
-    }
-
-    public BigDecimal getBaseScore() {
-        return this.baseScore;
-    }
-
-    public void setBaseScore(BigDecimal baseScore) {
-        this.baseScore = baseScore;
-    }
-
-    public BigDecimal getExploitabilitySubscore() {
-        return this.exploitabilitySubscore;
-    }
-
-    public void setExploitabilitySubscore(BigDecimal exploitabilitySubscore) {
-        this.exploitabilitySubscore = exploitabilitySubscore;
-    }
-
-    public BigDecimal getImpactSubscore() {
-        return this.impactSubscore;
-    }
-
-    public void setImpactSubscore(BigDecimal impactSubscore) {
-        this.impactSubscore = impactSubscore;
-    }
-
-    public BigDecimal getOverallScore() {
-        return this.overallScore;
-    }
-
-    public void setOverallScore(BigDecimal overallScore) {
-        this.overallScore = overallScore;
     }
 
     public VulnerabilitySeverityType getSeverity() {

--- a/provider-blackduck/src/test/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreatorTest.java
+++ b/provider-blackduck/src/test/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreatorTest.java
@@ -125,7 +125,7 @@ public class BlackDuckComponentVulnerabilityDetailsCreatorTest {
     @Test
     public void unknownCVSSVersionTest() throws IntegrationException {
         BlackDuckComponentVulnerabilityDetailsCreator vulnerabilityDetailsCreator = new BlackDuckComponentVulnerabilityDetailsCreator();
-        
+
         BlackDuckProjectVersionComponentVulnerabilitiesView cvss4VulnView = new BlackDuckProjectVersionComponentVulnerabilitiesView();
         cvss4VulnView.setCvssVersion("cvss4");
         ResourceMetadata meta = new ResourceMetadata();
@@ -139,6 +139,17 @@ public class BlackDuckComponentVulnerabilityDetailsCreatorTest {
         assertEquals(1, cvss4Vulns.getHigh().size());
         assertEquals(0, cvss4Vulns.getMedium().size());
         assertEquals(0, cvss4Vulns.getLow().size());
+
+        BlackDuckProjectVersionComponentVulnerabilitiesView nullCvssVersionView = new BlackDuckProjectVersionComponentVulnerabilitiesView();
+        nullCvssVersionView.setCvssVersion(null);
+        nullCvssVersionView.setMeta(meta);
+
+        ComponentVulnerabilities nullCvssVulns = vulnerabilityDetailsCreator.toComponentVulnerabilities(List.of(nullCvssVersionView));
+        assertTrue(nullCvssVulns.hasVulnerabilities(), EXPECTED_VULNERABILITIES_MESSAGE);
+        assertEquals(0, nullCvssVulns.getCritical().size());
+        assertEquals(1, nullCvssVulns.getHigh().size());
+        assertEquals(0, nullCvssVulns.getMedium().size());
+        assertEquals(0, nullCvssVulns.getLow().size());
     }
 
     private BlackDuckProjectVersionComponentVulnerabilitiesView createVulnsView(ProjectVersionComponentVersionVulnerabilityRemediationCvss2SeverityType severity) throws IntegrationException {

--- a/provider-blackduck/src/test/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreatorTest.java
+++ b/provider-blackduck/src/test/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreatorTest.java
@@ -122,6 +122,25 @@ public class BlackDuckComponentVulnerabilityDetailsCreatorTest {
         assertFalse(vulnerabilityDetailsCreator.hasSecurityRisk(comp3), UNEXPECTED_RISK_MESSAGE);
     }
 
+    @Test
+    public void unknownCVSSVersionTest() throws IntegrationException {
+        BlackDuckComponentVulnerabilityDetailsCreator vulnerabilityDetailsCreator = new BlackDuckComponentVulnerabilityDetailsCreator();
+        
+        BlackDuckProjectVersionComponentVulnerabilitiesView cvss4VulnView = new BlackDuckProjectVersionComponentVulnerabilitiesView();
+        cvss4VulnView.setCvssVersion("cvss4");
+        ResourceMetadata meta = new ResourceMetadata();
+        meta.setHref(new HttpUrl("https://google.com"));
+        meta.setLinks(List.of());
+        cvss4VulnView.setMeta(meta);
+
+        ComponentVulnerabilities cvss4Vulns = vulnerabilityDetailsCreator.toComponentVulnerabilities(List.of(cvss4VulnView));
+        assertTrue(cvss4Vulns.hasVulnerabilities(), EXPECTED_VULNERABILITIES_MESSAGE);
+        assertEquals(0, cvss4Vulns.getCritical().size());
+        assertEquals(1, cvss4Vulns.getHigh().size());
+        assertEquals(0, cvss4Vulns.getMedium().size());
+        assertEquals(0, cvss4Vulns.getLow().size());
+    }
+
     private BlackDuckProjectVersionComponentVulnerabilitiesView createVulnsView(ProjectVersionComponentVersionVulnerabilityRemediationCvss2SeverityType severity) throws IntegrationException {
         ResourceMetadata meta = new ResourceMetadata();
         meta.setHref(new HttpUrl("https://google.com"));
@@ -132,7 +151,7 @@ public class BlackDuckComponentVulnerabilityDetailsCreatorTest {
 
         BlackDuckProjectVersionComponentVulnerabilitiesView withCriticals = new BlackDuckProjectVersionComponentVulnerabilitiesView();
         withCriticals.setRemediationStatus(VulnerabilityRemediationStatusType.NEW);
-        withCriticals.setUseCvss3(false);
+        withCriticals.setCvssVersion("cvss2");
         withCriticals.setCvss2(cvss2);
         withCriticals.setTitle("VULN-123");
         withCriticals.setMeta(meta);

--- a/provider-blackduck/src/test/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreatorTest.java
+++ b/provider-blackduck/src/test/java/com/blackduck/integration/alert/provider/blackduck/processor/message/service/BlackDuckComponentVulnerabilityDetailsCreatorTest.java
@@ -14,30 +14,32 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.math.BigDecimal;
 import java.util.List;
 
+import com.blackduck.integration.blackduck.api.generated.enumeration.VulnerabilitySeverityType;
 import org.junit.jupiter.api.Test;
 
 import com.blackduck.integration.alert.api.processor.extract.model.project.ComponentVulnerabilities;
 import com.blackduck.integration.blackduck.api.core.ResourceMetadata;
-import com.blackduck.integration.blackduck.api.generated.component.ProjectVersionComponentVersionVulnerabilityRemediationCvss2View;
 import com.blackduck.integration.blackduck.api.generated.component.RiskProfileCountsView;
-import com.blackduck.integration.blackduck.api.generated.enumeration.ProjectVersionComponentVersionVulnerabilityRemediationCvss2SeverityType;
 import com.blackduck.integration.blackduck.api.generated.enumeration.RiskPriorityType;
 import com.blackduck.integration.blackduck.api.generated.enumeration.VulnerabilityRemediationStatusType;
 import com.blackduck.integration.blackduck.api.generated.view.ProjectVersionComponentVersionView;
 import com.blackduck.integration.blackduck.api.generated.view.RiskProfileView;
 import com.blackduck.integration.exception.IntegrationException;
 import com.blackduck.integration.rest.HttpUrl;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class BlackDuckComponentVulnerabilityDetailsCreatorTest {
     private static final String EXPECTED_RISK_MESSAGE = "Expected this component to have security risk";
     private static final String UNEXPECTED_RISK_MESSAGE = "Did not expect this component to have security risk";
     public static final String EXPECTED_VULNERABILITIES_MESSAGE = "Expected vulnerabilities to be present";
 
-    @Test
-    public void toComponentVulnerabilitiesTest() throws IntegrationException {
+    @ParameterizedTest
+    @ValueSource(strings = {"CVSS2", "CVSS3", "CVSS4"})
+    public void toComponentVulnerabilitiesTest(String cvssVersion) throws IntegrationException {
         BlackDuckComponentVulnerabilityDetailsCreator vulnerabilityDetailsCreator = new BlackDuckComponentVulnerabilityDetailsCreator();
 
-        BlackDuckProjectVersionComponentVulnerabilitiesView withCriticals = createVulnsView(ProjectVersionComponentVersionVulnerabilityRemediationCvss2SeverityType.CRITICAL);
+        BlackDuckProjectVersionComponentVulnerabilitiesView withCriticals = createVulnsView(VulnerabilitySeverityType.CRITICAL, cvssVersion);
         ComponentVulnerabilities criticalVulns = vulnerabilityDetailsCreator.toComponentVulnerabilities(List.of(withCriticals));
         assertTrue(criticalVulns.hasVulnerabilities(), EXPECTED_VULNERABILITIES_MESSAGE);
         assertEquals(1, criticalVulns.getCritical().size());
@@ -45,7 +47,7 @@ public class BlackDuckComponentVulnerabilityDetailsCreatorTest {
         assertEquals(0, criticalVulns.getMedium().size());
         assertEquals(0, criticalVulns.getLow().size());
 
-        BlackDuckProjectVersionComponentVulnerabilitiesView withHighs = createVulnsView(ProjectVersionComponentVersionVulnerabilityRemediationCvss2SeverityType.HIGH);
+        BlackDuckProjectVersionComponentVulnerabilitiesView withHighs = createVulnsView(VulnerabilitySeverityType.HIGH, cvssVersion);
         ComponentVulnerabilities highVulns = vulnerabilityDetailsCreator.toComponentVulnerabilities(List.of(withHighs));
         assertTrue(highVulns.hasVulnerabilities(), EXPECTED_VULNERABILITIES_MESSAGE);
         assertEquals(0, highVulns.getCritical().size());
@@ -53,7 +55,7 @@ public class BlackDuckComponentVulnerabilityDetailsCreatorTest {
         assertEquals(0, highVulns.getMedium().size());
         assertEquals(0, highVulns.getLow().size());
 
-        BlackDuckProjectVersionComponentVulnerabilitiesView withMediums = createVulnsView(ProjectVersionComponentVersionVulnerabilityRemediationCvss2SeverityType.MEDIUM);
+        BlackDuckProjectVersionComponentVulnerabilitiesView withMediums = createVulnsView(VulnerabilitySeverityType.MEDIUM, cvssVersion);
         ComponentVulnerabilities mediumVulns = vulnerabilityDetailsCreator.toComponentVulnerabilities(List.of(withMediums));
         assertTrue(mediumVulns.hasVulnerabilities(), EXPECTED_VULNERABILITIES_MESSAGE);
         assertEquals(0, mediumVulns.getCritical().size());
@@ -61,7 +63,7 @@ public class BlackDuckComponentVulnerabilityDetailsCreatorTest {
         assertEquals(1, mediumVulns.getMedium().size());
         assertEquals(0, mediumVulns.getLow().size());
 
-        BlackDuckProjectVersionComponentVulnerabilitiesView withLows = createVulnsView(ProjectVersionComponentVersionVulnerabilityRemediationCvss2SeverityType.LOW);
+        BlackDuckProjectVersionComponentVulnerabilitiesView withLows = createVulnsView(VulnerabilitySeverityType.LOW, cvssVersion);
         ComponentVulnerabilities lowVulns = vulnerabilityDetailsCreator.toComponentVulnerabilities(List.of(withLows));
         assertTrue(lowVulns.hasVulnerabilities(), EXPECTED_VULNERABILITIES_MESSAGE);
         assertEquals(0, lowVulns.getCritical().size());
@@ -126,14 +128,14 @@ public class BlackDuckComponentVulnerabilityDetailsCreatorTest {
     public void unknownCVSSVersionTest() throws IntegrationException {
         BlackDuckComponentVulnerabilityDetailsCreator vulnerabilityDetailsCreator = new BlackDuckComponentVulnerabilityDetailsCreator();
 
-        BlackDuckProjectVersionComponentVulnerabilitiesView cvss4VulnView = new BlackDuckProjectVersionComponentVulnerabilitiesView();
-        cvss4VulnView.setCvssVersion("cvss4");
+        BlackDuckProjectVersionComponentVulnerabilitiesView unknownCvssVulnView = new BlackDuckProjectVersionComponentVulnerabilitiesView();
+        unknownCvssVulnView.setCvssVersion("UNKNOWN VERSION");
         ResourceMetadata meta = new ResourceMetadata();
         meta.setHref(new HttpUrl("https://google.com"));
         meta.setLinks(List.of());
-        cvss4VulnView.setMeta(meta);
+        unknownCvssVulnView.setMeta(meta);
 
-        ComponentVulnerabilities cvss4Vulns = vulnerabilityDetailsCreator.toComponentVulnerabilities(List.of(cvss4VulnView));
+        ComponentVulnerabilities cvss4Vulns = vulnerabilityDetailsCreator.toComponentVulnerabilities(List.of(unknownCvssVulnView));
         assertTrue(cvss4Vulns.hasVulnerabilities(), EXPECTED_VULNERABILITIES_MESSAGE);
         assertEquals(0, cvss4Vulns.getCritical().size());
         assertEquals(1, cvss4Vulns.getHigh().size());
@@ -152,18 +154,72 @@ public class BlackDuckComponentVulnerabilityDetailsCreatorTest {
         assertEquals(0, nullCvssVulns.getLow().size());
     }
 
-    private BlackDuckProjectVersionComponentVulnerabilitiesView createVulnsView(ProjectVersionComponentVersionVulnerabilityRemediationCvss2SeverityType severity) throws IntegrationException {
+    @Test
+    public void useCvss3CompatibilityTest() throws IntegrationException {
+        BlackDuckComponentVulnerabilityDetailsCreator vulnerabilityDetailsCreator = new BlackDuckComponentVulnerabilityDetailsCreator();
+
+        // Create CVSS3 object with CRITICAL severity
+        ProjectVersionComponentVersionVulnerabilityRemediationCvssView cvss3 = new ProjectVersionComponentVersionVulnerabilityRemediationCvssView();
+        cvss3.setSeverity(VulnerabilitySeverityType.CRITICAL);
+        // Set the old useCvss3 field to true
+        BlackDuckProjectVersionComponentVulnerabilitiesView withCriticalsCvss3 = createVulnsView(VulnerabilitySeverityType.CRITICAL, null);
+        withCriticalsCvss3.setUseCvss3(Boolean.TRUE);
+        withCriticalsCvss3.setCvss3(cvss3);
+
+        ComponentVulnerabilities criticalVulnsCvss3 = vulnerabilityDetailsCreator.toComponentVulnerabilities(List.of(withCriticalsCvss3));
+        assertTrue(criticalVulnsCvss3.hasVulnerabilities(), EXPECTED_VULNERABILITIES_MESSAGE);
+        assertEquals(1, criticalVulnsCvss3.getCritical().size());
+        assertEquals(0, criticalVulnsCvss3.getHigh().size());
+        assertEquals(0, criticalVulnsCvss3.getMedium().size());
+        assertEquals(0, criticalVulnsCvss3.getLow().size());
+
+        // Create CVSS2 object with LOW severity
+        ProjectVersionComponentVersionVulnerabilityRemediationCvssView cvss2 = new ProjectVersionComponentVersionVulnerabilityRemediationCvssView();
+        cvss2.setSeverity(VulnerabilitySeverityType.LOW);
+        // Set the old useCvss3 field to false to indicate use of cvss2
+        BlackDuckProjectVersionComponentVulnerabilitiesView withLowsCvss2 = createVulnsView(VulnerabilitySeverityType.LOW, null);
+        withLowsCvss2.setUseCvss3(Boolean.FALSE);
+        withLowsCvss2.setCvss2(cvss2);
+
+        ComponentVulnerabilities criticalVulnsCvss2 = vulnerabilityDetailsCreator.toComponentVulnerabilities(List.of(withLowsCvss2));
+        assertTrue(criticalVulnsCvss2.hasVulnerabilities(), EXPECTED_VULNERABILITIES_MESSAGE);
+        assertEquals(0, criticalVulnsCvss2.getCritical().size());
+        assertEquals(0, criticalVulnsCvss2.getHigh().size());
+        assertEquals(0, criticalVulnsCvss2.getMedium().size());
+        assertEquals(1, criticalVulnsCvss2.getLow().size());
+    }
+
+    private BlackDuckProjectVersionComponentVulnerabilitiesView createVulnsView(VulnerabilitySeverityType severity, String cvssVersion) throws IntegrationException {
         ResourceMetadata meta = new ResourceMetadata();
         meta.setHref(new HttpUrl("https://google.com"));
         meta.setLinks(List.of());
 
-        ProjectVersionComponentVersionVulnerabilityRemediationCvss2View cvss2 = new ProjectVersionComponentVersionVulnerabilityRemediationCvss2View();
-        cvss2.setSeverity(severity);
+        ProjectVersionComponentVersionVulnerabilityRemediationCvssView cvss = new ProjectVersionComponentVersionVulnerabilityRemediationCvssView();
+        cvss.setSeverity(severity);
+        ProjectVersionComponentVersionVulnerabilityRemediationCvssView unusedCvss = new ProjectVersionComponentVersionVulnerabilityRemediationCvssView();
 
         BlackDuckProjectVersionComponentVulnerabilitiesView withCriticals = new BlackDuckProjectVersionComponentVulnerabilitiesView();
         withCriticals.setRemediationStatus(VulnerabilityRemediationStatusType.NEW);
-        withCriticals.setCvssVersion("cvss2");
-        withCriticals.setCvss2(cvss2);
+        withCriticals.setCvssVersion(cvssVersion);
+        // Possible for multiple cvss objects in view, cvssVersion denotes which one to use
+        // Populate all cvss objects as unused
+        withCriticals.setCvss4(unusedCvss);
+        withCriticals.setCvss3(unusedCvss);
+        withCriticals.setCvss2(unusedCvss);
+        // Tests should use the right cvss object based on cvssVersion
+        if (cvssVersion != null) {
+            switch (cvssVersion) {
+                case "CVSS4":
+                    withCriticals.setCvss4(cvss);
+                    break;
+                case "CVSS3":
+                    withCriticals.setCvss3(cvss);
+                    break;
+                case "CVSS2":
+                    withCriticals.setCvss2(cvss);
+                    break;
+            }
+        }
         withCriticals.setTitle("VULN-123");
         withCriticals.setMeta(meta);
 


### PR DESCRIPTION
Hub 2025.1.0 replaces `useCvss3` field with `cvssVersion` in notification objects. To ensure backwards compatibility with 2024.10.0 of hub, `useCvss3` is kept and `cvssVersion` is added. If `cvssVersion` value is available, it will use that; otherwise it will attempt to use `useCvss3`. Logic for getting CVSS4 severity is also included in this PR. 