### PR TITLE
ALERT-3312 - Adding volumeMounts option to postgres in values

### DIFF
--- a/deployment/helm/blackduck-alert/templates/postgres.yaml
+++ b/deployment/helm/blackduck-alert/templates/postgres.yaml
@@ -196,8 +196,13 @@ spec:
 {{ toYaml . | indent 10 }}
         {{- end }}
         volumeMounts:
-          - mountPath: /var/lib/postgresql/data
-            name: alert-postgres-data-volume
+        {{- range .Values.postgres.volumeMounts }}
+        - mountPath: {{ .mountPath }}
+          {{- if .subPath }}
+          subPath: {{ .subPath }}
+          {{- end }}
+          name: {{ .name }}
+        {{- end }}
       dnsPolicy: ClusterFirst
       {{- include "alert.imagePullSecrets" . | nindent 6 -}}
       {{- with .Values.postgres.nodeSelector }}

--- a/deployment/helm/blackduck-alert/values.yaml
+++ b/deployment/helm/blackduck-alert/values.yaml
@@ -78,6 +78,9 @@ postgres:
   claimSize: "5Gi" # PVC claim size
   storageClass: "" # PVC storage class name
   volumeName: "" # existing persistent volume name backing the PVC
+  volumeMounts:
+    - mountPath: /var/lib/postgresql/data
+      name: alert-postgres-data-volume
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
# Pull Request template

**Link to github issue (if applicable):**

ALERT-3312 
https://documentation.blackduck.com/bundle/alert/page/topics/troubleshooting/troubleshooting-issues-in-alert.html
Helm Deployment Storage Configuration Issue

"To workaround this issue you must update the postgres.yaml file under helm/blackduck-alert/templates/postgres.yaml.Update the following sections."

**If nothing above, what is your reason for this pull request:**

Allows to pass in config update to the postgres volumeMount using helm instead of having to patch the postgres.yaml file

Can do this update in values if require to use subPath
```
  volumeMounts:
    - mountPath: /var/lib/postgresql
      subPath: data
      name: alert-postgres-data-volume
```

This makes doing this update much easier and not needing to either patch or fork your helm chart to do this update in an automated fashion
*

**Changes proposed in this pull request:**

deployment/helm/blackduck-alert/templates/postgres.yaml
Add range so can loop over provided volumeMounts from values, this also allows if we require multiple mounts in future
Support for with or without subPath

deployment/helm/blackduck-alert/values.yaml
Adding default behaviour of mount without subpath
*
*
*

**Testing**

- Tested helm deployment with default behaviour - Saw expected volumeMounts: in postgres deployment
- Tested helm deployment with updated values - Saw expected volumeMounts: in postgres deployment
- Helm lint passed