### PR TITLE
IALERT-3805 - Remove default-src, set script-src to unsafe-inline

### DIFF
--- a/component/src/main/java/com/blackduck/integration/alert/component/authentication/security/AuthenticationHandler.java
+++ b/component/src/main/java/com/blackduck/integration/alert/component/authentication/security/AuthenticationHandler.java
@@ -96,7 +96,7 @@ public class AuthenticationHandler {
             .headers(customizer -> {
                 customizer.contentSecurityPolicy(cspCustomizer -> {
                     cspCustomizer.policyDirectives(
-                        "form-action 'self'; default-src 'none'; connect-src 'self'; object-src 'self'; script-src 'self' 'unsafe-eval'; img-src 'self' data: https://www.blackduck.com/; style-src 'self' 'unsafe-inline'; font-src 'self';"
+                        "default-src 'none'; connect-src 'self'; object-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data: https://www.blackduck.com/; style-src 'self' 'unsafe-inline'; font-src 'self';"
                     );
                 });
             })


### PR DESCRIPTION
Connecting to SAML stopped working in 8.0.0. @psantos1113 figured out the edits to the content security policy in order to get this working again.

I performed a deploy of the images from this branch, and I was able to connect and login to SAML successfully, and get redirected back to Alert.