### PR TITLE
Fix: IALERT-3810 add custom field type object and any support

### DIFF
--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldResolver.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldResolver.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +37,8 @@ public class JiraCustomFieldResolver {
     private static final String CUSTOM_FIELD_TYPE_PRIORITY_VALUE = "priority";
     private static final String CUSTOM_FIELD_TYPE_USER_VALUE = "user";
     private static final String CUSTOM_FIELD_TYPE_COMPONENT_VALUE = "component";
+    private static final String CUSTOM_FIELD_TYPE_OBJECT_VALUE = "object";
+    private static final String CUSTOM_FIELD_TYPE_ANY_VALUE = "any";
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -90,6 +94,10 @@ public class JiraCustomFieldResolver {
                 return createJsonObject("value", innerFieldValue);
             case CUSTOM_FIELD_TYPE_PRIORITY_VALUE:
                 return createJsonObject("name", innerFieldValue);
+            case CUSTOM_FIELD_TYPE_OBJECT_VALUE:
+                return createJsonObjectFromString(innerFieldValue, jiraCustomFieldConfig.getFieldName());
+            case CUSTOM_FIELD_TYPE_ANY_VALUE:
+                return createJsonObject("value", innerFieldValue);
             case CUSTOM_FIELD_TYPE_USER_VALUE:
                 // "name" is used for Jira Server (ignored on Jira Cloud)
                 JsonObject createUserObject = createJsonObject("name", innerFieldValue);
@@ -155,6 +163,14 @@ public class JiraCustomFieldResolver {
         JsonObject objectWithName = new JsonObject();
         objectWithName.addProperty(key, value);
         return objectWithName;
+    }
+
+    private JsonObject createJsonObjectFromString(String jsonValue, String fieldName) {
+        try {
+            return JsonParser.parseString(jsonValue).getAsJsonObject();
+        } catch (JsonSyntaxException jse) {
+            throw new AlertRuntimeException(String.format("Invalid JSON syntax for field type '%s' field: %s", CUSTOM_FIELD_TYPE_OBJECT_VALUE, fieldName));
+        }
     }
 
 }

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldResolver.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldResolver.java
@@ -94,9 +94,6 @@ public class JiraCustomFieldResolver {
                 return createJsonObject("value", innerFieldValue);
             case CUSTOM_FIELD_TYPE_PRIORITY_VALUE:
                 return createJsonObject("name", innerFieldValue);
-            case CUSTOM_FIELD_TYPE_OBJECT_VALUE:
-                // This is a Jira Cloud custom field type.  It is possible to create a JSON object
-                return createJsonObjectFromString(innerFieldValue, jiraCustomFieldConfig.getFieldName());
             case CUSTOM_FIELD_TYPE_USER_VALUE:
                 // "name" is used for Jira Server (ignored on Jira Cloud)
                 JsonObject createUserObject = createJsonObject("name", innerFieldValue);
@@ -104,6 +101,9 @@ public class JiraCustomFieldResolver {
                 createUserObject.addProperty("accountId", innerFieldValue);
                 // TODO consider separating this functionality depending on which Jira channel is being used
                 return createUserObject;
+            case CUSTOM_FIELD_TYPE_OBJECT_VALUE:
+                // This is a Jira Cloud custom field type.  It is possible to create a JSON object
+                return createJsonObjectFromString(innerFieldValue, jiraCustomFieldConfig.getFieldName());
             case CUSTOM_FIELD_TYPE_ANY_VALUE:
                 // Write the string value as is for any custom field of type any.
                 // custom fields are written to the Jira Server database as a string.

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldResolver.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldResolver.java
@@ -95,9 +95,8 @@ public class JiraCustomFieldResolver {
             case CUSTOM_FIELD_TYPE_PRIORITY_VALUE:
                 return createJsonObject("name", innerFieldValue);
             case CUSTOM_FIELD_TYPE_OBJECT_VALUE:
+                // This is a Jira Cloud custom field type.  It is possible to create a JSON object
                 return createJsonObjectFromString(innerFieldValue, jiraCustomFieldConfig.getFieldName());
-            case CUSTOM_FIELD_TYPE_ANY_VALUE:
-                return createJsonObject("value", innerFieldValue);
             case CUSTOM_FIELD_TYPE_USER_VALUE:
                 // "name" is used for Jira Server (ignored on Jira Cloud)
                 JsonObject createUserObject = createJsonObject("name", innerFieldValue);
@@ -105,6 +104,10 @@ public class JiraCustomFieldResolver {
                 createUserObject.addProperty("accountId", innerFieldValue);
                 // TODO consider separating this functionality depending on which Jira channel is being used
                 return createUserObject;
+            case CUSTOM_FIELD_TYPE_ANY_VALUE:
+                // Write the string value as is for any custom field of type any.
+                // custom fields are written to the Jira Server database as a string.
+                return innerFieldValue;
             default:
                 throw new AlertRuntimeException(String.format("Unsupported field type '%s' for field: %s", fieldType, jiraCustomFieldConfig.getFieldName()));
         }


### PR DESCRIPTION
Add support for the Jira Cloud Custom Field type of "object" and add support for Jira Server Custom Field type of "any".

Had to build a forge app to define a custom field of type "object" for Jira Cloud to be able to configure a custom field with the correct "object" type to test.  For this type Alert will create a `JsonObject`.

Had to build a plugin app for Jira Server to define a custom field of type "any" to be able to configure a custom field with the correct "any" type to test.  For this type Alert will pass the string as is to Jira Server.