### PR TITLE
Fix: IALERT-3810 add override for custom fields

### DIFF
--- a/alert-common/src/main/java/com/blackduck/integration/alert/common/persistence/model/job/details/JiraJobCustomFieldModel.java
+++ b/alert-common/src/main/java/com/blackduck/integration/alert/common/persistence/model/job/details/JiraJobCustomFieldModel.java
@@ -12,7 +12,7 @@ import com.blackduck.integration.alert.api.common.model.AlertSerializableModel;
 public class JiraJobCustomFieldModel extends AlertSerializableModel {
     private String fieldName;
     private String fieldValue;
-    private boolean createJsonObject;
+    private boolean treatValueAsJson;
 
     public JiraJobCustomFieldModel() {
     }
@@ -21,10 +21,10 @@ public class JiraJobCustomFieldModel extends AlertSerializableModel {
         this(fieldName, fieldValue, false);
     }
 
-    public JiraJobCustomFieldModel(String fieldName, String fieldValue, boolean createJsonObject) {
+    public JiraJobCustomFieldModel(String fieldName, String fieldValue, boolean treatValueAsJson) {
         this.fieldName = fieldName;
         this.fieldValue = fieldValue;
-        this.createJsonObject = createJsonObject;
+        this.treatValueAsJson = treatValueAsJson;
     }
 
     public String getFieldName() {
@@ -35,8 +35,8 @@ public class JiraJobCustomFieldModel extends AlertSerializableModel {
         return fieldValue;
     }
 
-    public boolean isCreateJsonObject() {
-        return createJsonObject;
+    public boolean isTreatValueAsJson() {
+        return treatValueAsJson;
     }
 
 }

--- a/alert-common/src/main/java/com/blackduck/integration/alert/common/persistence/model/job/details/JiraJobCustomFieldModel.java
+++ b/alert-common/src/main/java/com/blackduck/integration/alert/common/persistence/model/job/details/JiraJobCustomFieldModel.java
@@ -12,13 +12,19 @@ import com.blackduck.integration.alert.api.common.model.AlertSerializableModel;
 public class JiraJobCustomFieldModel extends AlertSerializableModel {
     private String fieldName;
     private String fieldValue;
+    private boolean createJsonObject;
 
     public JiraJobCustomFieldModel() {
     }
 
     public JiraJobCustomFieldModel(String fieldName, String fieldValue) {
+        this(fieldName, fieldValue, false);
+    }
+
+    public JiraJobCustomFieldModel(String fieldName, String fieldValue, boolean createJsonObject) {
         this.fieldName = fieldName;
         this.fieldValue = fieldValue;
+        this.createJsonObject = createJsonObject;
     }
 
     public String getFieldName() {
@@ -27,6 +33,10 @@ public class JiraJobCustomFieldModel extends AlertSerializableModel {
 
     public String getFieldValue() {
         return fieldValue;
+    }
+
+    public boolean isCreateJsonObject() {
+        return createJsonObject;
     }
 
 }

--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/job/jira/cloud/DefaultJiraCloudJobDetailsAccessor.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/job/jira/cloud/DefaultJiraCloudJobDetailsAccessor.java
@@ -56,8 +56,8 @@ public class DefaultJiraCloudJobDetailsAccessor implements JiraCloudJobDetailsAc
         jiraCloudJobCustomFieldRepository.bulkDeleteByJobId(jobId);
         List<JiraCloudJobCustomFieldEntity> customFieldsToSave = jiraCloudJobDetails.getCustomFields()
                                                                      .stream()
-                                                                     .map(model -> new JiraCloudJobCustomFieldEntity(savedJobDetails.getJobId(), model.getFieldName(), model.getFieldValue()))
-                                                                     .collect(Collectors.toList());
+                                                                     .map(model -> new JiraCloudJobCustomFieldEntity(savedJobDetails.getJobId(), model.getFieldName(), model.getFieldValue(), model.isCreateJsonObject()))
+                                                                     .toList();
         List<JiraCloudJobCustomFieldEntity> savedCustomFields = jiraCloudJobCustomFieldRepository.saveAll(customFieldsToSave);
         savedJobDetails.setJobCustomFields(savedCustomFields);
         return savedJobDetails;

--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/job/jira/cloud/DefaultJiraCloudJobDetailsAccessor.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/job/jira/cloud/DefaultJiraCloudJobDetailsAccessor.java
@@ -56,7 +56,7 @@ public class DefaultJiraCloudJobDetailsAccessor implements JiraCloudJobDetailsAc
         jiraCloudJobCustomFieldRepository.bulkDeleteByJobId(jobId);
         List<JiraCloudJobCustomFieldEntity> customFieldsToSave = jiraCloudJobDetails.getCustomFields()
                                                                      .stream()
-                                                                     .map(model -> new JiraCloudJobCustomFieldEntity(savedJobDetails.getJobId(), model.getFieldName(), model.getFieldValue(), model.isCreateJsonObject()))
+                                                                     .map(model -> new JiraCloudJobCustomFieldEntity(savedJobDetails.getJobId(), model.getFieldName(), model.getFieldValue(), model.isTreatValueAsJson()))
                                                                      .toList();
         List<JiraCloudJobCustomFieldEntity> savedCustomFields = jiraCloudJobCustomFieldRepository.saveAll(customFieldsToSave);
         savedJobDetails.setJobCustomFields(savedCustomFields);

--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/job/jira/cloud/custom_field/JiraCloudJobCustomFieldEntity.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/job/jira/cloud/custom_field/JiraCloudJobCustomFieldEntity.java
@@ -30,17 +30,17 @@ public class JiraCloudJobCustomFieldEntity {
     @Column(name = "field_value")
     private String fieldValue;
 
-    @Column(name = "create_json_object")
-    private boolean createJsonObject;
+    @Column(name = "treat_value_as_json")
+    private boolean treatValueAsJson;
 
     public JiraCloudJobCustomFieldEntity() {
     }
 
-    public JiraCloudJobCustomFieldEntity(UUID jobId, String fieldName, String fieldValue, boolean createJsonObject) {
+    public JiraCloudJobCustomFieldEntity(UUID jobId, String fieldName, String fieldValue, boolean treatValueAsJson) {
         this.jobId = jobId;
         this.fieldName = fieldName;
         this.fieldValue = fieldValue;
-        this.createJsonObject = createJsonObject;
+        this.treatValueAsJson = treatValueAsJson;
     }
 
     public UUID getJobId() {
@@ -55,8 +55,8 @@ public class JiraCloudJobCustomFieldEntity {
         return fieldValue;
     }
 
-    public boolean isCreateJsonObject() {
-        return createJsonObject;
+    public boolean isTreatValueAsJson() {
+        return treatValueAsJson;
     }
 
 }

--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/job/jira/cloud/custom_field/JiraCloudJobCustomFieldEntity.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/job/jira/cloud/custom_field/JiraCloudJobCustomFieldEntity.java
@@ -30,7 +30,7 @@ public class JiraCloudJobCustomFieldEntity {
     @Column(name = "field_value")
     private String fieldValue;
 
-    @Column(name = "create_object_json")
+    @Column(name = "create_json_object")
     private boolean createJsonObject;
 
     public JiraCloudJobCustomFieldEntity() {

--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/job/jira/cloud/custom_field/JiraCloudJobCustomFieldEntity.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/job/jira/cloud/custom_field/JiraCloudJobCustomFieldEntity.java
@@ -30,13 +30,17 @@ public class JiraCloudJobCustomFieldEntity {
     @Column(name = "field_value")
     private String fieldValue;
 
+    @Column(name = "create_object_json")
+    private boolean createJsonObject;
+
     public JiraCloudJobCustomFieldEntity() {
     }
 
-    public JiraCloudJobCustomFieldEntity(UUID jobId, String fieldName, String fieldValue) {
+    public JiraCloudJobCustomFieldEntity(UUID jobId, String fieldName, String fieldValue, boolean createJsonObject) {
         this.jobId = jobId;
         this.fieldName = fieldName;
         this.fieldValue = fieldValue;
+        this.createJsonObject = createJsonObject;
     }
 
     public UUID getJobId() {
@@ -49,6 +53,10 @@ public class JiraCloudJobCustomFieldEntity {
 
     public String getFieldValue() {
         return fieldValue;
+    }
+
+    public boolean isCreateJsonObject() {
+        return createJsonObject;
     }
 
 }

--- a/alert-database/src/main/resources/liquibase/8.1.0/changelog.xml
+++ b/alert-database/src/main/resources/liquibase/8.1.0/changelog.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+    <include file="jira-custom-field-add-create-object-column.xml" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/alert-database/src/main/resources/liquibase/8.1.0/jira-custom-field-add-create-object-column.xml
+++ b/alert-database/src/main/resources/liquibase/8.1.0/jira-custom-field-add-create-object-column.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+    <changeSet author="psantos" id="jira-cloud-custom-fields-add-create-json-object-column">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists schemaName="alert" tableName="jira_cloud_job_custom_fields" columnName="create_json_object"/>
+            </not>
+        </preConditions>
+        <addColumn schemaName="alert" tableName="jira_cloud_job_custom_fields">
+            <column name="create_json_object" type="BOOLEAN" defaultValue="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet author="psantos" id="jira-server-custom-fields-add-create-json-object-column">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists schemaName="alert" tableName="jira_server_job_custom_fields" columnName="create_json_object"/>
+            </not>
+        </preConditions>
+        <addColumn schemaName="alert" tableName="jira_server_job_custom_fields">
+            <column name="create_json_object" type="BOOLEAN" defaultValue="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/alert-database/src/main/resources/liquibase/8.1.0/jira-custom-field-add-create-object-column.xml
+++ b/alert-database/src/main/resources/liquibase/8.1.0/jira-custom-field-add-create-object-column.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
-    <changeSet author="psantos" id="jira-cloud-custom-fields-add-create-json-object-column">
+    <changeSet author="psantos" id="jira-cloud-custom-fields-add-treat-value-as-json-column">
         <preConditions onFail="MARK_RAN">
             <not>
-                <columnExists schemaName="alert" tableName="jira_cloud_job_custom_fields" columnName="create_json_object"/>
+                <columnExists schemaName="alert" tableName="jira_cloud_job_custom_fields" columnName="treat_value_as_json"/>
             </not>
         </preConditions>
         <addColumn schemaName="alert" tableName="jira_cloud_job_custom_fields">
-            <column name="create_json_object" type="BOOLEAN" defaultValue="false">
+            <column name="treat_value_as_json" type="BOOLEAN" defaultValue="false">
                 <constraints nullable="false"/>
             </column>
         </addColumn>
     </changeSet>
-    <changeSet author="psantos" id="jira-server-custom-fields-add-create-json-object-column">
+    <changeSet author="psantos" id="jira-server-custom-fields-add-treat-value-as-json-column">
         <preConditions onFail="MARK_RAN">
             <not>
-                <columnExists schemaName="alert" tableName="jira_server_job_custom_fields" columnName="create_json_object"/>
+                <columnExists schemaName="alert" tableName="jira_server_job_custom_fields" columnName="treat_value_as_json"/>
             </not>
         </preConditions>
         <addColumn schemaName="alert" tableName="jira_server_job_custom_fields">
-            <column name="create_json_object" type="BOOLEAN" defaultValue="false">
+            <column name="treat_value_as_json" type="BOOLEAN" defaultValue="false">
                 <constraints nullable="false"/>
             </column>
         </addColumn>

--- a/alert-database/src/main/resources/liquibase/changelog-postgres-master.xml
+++ b/alert-database/src/main/resources/liquibase/changelog-postgres-master.xml
@@ -30,4 +30,5 @@
     <include file="7.1.0/changelog.xml" relativeToChangelogFile="true"/>
     <include file="7.1.2/changelog.xml" relativeToChangelogFile="true"/>
     <include file="8.0.0/changelog.xml" relativeToChangelogFile="true"/>
+    <include file="8.1.0/changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/JiraIssueCreationRequestCreator.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/JiraIssueCreationRequestCreator.java
@@ -9,7 +9,6 @@ package com.blackduck.integration.alert.api.channel.jira.distribution;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.blackduck.integration.alert.api.channel.jira.distribution.custom.JiraCustomFieldConfig;
 import com.blackduck.integration.alert.api.channel.jira.distribution.custom.JiraCustomFieldResolver;
@@ -36,7 +35,7 @@ public class JiraIssueCreationRequestCreator {
     ) {
         List<JiraCustomFieldConfig> customFieldConfigs = customFields
                                                              .stream()
-                                                             .map(customField -> new JiraCustomFieldConfig(customField.getFieldName(), customField.getFieldValue(), customField.isCreateJsonObject()))
+                                                             .map(customField -> new JiraCustomFieldConfig(customField.getFieldName(), customField.getFieldValue(), customField.isTreatValueAsJson()))
                                                              .toList();
         return createIssueRequestModel(summary, description, projectId, issueType, customFieldConfigs, customFieldReplacementValues);
     }

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/JiraIssueCreationRequestCreator.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/JiraIssueCreationRequestCreator.java
@@ -36,8 +36,8 @@ public class JiraIssueCreationRequestCreator {
     ) {
         List<JiraCustomFieldConfig> customFieldConfigs = customFields
                                                              .stream()
-                                                             .map(customField -> new JiraCustomFieldConfig(customField.getFieldName(), customField.getFieldValue()))
-                                                             .collect(Collectors.toList());
+                                                             .map(customField -> new JiraCustomFieldConfig(customField.getFieldName(), customField.getFieldValue(), customField.isCreateJsonObject()))
+                                                             .toList();
         return createIssueRequestModel(summary, description, projectId, issueType, customFieldConfigs, customFieldReplacementValues);
     }
 

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldConfig.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldConfig.java
@@ -18,16 +18,16 @@ public class JiraCustomFieldConfig extends AlertSerializableModel {
     private final String fieldName;
     private final String fieldOriginalValue;
     private @Nullable String fieldReplacementValue;
-    private boolean createJsonObject;
+    private boolean treatValueAsJson;
 
     public JiraCustomFieldConfig(String fieldName, String fieldOriginalValue) {
         this(fieldName, fieldOriginalValue, false);
     }
 
-    public JiraCustomFieldConfig(String fieldName, String fieldOriginalValue, boolean createJsonObject) {
+    public JiraCustomFieldConfig(String fieldName, String fieldOriginalValue, boolean treatValueAsJson) {
         this.fieldName = fieldName;
         this.fieldOriginalValue = fieldOriginalValue;
-        this.createJsonObject = createJsonObject;
+        this.treatValueAsJson = treatValueAsJson;
     }
 
     public String getFieldName() {
@@ -38,8 +38,8 @@ public class JiraCustomFieldConfig extends AlertSerializableModel {
         return fieldOriginalValue;
     }
 
-    public boolean isCreateJsonObject() {
-        return createJsonObject;
+    public boolean isTreatValueAsJson() {
+        return treatValueAsJson;
     }
 
     public Optional<String> getFieldReplacementValue() {

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldConfig.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldConfig.java
@@ -18,10 +18,16 @@ public class JiraCustomFieldConfig extends AlertSerializableModel {
     private final String fieldName;
     private final String fieldOriginalValue;
     private @Nullable String fieldReplacementValue;
+    private boolean createJsonObject;
 
     public JiraCustomFieldConfig(String fieldName, String fieldOriginalValue) {
+        this(fieldName, fieldOriginalValue, false);
+    }
+
+    public JiraCustomFieldConfig(String fieldName, String fieldOriginalValue, boolean createJsonObject) {
         this.fieldName = fieldName;
         this.fieldOriginalValue = fieldOriginalValue;
+        this.createJsonObject = createJsonObject;
     }
 
     public String getFieldName() {
@@ -30,6 +36,10 @@ public class JiraCustomFieldConfig extends AlertSerializableModel {
 
     public String getFieldOriginalValue() {
         return fieldOriginalValue;
+    }
+
+    public boolean isCreateJsonObject() {
+        return createJsonObject;
     }
 
     public Optional<String> getFieldReplacementValue() {

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldResolver.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldResolver.java
@@ -86,7 +86,7 @@ public class JiraCustomFieldResolver {
         String fieldType = fieldDefinition.getFieldType();
         String innerFieldValue = extractUsableInnerValue(jiraCustomFieldConfig);
 
-        if(jiraCustomFieldConfig.isCreateJsonObject()) {
+        if(jiraCustomFieldConfig.isTreatValueAsJson()) {
             return JsonParser.parseString(innerFieldValue);
         } else {
             switch (fieldType) {

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldResolver.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldResolver.java
@@ -85,31 +85,36 @@ public class JiraCustomFieldResolver {
     protected Object convertValueToRequestObject(CustomFieldDefinitionModel fieldDefinition, JiraCustomFieldConfig jiraCustomFieldConfig) {
         String fieldType = fieldDefinition.getFieldType();
         String innerFieldValue = extractUsableInnerValue(jiraCustomFieldConfig);
-        switch (fieldType) {
-            case CUSTOM_FIELD_TYPE_STRING_VALUE:
-                return innerFieldValue;
-            case CUSTOM_FIELD_TYPE_ARRAY_VALUE:
-                return createJsonArray(innerFieldValue, fieldDefinition.getFieldArrayItems());
-            case CUSTOM_FIELD_TYPE_OPTION_VALUE:
-                return createJsonObject("value", innerFieldValue);
-            case CUSTOM_FIELD_TYPE_PRIORITY_VALUE:
-                return createJsonObject("name", innerFieldValue);
-            case CUSTOM_FIELD_TYPE_USER_VALUE:
-                // "name" is used for Jira Server (ignored on Jira Cloud)
-                JsonObject createUserObject = createJsonObject("name", innerFieldValue);
-                // "accountId" is used for Jira Cloud (ignored on Jira Server)
-                createUserObject.addProperty("accountId", innerFieldValue);
-                // TODO consider separating this functionality depending on which Jira channel is being used
-                return createUserObject;
-            case CUSTOM_FIELD_TYPE_OBJECT_VALUE:
-                // This is a Jira Cloud custom field type.  It is possible to create a JSON object
-                return createJsonObjectFromString(innerFieldValue, jiraCustomFieldConfig.getFieldName());
-            case CUSTOM_FIELD_TYPE_ANY_VALUE:
-                // Write the string value as is for any custom field of type any.
-                // custom fields are written to the Jira Server database as a string.
-                return innerFieldValue;
-            default:
-                throw new AlertRuntimeException(String.format("Unsupported field type '%s' for field: %s", fieldType, jiraCustomFieldConfig.getFieldName()));
+
+        if(jiraCustomFieldConfig.isCreateJsonObject()) {
+            return JsonParser.parseString(innerFieldValue);
+        } else {
+            switch (fieldType) {
+                case CUSTOM_FIELD_TYPE_STRING_VALUE:
+                    return innerFieldValue;
+                case CUSTOM_FIELD_TYPE_ARRAY_VALUE:
+                    return createJsonArray(innerFieldValue, fieldDefinition.getFieldArrayItems());
+                case CUSTOM_FIELD_TYPE_OPTION_VALUE:
+                    return createJsonObject("value", innerFieldValue);
+                case CUSTOM_FIELD_TYPE_PRIORITY_VALUE:
+                    return createJsonObject("name", innerFieldValue);
+                case CUSTOM_FIELD_TYPE_USER_VALUE:
+                    // "name" is used for Jira Server (ignored on Jira Cloud)
+                    JsonObject createUserObject = createJsonObject("name", innerFieldValue);
+                    // "accountId" is used for Jira Cloud (ignored on Jira Server)
+                    createUserObject.addProperty("accountId", innerFieldValue);
+                    // TODO consider separating this functionality depending on which Jira channel is being used
+                    return createUserObject;
+                case CUSTOM_FIELD_TYPE_OBJECT_VALUE:
+                    // This is a Jira Cloud custom field type.  It is possible to create a JSON object
+                    return createJsonObjectFromString(innerFieldValue, jiraCustomFieldConfig.getFieldName());
+                case CUSTOM_FIELD_TYPE_ANY_VALUE:
+                    // Write the string value as is for any custom field of type any.
+                    // custom fields are written to the Jira Server database as a string.
+                    return innerFieldValue;
+                default:
+                    throw new AlertRuntimeException(String.format("Unsupported field type '%s' for field: %s", fieldType, jiraCustomFieldConfig.getFieldName()));
+            }
         }
     }
 

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldResolver.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldResolver.java
@@ -87,7 +87,11 @@ public class JiraCustomFieldResolver {
         String innerFieldValue = extractUsableInnerValue(jiraCustomFieldConfig);
 
         if(jiraCustomFieldConfig.isTreatValueAsJson()) {
-            return JsonParser.parseString(innerFieldValue);
+            try {
+                return JsonParser.parseString(innerFieldValue);
+            } catch (JsonSyntaxException ex) {
+                throw new AlertRuntimeException(String.format("Invalid JSON value for field: %s error: %s", jiraCustomFieldConfig.getFieldName(), ex.getMessage()));
+            }
         } else {
             switch (fieldType) {
                 case CUSTOM_FIELD_TYPE_STRING_VALUE:

--- a/api-channel-jira/src/test/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldConfigTest.java
+++ b/api-channel-jira/src/test/java/com/blackduck/integration/alert/api/channel/jira/distribution/custom/JiraCustomFieldConfigTest.java
@@ -23,6 +23,7 @@ public class JiraCustomFieldConfigTest {
 
         assertEquals(fieldName, jiraCustomFieldConfig.getFieldName());
         assertEquals(fieldOriginalValue, jiraCustomFieldConfig.getFieldOriginalValue());
+        assertFalse(jiraCustomFieldConfig.isTreatValueAsJson());
     }
 
     @Test
@@ -41,5 +42,11 @@ public class JiraCustomFieldConfigTest {
         jiraCustomFieldConfig.setFieldReplacementValue(null);
 
         assertFalse(jiraCustomFieldConfig.getFieldReplacementValue().isPresent());
+    }
+
+    @Test
+    public void treatValueAsJsonTest() {
+        JiraCustomFieldConfig jiraCustomFieldConfig = new JiraCustomFieldConfig(fieldName, fieldOriginalValue, true);
+        assertTrue(jiraCustomFieldConfig.isTreatValueAsJson());
     }
 }

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/accessor/DefaultJiraServerJobDetailsAccessor.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/accessor/DefaultJiraServerJobDetailsAccessor.java
@@ -10,7 +10,6 @@ package com.blackduck.integration.alert.channel.jira.server.database.accessor;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -78,7 +77,7 @@ public class DefaultJiraServerJobDetailsAccessor implements JiraServerJobDetails
         jiraServerJobCustomFieldRepository.bulkDeleteByJobId(jobId);
         List<JiraServerJobCustomFieldEntity> customFieldsToSave = jobDetails.getCustomFields()
             .stream()
-            .map(model -> new JiraServerJobCustomFieldEntity(savedJobDetails.getJobId(), model.getFieldName(), model.getFieldValue(), model.isCreateJsonObject()))
+            .map(model -> new JiraServerJobCustomFieldEntity(savedJobDetails.getJobId(), model.getFieldName(), model.getFieldValue(), model.isTreatValueAsJson()))
             .toList();
         List<JiraServerJobCustomFieldEntity> savedJobCustomFields = jiraServerJobCustomFieldRepository.saveAll(customFieldsToSave);
         savedJobDetails.setJobCustomFields(savedJobCustomFields);
@@ -88,7 +87,7 @@ public class DefaultJiraServerJobDetailsAccessor implements JiraServerJobDetails
     private JiraServerJobDetailsModel convertToModel(JiraServerJobDetailsEntity jobDetails) {
         List<JiraJobCustomFieldModel> customFields = jiraServerJobCustomFieldRepository.findByJobId(jobDetails.getJobId())
             .stream()
-            .map(entity -> new JiraJobCustomFieldModel(entity.getFieldName(), entity.getFieldValue(), entity.isCreateJsonObject()))
+            .map(entity -> new JiraJobCustomFieldModel(entity.getFieldName(), entity.getFieldValue(), entity.isTreatValueAsJson()))
             .toList();
         return new JiraServerJobDetailsModel(
             jobDetails.getJobId(),

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/accessor/DefaultJiraServerJobDetailsAccessor.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/accessor/DefaultJiraServerJobDetailsAccessor.java
@@ -78,7 +78,7 @@ public class DefaultJiraServerJobDetailsAccessor implements JiraServerJobDetails
         jiraServerJobCustomFieldRepository.bulkDeleteByJobId(jobId);
         List<JiraServerJobCustomFieldEntity> customFieldsToSave = jobDetails.getCustomFields()
             .stream()
-            .map(model -> new JiraServerJobCustomFieldEntity(savedJobDetails.getJobId(), model.getFieldName(), model.getFieldValue()))
+            .map(model -> new JiraServerJobCustomFieldEntity(savedJobDetails.getJobId(), model.getFieldName(), model.getFieldValue(), model.isCreateJsonObject()))
             .collect(Collectors.toList());
         List<JiraServerJobCustomFieldEntity> savedJobCustomFields = jiraServerJobCustomFieldRepository.saveAll(customFieldsToSave);
         savedJobDetails.setJobCustomFields(savedJobCustomFields);

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/accessor/DefaultJiraServerJobDetailsAccessor.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/accessor/DefaultJiraServerJobDetailsAccessor.java
@@ -79,7 +79,7 @@ public class DefaultJiraServerJobDetailsAccessor implements JiraServerJobDetails
         List<JiraServerJobCustomFieldEntity> customFieldsToSave = jobDetails.getCustomFields()
             .stream()
             .map(model -> new JiraServerJobCustomFieldEntity(savedJobDetails.getJobId(), model.getFieldName(), model.getFieldValue(), model.isCreateJsonObject()))
-            .collect(Collectors.toList());
+            .toList();
         List<JiraServerJobCustomFieldEntity> savedJobCustomFields = jiraServerJobCustomFieldRepository.saveAll(customFieldsToSave);
         savedJobDetails.setJobCustomFields(savedJobCustomFields);
         return convertToModel(savedJobDetails);
@@ -88,8 +88,8 @@ public class DefaultJiraServerJobDetailsAccessor implements JiraServerJobDetails
     private JiraServerJobDetailsModel convertToModel(JiraServerJobDetailsEntity jobDetails) {
         List<JiraJobCustomFieldModel> customFields = jiraServerJobCustomFieldRepository.findByJobId(jobDetails.getJobId())
             .stream()
-            .map(entity -> new JiraJobCustomFieldModel(entity.getFieldName(), entity.getFieldValue()))
-            .collect(Collectors.toList());
+            .map(entity -> new JiraJobCustomFieldModel(entity.getFieldName(), entity.getFieldValue(), entity.isCreateJsonObject()))
+            .toList();
         return new JiraServerJobDetailsModel(
             jobDetails.getJobId(),
             jobDetails.getAddComments(),

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/job/custom_field/JiraServerJobCustomFieldEntity.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/job/custom_field/JiraServerJobCustomFieldEntity.java
@@ -30,17 +30,17 @@ public class JiraServerJobCustomFieldEntity {
     @Column(name = "field_value")
     private String fieldValue;
 
-    @Column(name = "create_json_object")
-    private boolean createJsonObject;
+    @Column(name = "treat_value_as_json")
+    private boolean treatValueAsJson;
 
     public JiraServerJobCustomFieldEntity() {
     }
 
-    public JiraServerJobCustomFieldEntity(UUID jobId, String fieldName, String fieldValue, boolean createJsonObject) {
+    public JiraServerJobCustomFieldEntity(UUID jobId, String fieldName, String fieldValue, boolean treatValueAsJson) {
         this.jobId = jobId;
         this.fieldName = fieldName;
         this.fieldValue = fieldValue;
-        this.createJsonObject = createJsonObject;
+        this.treatValueAsJson = treatValueAsJson;
     }
 
     public UUID getJobId() {
@@ -55,8 +55,8 @@ public class JiraServerJobCustomFieldEntity {
         return fieldValue;
     }
 
-    public boolean isCreateJsonObject() {
-        return createJsonObject;
+    public boolean isTreatValueAsJson() {
+        return treatValueAsJson;
     }
 
 }

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/job/custom_field/JiraServerJobCustomFieldEntity.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/job/custom_field/JiraServerJobCustomFieldEntity.java
@@ -30,13 +30,17 @@ public class JiraServerJobCustomFieldEntity {
     @Column(name = "field_value")
     private String fieldValue;
 
+    @Column(name = "create_object_json")
+    private boolean createJsonObject;
+
     public JiraServerJobCustomFieldEntity() {
     }
 
-    public JiraServerJobCustomFieldEntity(UUID jobId, String fieldName, String fieldValue) {
+    public JiraServerJobCustomFieldEntity(UUID jobId, String fieldName, String fieldValue, boolean createJsonObject) {
         this.jobId = jobId;
         this.fieldName = fieldName;
         this.fieldValue = fieldValue;
+        this.createJsonObject = createJsonObject;
     }
 
     public UUID getJobId() {
@@ -49,6 +53,10 @@ public class JiraServerJobCustomFieldEntity {
 
     public String getFieldValue() {
         return fieldValue;
+    }
+
+    public boolean isCreateJsonObject() {
+        return createJsonObject;
     }
 
 }

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/job/custom_field/JiraServerJobCustomFieldEntity.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/job/custom_field/JiraServerJobCustomFieldEntity.java
@@ -30,7 +30,7 @@ public class JiraServerJobCustomFieldEntity {
     @Column(name = "field_value")
     private String fieldValue;
 
-    @Column(name = "create_object_json")
+    @Column(name = "create_json_object")
     private boolean createJsonObject;
 
     public JiraServerJobCustomFieldEntity() {

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/database/accessor/JiraServerJobDetailsAccessorTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/database/accessor/JiraServerJobDetailsAccessorTest.java
@@ -105,6 +105,6 @@ class JiraServerJobDetailsAccessorTest {
     }
 
     private List<JiraServerJobCustomFieldEntity> createCustomFieldEntities(UUID jobID) {
-        return List.of(new JiraServerJobCustomFieldEntity(jobID, "customField", "customFieldValue"));
+        return List.of(new JiraServerJobCustomFieldEntity(jobID, "customField", "customFieldValue", false));
     }
 }

--- a/ui/src/main/js/page/channel/jira/common/FieldMappingModal.js
+++ b/ui/src/main/js/page/channel/jira/common/FieldMappingModal.js
@@ -6,7 +6,7 @@ import Checkbox from "../../../../common/component/input/Checkbox";
 import CheckboxInput from "../../../../common/component/input/CheckboxInput";
 
 const FieldMappingModal = ({ tableData, selectedData, selectedIndex, isOpen, toggleModal, modalOptions, updateTableData }) => {
-    const [model, setModel] = useState(selectedData || { fieldName: '', fieldValue: '', createJsonObject: false });
+    const [model, setModel] = useState(selectedData || { fieldName: '', fieldValue: '', treatValueAsJson: false });
     const { title, type } = modalOptions;
 
     function handleClose() {
@@ -60,10 +60,11 @@ const FieldMappingModal = ({ tableData, selectedData, selectedIndex, isOpen, tog
             />
             <CheckboxInput
                 id="jira-value-json"
-                name="createJsonObject"
-                label="Always create JSON object"
+                name="treatValueAsJson"
+                label="Treat value as JSON"
+                description="If checked, Alert will treat the value as a JSON object or JSON Array.  This overrides any custom field processing that Alert does by inspecting the custom field type.  Alert will parse the value as JSON and send the JSON as the value for the custom field. "
                 onChange={handleCheckBoxChange}
-                isChecked={model.createJsonObject}
+                isChecked={model.treatValueAsJson}
             />
         </Modal>
     );

--- a/ui/src/main/js/page/channel/jira/common/FieldMappingModal.js
+++ b/ui/src/main/js/page/channel/jira/common/FieldMappingModal.js
@@ -3,10 +3,13 @@ import PropTypes from 'prop-types';
 import Modal from 'common/component/modal/Modal';
 import TextInput from 'common/component/input/TextInput';
 import CheckboxInput from "../../../../common/component/input/CheckboxInput";
+import ReadOnlyField from "../../../../common/component/input/field/ReadOnlyField";
 
 const FieldMappingModal = ({ tableData, selectedData, selectedIndex, isOpen, toggleModal, modalOptions, updateTableData }) => {
     const [model, setModel] = useState(selectedData || { fieldName: '', fieldValue: '', treatValueAsJson: false });
     const { title, type } = modalOptions;
+    const submitText = type === 'EDIT' ? 'Update' : 'Add';
+
 
     function handleClose() {
         toggleModal(false);
@@ -41,15 +44,25 @@ const FieldMappingModal = ({ tableData, selectedData, selectedIndex, isOpen, tog
             closeModal={handleClose}
             handleCancel={handleClose}
             handleSubmit={() => handleSubmit()}
-            submitText="Add"
+            submitText={submitText}
         >
-            <TextInput
-                id="jira-field-input"
-                name="fieldName"
-                label="Jira Field"
-                onChange={handleChange}
-                value={model.fieldName}
-            />
+            {type === 'EDIT' ? (
+                <ReadOnlyField
+                    id="jira-field-input"
+                    name="fieldName"
+                    label="Jira Field"
+                    value={model.fieldName}
+                />
+            ) : (
+                <TextInput
+                    id="jira-field-input"
+                    name="fieldName"
+                    label="Jira Field"
+                    onChange={handleChange}
+                    value={model.fieldName}
+                />
+            )}
+
             <TextInput
                 id="jira-value-input"
                 name="fieldValue"
@@ -60,8 +73,8 @@ const FieldMappingModal = ({ tableData, selectedData, selectedIndex, isOpen, tog
             <CheckboxInput
                 id="jira-value-json"
                 name="treatValueAsJson"
-                label="Treat value as JSON"
-                description="If checked, Alert will treat the value as a JSON object or JSON Array.  This overrides any custom field processing that Alert does by inspecting the custom field type.  Alert will parse the value as JSON and send the JSON as the value for the custom field. "
+                label="Treat Value as JSON"
+                customDescription="If checked, Alert will parse the value as JSON and send the JSON as the content for the custom field. This overrides any custom field processing that Alert does by inspecting the custom field type."
                 onChange={handleCheckBoxChange}
                 isChecked={model.treatValueAsJson}
             />

--- a/ui/src/main/js/page/channel/jira/common/FieldMappingModal.js
+++ b/ui/src/main/js/page/channel/jira/common/FieldMappingModal.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'common/component/modal/Modal';
 import TextInput from 'common/component/input/TextInput';
-import Checkbox from "../../../../common/component/input/Checkbox";
 import CheckboxInput from "../../../../common/component/input/CheckboxInput";
 
 const FieldMappingModal = ({ tableData, selectedData, selectedIndex, isOpen, toggleModal, modalOptions, updateTableData }) => {

--- a/ui/src/main/js/page/channel/jira/common/FieldMappingModal.js
+++ b/ui/src/main/js/page/channel/jira/common/FieldMappingModal.js
@@ -2,9 +2,11 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'common/component/modal/Modal';
 import TextInput from 'common/component/input/TextInput';
+import Checkbox from "../../../../common/component/input/Checkbox";
+import CheckboxInput from "../../../../common/component/input/CheckboxInput";
 
 const FieldMappingModal = ({ tableData, selectedData, selectedIndex, isOpen, toggleModal, modalOptions, updateTableData }) => {
-    const [model, setModel] = useState(selectedData || { fieldName: '', fieldValue: '' });
+    const [model, setModel] = useState(selectedData || { fieldName: '', fieldValue: '', createJsonObject: false });
     const { title, type } = modalOptions;
 
     function handleClose() {
@@ -27,6 +29,10 @@ const FieldMappingModal = ({ tableData, selectedData, selectedIndex, isOpen, tog
     const handleChange = (e) => {
         setModel({ ...model, [e.target.name]: e.target.value });
     };
+
+    const handleCheckBoxChange = (e) => {
+        setModel({...model, [e.target.name]:e.target.checked});
+    }
 
     return (
         <Modal
@@ -51,6 +57,13 @@ const FieldMappingModal = ({ tableData, selectedData, selectedIndex, isOpen, tog
                 label="Value"
                 onChange={handleChange}
                 value={model.fieldValue}
+            />
+            <CheckboxInput
+                id="jira-value-json"
+                name="createJsonObject"
+                label="Always create JSON object"
+                onChange={handleCheckBoxChange}
+                isChecked={model.createJsonObject}
             />
         </Modal>
     );

--- a/ui/src/main/js/page/channel/jira/common/JiraFieldAlwaysCreateJsonCell.js
+++ b/ui/src/main/js/page/channel/jira/common/JiraFieldAlwaysCreateJsonCell.js
@@ -14,11 +14,11 @@ const useStyles = createUseStyles({
 
 const JiraFieldAlwaysCreateJsonCell = ({ data }) => {
     const classes = useStyles();
-    const { createJsonObject } = data;
+    const { treatValueAsJson } = data;
 
     return (
-        <div className={createJsonObject ? classes.enabled : classes.disabled}>
-            <FontAwesomeIcon icon={createJsonObject ? 'check' : 'times'} />
+        <div className={treatValueAsJson ? classes.enabled : classes.disabled}>
+            <FontAwesomeIcon icon={treatValueAsJson ? 'check' : 'times'} />
         </div>
 
     );
@@ -26,7 +26,7 @@ const JiraFieldAlwaysCreateJsonCell = ({ data }) => {
 
 JiraFieldAlwaysCreateJsonCell.propTypes = {
     data: PropTypes.shape({
-        createJsonObject: PropTypes.bool
+        treatValueAsJson: PropTypes.bool
     })
 };
 

--- a/ui/src/main/js/page/channel/jira/common/JiraFieldAlwaysCreateJsonCell.js
+++ b/ui/src/main/js/page/channel/jira/common/JiraFieldAlwaysCreateJsonCell.js
@@ -1,0 +1,33 @@
+import {createUseStyles} from "react-jss";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import PropTypes from "prop-types";
+import React from "react";
+
+const useStyles = createUseStyles({
+    enabled: {
+        color: 'green'
+    },
+    disabled: {
+        color: 'red'
+    }
+});
+
+const JiraFieldAlwaysCreateJsonCell = ({ data }) => {
+    const classes = useStyles();
+    const { createJsonObject } = data;
+
+    return (
+        <div className={createJsonObject ? classes.enabled : classes.disabled}>
+            <FontAwesomeIcon icon={createJsonObject ? 'check' : 'times'} />
+        </div>
+
+    );
+};
+
+JiraFieldAlwaysCreateJsonCell.propTypes = {
+    data: PropTypes.shape({
+        createJsonObject: PropTypes.bool
+    })
+};
+
+export default JiraFieldAlwaysCreateJsonCell;

--- a/ui/src/main/js/page/channel/jira/common/JiraFieldMapDistributionTable.js
+++ b/ui/src/main/js/page/channel/jira/common/JiraFieldMapDistributionTable.js
@@ -12,14 +12,13 @@ const emptyTableConfig = {
 const JiraFieldMapDistributionTable = ({ initialData, onFieldMappingUpdate }) => {
     const [tableData, setTableData] = useState(initialData);
     const [selected, setSelected] = useState([]);
-    const [data, setData] = useState();
 
     useEffect(() => {
         onFieldMappingUpdate(tableData);
     }, [tableData]);
 
     function handleEditData(editedData) {
-        setData(editedData);
+        onFieldMappingUpdate(editedData)
     }
 
     const COLUMNS = [{

--- a/ui/src/main/js/page/channel/jira/common/JiraFieldMapDistributionTable.js
+++ b/ui/src/main/js/page/channel/jira/common/JiraFieldMapDistributionTable.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Table from 'common/component/table/Table';
 import JiraFieldMapEditCell from 'page/channel/jira/common/JiraFieldMapEditCell';
 import JiraFieldMapTableActions from 'page/channel/jira/common/JiraFieldMapTableActions';
+import JiraFieldAlwaysCreateJsonCell from "./JiraFieldAlwaysCreateJsonCell";
 
 const emptyTableConfig = {
     message: 'There are no records to display for this table.  Please add a Jira field mapping to use this table.'
@@ -29,6 +30,12 @@ const JiraFieldMapDistributionTable = ({ initialData, onFieldMappingUpdate }) =>
         key: 'fieldValue',
         label: 'Value',
         sortable: true
+    }, {
+        key: 'createJsonObject',
+        label: 'Always create JSON Object',
+        sortable: false,
+        customCell: JiraFieldAlwaysCreateJsonCell,
+        settings: { alignment: 'center' }
     }, {
         key: 'editJiraCloudFieldMapping',
         label: 'Edit',

--- a/ui/src/main/js/page/channel/jira/common/JiraFieldMapDistributionTable.js
+++ b/ui/src/main/js/page/channel/jira/common/JiraFieldMapDistributionTable.js
@@ -32,7 +32,7 @@ const JiraFieldMapDistributionTable = ({ initialData, onFieldMappingUpdate }) =>
         sortable: true
     }, {
         key: 'createJsonObject',
-        label: 'Always create JSON Object',
+        label: 'Treat Value as JSON',
         sortable: false,
         customCell: JiraFieldAlwaysCreateJsonCell,
         settings: { alignment: 'center' }


### PR DESCRIPTION
# Problem
Add a checkbox to indicate that the value for the custom field should be serialized as a JSON element when sent as a value for a custom field.  This overrides the inspection of the custom field type done by Alert to create JSON content for  custom fields that match the defined type.  This is because when a custom field has a type of any the implementation of the custom field controls what the REST API accepts as a value for the type.  When this checkbox is selected the value is assumed to be a valid JSON string that can be parsed into a JSON object or JSON array.

In order to provide this functionality the following was needed:

1. Add a new database column
2. Change the models the accessor to include the new field
3. Change the UI to display a checkbox in the custom field modal
4. Make the edit modal have the custom field name be read only
5. Change the save button to Update when editing a custom field
6. Fix an issue where editing a custom field would not persist and the custom field had to be deleted to be applied.

# Validation
- Updated the `JiraFieldMappingValidator` class to parse the value of fields with the `treatValueAsJson` set to true.
- Create a field error message indicating which fields are invalid
- Log a message to indicate which fields are invalid

```
JiraFieldMappingValidator : Custom Field Validation error: Invalid JSON value field name(s): Alert Object Custom Field
```

# User Interface Changes:
The user interface changes are described here.

## Add Custom Field Dialog:

- Added checkbox override to parse the value as JSON and serialize the JSON as the value for the custom field.
- By default the checkbox is false so the original processing of custom fields still applies.

<img width="909" alt="custom_field_add" src="https://github.com/user-attachments/assets/477a45fe-ed2a-487a-acd0-fbfff8d5cb90" />



## Update Custom Field Dialog:
- Make the field name read only.
- Change the submit button for the modal to have the text 'Update'

<img width="908" alt="custom_field_update" src="https://github.com/user-attachments/assets/6c41d189-29e1-4e63-96f2-c631e9746981" />


## Custom Field Mapping Table:
- Added a column to display if the Treat value as JSON override is selected
- Fixed a bug where you cannot edit existing values and would have to delete and re-add the custom field

<img width="1594" alt="custom_field_table" src="https://github.com/user-attachments/assets/22bb0db2-2ff8-4733-bf44-2f469ded6f10" />



