### PR TITLE
IALERT-3312 - Include subPath in values.yaml with defaults

### DIFF
--- a/deployment/helm/blackduck-alert/values.yaml
+++ b/deployment/helm/blackduck-alert/values.yaml
@@ -79,7 +79,8 @@ postgres:
   storageClass: "" # PVC storage class name
   volumeName: "" # existing persistent volume name backing the PVC
   volumeMounts:
-    - mountPath: /var/lib/postgresql/data
+    - mountPath: /var/lib/postgresql
+      subPath: data
       name: alert-postgres-data-volume
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
The logic to handle subPath was added to `templates/postgres.yaml`, but we weren't adding this to values.yaml with a default. Adjust the implementation to do this, but still have the final directory that the PV/PVC points at is ultimately the same thing. 
To see the original change, see this MR --> [https://github.com/blackducksoftware/blackduck-alert/pull/2650/files](https://github.com/blackducksoftware/blackduck-alert/pull/2650/files)