### PR TITLE
IALERT-3811: Stop User from Adding Duplicate Descriptors When Creating Roles

### DIFF
--- a/ui/src/main/js/page/usermgmt/roles/PermissionTable.js
+++ b/ui/src/main/js/page/usermgmt/roles/PermissionTable.js
@@ -12,7 +12,7 @@ const emptyTableConfig = {
     message: 'There are no records to display for this table.  Please create a Permission above to use this table.'
 };
 
-const PermissionTable = ({ role, sendPermissionArray, handleFilterPermission }) => {
+const PermissionTable = ({ role, sendPermissionArray, handleFilterPermission, setCustomValidationMessage }) => {
     const permissionData = role.permissions;
 
     const descriptors = useSelector((state) => state.descriptors.items);
@@ -56,7 +56,12 @@ const PermissionTable = ({ role, sendPermissionArray, handleFilterPermission }) 
             tableData={role.permissions}
             columns={COLUMNS}
             emptyTableConfig={emptyTableConfig}
-            tableActions={() => <PermissionTableActions data={role} canDelete={canDelete} handleValidatePermission={handleValidatePermission} />}
+            tableActions={() => <PermissionTableActions 
+                data={role}
+                canDelete={canDelete}
+                handleValidatePermission={handleValidatePermission}
+                setCustomValidationMessage={setCustomValidationMessage}
+            />}
         />
     );
 };
@@ -94,6 +99,7 @@ PermissionTable.propTypes = {
         })
     }),
     sendPermissionArray: PropTypes.func,
+    setCustomValidationMessage: PropTypes.func,
     handleFilterPermission: PropTypes.func
 };
 

--- a/ui/src/main/js/page/usermgmt/roles/PermissionTableActions.js
+++ b/ui/src/main/js/page/usermgmt/roles/PermissionTableActions.js
@@ -31,7 +31,7 @@ const useStyles = createUseStyles({
     }
 });
 
-const PermissionTableActions = ({ handleValidatePermission }) => {
+const PermissionTableActions = ({ data, handleValidatePermission, setCustomValidationMessage }) => {
     const classes = useStyles();
     const CONTEXT = 'context';
     const DESCRIPTOR = 'descriptorName';
@@ -90,8 +90,18 @@ const PermissionTableActions = ({ handleValidatePermission }) => {
         setNewPermission((permission) => ({ ...permission, [name]: selectedValue.name, label: value[0] }));
     }
 
+    function checkIfDescriptorExists(descriptorName, existingPermissions) {
+        return existingPermissions.some((permission) => permission.descriptorName === descriptorName);
+    }
+    
     function handleSave(permission) {
-        if (!permission[DESCRIPTOR] && !permission[CONTEXT]) {
+        setCustomValidationMessage();
+
+        if (checkIfDescriptorExists(permission.descriptorName, data.permissions)) {
+            setCustomValidationMessage({
+                message: 'Cannot have duplicate descriptors. Please select a different \'Descriptor Name\'.',
+            })
+        } else if (!permission[DESCRIPTOR] && !permission[CONTEXT]) {
             setFieldErrors({
                 descriptorName: {
                     fieldMessage: 'Descriptor is required',
@@ -207,7 +217,13 @@ const PermissionTableActions = ({ handleValidatePermission }) => {
 };
 
 PermissionTableActions.propTypes = {
-    handleValidatePermission: PropTypes.func
+    data: PropTypes.shape({
+        permissions: PropTypes.arrayOf(PropTypes.shape({
+            descriptorName: PropTypes.string
+        }))
+    }),
+    handleValidatePermission: PropTypes.func,
+    setCustomValidationMessage: PropTypes.func,
 };
 
 export default PermissionTableActions;

--- a/ui/src/main/js/page/usermgmt/roles/RoleModal.js
+++ b/ui/src/main/js/page/usermgmt/roles/RoleModal.js
@@ -7,6 +7,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Modal from 'common/component/modal/Modal';
 import TextInput from 'common/component/input/TextInput';
 import PermissionTable from 'page/usermgmt/roles/PermissionTable';
+import Alert from 'react-bootstrap/Alert';
+import MessageFormatter from 'common/component/MessageFormatter';
 
 const useStyles = createUseStyles({
     descriptorContainer: {
@@ -31,6 +33,7 @@ const RoleModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
     const { copyDescription, type, title, submitText } = modalOptions;
     const [role, setRole] = useState(type === 'CREATE' ? { permissions: [] } : data);
     const [showLoader, setShowLoader] = useState(false);
+    const [customValidationMessage, setCustomValidationMessage] = useState();
 
     const ROLE_NAME_KEY = 'roleName';
 
@@ -123,6 +126,14 @@ const RoleModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
             submitText={submitText}
             showLoader={showLoader}
         >
+            { customValidationMessage && (
+                <Alert
+                    bsPrefix="alert"
+                    variant="danger"
+                >
+                    <MessageFormatter message={customValidationMessage.message} />
+                </Alert>
+            )}
             { type === 'COPY' && (
                 <div className={classes.descriptorContainer}>
                     <FontAwesomeIcon icon="exclamation-circle" size="2x" />
@@ -143,7 +154,12 @@ const RoleModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
                 errorValue={error.fieldErrors[ROLE_NAME_KEY]}
             />
             <div className={classes.permissionTable}>
-                <PermissionTable role={role} sendPermissionArray={getPermissionArray} handleFilterPermission={handleFilterPermission} />
+                <PermissionTable
+                    role={role}
+                    handleFilterPermission={handleFilterPermission} 
+                    sendPermissionArray={getPermissionArray}
+                    setCustomValidationMessage={setCustomValidationMessage}
+                />
             </div>
         </Modal>
     );


### PR DESCRIPTION
# Bug Description
When a user creates a role in the UI, we currently allow them to add as many permissions with as many descriptors as they want, regardless of if there are duplicate descriptors.  If a user then tries to remove a permission, we will remove all permissions that match the descriptor name.  This happens because we remove a permission based on the descriptor name (**That is the bug**).  The catch all is that a user should not be allowed to add duplicate descriptors, as the validation will fail and a message will show, letting the user know this cannot happen.

# Fix Description
To fix this, the UI will proactively check if there are duplicate descriptors and not allow the user to add a second descriptor if this is the case.  We now will show a validation message inside of the modal that lets the user know this (see screenshot).

# Technical Description of the Fix
I added in an `<Alert>` component to the top of the modal that will only show if `checkIfDescriptorExists()` returns true.  
  
![Screenshot 2025-05-15 at 4 34 39 PM](https://github.com/user-attachments/assets/e5ca15a8-1f63-4b73-bc96-47941f4a4a56)


