### PR TITLE
Address docker build warnings

### DIFF
--- a/docker/blackduck-alert-db/Dockerfile
+++ b/docker/blackduck-alert-db/Dockerfile
@@ -1,7 +1,7 @@
 # The ARG for the FROM image comes from Gradle. It is based off of postgresContainerVersion,
 # and used in buildSrc/docker.gradle
-ARG POSTGRESIMAGEVERSION_MIGRATION=""
-ARG POSTGRESIMAGEVERSION=""
+ARG POSTGRESIMAGEVERSION_MIGRATION="default"
+ARG POSTGRESIMAGEVERSION="default"
 
 FROM ${POSTGRESIMAGEVERSION_MIGRATION} AS old
 
@@ -9,8 +9,8 @@ FROM ${POSTGRESIMAGEVERSION}
 
 COPY --from=old /usr/local /usr/local-old
 
-ENV PGBINOLD /usr/local-old/bin
-ENV PGBINNEW /usr/local/bin
+ENV PGBINOLD=/usr/local-old/bin
+ENV PGBINNEW=/usr/local/bin
 
 ARG VERSION
 ARG COMMITHASH

--- a/docker/blackduck-alert-rabbitmq/Dockerfile
+++ b/docker/blackduck-alert-rabbitmq/Dockerfile
@@ -1,4 +1,4 @@
-FROM blackducksoftware/hub-docker-common:1.0.7 as docker-common
+FROM blackducksoftware/hub-docker-common:1.0.7 AS docker-common
 FROM rabbitmq:3.13-alpine
 
 ARG VERSION
@@ -12,8 +12,8 @@ ENV BLACKDUCK_HOME="/opt/blackduck"
 ENV APPLICATION_NAME="rabbitmq"
 ENV APPLICATION_HOME="$BLACKDUCK_HOME/$APPLICATION_NAME"
 ENV RABBITMQ_HOME="/etc/rabbitmq"
-ENV SECURITY_DIR $APPLICATION_HOME/security
-ENV CERTIFICATE_MANAGER_DIR $APPLICATION_HOME/bin
+ENV SECURITY_DIR=$APPLICATION_HOME/security
+ENV CERTIFICATE_MANAGER_DIR=$APPLICATION_HOME/bin
 
 RUN set -ex \
     && mkdir -p -m 775 "$APPLICATION_HOME/bin" "$APPLICATION_HOME/security" "$APPLICATION_HOME/logs" \

--- a/docker/blackduck-alert/Dockerfile
+++ b/docker/blackduck-alert/Dockerfile
@@ -1,4 +1,4 @@
-FROM blackducksoftware/hub-docker-common:1.0.7 as docker-common
+FROM blackducksoftware/hub-docker-common:1.0.7 AS docker-common
 FROM alpine:3.20
 
 ARG VERSION
@@ -8,19 +8,19 @@ LABEL com.blackducksoftware.integration.alert.vendor="Black Duck Software, Inc."
       com.blackducksoftware.integration.alert.version="$VERSION" \
       com.blackducksoftware.integration.alert.commitHash="$COMMITHASH"
 
-ENV ALERT_HOME /opt/blackduck/alert
-ENV ALERT_TAR_HOME $ALERT_HOME/alert-tar
-ENV ALERT_IMAGES_DIR $ALERT_TAR_HOME/images
-ENV ALERT_CONFIG_HOME $ALERT_HOME/alert-config
-ENV ALERT_DATA_DIR $ALERT_CONFIG_HOME/data
-ENV ALERT_MAX_HEAP_SIZE 2048m
+ENV ALERT_HOME=/opt/blackduck/alert
+ENV ALERT_TAR_HOME=$ALERT_HOME/alert-tar
+ENV ALERT_IMAGES_DIR=$ALERT_TAR_HOME/images
+ENV ALERT_CONFIG_HOME=$ALERT_HOME/alert-config
+ENV ALERT_DATA_DIR=$ALERT_CONFIG_HOME/data
+ENV ALERT_MAX_HEAP_SIZE=2048m
 
-ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk
-ENV PATH $JAVA_HOME/bin:$ALERT_TAR_HOME/bin:$PATH
-ENV CERTIFICATE_MANAGER_DIR $ALERT_HOME/bin
-ENV SECURITY_DIR $ALERT_HOME/security
-ENV DEFAULT_BLACKDUCK_ALERT_OPTS -Djava.security.properties=${SECURITY_DIR}/java.security
-ENV APPLICATION_NAME blackduck-alert
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+ENV PATH=$JAVA_HOME/bin:$ALERT_TAR_HOME/bin:$PATH
+ENV CERTIFICATE_MANAGER_DIR=$ALERT_HOME/bin
+ENV SECURITY_DIR=$ALERT_HOME/security
+ENV DEFAULT_BLACKDUCK_ALERT_OPTS=-Djava.security.properties=${SECURITY_DIR}/java.security
+ENV APPLICATION_NAME=blackduck-alert
 
 RUN set -ex \
     && mkdir -p -m 775 $ALERT_CONFIG_HOME $ALERT_TAR_HOME $ALERT_DATA_DIR $CERTIFICATE_MANAGER_DIR \


### PR DESCRIPTION
Address the docker build warnings listed below before they become build failures.


**blackduck-alert-db**
```
 4 warnings found (use docker --debug to expand):
 - InvalidDefaultArgInFrom: Default value for ARG ${POSTGRESIMAGEVERSION_MIGRATION} results in empty or invalid base image name (line 6)
 - InvalidDefaultArgInFrom: Default value for ARG ${POSTGRESIMAGEVERSION} results in empty or invalid base image name (line 8)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 12)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 13)
```

**blackduck-alert-rabbitmq**
```
 3 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 15)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 16)
```

**blackduck-alert**
```
 13 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 12)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 18)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 19)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 23)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 22)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 11)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 13)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 14)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 15)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 16)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 20)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 21)
```