### PR TITLE
IALERT-3808: Create User Field Validation

### DIFF
--- a/ui/src/main/js/page/usermgmt/user/UserModal.js
+++ b/ui/src/main/js/page/usermgmt/user/UserModal.js
@@ -41,7 +41,7 @@ const UserModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
     const messageContainerClass = classNames(classes.messageContainer, {
         [classes.warningStyle]: type === 'EDIT'
     });
-    const [confirmPassword, setConfirmPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState();
     const [confirmPasswordError, setConfirmPasswordError] = useState({});
 
     const fieldErrors = useSelector((state) => state.users.error.fieldErrors);
@@ -84,7 +84,6 @@ const UserModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
     }
 
     useEffect(() => {
-        console.log(saveStatus);
         if (saveStatus === 'VALIDATING' || saveStatus === 'SAVING') {
             setShowLoader(true);
         }
@@ -129,6 +128,7 @@ const UserModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
             closeModal={handleClose}
             handleCancel={handleClose}
             handleSubmit={handleSubmit}
+            disableSubmit={!userModel[USER_INPUT_FIELD_KEYS.PASSWORD_KEY] || !confirmPassword}
             submitText={submitText}
             showLoader={showLoader}
             noOverflow


### PR DESCRIPTION
# Bug Description
When a user attempts to create a user, but does not enter any information into the fields, the network request returns a 500 but the form field errors do not appear.  This happens because the design of the endpoint.  The request will not be successful if the password fields do not have values.  Because of this, the form validation never occurs.  As a side note, if the user places any values into the password/confirm password fields and submits the form, then the form validation will occur thus showing the proper field errors.  
  
# Fix Description 
So as to not change anything on the BE, the UI will now proactively check if the password/confirm password fields contain values. In the event that they do not, we will disable the ability to submit the form (the 'Create' button will be disabled in the modal). While this is not a pattern I'd like to replicate in other areas of the UI, I believe this is the best option at the time without disrupting the BE code.  
  
# Technical Description of the Fix
The line `disableSubmit={!userModel[USER_INPUT_FIELD_KEYS.PASSWORD_KEY] || !confirmPassword}` determines if the user has placed any values in both the Password and Confirm Password fields.  If this returns true, it means that they have not placed any values there and we should disable the ability to create a user. 
  
![Screenshot 2025-05-16 at 3 30 39 PM](https://github.com/user-attachments/assets/a548278f-2c0f-4529-85a3-a9023044b41d)