### PR TITLE
IALERT-3806: Ensure SAML Config Modal Renders on Screen

### DIFF
--- a/ui/src/main/js/application/auth/SamlForm.js
+++ b/ui/src/main/js/application/auth/SamlForm.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { createUseStyles } from 'react-jss';
 
 import { AUTHENTICATION_SAML_GLOBAL_FIELD_KEYS } from 'application/auth/AuthenticationModel';
+import { BLACKDUCK_INFO } from 'page/provider/blackduck/BlackDuckModel';
+import { CONTEXT_TYPE } from 'common/util/descriptorUtilities';
 
 import CollapsiblePane from 'common/component/CollapsiblePane';
 import ConcreteConfigurationForm from 'common/configuration/global/concrete/ConcreteConfigurationForm';
@@ -49,6 +51,8 @@ const SamlForm = ({ csrfToken, errorHandler, readonly, fileDelete, fileRead, fil
     const [formData, setFormData] = useState({});
     const [errors, setErrors] = useState(HttpErrorUtilities.createEmptyErrorObject());
     const [showBlackDuckSSOImportModal, setShowBlackDuckSSOImportModal] = useState(false);
+    const [providerModel, setProviderModel] = useState(FieldModelUtilities.createEmptyFieldModel([], CONTEXT_TYPE.DISTRIBUTION, BLACKDUCK_INFO.key));
+
     const [triggerClearUploaded, setTriggerClearUploaded] = useState(false);
     const samlRequestUrl = `${ConfigurationRequestBuilder.AUTHENTICATION_SAML_API_URL}`;
 
@@ -84,6 +88,10 @@ const SamlForm = ({ csrfToken, errorHandler, readonly, fileDelete, fileRead, fil
 
     function clearUploadedButtonsPostDelete() {
         setTriggerClearUploaded(!triggerClearUploaded);
+    }
+
+    function handleShowModal() {
+        setShowBlackDuckSSOImportModal(true);
     }
 
     return (
@@ -148,20 +156,23 @@ const SamlForm = ({ csrfToken, errorHandler, readonly, fileDelete, fileRead, fil
                             <div className={classes.fillForm}>
                                 <Button
                                     id="blackduck-sso-import-button"
-                                    onClick={() => setShowBlackDuckSSOImportModal(true)}
+                                    onClick={handleShowModal}
                                     text="Fill Form"
                                 />
                             </div>
                         </LabeledField>
-                        <BlackDuckSSOConfigImportModal
-                            label={importBlackDuckSSOConfigLabel}
-                            csrfToken={csrfToken}
-                            readOnly={readonly}
-                            show={showBlackDuckSSOImportModal}
-                            onHide={() => setShowBlackDuckSSOImportModal(false)}
-                            initialSSOFieldData={formData}
-                            updateSSOFieldData={(data) => setFormData(data)}
-                        />
+                        {showBlackDuckSSOImportModal && (
+                            <BlackDuckSSOConfigImportModal
+                                csrfToken={csrfToken}
+                                initialSSOFieldData={formData}
+                                isOpen={showBlackDuckSSOImportModal}
+                                providerModel={providerModel}
+                                readOnly={readonly}
+                                setProviderModel={setProviderModel}
+                                toggleModal={setShowBlackDuckSSOImportModal}
+                                updateSSOFieldData={(data) => setFormData(data)}
+                            />
+                        )}
                     </>
                 )}
 


### PR DESCRIPTION
# Bug Description
When a user would navigate to Manage > Authentication > SAML, and press the 'Fill Form' button, the modal would render off screen.  This was due to this modal having never been updated to the `<Modal>` component in `7.0.0`. Instead it was using our somewhat outdated `<PopUp>` component.  
  
# Fix Description
To fix this, we really just needed to update the component to leverage the `<Modal>` component.  I also had to provide some height to the modal (`100px`) to ensure that the dropdown would fit within the modal.  
  
# Technical Fix Description  
I switched out the `<PopUp>` component in `<BlackDuckSSOConfigImportModal>` to use our `<Modal>` component. I also had to place the state variable, `providerModel` one level higher as it was being reset every time the modal would open.  
  
 
![Screenshot 2025-05-19 at 2 21 16 PM](https://github.com/user-attachments/assets/e9a786c7-8709-4942-8599-f1cebe77a9df)