### PR TITLE
IALERT-3312 - Revert adding subPath to values.

### DIFF
--- a/deployment/helm/blackduck-alert/values.yaml
+++ b/deployment/helm/blackduck-alert/values.yaml
@@ -79,8 +79,7 @@ postgres:
   storageClass: "" # PVC storage class name
   volumeName: "" # existing persistent volume name backing the PVC
   volumeMounts:
-    - mountPath: /var/lib/postgresql
-      subPath: data
+    - mountPath: /var/lib/postgresql/data
       name: alert-postgres-data-volume
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
On upgrade, having a different mountPath is breaking the installation. Revert the addition of subPath, and set mountPath to be the same as what it was before the edit for this ticket.
