### PR TITLE
IALERT-3810: fix jira cloud custom field

### DIFF
--- a/alert-database-job/src/main/java/com/blackduck/integration/alert/database/job/api/StaticJobAccessor.java
+++ b/alert-database-job/src/main/java/com/blackduck/integration/alert/database/job/api/StaticJobAccessor.java
@@ -260,7 +260,7 @@ public class StaticJobAccessor implements JobAccessor {
             JiraCloudJobDetailsEntity jobDetails = jobEntity.getJiraCloudJobDetails();
             List<JiraJobCustomFieldModel> customFields = jobDetails.getJobCustomFields()
                 .stream()
-                .map(entity -> new JiraJobCustomFieldModel(entity.getFieldName(), entity.getFieldValue()))
+                .map(entity -> new JiraJobCustomFieldModel(entity.getFieldName(), entity.getFieldValue(), entity.isTreatValueAsJson()))
                 .collect(Collectors.toList());
             distributionJobDetailsModel = new JiraCloudJobDetailsModel(
                 jobId,

--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/job/jira/cloud/DefaultJiraCloudJobDetailsAccessor.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/job/jira/cloud/DefaultJiraCloudJobDetailsAccessor.java
@@ -67,14 +67,14 @@ public class DefaultJiraCloudJobDetailsAccessor implements JiraCloudJobDetailsAc
         return jiraCloudJobCustomFieldRepository.findByJobId(jobId)
                    .stream()
                    .map(customFieldEntity -> new JiraJobCustomFieldModel(customFieldEntity.getFieldName(), customFieldEntity.getFieldValue()))
-                   .collect(Collectors.toList());
+                   .toList();
     }
 
     private JiraCloudJobDetailsModel convertToModel(JiraCloudJobDetailsEntity jobDetails) {
         List<JiraJobCustomFieldModel> customFields = jiraCloudJobCustomFieldRepository.findByJobId(jobDetails.getJobId())
                                                          .stream()
-                                                         .map(entity -> new JiraJobCustomFieldModel(entity.getFieldName(), entity.getFieldValue()))
-                                                         .collect(Collectors.toList());
+                                                         .map(entity -> new JiraJobCustomFieldModel(entity.getFieldName(), entity.getFieldValue(), entity.isTreatValueAsJson()))
+                                                         .toList();
         return new JiraCloudJobDetailsModel(
             jobDetails.getJobId(),
             jobDetails.getAddComments(),

--- a/ui/src/main/js/page/channel/jira/common/JiraFieldMapDistributionTable.js
+++ b/ui/src/main/js/page/channel/jira/common/JiraFieldMapDistributionTable.js
@@ -30,7 +30,7 @@ const JiraFieldMapDistributionTable = ({ initialData, onFieldMappingUpdate }) =>
         label: 'Value',
         sortable: true
     }, {
-        key: 'createJsonObject',
+        key: 'treatValueAsJson',
         label: 'Treat Value as JSON',
         sortable: false,
         customCell: JiraFieldAlwaysCreateJsonCell,


### PR DESCRIPTION
The Jira cloud custom fields UI was not showing the correct value for the "Treat Value as JSON" checkbox.  The correct data was being persisted but when converting from the database model to a distribution model the wrong constructor was being used.  The value was always being set to false for Jira Cloud jobs specifically resulting in the wrong state being viewed in the UI for Jira Cloud only.