### PR TITLE
Fix: IALERT-3832 resovle policy tickets when component version is updated

### DIFF
--- a/channel-azure-boards/src/main/java/com/blackduck/integration/alert/channel/azure/boards/distribution/search/AzureBoardsComponentIssueFinder.java
+++ b/channel-azure-boards/src/main/java/com/blackduck/integration/alert/channel/azure/boards/distribution/search/AzureBoardsComponentIssueFinder.java
@@ -27,6 +27,7 @@ import com.blackduck.integration.alert.api.processor.extract.model.project.Abstr
 import com.blackduck.integration.alert.api.processor.extract.model.project.BomComponentDetails;
 import com.blackduck.integration.alert.azure.boards.common.service.workitem.response.WorkItemResponseModel;
 import com.blackduck.integration.alert.channel.azure.boards.distribution.util.AzureBoardsSearchPropertiesUtils;
+import com.blackduck.integration.alert.common.enumeration.ItemOperation;
 import com.blackduck.integration.alert.common.message.model.LinkableItem;
 import com.google.gson.Gson;
 
@@ -84,6 +85,12 @@ public class AzureBoardsComponentIssueFinder implements ProjectVersionComponentI
 
             String additionalInfoKey = AzureBoardsAlertIssuePropertiesManager.POLICY_ADDITIONAL_KEY_COMPATIBILITY_LABEL + optionalPolicyName.get();
             fieldRefNameToValue.addAdditionalInfoKey(additionalInfoKey);
+
+            if(policyDetails.map(IssuePolicyDetails::getOperation).filter(ItemOperation.DELETE::equals).isPresent()) {
+                // policy cleared notification or override.  The component version doesn't matter just component
+                // and policy name.
+                fieldRefNameToValue.removeSubComponentKey();
+            }
         }
 
         if (projectIssueModel.getComponentUnknownVersionDetails().isPresent()) {

--- a/channel-azure-boards/src/main/java/com/blackduck/integration/alert/channel/azure/boards/distribution/search/AzureSearchFieldMappingBuilder.java
+++ b/channel-azure-boards/src/main/java/com/blackduck/integration/alert/channel/azure/boards/distribution/search/AzureSearchFieldMappingBuilder.java
@@ -15,8 +15,11 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 import com.blackduck.integration.alert.channel.azure.boards.distribution.util.AzureBoardsSearchPropertiesUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AzureSearchFieldMappingBuilder {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final Map<String, String> customFieldMapping = new HashMap<>();
 
     public static AzureSearchFieldMappingBuilder create() {
@@ -30,33 +33,44 @@ public class AzureSearchFieldMappingBuilder {
     }
 
     public AzureSearchFieldMappingBuilder addSubTopic(String subTopic) {
-        addMapping(AzureCustomFieldManager.ALERT_SUB_TOPIC_KEY_FIELD_REFERENCE_NAME, subTopic);
+        addOrRemoveNullValueMapping(AzureCustomFieldManager.ALERT_SUB_TOPIC_KEY_FIELD_REFERENCE_NAME, subTopic);
         return this;
     }
 
     public AzureSearchFieldMappingBuilder addComponentKey(String componentKey) {
-        addMapping(AzureCustomFieldManager.ALERT_COMPONENT_KEY_FIELD_REFERENCE_NAME, componentKey);
+        addOrRemoveNullValueMapping(AzureCustomFieldManager.ALERT_COMPONENT_KEY_FIELD_REFERENCE_NAME, componentKey);
         return this;
     }
 
     public AzureSearchFieldMappingBuilder addSubComponentKey(String subComponentKey) {
-        addMapping(AzureCustomFieldManager.ALERT_SUB_COMPONENT_KEY_FIELD_REFERENCE_NAME, subComponentKey);
+        addOrRemoveNullValueMapping(AzureCustomFieldManager.ALERT_SUB_COMPONENT_KEY_FIELD_REFERENCE_NAME, subComponentKey);
+        return this;
+    }
+
+    public AzureSearchFieldMappingBuilder removeSubComponentKey() {
+        addOrRemoveNullValueMapping(AzureCustomFieldManager.ALERT_SUB_COMPONENT_KEY_FIELD_REFERENCE_NAME, null);
         return this;
     }
 
     public AzureSearchFieldMappingBuilder addAdditionalInfoKey(String additionalInfo) {
-        addMapping(AzureCustomFieldManager.ALERT_ADDITIONAL_INFO_KEY_FIELD_REFERENCE_NAME, additionalInfo);
+        addOrRemoveNullValueMapping(AzureCustomFieldManager.ALERT_ADDITIONAL_INFO_KEY_FIELD_REFERENCE_NAME, additionalInfo);
         return this;
     }
 
     public AzureSearchFieldMappingBuilder addCategoryKey(String categoryKey) {
-        addMapping(AzureCustomFieldManager.ALERT_CATEGORY_KEY_FIELD_REFERENCE_NAME, categoryKey);
+        addOrRemoveNullValueMapping(AzureCustomFieldManager.ALERT_CATEGORY_KEY_FIELD_REFERENCE_NAME, categoryKey);
         return this;
     }
 
-    private void addMapping(String key, String value) {
+    private void addOrRemoveNullValueMapping(String key, String value) {
         String shortenedKeyValue = StringUtils.truncate(value, AzureBoardsSearchPropertiesUtils.MAX_STRING_VALUE_LENGTH);
-        customFieldMapping.put(key, shortenedKeyValue);
+        // a map does not permit a null value so if the shortened key value is null then remove the key from the map.
+        if(null != shortenedKeyValue) {
+            customFieldMapping.put(key, shortenedKeyValue);
+        } else {
+            logger.debug("Removing Azure boards search field mapping: {}", key);
+            customFieldMapping.remove(key);
+        }
     }
 
     class ReferenceToValue {

--- a/channel-azure-boards/src/test/java/com/blackduck/integration/alert/channel/azure/boards/distribution/search/AzureSearchFieldMappingBuilderTest.java
+++ b/channel-azure-boards/src/test/java/com/blackduck/integration/alert/channel/azure/boards/distribution/search/AzureSearchFieldMappingBuilderTest.java
@@ -1,0 +1,67 @@
+package com.blackduck.integration.alert.channel.azure.boards.distribution.search;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+class AzureSearchFieldMappingBuilderTest {
+
+    @Test
+    void testBuild() {
+        String subTopicKey = "subTopicKey";
+        String componentKey = "componentKey";
+        String subComponentKey = "subComponentKey";
+        String additionalInfoKey = "additionalInfoKey";
+        String categoryKey = "categoryKey";
+
+        AzureSearchFieldMappingBuilder builder = AzureSearchFieldMappingBuilder.create()
+                .addSubTopic(subTopicKey)
+                .addComponentKey(componentKey)
+                .addSubComponentKey(subComponentKey)
+                .addAdditionalInfoKey(additionalInfoKey)
+                .addCategoryKey(categoryKey);
+
+        List<AzureSearchFieldMappingBuilder.ReferenceToValue> referenceList = builder.buildAsList();
+
+        Assertions.assertEquals(5, referenceList.size());
+        Assertions.assertTrue(keyAndValueFound(referenceList, AzureCustomFieldManager.ALERT_SUB_TOPIC_KEY_FIELD_REFERENCE_NAME, subTopicKey));
+        Assertions.assertTrue(keyAndValueFound(referenceList, AzureCustomFieldManager.ALERT_COMPONENT_KEY_FIELD_REFERENCE_NAME, componentKey));
+        Assertions.assertTrue(keyAndValueFound(referenceList, AzureCustomFieldManager.ALERT_SUB_COMPONENT_KEY_FIELD_REFERENCE_NAME, subComponentKey));
+        Assertions.assertTrue(keyAndValueFound(referenceList, AzureCustomFieldManager.ALERT_ADDITIONAL_INFO_KEY_FIELD_REFERENCE_NAME, additionalInfoKey));
+        Assertions.assertTrue(keyAndValueFound(referenceList, AzureCustomFieldManager.ALERT_CATEGORY_KEY_FIELD_REFERENCE_NAME, categoryKey));
+    }
+
+    @Test
+    void testSubComponentRemovalBuild() {
+        String subTopicKey = "subTopicKey";
+        String componentKey = "componentKey";
+        String subComponentKey = "subComponentKey";
+        String additionalInfoKey = "additionalInfoKey";
+        String categoryKey = "categoryKey";
+
+        AzureSearchFieldMappingBuilder builder = AzureSearchFieldMappingBuilder.create()
+                .addSubTopic(subTopicKey)
+                .addComponentKey(componentKey)
+                .addSubComponentKey(subComponentKey)
+                .addAdditionalInfoKey(additionalInfoKey)
+                .addCategoryKey(categoryKey)
+                .removeSubComponentKey();
+
+        List<AzureSearchFieldMappingBuilder.ReferenceToValue> referenceList = builder.buildAsList();
+
+        Assertions.assertEquals(4, referenceList.size());
+        Assertions.assertTrue(keyAndValueFound(referenceList, AzureCustomFieldManager.ALERT_SUB_TOPIC_KEY_FIELD_REFERENCE_NAME, subTopicKey));
+        Assertions.assertTrue(keyAndValueFound(referenceList, AzureCustomFieldManager.ALERT_COMPONENT_KEY_FIELD_REFERENCE_NAME, componentKey));
+        Assertions.assertFalse(keyAndValueFound(referenceList, AzureCustomFieldManager.ALERT_SUB_COMPONENT_KEY_FIELD_REFERENCE_NAME, subComponentKey));
+        Assertions.assertTrue(keyAndValueFound(referenceList, AzureCustomFieldManager.ALERT_ADDITIONAL_INFO_KEY_FIELD_REFERENCE_NAME, additionalInfoKey));
+        Assertions.assertTrue(keyAndValueFound(referenceList, AzureCustomFieldManager.ALERT_CATEGORY_KEY_FIELD_REFERENCE_NAME, categoryKey));
+    }
+
+    boolean keyAndValueFound(List<AzureSearchFieldMappingBuilder.ReferenceToValue> fieldList, String fieldKey, String fieldValue ) {
+        Predicate<AzureSearchFieldMappingBuilder.ReferenceToValue> predicate = (referenceToValue -> referenceToValue.getReferenceKey().equals(fieldKey) && referenceToValue.getFieldValue().equals(fieldValue));
+        List<AzureSearchFieldMappingBuilder.ReferenceToValue> filteredList = fieldList.stream().filter(predicate).toList();
+        return filteredList.size() == 1;
+    }
+}


### PR DESCRIPTION
The issue occurs when you have a component with a specific version that violates policy i.e. Component 1.0.0. This generates a policy violation ticket and Alert creates the Policy related issue tracking ticket.  When a new scan is performed or the component is manually edited in Black Duck SCA to a new version, then the policy related issue tracking ticket will not be resolved because the component version is included in the query for the issue.  When the component is updated to a new version then the original ticket will not be updated.  

For example if Component 1.0.0 violates the policy then the component version is used when the issue is created.  Now if the component is updated to Component 1.0.1, a patched version that no longer violates policy, the issue would not be found because the original ticket was created with version 1.0.0, and the search would use version 1.0.1.  No issues exist for 1.0.1.

The fix is to omit the component version with a policy cleared or policy override notification which will result in a query that searches for the component and the policy name.  This will find the issue and resolve it correctly.

Tested:

- Policy Violation for a component
   - Result: Ticket Created
- Policy Override for a component 
   - Result: Ticket Resolved
- Undo of Override for a component
   - Result:  Ticket Re-opened
- Change of component version
   - Result:  Ticket Resolved
- Change component version back to version that violates policy
   - Result:  Ticket  Re-opened
- Delete component
   - Result: Ticket Resolved 
