### PR TITLE
IALERT-3811: (Regression) Stop User from Adding Duplicate Descriptors When Creating Roles

### DIFF
--- a/ui/src/main/js/page/usermgmt/roles/PermissionTable.js
+++ b/ui/src/main/js/page/usermgmt/roles/PermissionTable.js
@@ -12,7 +12,7 @@ const emptyTableConfig = {
     message: 'There are no records to display for this table.  Please create a Permission above to use this table.'
 };
 
-const PermissionTable = ({ role, sendPermissionArray, handleFilterPermission, setCustomValidationMessage }) => {
+const PermissionTable = ({ role, sendPermissionArray, handleFilterPermission }) => {
     const permissionData = role.permissions;
 
     const descriptors = useSelector((state) => state.descriptors.items);
@@ -60,7 +60,6 @@ const PermissionTable = ({ role, sendPermissionArray, handleFilterPermission, se
                 data={role}
                 canDelete={canDelete}
                 handleValidatePermission={handleValidatePermission}
-                setCustomValidationMessage={setCustomValidationMessage}
             />}
         />
     );
@@ -99,7 +98,6 @@ PermissionTable.propTypes = {
         })
     }),
     sendPermissionArray: PropTypes.func,
-    setCustomValidationMessage: PropTypes.func,
     handleFilterPermission: PropTypes.func
 };
 

--- a/ui/src/main/js/page/usermgmt/roles/RoleModal.js
+++ b/ui/src/main/js/page/usermgmt/roles/RoleModal.js
@@ -7,8 +7,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Modal from 'common/component/modal/Modal';
 import TextInput from 'common/component/input/TextInput';
 import PermissionTable from 'page/usermgmt/roles/PermissionTable';
-import Alert from 'react-bootstrap/Alert';
-import MessageFormatter from 'common/component/MessageFormatter';
 
 const useStyles = createUseStyles({
     descriptorContainer: {
@@ -33,7 +31,6 @@ const RoleModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
     const { copyDescription, type, title, submitText } = modalOptions;
     const [role, setRole] = useState(type === 'CREATE' ? { permissions: [] } : data);
     const [showLoader, setShowLoader] = useState(false);
-    const [customValidationMessage, setCustomValidationMessage] = useState();
 
     const ROLE_NAME_KEY = 'roleName';
 
@@ -126,14 +123,6 @@ const RoleModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
             submitText={submitText}
             showLoader={showLoader}
         >
-            { customValidationMessage && (
-                <Alert
-                    bsPrefix="alert"
-                    variant="danger"
-                >
-                    <MessageFormatter message={customValidationMessage.message} />
-                </Alert>
-            )}
             { type === 'COPY' && (
                 <div className={classes.descriptorContainer}>
                     <FontAwesomeIcon icon="exclamation-circle" size="2x" />
@@ -158,7 +147,6 @@ const RoleModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
                     role={role}
                     handleFilterPermission={handleFilterPermission} 
                     sendPermissionArray={getPermissionArray}
-                    setCustomValidationMessage={setCustomValidationMessage}
                 />
             </div>
         </Modal>


### PR DESCRIPTION
## Bug Description
When a user creates a role in the UI, we currently allow them to add as many permissions with as many descriptors as they want, regardless of if there are duplicate descriptors. If a user then tries to remove a permission, we will remove all permissions that match the descriptor name. This happens because we remove a permission based on the descriptor name (That is the bug). The catch all is that a user should not be allowed to add duplicate descriptors, as the validation will fail and a message will show, letting the user know this cannot happen.

## Regression Description  
This was a regression based on the fact that a user could no longer add a descriptor with differing contexts, as Dana mentioned offline, "Azure Boards has 2 types for Context. If you use the Descriptor Name as the only value to prove uniqueness, I can't add each of the context's". 

## Fix Description
I went with a different plan of attack on this.  Instead of waiting for the user to add descriptors and then validate, we now will proactively check and remove context options based on if the user has already added a descriptor/context combination.  In the case that they have, they will not see that context option in the dropdown.  This eliminates the need to validate their list of descriptors when saving, as there won't be a case where they have duplicate descriptors (more info on this - if you add Azure Board with context, Global; the next time you try to add Azure Board you will only have the option to select context, Distribution; and then if you try to add Azure Board again, you will have no options in the context dropdown, which will fail server side validation).  
  
## Technical Fix Description
I removed the Alert message when a validation would fail as this was no longer needed.  Instead, I updated the `createContextOptions` function to:

1. First filter the list of available descriptors based on the selected descriptor's name into a `matching` array
2. Second filter the `matching` array to no longer include any options that exist in the array of existing permissions (these are the ones that the user has already selected and appear in the table below)