### PR TITLE
IALERT-3853 - Avoid syntax error in database-utilities.sh

### DIFF
--- a/deployment/helm/database-utilities.sh
+++ b/deployment/helm/database-utilities.sh
@@ -184,7 +184,7 @@ while getopts "b,d:,f:,k:,n:,p,r,t:,u:,h" option; do
 done
 shift $((OPTIND -1))
 
-podId=$(kubectl -n $deploymentNamespace get pods | grep $databaseKeyword | awk '{print $1}');
+podId=$(kubectl -n $deploymentNamespace get pods | grep -- $databaseKeyword | awk '{print $1}');
 
 displayConfiguration
 checkFormat

--- a/src/test/java/com/blackduck/integration/alert/scripts/HelmDatabaseUtilitiesScriptTest.java
+++ b/src/test/java/com/blackduck/integration/alert/scripts/HelmDatabaseUtilitiesScriptTest.java
@@ -171,6 +171,21 @@ class HelmDatabaseUtilitiesScriptTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = { "binary", "BINARY", "plain", "PLAIN" })
+    void testBackupAndRestoreWithoutPodName(String formatType) throws ExecutableRunnerException {
+        File backupFile = makeTempFile();
+        List<String> backupArguments = List.of("-b", "-n", TEST_NAMESPACE, "-t", formatType, "-f", backupFile.getAbsolutePath());
+        Executable scriptRestoreExecutable = Executable.create(workingDirectory, scriptFile, backupArguments);
+        ExecutableOutput restoreOutput = processBuilderRunner.execute(scriptRestoreExecutable);
+        assertEquals(0, restoreOutput.getReturnCode());
+
+        List<String> restoreArguments = List.of("-r", "-n", TEST_NAMESPACE, "-k", podName, "-t", formatType, "-f", backupFile.getAbsolutePath());
+        Executable scriptBackupExecutable = Executable.create(workingDirectory, scriptFile, restoreArguments);
+        ExecutableOutput backupOutput = processBuilderRunner.execute(scriptBackupExecutable);
+        assertEquals(0, backupOutput.getReturnCode());
+    }
+
+    @ParameterizedTest
     @ValueSource(strings = { "Binary", "bINARY", "Plain", "pLAIN", "bad", "unknown", "", "  ", "''", "'    '" })
     void testBackupAndRestoreInvalidFormat(String formatType) throws ExecutableRunnerException {
         File backupFile = makeTempFile();

--- a/src/test/resources/database/helm-test-postgres/templates/postgres.yaml
+++ b/src/test/resources/database/helm-test-postgres/templates/postgres.yaml
@@ -105,10 +105,10 @@ spec:
               key: ALERT_POSTGRES_USER_PASSWORD_FILE
               name: {{ .Release.Name }}-db-creds
         {{- if .Values.postgres.registry }}
-        image: { { .Values.postgres.registry } }/postgres:15.7-alpine
+        image: {{ .Values.postgres.registry }}/postgres:15.7-alpine
         {{- else }}
-        image: { { .Values.registry } }/postgres:15.7-alpine
-        {{- end}}
+        image: {{ .Values.registry }}/postgres:15.7-alpine
+        {{- end }}
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/src/test/resources/database/init-helm-db.sh
+++ b/src/test/resources/database/init-helm-db.sh
@@ -1,32 +1,60 @@
 #!/bin/bash
+set -e
+
+formatLine() {
+  local text="$1"
+  local prefix="- "
+  local suffix="-"
+  local total_length=62
+
+  # Special case: if the input is "-----", print all dashes
+  if [[ "$text" == "-----" ]]; then
+    printf '%*s\n' $total_length '' | tr ' ' '-'
+    return
+  fi
+
+  local padding_length=$((total_length - ${#prefix} - ${#text} - 1))
+  local padding=$(printf '%*s' "$padding_length")
+
+  echo "${prefix}${text}${padding}${suffix}"
+}
 
 usage() {
-  echo "--------------------------------------------------------------"
-  echo "- Usage: ./init-helm-db.sh                                   -"
-  echo "- Parameters                                                 -"
-  echo "-   -n: specify the path to the helm chart                   -"
-  echo "-   -n: specify the namespace name to be created             -"
-  echo "-   -i: postgres password                                    -"
-  echo "-                                                            -"
-  echo "- Example:                                                   -"
-  echo "    ./init-helm-db.sh -n postgres-namespace -i install-name  -"
-  echo "_____________________________________________________________-"
+  formatLine "-----"
+  formatLine "Usage: ./init-helm-db.sh"
+  formatLine "Parameters"
+  formatLine "  -c: specify the path to the Helm chart"
+  formatLine "  -d: specify the name of the Alert database"
+  formatLine "  -n: specify the Kubernetes namespace name to be created"
+  formatLine "  -i: specify the Helm install name"
+  formatLine "  -u: specify the Alert DB user name"
+  formatLine ""
+  formatLine "Example:"
+  formatLine "  ./init-helm-db.sh -n postgres-namespace -i install-name"
+  formatLine ""
+  formatLine "Defaults:"
+  formatLine "   -c: ${chart_path}"
+  formatLine "   -d: ${db_name}"
+  formatLine "   -n: ${namespace}"
+  formatLine "   -i: ${installation_name}"
+  formatLine "   -u: ${user}"
+  formatLine "-----"
 }
+
+chart_path="."
+db_name='alertdb'
+namespace='test-postgres'
+installation_name='alert-install'
+user='sa'
 
 if [ $# -eq 0 ];
   then
-      echo "--------------------------------------------------------------"
-      echo "- Error: No arguments supplied                               -"
-      echo "______________________________________________________________"
+      formatLine "-----"
+      formatLine "Error: No arguments supplied"
+      formatLine "-----"
       usage
       exit 1
 fi
-
-namespace='test-postgres'
-installation_name='alert-install'
-chart_path="."
-user=sa
-db_name=alertdb
 
 while getopts "c:,d:,n:,i:,u:,h" option; do
   case ${option} in


### PR DESCRIPTION
The default setting for `databaseKeyword` within `deployment/helm/database-utilities.sh` is "-postgres-". This variable is used in a grep statement, and when the default is used, it produces a syntax error.

* Change the grep statement to pass "--" before `databaseKeyword`. This tells grep that what follows are not options, even if they start with a hyphen.
* Add a parameterizedTest to test running the script without overriding `databaseKeyword`.
* Clean up spaces in postgres.yaml (used in tests) which will cause a yaml syntax error
* Edit `src/test/resources/database/init-helm-db.sh` (used in tests):
** Run with `set -e` which will fail the script if any error is encountered
** Add a formatLine function to eliminate need to line everything up.
** Include all params in usage
** Include defaults in usage