### PR TITLE
IALERT-3855: Create/Edit/Copy User Client Side Password Validation

### DIFF
--- a/ui/src/main/js/page/usermgmt/user/UserModal.js
+++ b/ui/src/main/js/page/usermgmt/user/UserModal.js
@@ -48,6 +48,26 @@ const UserModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
     const roles = useSelector((state) => state.roles.data);
     const { saveStatus, error } = useSelector((state) => state.users);
 
+    function disableSubmit() {
+        const password = userModel[USER_INPUT_FIELD_KEYS.PASSWORD_KEY];
+        const isPasswordSet = userModel[USER_INPUT_FIELD_KEYS.IS_PASSWORD_SET];
+
+        // isPasswordSet will be set when the user is being edited. We don't need to disable the submit button in this case
+        if (isPasswordSet) {
+            return false;
+        }
+        // When copying or creating a user, these fields will be empty initially.
+        // We want to disable the submit button until the user enters a password and confirms it
+        if (!password || !confirmPassword) {
+            return true;
+        } else if (password && confirmPassword){
+            return false;
+        }
+
+        // Otherwise, disable
+        return true;
+    }
+
     function passwordsMatch(user) {
         let passwordError = {};
         let matching = true;
@@ -128,7 +148,7 @@ const UserModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
             closeModal={handleClose}
             handleCancel={handleClose}
             handleSubmit={handleSubmit}
-            disableSubmit={!userModel[USER_INPUT_FIELD_KEYS.PASSWORD_KEY] || !confirmPassword}
+            disableSubmit={disableSubmit()}
             submitText={submitText}
             showLoader={showLoader}
             noOverflow


### PR DESCRIPTION
## Bug Description
When a user attempts to edit a user, they are unable to click 'Save' as the button is disabled based on some client side validation in the code

## Fix Description
Since we are validating the password fields are entered in the UI code (before they are server side validated to match the requirements), we need to update the validation to allow for editing.  Previously we would disable submit in this modal if one or both Password and Confirm Password fields were empty.  This creates an issue when editing a user, as the Confirm Password field will be empty.  To combat this, I've updated the validation to:

- First check if the password is set (this means the user has already created a password and only occurs when the user is editing)
- Second check if either the Password or Confirm Password fields are empty, if they are we want to disable submit on the modal
- Third check if both the Password and Confirm Password fields are empty, if they aren't we want to allow the user to submit


## Technical Fix Description
I added a validation function, `disableSubmit()` that returns a boolean value based on the above steps in the "Fix Description".  This should serve as a proper validation on the client side, before the user submits and is hit with server side validation.