### PR TITLE
IALERT-3713: Update java library: int-jira-common

### DIFF
--- a/alert-platform/build.gradle
+++ b/alert-platform/build.gradle
@@ -21,7 +21,7 @@ dependencies {
         api 'com.blackduck.integration:integration-rest:11.1.2'
         api 'com.blackduck.integration:integration-common:27.0.2'
         api 'com.blackduck.integration:blackduck-common:67.0.9'
-        api 'com.blackduck.integration:int-jira-common:5.0.0'
+        api 'com.blackduck.integration:int-jira-common:5.0.1'
 
         api 'com.google.cloud:libraries-bom:2.2.0'
         api 'com.google.oauth-client:google-oauth-client:1.34.1'


### PR DESCRIPTION
Upgrade to latest int-jira-common, which has the latest internal (integration) libraries