### PR TITLE
IALERT-3685: Show Password Set Field Asterisks

### DIFF
--- a/ui/src/main/js/page/usermgmt/user/UserModal.js
+++ b/ui/src/main/js/page/usermgmt/user/UserModal.js
@@ -139,7 +139,7 @@ const UserModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
             };
         });
     }
-    console.log(Boolean(confirmPassword))
+
     return (
         <Modal
             isOpen={isOpen}

--- a/ui/src/main/js/page/usermgmt/user/UserModal.js
+++ b/ui/src/main/js/page/usermgmt/user/UserModal.js
@@ -139,7 +139,7 @@ const UserModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
             };
         });
     }
-
+    console.log(Boolean(confirmPassword))
     return (
         <Modal
             isOpen={isOpen}
@@ -206,7 +206,7 @@ const UserModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMessage, 
                         placeholder="Confirm password..."
                         readOnly={false}
                         required
-                        isSet={Boolean(confirmPassword)}
+                        isSet={userModel[USER_INPUT_FIELD_KEYS.IS_PASSWORD_SET]}
                         onChange={(e) => setConfirmPassword(e.target.value)}
                         value={confirmPassword || undefined}
                         errorName="confirmPasswordError"


### PR DESCRIPTION
# Bug Description
In https://github.com/blackducksoftware/blackduck-alert/pull/2669, we improved the validation steps on the confirm password field but unintentionally removed the asterisks associated with a filled in password on that field.  When a user is editing within the User Modal, we should show that the "Confirm Password" field is indeed filled in by showing the asterisks.  
  
# Fix Description
In component, `UserModal` on line 209, revert the `isSet` prop to check if the model does have `IS_PASSWORD_SET`.  This does not impact the work done in IALERT-3811.