### PR TITLE
IALERT-3815: Upgrade spring-boot to 3.3.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '3.3.12'
+        springBootVersion = '3.3.13'
     }
 
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-repositories.gradle', to: buildscript


### PR DESCRIPTION
Updating the version of spring-boot to 3.3.13 to update versions of transitive dependencies.