### PR TITLE
Create Issue search keys comment for finding issues without the indexer plugin

### DIFF
--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerIssueCreator.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerIssueCreator.java
@@ -89,9 +89,7 @@ public abstract class IssueTrackerIssueCreator<T extends Serializable> {
         Optional<String> searchKeys = getAlertSearchKeys(issueDetails, projectSource);
         postCreateComments.add("This issue was automatically created by Alert.");
         // if the issue tracker creates a comment with search keys then add it here.
-        if(searchKeys.isPresent()) {
-            postCreateComments.add(searchKeys.get());
-        }
+        searchKeys.ifPresent(postCreateComments::add);
         postCreateComments.addAll(creationModel.getPostCreateComments());
 
         IssueCommentModel<T> commentRequestModel = new IssueCommentModel<>(issueDetails, postCreateComments, projectSource);

--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerIssueCreator.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerIssueCreator.java
@@ -9,6 +9,7 @@ package com.blackduck.integration.alert.api.channel.issue.tracker.send;
 
 import java.io.Serializable;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Optional;
 
 import org.jetbrains.annotations.Nullable;
@@ -65,6 +66,7 @@ public abstract class IssueTrackerIssueCreator<T extends Serializable> {
         }
         addPostCreateComments(createdIssueDetails, alertIssueCreationModel, optionalSource.orElse(null));
 
+
         return new IssueTrackerIssueResponseModel<>(
             createdIssueDetails.getIssueId(),
             createdIssueDetails.getIssueKey(),
@@ -78,10 +80,19 @@ public abstract class IssueTrackerIssueCreator<T extends Serializable> {
     protected abstract ExistingIssueDetails<T> createIssueAndExtractDetails(IssueCreationModel alertIssueCreationModel) throws AlertException;
 
     protected abstract void assignAlertSearchProperties(ExistingIssueDetails<T> createdIssueDetails, ProjectIssueModel alertIssueSource) throws AlertException;
+    protected Optional<String> getAlertSearchKeys(ExistingIssueDetails<T> existingIssueDetails, ProjectIssueModel alertIssueSource) {
+        return Optional.empty();
+    }
 
     private void addPostCreateComments(ExistingIssueDetails<T> issueDetails, IssueCreationModel creationModel, @Nullable ProjectIssueModel projectSource) throws AlertException {
-        LinkedList<String> postCreateComments = new LinkedList<>(creationModel.getPostCreateComments());
-        postCreateComments.addFirst("This issue was automatically created by Alert.");
+        LinkedList<String> postCreateComments = new LinkedList<>();
+        Optional<String> searchKeys = getAlertSearchKeys(issueDetails, projectSource);
+        postCreateComments.add("This issue was automatically created by Alert.");
+        // if the issue tracker creates a comment with search keys then add it here.
+        if(searchKeys.isPresent()) {
+            postCreateComments.add(searchKeys.get());
+        }
+        postCreateComments.addAll(creationModel.getPostCreateComments());
 
         IssueCommentModel<T> commentRequestModel = new IssueCommentModel<>(issueDetails, postCreateComments, projectSource);
         commenter.commentOnIssue(commentRequestModel);

--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerIssueCreator.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerIssueCreator.java
@@ -80,7 +80,7 @@ public abstract class IssueTrackerIssueCreator<T extends Serializable> {
     protected abstract ExistingIssueDetails<T> createIssueAndExtractDetails(IssueCreationModel alertIssueCreationModel) throws AlertException;
 
     protected abstract void assignAlertSearchProperties(ExistingIssueDetails<T> createdIssueDetails, ProjectIssueModel alertIssueSource) throws AlertException;
-    protected Optional<String> getAlertSearchKeys(ExistingIssueDetails<T> existingIssueDetails, ProjectIssueModel alertIssueSource) {
+    protected Optional<String> getAlertSearchKeys(ExistingIssueDetails<T> existingIssueDetails, @Nullable ProjectIssueModel alertIssueSource) {
         return Optional.empty();
     }
 

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/delegate/JiraIssueCreator.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/delegate/JiraIssueCreator.java
@@ -260,8 +260,8 @@ public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<Strin
         int versionUUIDEnd = StringUtils.indexOf(projectVersion.getUrl().orElse(""), "/", versionUUIDStart);
         String projectVersionId = StringUtils.substring(projectVersion.getUrl().orElse(""), versionUUIDStart, versionUUIDEnd);
         String componentName = bomComponent.getComponent().getValue();
-        String componentVersionName = bomComponent.getComponentVersion().map(LinkableItem::getValue).orElse(null);
-
+        Optional<LinkableItem> componentVersionName = bomComponent.getComponentVersion();
+        keyBuilder.append("This comment was automatically created by Alert. DO NOT REMOVE.");
         keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_START_HEADER);
         keyBuilder.append(StringUtils.SPACE);
         keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_PROJECT_ID);
@@ -276,10 +276,12 @@ public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<Strin
         keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_SEPARATOR);
         keyBuilder.append(componentName);
         keyBuilder.append(StringUtils.SPACE);
-        keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_COMPONENT_VERSION_NAME);
-        keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_SEPARATOR);
-        keyBuilder.append(componentVersionName);
-        keyBuilder.append(StringUtils.SPACE);
+        if(componentVersionName.isPresent()) {
+            keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_COMPONENT_VERSION_NAME);
+            keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_SEPARATOR);
+            keyBuilder.append(componentVersionName.get().getValue());
+            keyBuilder.append(StringUtils.SPACE);
+        }
         Optional<IssuePolicyDetails> policyDetails = alertIssueSource.getPolicyDetails();
         Optional<ComponentConcernType> category = Optional.empty();
         if (alertIssueSource.getVulnerabilityDetails().isPresent()) {

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/delegate/JiraIssueCreator.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/delegate/JiraIssueCreator.java
@@ -49,6 +49,7 @@ import com.blackduck.integration.jira.common.model.components.IssueFieldsCompone
 import com.blackduck.integration.jira.common.model.response.IssueCreationResponseModel;
 import com.blackduck.integration.jira.common.model.response.IssueResponseModel;
 import com.blackduck.integration.rest.exception.IntegrationRestException;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<String> {
     private static final String FAILED_TO_CREATE_ISSUE_MESSAGE = "Failed to create an issue in Jira.";
@@ -237,8 +238,12 @@ public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<Strin
     }
 
     @Override
-    protected Optional<String> getAlertSearchKeys(ExistingIssueDetails<String> existingIssueDetails, ProjectIssueModel alertIssueSource) {
+    protected Optional<String> getAlertSearchKeys(ExistingIssueDetails<String> existingIssueDetails, @Nullable ProjectIssueModel alertIssueSource) {
         StringBuilder keyBuilder = new StringBuilder();
+
+        if(alertIssueSource == null) {
+            return Optional.empty();
+        }
         // the uuid for project and project version is the last uuid
         // use the component and version name
         // category and if policy include the policy name

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/delegate/JiraIssueCreator.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/delegate/JiraIssueCreator.java
@@ -7,9 +7,12 @@
  */
 package com.blackduck.integration.alert.api.channel.jira.distribution.delegate;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 
+import com.blackduck.integration.alert.api.channel.jira.distribution.search.JiraIssuePropertyKeys;
 import io.opencensus.trace.Link;
 import org.apache.commons.lang3.StringUtils;
 
@@ -240,7 +243,6 @@ public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<Strin
         // use the component and version name
         // category and if policy include the policy name
 
-        LinkableItem provider = alertIssueSource.getProvider();
         LinkableItem project = alertIssueSource.getProject();
 
         LinkableItem projectVersion = alertIssueSource.getProjectVersion()
@@ -254,6 +256,50 @@ public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<Strin
         String projectVersionId = StringUtils.substring(projectVersion.getUrl().orElse(""), versionUUIDStart, versionUUIDEnd);
         String componentName = bomComponent.getComponent().getValue();
         String componentVersionName = bomComponent.getComponentVersion().map(LinkableItem::getValue).orElse(null);
+
+        keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_START_HEADER);
+        keyBuilder.append(StringUtils.SPACE);
+        keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_PROJECT_ID);
+        keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_SEPARATOR);
+        keyBuilder.append(projectId);
+        keyBuilder.append(StringUtils.SPACE);
+        keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_PROJECT_VERSION_ID);
+        keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_SEPARATOR);
+        keyBuilder.append(projectVersionId);
+        keyBuilder.append(StringUtils.SPACE);
+        keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_COMPONENT_NAME);
+        keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_SEPARATOR);
+        keyBuilder.append(componentName);
+        keyBuilder.append(StringUtils.SPACE);
+        keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_COMPONENT_VERSION_NAME);
+        keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_SEPARATOR);
+        keyBuilder.append(componentVersionName);
+        keyBuilder.append(StringUtils.SPACE);
+        Optional<IssuePolicyDetails> policyDetails = alertIssueSource.getPolicyDetails();
+        Optional<ComponentConcernType> category = Optional.empty();
+        if (alertIssueSource.getVulnerabilityDetails().isPresent()) {
+          category = Optional.of(ComponentConcernType.VULNERABILITY);
+        } else if(policyDetails.isPresent()) {
+            category = Optional.of(ComponentConcernType.POLICY);
+        } else if(alertIssueSource.getComponentUnknownVersionDetails().isPresent()) {
+            category = Optional.of(ComponentConcernType.UNKNOWN_VERSION);
+        }
+        if(category.isPresent()) {
+            keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_CATEGORY);
+            keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_SEPARATOR);
+            keyBuilder.append(category.get().name());
+            keyBuilder.append(StringUtils.SPACE);
+        }
+
+        if(policyDetails.isPresent()) {
+            // add policy name
+            keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_POLICY_NAME);
+            keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_SEPARATOR);
+            keyBuilder.append(JiraIssueSearchPropertyStringCompatibilityUtils.createPolicyAdditionalKey(policyDetails.get().getName()));
+            keyBuilder.append(StringUtils.SPACE);
+        }
+        keyBuilder.append(StringUtils.SPACE);
+        keyBuilder.append(JiraIssuePropertyKeys.JIRA_ISSUE_KEY_END_HEADER);
 
         return Optional.of(keyBuilder.toString());
     }

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/delegate/JiraIssueCreator.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/delegate/JiraIssueCreator.java
@@ -257,7 +257,7 @@ public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<Strin
 
         String projectId = StringUtils.substringAfterLast(project.getUrl().orElse(""), "/");
         int versionUUIDStart = StringUtils.lastIndexOf(projectVersion.getUrl().orElse(""), "versions/") +"versions/".length();
-        int versionUUIDEnd = StringUtils.lastIndexOf(projectVersion.getUrl().orElse(""), "/");
+        int versionUUIDEnd = StringUtils.indexOf(projectVersion.getUrl().orElse(""), "/", versionUUIDStart);
         String projectVersionId = StringUtils.substring(projectVersion.getUrl().orElse(""), versionUUIDStart, versionUUIDEnd);
         String componentName = bomComponent.getComponent().getValue();
         String componentVersionName = bomComponent.getComponentVersion().map(LinkableItem::getValue).orElse(null);

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JiraIssuePropertyKeys.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JiraIssuePropertyKeys.java
@@ -24,6 +24,16 @@ public final class JiraIssuePropertyKeys {
     public static final String JIRA_ISSUE_PROPERTY_OBJECT_KEY_SUB_COMPONENT_VALUE = "subComponentValue";
     public static final String JIRA_ISSUE_PROPERTY_OBJECT_KEY_ADDITIONAL_KEY = "additionalKey";
 
+    public static final String JIRA_ISSUE_KEY_SEPARATOR = ": ";
+    public static final String JIRA_ISSUE_KEY_START_HEADER = "=== BEGIN JIRA ISSUE KEYS ===";
+    public static final String JIRA_ISSUE_KEY_END_HEADER = "=== END JIRA ISSUE KEYS ===";
+    public static final String JIRA_ISSUE_KEY_PROJECT_ID = "projectId";
+    public static final String JIRA_ISSUE_KEY_PROJECT_VERSION_ID = "projectVersionId";
+    public static final String JIRA_ISSUE_KEY_COMPONENT_NAME = "projectVersionId";
+    public static final String JIRA_ISSUE_KEY_COMPONENT_VERSION_NAME = "projectVersionId";
+    public static final String JIRA_ISSUE_KEY_CATEGORY = "category";
+    public static final String JIRA_ISSUE_KEY_POLICY_NAME = "projectVersionId";
+
     private JiraIssuePropertyKeys() {
     }
 

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JiraIssuePropertyKeys.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JiraIssuePropertyKeys.java
@@ -29,10 +29,10 @@ public final class JiraIssuePropertyKeys {
     public static final String JIRA_ISSUE_KEY_END_HEADER = "=== END JIRA ISSUE KEYS ===";
     public static final String JIRA_ISSUE_KEY_PROJECT_ID = "projectId";
     public static final String JIRA_ISSUE_KEY_PROJECT_VERSION_ID = "projectVersionId";
-    public static final String JIRA_ISSUE_KEY_COMPONENT_NAME = "projectVersionId";
-    public static final String JIRA_ISSUE_KEY_COMPONENT_VERSION_NAME = "projectVersionId";
+    public static final String JIRA_ISSUE_KEY_COMPONENT_NAME = "componentName";
+    public static final String JIRA_ISSUE_KEY_COMPONENT_VERSION_NAME = "componentVersionName";
     public static final String JIRA_ISSUE_KEY_CATEGORY = "category";
-    public static final String JIRA_ISSUE_KEY_POLICY_NAME = "projectVersionId";
+    public static final String JIRA_ISSUE_KEY_POLICY_NAME = "policyName";
 
     private JiraIssuePropertyKeys() {
     }

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JqlStringCreator.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JqlStringCreator.java
@@ -82,6 +82,54 @@ public final class JqlStringCreator {
 
     // Helper methods
 
+    private static void appendBlackDuckCommentSearchStrings(
+        StringBuilder jqlBuilder,
+        String jiraProjectKey,
+        LinkableItem project,
+        @Nullable LinkableItem projectVersion,
+        @Nullable LinkableItem component,
+        @Nullable LinkableItem componentVersion,
+        @Nullable ComponentConcernType concernType,
+        @Nullable String policyName) {
+        jqlBuilder.append("(");
+        jqlBuilder.append(StringUtils.SPACE);
+        appendProjectKey(jqlBuilder, jiraProjectKey);
+        jqlBuilder.append(StringUtils.SPACE);
+        jqlBuilder.append(SEARCH_CONJUNCTION);
+        jqlBuilder.append(String.format("comment ~\"%s\"", JiraIssuePropertyKeys.JIRA_ISSUE_KEY_START_HEADER));
+        jqlBuilder.append(StringUtils.SPACE);
+        appendCommentSearchString(jqlBuilder, JiraIssuePropertyKeys.JIRA_ISSUE_KEY_PROJECT_ID, "");
+
+        if(projectVersion != null) {
+            jqlBuilder.append(StringUtils.SPACE);
+            appendCommentSearchString(jqlBuilder, JiraIssuePropertyKeys.JIRA_ISSUE_KEY_PROJECT_VERSION_ID, "");
+        }
+
+        if(component != null) {
+            jqlBuilder.append(StringUtils.SPACE);
+            appendCommentSearchString(jqlBuilder, JiraIssuePropertyKeys.JIRA_ISSUE_KEY_COMPONENT_NAME, component.getValue());
+        }
+
+        if(componentVersion != null) {
+            jqlBuilder.append(StringUtils.SPACE);
+            appendCommentSearchString(jqlBuilder, JiraIssuePropertyKeys.JIRA_ISSUE_KEY_COMPONENT_VERSION_NAME, componentVersion.getValue());
+        }
+
+        if(concernType != null) {
+            jqlBuilder.append(StringUtils.SPACE);
+            appendCommentSearchString(jqlBuilder, JiraIssuePropertyKeys.JIRA_ISSUE_KEY_CATEGORY, concernType.name());
+        }
+
+        if(StringUtils.isNotBlank(policyName)) {
+            String escapedPolicyName = JiraIssueSearchPropertyStringCompatibilityUtils.createPolicyAdditionalKey(policyName);
+            jqlBuilder.append(StringUtils.SPACE);
+            appendCommentSearchString(jqlBuilder, JiraIssuePropertyKeys.JIRA_ISSUE_KEY_POLICY_NAME, escapedPolicyName);
+        }
+        jqlBuilder.append(StringUtils.SPACE);
+        jqlBuilder.append(")");
+    }
+
+
     private static void appendBlackDuckComponentSearchStrings(
         StringBuilder jqlBuilder,
         String jiraProjectKey,
@@ -130,6 +178,14 @@ public final class JqlStringCreator {
         jqlBuilder.append(" = '");
         jqlBuilder.append(escapeSearchString(jiraProjectKey));
         jqlBuilder.append("' ");
+    }
+
+    private static void appendCommentSearchString(StringBuilder jqlBuilder, String key, String value) {
+        jqlBuilder.append(SEARCH_CONJUNCTION);
+        jqlBuilder.append(" comment ~ \"");
+        jqlBuilder.append(String.format("%s%s %s", key,JiraIssuePropertyKeys.JIRA_ISSUE_KEY_SEPARATOR, escapeSearchString(value)));
+        jqlBuilder.append("\"");
+        jqlBuilder.append(StringUtils.SPACE);
     }
 
     private static void appendPropertySearchString(StringBuilder jqlBuilder, String key, String value) {

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JqlStringCreator.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JqlStringCreator.java
@@ -10,6 +10,7 @@ package com.blackduck.integration.alert.api.channel.jira.distribution.search;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import com.blackduck.integration.alert.api.channel.jira.JiraConstants;
@@ -26,7 +27,12 @@ public final class JqlStringCreator {
         LinkableItem project
     ) {
         StringBuilder jqlBuilder = new StringBuilder();
+        appendBlackDuckCommentSearchStrings(jqlBuilder, jiraProjectKey, project, null, null, null, null, null);
+        jqlBuilder.append(" OR ");
+        jqlBuilder.append("(");
         appendBlackDuckProjectSearchStrings(jqlBuilder, jiraProjectKey, provider, project);
+        jqlBuilder.append(")");
+
         return jqlBuilder.toString();
     }
 
@@ -37,7 +43,11 @@ public final class JqlStringCreator {
         LinkableItem projectVersion
     ) {
         StringBuilder jqlBuilder = new StringBuilder();
+        appendBlackDuckCommentSearchStrings(jqlBuilder, jiraProjectKey, project, projectVersion, null, null, null, null);
+        jqlBuilder.append(" OR ");
+        jqlBuilder.append("(");
         appendBlackDuckProjectVersionSearchStrings(jqlBuilder, jiraProjectKey, provider, project, projectVersion);
+        jqlBuilder.append(")");
 
         return jqlBuilder.toString();
     }
@@ -51,7 +61,11 @@ public final class JqlStringCreator {
         @Nullable LinkableItem componentVersion
     ) {
         StringBuilder jqlBuilder = new StringBuilder();
+        appendBlackDuckCommentSearchStrings(jqlBuilder, jiraProjectKey, project, projectVersion, component, componentVersion, null, null);
+        jqlBuilder.append(" OR ");
+        jqlBuilder.append("(");
         appendBlackDuckComponentSearchStrings(jqlBuilder, jiraProjectKey, provider, project, projectVersion, component, componentVersion);
+        jqlBuilder.append(")");
 
         return jqlBuilder.toString();
     }
@@ -67,6 +81,9 @@ public final class JqlStringCreator {
         @Nullable String policyName
     ) {
         StringBuilder jqlBuilder = new StringBuilder();
+        appendBlackDuckCommentSearchStrings(jqlBuilder, jiraProjectKey, project, projectVersion, component, componentVersion, concernType, policyName);
+        jqlBuilder.append(" OR ");
+        jqlBuilder.append("(");
         appendBlackDuckComponentSearchStrings(jqlBuilder, jiraProjectKey, provider, project, projectVersion, component, componentVersion);
 
         String category = JiraIssueSearchPropertyStringCompatibilityUtils.createCategory(concernType);
@@ -76,6 +93,7 @@ public final class JqlStringCreator {
             String additionalKey = JiraIssueSearchPropertyStringCompatibilityUtils.createPolicyAdditionalKey(policyName);
             appendPropertySearchString(jqlBuilder, JiraIssuePropertyKeys.JIRA_ISSUE_PROPERTY_OBJECT_KEY_ADDITIONAL_KEY, additionalKey);
         }
+        jqlBuilder.append(")");
 
         return jqlBuilder.toString();
     }
@@ -91,42 +109,55 @@ public final class JqlStringCreator {
         @Nullable LinkableItem componentVersion,
         @Nullable ComponentConcernType concernType,
         @Nullable String policyName) {
+
         jqlBuilder.append("(");
-        jqlBuilder.append(StringUtils.SPACE);
         appendProjectKey(jqlBuilder, jiraProjectKey);
-        jqlBuilder.append(StringUtils.SPACE);
         jqlBuilder.append(SEARCH_CONJUNCTION);
+        jqlBuilder.append(StringUtils.SPACE);
         jqlBuilder.append(String.format("comment ~\"%s\"", JiraIssuePropertyKeys.JIRA_ISSUE_KEY_START_HEADER));
         jqlBuilder.append(StringUtils.SPACE);
-        appendCommentSearchString(jqlBuilder, JiraIssuePropertyKeys.JIRA_ISSUE_KEY_PROJECT_ID, "");
 
-        if(projectVersion != null) {
-            jqlBuilder.append(StringUtils.SPACE);
-            appendCommentSearchString(jqlBuilder, JiraIssuePropertyKeys.JIRA_ISSUE_KEY_PROJECT_VERSION_ID, "");
+        if(project != null && project.getUrl().isPresent()) {
+            String projectId = extractUuid(project.getUrl().get(), "/api/projects/");
+            appendCommentSearchString(jqlBuilder, JiraIssuePropertyKeys.JIRA_ISSUE_KEY_PROJECT_ID, projectId);
+        }
+
+        if(projectVersion != null && projectVersion.getUrl().isPresent()) {
+            String projectVersionId = extractUuid(projectVersion.getUrl().get(), "/versions/");
+            appendCommentSearchString(jqlBuilder, JiraIssuePropertyKeys.JIRA_ISSUE_KEY_PROJECT_VERSION_ID, projectVersionId);
         }
 
         if(component != null) {
-            jqlBuilder.append(StringUtils.SPACE);
             appendCommentSearchString(jqlBuilder, JiraIssuePropertyKeys.JIRA_ISSUE_KEY_COMPONENT_NAME, component.getValue());
         }
 
         if(componentVersion != null) {
-            jqlBuilder.append(StringUtils.SPACE);
             appendCommentSearchString(jqlBuilder, JiraIssuePropertyKeys.JIRA_ISSUE_KEY_COMPONENT_VERSION_NAME, componentVersion.getValue());
         }
 
         if(concernType != null) {
-            jqlBuilder.append(StringUtils.SPACE);
             appendCommentSearchString(jqlBuilder, JiraIssuePropertyKeys.JIRA_ISSUE_KEY_CATEGORY, concernType.name());
         }
 
         if(StringUtils.isNotBlank(policyName)) {
             String escapedPolicyName = JiraIssueSearchPropertyStringCompatibilityUtils.createPolicyAdditionalKey(policyName);
-            jqlBuilder.append(StringUtils.SPACE);
             appendCommentSearchString(jqlBuilder, JiraIssuePropertyKeys.JIRA_ISSUE_KEY_POLICY_NAME, escapedPolicyName);
         }
-        jqlBuilder.append(StringUtils.SPACE);
         jqlBuilder.append(")");
+    }
+
+    private static @NotNull String extractUuid(String url, String pathSearchToken) {
+        int searchTokenStart = StringUtils.indexOf(url, pathSearchToken);
+        int startIndex = searchTokenStart + pathSearchToken.length();
+        int endSlashIndex = StringUtils.lastIndexOf(url, '/', startIndex);
+        String uuid;
+        if(endSlashIndex > startIndex) {
+            uuid = StringUtils.substring(url, startIndex, endSlashIndex);
+        } else {
+            uuid = StringUtils.substring(url, startIndex);
+        }
+
+        return uuid;
     }
 
 
@@ -183,7 +214,7 @@ public final class JqlStringCreator {
     private static void appendCommentSearchString(StringBuilder jqlBuilder, String key, String value) {
         jqlBuilder.append(SEARCH_CONJUNCTION);
         jqlBuilder.append(" comment ~ \"");
-        jqlBuilder.append(String.format("%s%s %s", key,JiraIssuePropertyKeys.JIRA_ISSUE_KEY_SEPARATOR, escapeSearchString(value)));
+        jqlBuilder.append(String.format("%s%s%s", key,JiraIssuePropertyKeys.JIRA_ISSUE_KEY_SEPARATOR, escapeSearchString(value)));
         jqlBuilder.append("\"");
         jqlBuilder.append(StringUtils.SPACE);
     }

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JqlStringCreator.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JqlStringCreator.java
@@ -149,7 +149,7 @@ public final class JqlStringCreator {
     private static @NotNull String extractUuid(String url, String pathSearchToken) {
         int searchTokenStart = StringUtils.indexOf(url, pathSearchToken);
         int startIndex = searchTokenStart + pathSearchToken.length();
-        int endSlashIndex = StringUtils.lastIndexOf(url, '/', startIndex);
+        int endSlashIndex = StringUtils.indexOf(url, '/', startIndex);
         String uuid;
         if(endSlashIndex > startIndex) {
             uuid = StringUtils.substring(url, startIndex, endSlashIndex);

--- a/api-channel-jira/src/test/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JqlStringCreatorTest.java
+++ b/api-channel-jira/src/test/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JqlStringCreatorTest.java
@@ -20,12 +20,12 @@ class JqlStringCreatorTest {
     private final LinkableItem project = new LinkableItem(
         "Project",
         "project_with_single_quote'",
-        "http://projectUrl"
+        "http://projectUrl/api/projects/project-uuid"
     );
     private final LinkableItem projectVersion = new LinkableItem(
         "Project Version",
         "v1.0 \\& v2.0",
-        "http://projectVersionUrl"
+        "http://projectVersionUrl/api/projects/project-uuid/versions/project-version-uuid"
     );
     private final LinkableItem component = new LinkableItem(
         "Component",
@@ -52,7 +52,17 @@ class JqlStringCreatorTest {
             policyName
         );
         String expectedSearchString =
-            "project = 'TEST' "
+            "("
+                + "project = 'TEST'"
+                + " AND comment ~\"=== BEGIN JIRA ISSUE KEYS ===\""
+                + " AND comment ~ \"projectId: project-uuid\""
+                + " AND comment ~ \"projectVersionId: project-version-uuid\""
+                + " AND comment ~ \"componentName: myVulnerableComponent\""
+                + " AND comment ~ \"componentVersionName: 1.1.2\""
+                + " AND comment ~ \"category: POLICY\""
+                + " AND comment ~ \"policyName: Policy ViolatedMyPolicy\""
+                + " ) OR ("
+                + "project = 'TEST' "
                 + "AND (issue.property[com-blackduck-integration-alert].provider = 'Black Duck' OR issue.property[com-synopsys-integration-alert].provider = 'Black Duck') "
                 + "AND (issue.property[com-blackduck-integration-alert].providerUrl = 'http://providerUrl/' OR issue.property[com-synopsys-integration-alert].providerUrl = 'http://providerUrl/') "
                 + "AND (issue.property[com-blackduck-integration-alert].topicName = 'Project' OR issue.property[com-synopsys-integration-alert].topicName = 'Project') "
@@ -64,7 +74,8 @@ class JqlStringCreatorTest {
                 + "AND (issue.property[com-blackduck-integration-alert].subComponentName = 'Component Version' OR issue.property[com-synopsys-integration-alert].subComponentName = 'Component Version') "
                 + "AND (issue.property[com-blackduck-integration-alert].subComponentValue = '1.1.2' OR issue.property[com-synopsys-integration-alert].subComponentValue = '1.1.2') "
                 + "AND (issue.property[com-blackduck-integration-alert].category = 'Policy' OR issue.property[com-synopsys-integration-alert].category = 'Policy') "
-                + "AND (issue.property[com-blackduck-integration-alert].additionalKey = 'Policy ViolatedMyPolicy' OR issue.property[com-synopsys-integration-alert].additionalKey = 'Policy ViolatedMyPolicy') ";
+                + "AND (issue.property[com-blackduck-integration-alert].additionalKey = 'Policy ViolatedMyPolicy' OR issue.property[com-synopsys-integration-alert].additionalKey = 'Policy ViolatedMyPolicy') "
+                + ")";
 
         assertEquals(expectedSearchString, jqlString);
     }
@@ -82,7 +93,16 @@ class JqlStringCreatorTest {
             null
         );
         String expectedSearchString =
-            "project = 'TEST' "
+            "("
+                + "project = 'TEST'"
+                + " AND comment ~\"=== BEGIN JIRA ISSUE KEYS ===\""
+                + " AND comment ~ \"projectId: project-uuid\""
+                + " AND comment ~ \"projectVersionId: project-version-uuid\""
+                + " AND comment ~ \"componentName: myVulnerableComponent\""
+                + " AND comment ~ \"componentVersionName: 1.1.2\""
+                + " AND comment ~ \"category: VULNERABILITY\""
+                + " ) OR ("
+                + "project = 'TEST' "
                 + "AND (issue.property[com-blackduck-integration-alert].provider = 'Black Duck' OR issue.property[com-synopsys-integration-alert].provider = 'Black Duck') "
                 + "AND (issue.property[com-blackduck-integration-alert].providerUrl = 'http://providerUrl/' OR issue.property[com-synopsys-integration-alert].providerUrl = 'http://providerUrl/') "
                 + "AND (issue.property[com-blackduck-integration-alert].topicName = 'Project' OR issue.property[com-synopsys-integration-alert].topicName = 'Project') "
@@ -93,7 +113,8 @@ class JqlStringCreatorTest {
                 + "AND (issue.property[com-blackduck-integration-alert].componentValue = 'myVulnerableComponent' OR issue.property[com-synopsys-integration-alert].componentValue = 'myVulnerableComponent') "
                 + "AND (issue.property[com-blackduck-integration-alert].subComponentName = 'Component Version' OR issue.property[com-synopsys-integration-alert].subComponentName = 'Component Version') "
                 + "AND (issue.property[com-blackduck-integration-alert].subComponentValue = '1.1.2' OR issue.property[com-synopsys-integration-alert].subComponentValue = '1.1.2') "
-                + "AND (issue.property[com-blackduck-integration-alert].category = 'Vulnerability' OR issue.property[com-synopsys-integration-alert].category = 'Vulnerability') ";
+                + "AND (issue.property[com-blackduck-integration-alert].category = 'Vulnerability' OR issue.property[com-synopsys-integration-alert].category = 'Vulnerability') "
+                + ")";
 
         assertEquals(expectedSearchString, jqlString);
     }
@@ -104,7 +125,7 @@ class JqlStringCreatorTest {
         LinkableItem projectVersionInjected = new LinkableItem(
             "Project Version",
             exploitableString,
-            "http://projectVersionUrl"
+            "http:///api/projects/project-uuid/versions/projectVersionUrl"
         );
         String jqlString = JqlStringCreator.createBlackDuckComponentConcernIssuesSearchString(
             JIRA_PROJECT_KEY,
@@ -117,7 +138,16 @@ class JqlStringCreatorTest {
             null
         );
         String expectedSearchString =
-            "project = 'TEST' "
+            "("
+                + "project = 'TEST'"
+                + " AND comment ~\"=== BEGIN JIRA ISSUE KEYS ===\""
+                + " AND comment ~ \"projectId: project-uuid\""
+                + " AND comment ~ \"projectVersionId: projectVersionUrl\""
+                + " AND comment ~ \"componentName: myVulnerableComponent\""
+                + " AND comment ~ \"componentVersionName: 1.1.2\""
+                + " AND comment ~ \"category: VULNERABILITY\""
+                + " ) OR ("
+                + "project = 'TEST' "
                 + "AND (issue.property[com-blackduck-integration-alert].provider = 'Black Duck' OR issue.property[com-synopsys-integration-alert].provider = 'Black Duck') "
                 + "AND (issue.property[com-blackduck-integration-alert].providerUrl = 'http://providerUrl/' OR issue.property[com-synopsys-integration-alert].providerUrl = 'http://providerUrl/') "
                 + "AND (issue.property[com-blackduck-integration-alert].topicName = 'Project' OR issue.property[com-synopsys-integration-alert].topicName = 'Project') "
@@ -128,7 +158,8 @@ class JqlStringCreatorTest {
                 + "AND (issue.property[com-blackduck-integration-alert].componentValue = 'myVulnerableComponent' OR issue.property[com-synopsys-integration-alert].componentValue = 'myVulnerableComponent') "
                 + "AND (issue.property[com-blackduck-integration-alert].subComponentName = 'Component Version' OR issue.property[com-synopsys-integration-alert].subComponentName = 'Component Version') "
                 + "AND (issue.property[com-blackduck-integration-alert].subComponentValue = '1.1.2' OR issue.property[com-synopsys-integration-alert].subComponentValue = '1.1.2') "
-                + "AND (issue.property[com-blackduck-integration-alert].category = 'Vulnerability' OR issue.property[com-synopsys-integration-alert].category = 'Vulnerability') ";
+                + "AND (issue.property[com-blackduck-integration-alert].category = 'Vulnerability' OR issue.property[com-synopsys-integration-alert].category = 'Vulnerability') "
+                + ")";
 
         assertEquals(expectedSearchString, jqlString);
     }

--- a/api-channel-jira/src/test/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JqlStringCreatorTest.java
+++ b/api-channel-jira/src/test/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JqlStringCreatorTest.java
@@ -25,7 +25,7 @@ class JqlStringCreatorTest {
     private final LinkableItem projectVersion = new LinkableItem(
         "Project Version",
         "v1.0 \\& v2.0",
-        "http://projectVersionUrl/api/projects/project-uuid/versions/project-version-uuid"
+        "http://projectVersionUrl/api/projects/project-uuid/versions/project-version-uuid/components"
     );
     private final LinkableItem component = new LinkableItem(
         "Component",


### PR DESCRIPTION
# Pull Request template

When creating a Jira issue add a comment containing the search keys to be able to fin the issue without the need for the alert-issue-property indexer plugin.  The contents of the properties that are added to the Jira tickets is essentially added to the Jira tickets as a comment.  The comment will look like this example:

```
This comment was automatically created by Alert. DO NOT REMOVE.=== BEGIN JIRA ISSUE KEYS === projectId: dca08da8-349a-4556-a608-ace2523a9f13 projectVersionId: 8f9ad494-9b90-4c79-9463-de345183acf6 componentName: Apache Commons FileUpload componentVersionName: 1.2.1 category: POLICY policyName: Policy ViolatedOpenSSL not 1.0 === END JIRA ISSUE KEYS ===
```

The JQL query string will create a query string looking for comments first then falls back to the properties search. (jql for comment search) OR (JQL for original properties search)
