### PR TITLE
IALERT-3868 remove add comments from Jira Server and Jira Cloud Distribution Jobs

### DIFF
--- a/alert-common/src/main/java/com/blackduck/integration/alert/common/persistence/model/job/details/JiraCloudJobDetailsModel.java
+++ b/alert-common/src/main/java/com/blackduck/integration/alert/common/persistence/model/job/details/JiraCloudJobDetailsModel.java
@@ -13,7 +13,6 @@ import java.util.UUID;
 import com.blackduck.integration.alert.api.descriptor.model.ChannelKeys;
 
 public class JiraCloudJobDetailsModel extends DistributionJobDetailsModel {
-    private final boolean addComments;
     private final String issueCreatorEmail;
     private final String projectNameOrKey;
     private final String issueType;
@@ -24,7 +23,6 @@ public class JiraCloudJobDetailsModel extends DistributionJobDetailsModel {
 
     public JiraCloudJobDetailsModel(
         UUID jobId,
-        boolean addComments,
         String issueCreatorEmail,
         String projectNameOrKey,
         String issueType,
@@ -34,7 +32,6 @@ public class JiraCloudJobDetailsModel extends DistributionJobDetailsModel {
         String issueSummary
     ) {
         super(ChannelKeys.JIRA_CLOUD, jobId);
-        this.addComments = addComments;
         this.issueCreatorEmail = issueCreatorEmail;
         this.projectNameOrKey = projectNameOrKey;
         this.issueType = issueType;
@@ -42,10 +39,6 @@ public class JiraCloudJobDetailsModel extends DistributionJobDetailsModel {
         this.reopenTransition = reopenTransition;
         this.customFields = customFields;
         this.issueSummary = issueSummary;
-    }
-
-    public boolean isAddComments() {
-        return addComments;
     }
 
     public String getIssueCreatorEmail() {

--- a/alert-common/src/main/java/com/blackduck/integration/alert/common/persistence/model/job/details/JiraServerJobDetailsModel.java
+++ b/alert-common/src/main/java/com/blackduck/integration/alert/common/persistence/model/job/details/JiraServerJobDetailsModel.java
@@ -13,7 +13,6 @@ import java.util.UUID;
 import com.blackduck.integration.alert.api.descriptor.model.ChannelKeys;
 
 public class JiraServerJobDetailsModel extends DistributionJobDetailsModel {
-    private final boolean addComments;
     private final String issueCreatorUsername;
     private final String projectNameOrKey;
     private final String issueType;
@@ -24,7 +23,6 @@ public class JiraServerJobDetailsModel extends DistributionJobDetailsModel {
 
     public JiraServerJobDetailsModel(
         UUID jobId,
-        boolean addComments,
         String issueCreatorUsername,
         String projectNameOrKey,
         String issueType,
@@ -34,7 +32,6 @@ public class JiraServerJobDetailsModel extends DistributionJobDetailsModel {
         String issueSummary
     ) {
         super(ChannelKeys.JIRA_SERVER, jobId);
-        this.addComments = addComments;
         this.issueCreatorUsername = issueCreatorUsername;
         this.projectNameOrKey = projectNameOrKey;
         this.issueType = issueType;
@@ -42,10 +39,6 @@ public class JiraServerJobDetailsModel extends DistributionJobDetailsModel {
         this.reopenTransition = reopenTransition;
         this.customFields = customFields;
         this.issueSummary = issueSummary;
-    }
-
-    public boolean isAddComments() {
-        return addComments;
     }
 
     public String getIssueCreatorUsername() {

--- a/alert-common/src/test/java/com/blackduck/integration/alert/common/persistence/model/job/details/DistributionJobDetailsModelJsonAdapterTest.java
+++ b/alert-common/src/test/java/com/blackduck/integration/alert/common/persistence/model/job/details/DistributionJobDetailsModelJsonAdapterTest.java
@@ -65,7 +65,7 @@ public class DistributionJobDetailsModelJsonAdapterTest {
     @Test
     public void serializeJiraCloudJobDetailsModelTest() {
         UUID jobId = UUID.randomUUID();
-        JiraCloudJobDetailsModel baseModel = new JiraCloudJobDetailsModel(jobId, true, "unknown", "JIRA-X", "bug", "done", "undone", List.of(), null);
+        JiraCloudJobDetailsModel baseModel = new JiraCloudJobDetailsModel(jobId, "unknown", "JIRA-X", "bug", "done", "undone", List.of(), null);
         JsonElement baseJson = gson.toJsonTree(baseModel);
         serializeAndAssert(baseModel, baseJson);
     }
@@ -73,7 +73,7 @@ public class DistributionJobDetailsModelJsonAdapterTest {
     @Test
     public void serializeJiraServerJobDetailsModelTest() {
         UUID jobId = UUID.randomUUID();
-        JiraServerJobDetailsModel baseModel = new JiraServerJobDetailsModel(jobId, true, "user_name01", "JIRA-Y", "other", "finished", "unfinished", List.of(), "issueSummary");
+        JiraServerJobDetailsModel baseModel = new JiraServerJobDetailsModel(jobId, "user_name01", "JIRA-Y", "other", "finished", "unfinished", List.of(), "issueSummary");
         JsonElement baseJson = gson.toJsonTree(baseModel);
         serializeAndAssert(baseModel, baseJson);
     }
@@ -144,13 +144,12 @@ public class DistributionJobDetailsModelJsonAdapterTest {
     @Test
     public void deserializeJiraCloudJobDetailsModelTest() {
         UUID jobId = UUID.randomUUID();
-        JiraCloudJobDetailsModel baseModel = new JiraCloudJobDetailsModel(jobId, true, "unknown", "JIRA-X", "bug", "done", "undone", List.of(), null);
+        JiraCloudJobDetailsModel baseModel = new JiraCloudJobDetailsModel(jobId, "unknown", "JIRA-X", "bug", "done", "undone", List.of(), null);
 
         DistributionJobDetailsModel deserializedModel = runDeserializerAndAssert(baseModel, (distributionJobDetailsModel -> distributionJobDetailsModel.isA(ChannelKeys.JIRA_CLOUD)));
 
         JiraCloudJobDetailsModel jobDetails = deserializedModel.getAs(DistributionJobDetailsModel.JIRA_CLOUD);
         assertEquals(baseModel.getJobId(), jobDetails.getJobId());
-        assertEquals(baseModel.isAddComments(), jobDetails.isAddComments());
         assertEquals(baseModel.getIssueCreatorEmail(), jobDetails.getIssueCreatorEmail());
         assertEquals(baseModel.getProjectNameOrKey(), jobDetails.getProjectNameOrKey());
         assertEquals(baseModel.getIssueType(), jobDetails.getIssueType());
@@ -161,13 +160,12 @@ public class DistributionJobDetailsModelJsonAdapterTest {
     @Test
     public void deserializeJiraServerJobDetailsModelTest() {
         UUID jobId = UUID.randomUUID();
-        JiraServerJobDetailsModel baseModel = new JiraServerJobDetailsModel(jobId, true, "user_name01", "JIRA-Y", "other", "finished", "unfinished", List.of(), "issueSummary");
+        JiraServerJobDetailsModel baseModel = new JiraServerJobDetailsModel(jobId, "user_name01", "JIRA-Y", "other", "finished", "unfinished", List.of(), "issueSummary");
 
         DistributionJobDetailsModel deserializedModel = runDeserializerAndAssert(baseModel, (distributionJobDetailsModel -> distributionJobDetailsModel.isA(ChannelKeys.JIRA_SERVER)));
 
         JiraServerJobDetailsModel jobDetails = deserializedModel.getAs(DistributionJobDetailsModel.JIRA_SERVER);
         assertEquals(baseModel.getJobId(), jobDetails.getJobId());
-        assertEquals(baseModel.isAddComments(), jobDetails.isAddComments());
         assertEquals(baseModel.getIssueCreatorUsername(), jobDetails.getIssueCreatorUsername());
         assertEquals(baseModel.getProjectNameOrKey(), jobDetails.getProjectNameOrKey());
         assertEquals(baseModel.getIssueType(), jobDetails.getIssueType());

--- a/alert-database-job/src/main/java/com/blackduck/integration/alert/database/job/api/StaticJobAccessor.java
+++ b/alert-database-job/src/main/java/com/blackduck/integration/alert/database/job/api/StaticJobAccessor.java
@@ -264,7 +264,6 @@ public class StaticJobAccessor implements JobAccessor {
                 .collect(Collectors.toList());
             distributionJobDetailsModel = new JiraCloudJobDetailsModel(
                 jobId,
-                jobDetails.getAddComments(),
                 jobDetails.getIssueCreatorEmail(),
                 jobDetails.getProjectNameOrKey(),
                 jobDetails.getIssueType(),

--- a/alert-database-job/src/test/java/com/blackduck/integration/alert/database/job/api/StaticJobAccessorTest.java
+++ b/alert-database-job/src/test/java/com/blackduck/integration/alert/database/job/api/StaticJobAccessorTest.java
@@ -406,10 +406,10 @@ class StaticJobAccessorTest {
     @Test
     void createJiraCloudJobTest() {
         UUID jobId = UUID.randomUUID();
-        JiraCloudJobDetailsModel jiraCloudJobDetailsModel = new JiraCloudJobDetailsModel(jobId, false, null, null, null, null, null, List.of(), null);
+        JiraCloudJobDetailsModel jiraCloudJobDetailsModel = new JiraCloudJobDetailsModel(jobId, null, null, null, null, null, List.of(), null);
         DistributionJobRequestModel distributionJobRequestModel = createDistributionJobEntity(ChannelKeys.JIRA_CLOUD.getUniversalKey(), jiraCloudJobDetailsModel);
 
-        JiraCloudJobDetailsEntity jiraCloudJobDetailsEntity = new JiraCloudJobDetailsEntity(null, false, null, null, null, null, null, null);
+        JiraCloudJobDetailsEntity jiraCloudJobDetailsEntity = new JiraCloudJobDetailsEntity(null, null, null, null, null, null, null);
         jiraCloudJobDetailsEntity.setJobCustomFields(List.of());
         DistributionJobEntity distributionJobEntity = createDistributionJobEntity(jobId, distributionJobRequestModel);
         distributionJobEntity.setJiraCloudJobDetails(jiraCloudJobDetailsEntity);
@@ -428,10 +428,10 @@ class StaticJobAccessorTest {
     @Test
     void createJiraServerJobTest() {
         UUID jobId = UUID.randomUUID();
-        JiraServerJobDetailsModel jiraServerJobDetailsModel = new JiraServerJobDetailsModel(jobId, false, null, null, null, null, null, List.of(), "issueSummary");
+        JiraServerJobDetailsModel jiraServerJobDetailsModel = new JiraServerJobDetailsModel(jobId, null, null, null, null, null, List.of(), "issueSummary");
         DistributionJobRequestModel distributionJobRequestModel = createDistributionJobEntity(ChannelKeys.JIRA_SERVER.getUniversalKey(), jiraServerJobDetailsModel);
 
-        JiraServerJobDetailsEntity jiraServerJobDetailsEntity = new JiraServerJobDetailsEntity(null, false, null, null, null, null, null, null);
+        JiraServerJobDetailsEntity jiraServerJobDetailsEntity = new JiraServerJobDetailsEntity(null, null, null, null, null, null, null);
         jiraServerJobDetailsEntity.setJobCustomFields(List.of());
         DistributionJobEntity distributionJobEntity = createDistributionJobEntity(jobId, distributionJobRequestModel);
         distributionJobEntity.setJiraServerJobDetails(jiraServerJobDetailsEntity);

--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/job/jira/cloud/DefaultJiraCloudJobDetailsAccessor.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/job/jira/cloud/DefaultJiraCloudJobDetailsAccessor.java
@@ -44,7 +44,6 @@ public class DefaultJiraCloudJobDetailsAccessor implements JiraCloudJobDetailsAc
     public JiraCloudJobDetailsEntity saveJiraCloudJobDetails(UUID jobId, JiraCloudJobDetailsModel jiraCloudJobDetails) {
         JiraCloudJobDetailsEntity jiraCloudJobDetailsToSave = new JiraCloudJobDetailsEntity(
             jobId,
-            jiraCloudJobDetails.isAddComments(),
             jiraCloudJobDetails.getIssueCreatorEmail(),
             jiraCloudJobDetails.getProjectNameOrKey(),
             jiraCloudJobDetails.getIssueType(),
@@ -77,7 +76,6 @@ public class DefaultJiraCloudJobDetailsAccessor implements JiraCloudJobDetailsAc
                                                          .toList();
         return new JiraCloudJobDetailsModel(
             jobDetails.getJobId(),
-            jobDetails.getAddComments(),
             jobDetails.getIssueCreatorEmail(),
             jobDetails.getProjectNameOrKey(),
             jobDetails.getIssueType(),

--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/job/jira/cloud/JiraCloudJobDetailsEntity.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/job/jira/cloud/JiraCloudJobDetailsEntity.java
@@ -26,9 +26,6 @@ public class JiraCloudJobDetailsEntity {
     @Column(name = "job_id")
     private UUID jobId;
 
-    @Column(name = "add_comments")
-    private Boolean addComments;
-
     @Column(name = "issue_creator_email")
     private String issueCreatorEmail;
 
@@ -54,9 +51,8 @@ public class JiraCloudJobDetailsEntity {
     public JiraCloudJobDetailsEntity() {
     }
 
-    public JiraCloudJobDetailsEntity(UUID jobId, Boolean addComments, String issueCreatorEmail, String projectNameOrKey, String issueType, String resolveTransition, String reopenTransition, String issueSummary) {
+    public JiraCloudJobDetailsEntity(UUID jobId, String issueCreatorEmail, String projectNameOrKey, String issueType, String resolveTransition, String reopenTransition, String issueSummary) {
         this.jobId = jobId;
-        this.addComments = addComments;
         this.issueCreatorEmail = issueCreatorEmail;
         this.projectNameOrKey = projectNameOrKey;
         this.issueType = issueType;
@@ -71,14 +67,6 @@ public class JiraCloudJobDetailsEntity {
 
     public void setJobId(UUID jobId) {
         this.jobId = jobId;
-    }
-
-    public Boolean getAddComments() {
-        return addComments;
-    }
-
-    public void setAddComments(Boolean addComments) {
-        this.addComments = addComments;
     }
 
     public String getIssueCreatorEmail() {

--- a/alert-database/src/main/resources/liquibase/9.0.0/changelog.xml
+++ b/alert-database/src/main/resources/liquibase/9.0.0/changelog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+    <include file="jira-cloud-job-details-remove-comments.xml" relativeToChangelogFile="true"/>
+    <include file="jira-server-job-details-remove-comments.xml" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/alert-database/src/main/resources/liquibase/9.0.0/jira-cloud-job-details-remove-comments.xml
+++ b/alert-database/src/main/resources/liquibase/9.0.0/jira-cloud-job-details-remove-comments.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+    <changeSet author="psantos" id="jira-cloud-drop-comments-column">
+        <preConditions onFail="MARK_RAN">
+            <columnExists schemaName="alert" tableName="jira_cloud_job_details" columnName="add_comments"/>
+        </preConditions>
+        <dropColumn schemaName="alert" tableName="jira_cloud_job_details" columnName="add_comments"/>
+    </changeSet>
+</databaseChangeLog>

--- a/alert-database/src/main/resources/liquibase/9.0.0/jira-server-job-details-remove-comments.xml
+++ b/alert-database/src/main/resources/liquibase/9.0.0/jira-server-job-details-remove-comments.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+    <changeSet author="psantos" id="jira-server-drop-comments-column">
+        <preConditions onFail="MARK_RAN">
+            <columnExists schemaName="alert" tableName="jira_server_job_details" columnName="add_comments"/>
+        </preConditions>
+        <dropColumn schemaName="alert" tableName="jira_server_job_details" columnName="add_comments"/>
+    </changeSet>
+</databaseChangeLog>

--- a/alert-database/src/main/resources/liquibase/changelog-postgres-master.xml
+++ b/alert-database/src/main/resources/liquibase/changelog-postgres-master.xml
@@ -31,4 +31,5 @@
     <include file="7.1.2/changelog.xml" relativeToChangelogFile="true"/>
     <include file="8.0.0/changelog.xml" relativeToChangelogFile="true"/>
     <include file="8.1.0/changelog.xml" relativeToChangelogFile="true"/>
+    <include file="9.0.0/changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/action/JiraCloudJobDetailsExtractor.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/action/JiraCloudJobDetailsExtractor.java
@@ -34,7 +34,6 @@ public class JiraCloudJobDetailsExtractor extends JiraJobDetailsExtractor {
     public DistributionJobDetailsModel extractDetails(UUID jobId, Map<String, ConfigurationFieldModel> configuredFieldsMap) {
         return new JiraCloudJobDetailsModel(
             jobId,
-            fieldExtractor.extractFieldValue(JiraCloudDescriptor.KEY_ADD_COMMENTS, configuredFieldsMap).map(Boolean::valueOf).orElse(false),
             fieldExtractor.extractFieldValueOrEmptyString(JiraCloudDescriptor.KEY_ISSUE_CREATOR, configuredFieldsMap),
             fieldExtractor.extractFieldValueOrEmptyString(JiraCloudDescriptor.KEY_JIRA_PROJECT_NAME, configuredFieldsMap),
             fieldExtractor.extractFieldValueOrEmptyString(JiraCloudDescriptor.KEY_ISSUE_TYPE, configuredFieldsMap),

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/descriptor/JiraCloudDescriptor.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/descriptor/JiraCloudDescriptor.java
@@ -45,7 +45,6 @@ public class JiraCloudDescriptor extends ChannelDescriptor {
     public static final String JIRA_URL = "jira";
     public static final String JIRA_DESCRIPTION = "Configure the Jira Cloud instance that Alert will send issue updates to.";
 
-    public static final String LABEL_ADD_COMMENTS = "Add Comments";
     public static final String LABEL_ISSUE_CREATOR = "Issue Creator";
     public static final String LABEL_JIRA_PROJECT = "Jira Project";
     public static final String LABEL_ISSUE_TYPE = "Issue Type";

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/delegate/JiraCloudIssueCommenter.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/delegate/JiraCloudIssueCommenter.java
@@ -26,7 +26,7 @@ public class JiraCloudIssueCommenter extends JiraIssueCommenter {
 
     @Override
     protected boolean isCommentingEnabled() {
-        return distributionDetails.isAddComments();
+        return true;
     }
 
     @Override

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/JiraCloudIssueCreatorTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/JiraCloudIssueCreatorTest.java
@@ -42,7 +42,6 @@ public class JiraCloudIssueCreatorTest {
         String projectNameOrKey = "FakeProject";
         JiraCloudJobDetailsModel jiraCloudJobDetailsModel = new JiraCloudJobDetailsModel(
             UUID.randomUUID(),
-            false,
             "my@email.com",
             projectNameOrKey,
             "Task",
@@ -72,7 +71,6 @@ public class JiraCloudIssueCreatorTest {
         String projectNameOrKey = "FakeProject";
         JiraCloudJobDetailsModel jiraCloudJobDetailsModel = new JiraCloudJobDetailsModel(
             UUID.randomUUID(),
-            false,
             "my@email.com",
             projectNameOrKey,
             "Task",

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/JiraCloudSummaryFieldLengthTestIT.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/JiraCloudSummaryFieldLengthTestIT.java
@@ -125,7 +125,6 @@ public class JiraCloudSummaryFieldLengthTestIT {
 
         return new JiraCloudJobDetailsModel(
             UUID.randomUUID(),
-            true,
             issueCreator,
             projectName,
             issueType,

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandlerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandlerTest.java
@@ -167,7 +167,6 @@ class JiraCloudCommentEventHandlerTest {
     private JiraCloudJobDetailsModel createJobDetails(UUID jobId) {
         return new JiraCloudJobDetailsModel(
             jobId,
-            true,
             "user",
             "jiraProject",
             "Task",

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandlerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandlerTest.java
@@ -344,7 +344,6 @@ class JiraCloudCreateIssueEventHandlerTest {
     private JiraCloudJobDetailsModel createJobDetails(UUID jobId) {
         return new JiraCloudJobDetailsModel(
             jobId,
-            true,
             "user",
             "jiraProject",
             "Task",

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandlerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandlerTest.java
@@ -175,7 +175,6 @@ class JiraCloudTransitionEventHandlerTest {
     private JiraCloudJobDetailsModel createJobDetails(UUID jobId) {
         return new JiraCloudJobDetailsModel(
             jobId,
-            true,
             "user",
             "jiraProject",
             "Task",

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/action/JiraServerJobDetailsExtractor.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/action/JiraServerJobDetailsExtractor.java
@@ -36,7 +36,6 @@ public class JiraServerJobDetailsExtractor extends JiraJobDetailsExtractor {
     public DistributionJobDetailsModel extractDetails(UUID jobId, Map<String, ConfigurationFieldModel> configuredFieldsMap) {
         return new JiraServerJobDetailsModel(
             jobId,
-            fieldExtractor.extractFieldValue(JiraServerDescriptor.KEY_ADD_COMMENTS, configuredFieldsMap).map(Boolean::valueOf).orElse(false),
             fieldExtractor.extractFieldValueOrEmptyString(JiraServerDescriptor.KEY_ISSUE_CREATOR, configuredFieldsMap),
             fieldExtractor.extractFieldValueOrEmptyString(JiraServerDescriptor.KEY_JIRA_PROJECT_NAME, configuredFieldsMap),
             fieldExtractor.extractFieldValueOrEmptyString(JiraServerDescriptor.KEY_ISSUE_TYPE, configuredFieldsMap),

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/accessor/DefaultJiraServerJobDetailsAccessor.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/accessor/DefaultJiraServerJobDetailsAccessor.java
@@ -64,7 +64,6 @@ public class DefaultJiraServerJobDetailsAccessor implements JiraServerJobDetails
     public JiraServerJobDetailsModel saveConcreteJobDetails(UUID jobId, JiraServerJobDetailsModel jobDetails) {
         JiraServerJobDetailsEntity jiraServerJobDetailsToSave = new JiraServerJobDetailsEntity(
             jobId,
-            true,
             jobDetails.getIssueCreatorUsername(),
             jobDetails.getProjectNameOrKey(),
             jobDetails.getIssueType(),
@@ -91,7 +90,6 @@ public class DefaultJiraServerJobDetailsAccessor implements JiraServerJobDetails
             .toList();
         return new JiraServerJobDetailsModel(
             jobDetails.getJobId(),
-            true,
             jobDetails.getIssueCreatorUsername(),
             jobDetails.getProjectNameOrKey(),
             jobDetails.getIssueType(),

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/accessor/DefaultJiraServerJobDetailsAccessor.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/accessor/DefaultJiraServerJobDetailsAccessor.java
@@ -64,7 +64,7 @@ public class DefaultJiraServerJobDetailsAccessor implements JiraServerJobDetails
     public JiraServerJobDetailsModel saveConcreteJobDetails(UUID jobId, JiraServerJobDetailsModel jobDetails) {
         JiraServerJobDetailsEntity jiraServerJobDetailsToSave = new JiraServerJobDetailsEntity(
             jobId,
-            jobDetails.isAddComments(),
+            true,
             jobDetails.getIssueCreatorUsername(),
             jobDetails.getProjectNameOrKey(),
             jobDetails.getIssueType(),
@@ -91,7 +91,7 @@ public class DefaultJiraServerJobDetailsAccessor implements JiraServerJobDetails
             .toList();
         return new JiraServerJobDetailsModel(
             jobDetails.getJobId(),
-            jobDetails.getAddComments(),
+            true,
             jobDetails.getIssueCreatorUsername(),
             jobDetails.getProjectNameOrKey(),
             jobDetails.getIssueType(),

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/job/JiraServerJobDetailsEntity.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/database/job/JiraServerJobDetailsEntity.java
@@ -26,9 +26,6 @@ public class JiraServerJobDetailsEntity {
     @Column(name = "job_id")
     private UUID jobId;
 
-    @Column(name = "add_comments")
-    private Boolean addComments;
-
     @Column(name = "issue_creator_username")
     private String issueCreatorUsername;
 
@@ -54,9 +51,8 @@ public class JiraServerJobDetailsEntity {
     public JiraServerJobDetailsEntity() {
     }
 
-    public JiraServerJobDetailsEntity(UUID jobId, Boolean addComments, String issueCreatorUsername, String projectNameOrKey, String issueType, String resolveTransition, String reopenTransition, String issueSummary) {
+    public JiraServerJobDetailsEntity(UUID jobId, String issueCreatorUsername, String projectNameOrKey, String issueType, String resolveTransition, String reopenTransition, String issueSummary) {
         this.jobId = jobId;
-        this.addComments = addComments;
         this.issueCreatorUsername = issueCreatorUsername;
         this.projectNameOrKey = projectNameOrKey;
         this.issueType = issueType;
@@ -71,14 +67,6 @@ public class JiraServerJobDetailsEntity {
 
     public void setJobId(UUID jobId) {
         this.jobId = jobId;
-    }
-
-    public Boolean getAddComments() {
-        return addComments;
-    }
-
-    public void setAddComments(Boolean addComments) {
-        this.addComments = addComments;
     }
 
     public String getIssueCreatorUsername() {

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/descriptor/JiraServerDescriptor.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/descriptor/JiraServerDescriptor.java
@@ -46,7 +46,6 @@ public class JiraServerDescriptor extends ChannelDescriptor {
     public static final String JIRA_DESCRIPTION = "Configure the Jira Server instance that Alert will send issue updates to.";
 
     public static final String LABEL_FIELD_MAPPING = "Field Mapping";
-    public static final String LABEL_ADD_COMMENTS = "Add comments";
     public static final String LABEL_ISSUE_CREATOR = "Issue Creator";
     public static final String LABEL_JIRA_PROJECT = "Jira Project";
     public static final String LABEL_ISSUE_TYPE = "Issue Type";

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/delegate/JiraServerIssueCommenter.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/delegate/JiraServerIssueCommenter.java
@@ -26,7 +26,7 @@ public class JiraServerIssueCommenter extends JiraIssueCommenter {
 
     @Override
     protected boolean isCommentingEnabled() {
-        return distributionDetails.isAddComments();
+        return true;
     }
 
     @Override

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/JiraServerExternalConnectionTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/JiraServerExternalConnectionTest.java
@@ -146,7 +146,6 @@ class JiraServerExternalConnectionTest {
 
         return new JiraServerJobDetailsModel(
             uuid,
-            Boolean.parseBoolean(testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_ADD_COMMENTS)),
             testProperties.getOptionalProperty(TestPropertyKey.TEST_JIRA_SERVER_ISSUE_CREATOR).orElse(null),
             testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_PROJECT_NAME),
             testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_ISSUE_TYPE),

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/JiraServerSummaryFieldLengthTestIT.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/JiraServerSummaryFieldLengthTestIT.java
@@ -135,7 +135,6 @@ public class JiraServerSummaryFieldLengthTestIT {
 
         return new JiraServerJobDetailsModel(
             UUID.randomUUID(),
-            true,
             issueCreator,
             projectName,
             issueType,

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/database/accessor/JiraServerJobDetailsAccessorTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/database/accessor/JiraServerJobDetailsAccessorTest.java
@@ -91,12 +91,12 @@ class JiraServerJobDetailsAccessorTest {
     }
 
     private JiraServerJobDetailsModel createDetailsModel(JiraServerJobDetailsEntity jobDetailsModel) {
-        return new JiraServerJobDetailsModel(jobDetailsModel.getJobId(), jobDetailsModel.getAddComments(), jobDetailsModel.getIssueCreatorUsername(), jobDetailsModel.getProjectNameOrKey(),
+        return new JiraServerJobDetailsModel(jobDetailsModel.getJobId(), jobDetailsModel.getIssueCreatorUsername(), jobDetailsModel.getProjectNameOrKey(),
             jobDetailsModel.getIssueType(), jobDetailsModel.getResolveTransition(), jobDetailsModel.getReopenTransition(), createCustomFieldModels(), jobDetailsModel.getIssueSummary());
     }
 
     private JiraServerJobDetailsEntity createDetailsEntity(UUID jobId) {
-        return new JiraServerJobDetailsEntity(jobId, false, "user", "project",
+        return new JiraServerJobDetailsEntity(jobId, "user", "project",
             "Task", "Resolve", "Reopen", "summary");
     }
 

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/delegate/JiraServerIssueCreatorTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/delegate/JiraServerIssueCreatorTest.java
@@ -54,7 +54,6 @@ public class JiraServerIssueCreatorTest {
     final String TEST_TITLE = "title";
     final JiraServerJobDetailsModel distributionDetails = new JiraServerJobDetailsModel(
         UUID.randomUUID(),
-        true,
         TEST_ISSUE_CREATOR_NAME,
         TEST_PROJECT_NAME_OR_KEY,
         TEST_ISSUE_TYPE,
@@ -121,7 +120,6 @@ public class JiraServerIssueCreatorTest {
     void createRequestReturnsCorrectModelUsingTitle() throws AlertException {
         JiraServerJobDetailsModel distDetailsEmptyIssueSummary = new JiraServerJobDetailsModel(
             UUID.randomUUID(),
-            true,
             TEST_ISSUE_CREATOR_NAME,
             TEST_PROJECT_NAME_OR_KEY,
             TEST_ISSUE_TYPE,

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandlerTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandlerTest.java
@@ -181,7 +181,6 @@ class JiraServerCommentEventHandlerTest {
     private JiraServerJobDetailsModel createJobDetails(UUID jobId) {
         return new JiraServerJobDetailsModel(
             jobId,
-            true,
             "user",
             "jiraProject",
             "Task",

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandlerTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandlerTest.java
@@ -352,7 +352,6 @@ class JiraServerCreateIssueEventHandlerTest {
     private JiraServerJobDetailsModel createJobDetails(UUID jobId) {
         return new JiraServerJobDetailsModel(
             jobId,
-            true,
             "user",
             "jiraProject",
             "Task",

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandlerTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandlerTest.java
@@ -189,7 +189,6 @@ class JiraServerTransitionEventHandlerTest {
     private JiraServerJobDetailsModel createJobDetails(UUID jobId) {
         return new JiraServerJobDetailsModel(
             jobId,
-            true,
             "user",
             "jiraProject",
             "Task",

--- a/src/test/java/com/blackduck/integration/alert/database/job/api/StaticJobAccessorTestIT.java
+++ b/src/test/java/com/blackduck/integration/alert/database/job/api/StaticJobAccessorTestIT.java
@@ -73,7 +73,6 @@ class StaticJobAccessorTestIT {
     void verifyJiraServerSavesTest() {
         JiraServerJobDetailsModel jiraServerJobDetailsModel = new JiraServerJobDetailsModel(
             UUID.randomUUID(),
-            true,
             "issueCreatorUsername",
             "projectNameOrKey",
             "issueType",
@@ -91,7 +90,6 @@ class StaticJobAccessorTestIT {
     void verifyJiraCloudSavesTest() {
         JiraCloudJobDetailsModel jiraCloudJobDetailsModel = new JiraCloudJobDetailsModel(
             UUID.randomUUID(),
-            true,
             "issueCreatorEmail",
             "projectNameOrKey",
             "issueType",

--- a/ui/src/main/js/common/util/fieldModelUtilities.js
+++ b/ui/src/main/js/common/util/fieldModelUtilities.js
@@ -278,6 +278,13 @@ export const handleTestChange = (testData, setTestData) => ({ target }) => {
     setTestData(newState);
 };
 
+export const createBooleanInputChangeHandler = (testData, setTestData) => ({ target }) => {
+    const { type, name, value } = target;
+    const updatedValue = type === 'checkbox' ? target.checked : value;
+    const newState = { ...testData, [name]: updatedValue };
+    setTestData(newState);
+};
+
 export const handleConcreteModelChange = (data, setData) => ({ target }) => {
     const { type, name, value } = target;
     let updatedValue = type === 'checkbox' ? target.checked : value;

--- a/ui/src/main/js/page/channel/jira/cloud/JiraCloudDistributionConfiguration.js
+++ b/ui/src/main/js/page/channel/jira/cloud/JiraCloudDistributionConfiguration.js
@@ -23,17 +23,6 @@ const JiraCloudDistributionConfiguration = ({
 
     return (
         <>
-            <CheckboxInput
-                id={JIRA_CLOUD_DISTRIBUTION_FIELD_KEYS.comment}
-                name={JIRA_CLOUD_DISTRIBUTION_FIELD_KEYS.comment}
-                label="Add Comments"
-                description="If true, this will add comments to the Jira ticket with data describing the latest change."
-                readOnly={readonly}
-                onChange={FieldModelUtilities.handleChange(data, setData)}
-                isChecked={FieldModelUtilities.getFieldModelBooleanValue(data, JIRA_CLOUD_DISTRIBUTION_FIELD_KEYS.comment)}
-                errorName={FieldModelUtilities.createFieldModelErrorKey(JIRA_CLOUD_DISTRIBUTION_FIELD_KEYS.comment)}
-                errorValue={errors.fieldErrors[JIRA_CLOUD_DISTRIBUTION_FIELD_KEYS.comment]}
-            />
             <TextInput
                 id={JIRA_CLOUD_DISTRIBUTION_FIELD_KEYS.issueCreator}
                 label="Issue Creator"

--- a/ui/src/main/js/page/channel/jira/cloud/JiraCloudGlobalConfiguration.js
+++ b/ui/src/main/js/page/channel/jira/cloud/JiraCloudGlobalConfiguration.js
@@ -15,13 +15,23 @@ import * as GlobalRequestHelper from 'common/configuration/global/GlobalRequestH
 const JiraCloudGlobalConfiguration = ({
     csrfToken, errorHandler, readonly, displayTest, displaySave, displayDelete
 }) => {
-    const [formData, setFormData] = useState(FieldModelUtilities.createEmptyFieldModel([], CONTEXT_TYPE.GLOBAL, JIRA_CLOUD_INFO.key));
+    const initModelFunction = () => {
+        let initModel = FieldModelUtilities.createEmptyFieldModel([], CONTEXT_TYPE.GLOBAL, JIRA_CLOUD_INFO.key);
+        initModel = FieldModelUtilities.updateFieldModelSingleValue(initModel, JIRA_CLOUD_GLOBAL_FIELD_KEYS.disablePluginCheck, 'true');
+        return initModel;
+    };
+    const [formData, setFormData] = useState(initModelFunction());
     const [errors, setErrors] = useState(HttpErrorUtilities.createEmptyErrorObject());
 
     const retrieveData = async () => {
         const data = await GlobalRequestHelper.getDataFindFirst(JIRA_CLOUD_INFO.key, csrfToken);
         if (data) {
-            setFormData(data);
+            let updateData = { ...data };
+            // if the Jira cloud configuration isn't set then keyToValues will be empty and have no keys. Add the default value in this case.
+            if (data.keyToValues && Object.keys(data.keyToValues).length <= 0) {
+                updateData = FieldModelUtilities.updateFieldModelSingleValue(data, JIRA_CLOUD_GLOBAL_FIELD_KEYS.disablePluginCheck, 'true');
+            }
+            setFormData(updateData);
         }
     };
 

--- a/ui/src/main/js/page/channel/jira/server/JiraServerDistributionConfiguration.js
+++ b/ui/src/main/js/page/channel/jira/server/JiraServerDistributionConfiguration.js
@@ -60,17 +60,6 @@ const JiraServerDistributionConfiguration = ({
                 errorName={FieldModelUtilities.createFieldModelErrorKey(DISTRIBUTION_COMMON_FIELD_KEYS.channelGlobalConfigId)}
                 errorValue={errors.fieldErrors[DISTRIBUTION_COMMON_FIELD_KEYS.channelGlobalConfigId]}
             />
-            <CheckboxInput
-                id={JIRA_SERVER_DISTRIBUTION_FIELD_KEYS.comment}
-                name={JIRA_SERVER_DISTRIBUTION_FIELD_KEYS.comment}
-                label="Add Comments"
-                description="If true, this will add comments to the Jira ticket with data describing the latest change."
-                readOnly={readonly}
-                onChange={FieldModelUtilities.handleChange(data, setData)}
-                isChecked={FieldModelUtilities.getFieldModelBooleanValue(data, JIRA_SERVER_DISTRIBUTION_FIELD_KEYS.comment)}
-                errorName={FieldModelUtilities.createFieldModelErrorKey(JIRA_SERVER_DISTRIBUTION_FIELD_KEYS.comment)}
-                errorValue={errors.fieldErrors[JIRA_SERVER_DISTRIBUTION_FIELD_KEYS.comment]}
-            />
             <TextInput
                 id={JIRA_SERVER_DISTRIBUTION_FIELD_KEYS.issueCreator}
                 label="Issue Creator"

--- a/ui/src/main/js/page/channel/jira/server/JiraServerModal.js
+++ b/ui/src/main/js/page/channel/jira/server/JiraServerModal.js
@@ -56,7 +56,8 @@ const JiraServerModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMes
     const classes = useStyles();
     const dispatch = useDispatch();
     const { copyDescription, submitText, title, type } = modalOptions;
-    const [jiraServerModel, setJiraServerModel] = useState(type === 'CREATE' ? { authorizationMethod: 'BASIC' } : getInitialData(type, data));
+    const [jiraServerModel, setJiraServerModel] = useState(type === 'CREATE' ? { authorizationMethod: 'BASIC',
+        disablePluginCheck: true } : getInitialData(type, data));
     const [showLoader, setShowLoader] = useState(false);
     const [requestType, setRequestType] = useState();
     const [notificationConfig, setNotificationConfig] = useState();
@@ -285,7 +286,7 @@ const JiraServerModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMes
                     label="Disable Plugin Check"
                     customDescription="This will disable checking whether the 'Alert Issue Property Indexer' plugin is installed on the specified Jira instance. Please ensure that the plugin is manually installed before using Alert with Jira. If not, issues created by Alert will not be updated properly, and duplicate issues may be created."
                     readOnly={readonly}
-                    onChange={FieldModelUtilities.handleTestChange(jiraServerModel, setJiraServerModel)}
+                    onChange={FieldModelUtilities.createBooleanInputChangeHandler(jiraServerModel, setJiraServerModel)}
                     isChecked={jiraServerModel.disablePluginCheck}
                     errorName={JIRA_SERVER_GLOBAL_FIELD_KEYS.disablePluginCheck}
                     errorValue={error.fieldErrors.disablePluginCheck}

--- a/web/src/main/java/com/blackduck/integration/alert/web/api/job/JobFieldModelPopulationUtils.java
+++ b/web/src/main/java/com/blackduck/integration/alert/web/api/job/JobFieldModelPopulationUtils.java
@@ -156,7 +156,6 @@ public final class JobFieldModelPopulationUtils {
 
     private static void populateJiraCloudFields(FieldModel channelFieldModel, JiraCloudJobDetailsModel jiraCloudJobDetails) {
         if (null != jiraCloudJobDetails) {
-            putField(channelFieldModel, JiraCloudDescriptor.KEY_ADD_COMMENTS, Boolean.toString(jiraCloudJobDetails.isAddComments()));
             putField(channelFieldModel, JiraCloudDescriptor.KEY_ISSUE_CREATOR, jiraCloudJobDetails.getIssueCreatorEmail());
             putField(channelFieldModel, JiraCloudDescriptor.KEY_JIRA_PROJECT_NAME, jiraCloudJobDetails.getProjectNameOrKey());
             putField(channelFieldModel, JiraCloudDescriptor.KEY_ISSUE_TYPE, jiraCloudJobDetails.getIssueType());
@@ -169,7 +168,6 @@ public final class JobFieldModelPopulationUtils {
 
     private static void populateJiraServerFields(FieldModel channelFieldModel, JiraServerJobDetailsModel jiraServerJobDetails) {
         if (null != jiraServerJobDetails) {
-            putField(channelFieldModel, JiraServerDescriptor.KEY_ADD_COMMENTS, Boolean.toString(jiraServerJobDetails.isAddComments()));
             putField(channelFieldModel, JiraServerDescriptor.KEY_ISSUE_CREATOR, jiraServerJobDetails.getIssueCreatorUsername());
             putField(channelFieldModel, JiraServerDescriptor.KEY_JIRA_PROJECT_NAME, jiraServerJobDetails.getProjectNameOrKey());
             putField(channelFieldModel, JiraServerDescriptor.KEY_ISSUE_TYPE, jiraServerJobDetails.getIssueType());


### PR DESCRIPTION
This removes from the Jira Server and Jira Cloud distribution jobs the ability to configure whether comments are added to ticket or not.  Now comments are required to be added to Jira Tickets.  Both Jira Server and Jira Cloud always enable the addition of comments to tickets.  The user will need to have permission in Jira to be able to add comments.  

This PR does the following:

- Remove the database columns from the jira server and jira cloud distribution job details
- Remove from the Jira Server and Jira Cloud Distribution jobs configuration UI the "Add Comments" Checkbox
- To prepare for no longer using the indexer plugin make the disable plugin check the default behavior when creating a new Jira Cloud or Jira Server Channel configuration.