### PR TITLE
IALERT-3816: (UI) Permission Check for Navigational Items

### DIFF
--- a/ui/src/main/js/application/Navigation.js
+++ b/ui/src/main/js/application/Navigation.js
@@ -46,7 +46,7 @@ const Navigation = ({ confirmLogoutPressed, cancelLogout, globalDescriptorMap })
     const classes = useStyles();
 
     const hasType = (descriptorType) => Object.values(globalDescriptorMap).some((descriptor) => descriptorType === descriptor.type);
-    console.log(globalDescriptorMap)
+
     const channelGroup = [{
         id: 'azure_boards',
         label: 'Azure Boards',


### PR DESCRIPTION
## Bug Description
Depending on the permissions a user has given their role, the navigational items in the left-hand nav bar will conditionally render.  There seems to be a bug where `ALERT_JOB_MANAGER` role can no longer see `Audit Failures`, `Scheduling`, and `Task Management` (all of these fall under our `Manage` submenu).  
  
## Fix Description
When working on version 7.0, I added one too many checks for these nav menu items.  Essentially I was triple checking whether an item should be shown: First in the `application/Navigation.js` component (this was the root of the bug), second in the `common/component/naviation/SideNavItem.js` component (this one is necessary, I'll explain in the technical fix description below), and third in the `common/component/naviation/SideNavSubmenu.js` (also necessary and explained below).

Removing the check in `application/Navigation.js` resolved this bug.  It was an unnecessary extra check and I wish I could recall just why I added it there.  
  
## Technical Fix Description
The three checks outlined above, further explained here:

1. **`application/Navigation.js`:** This is the change in this PR - this component creates two arrays of objects (`channelGroup` & `manageGroup`) where each object has a property, `showOption`.  Each of these items (objects) in the array pertains to an item in the Nav bar, grouped together to create sub nav menus that expand when a user clicks on it so the user can select one of these items/options.  The line that was removed checked if EVERY item in the array had the ability to be shown (showOption = true).  If not, it would not render that entire sub nav menu.  Removing this allows for the next level of conditional highlighted below.
2. **`common/component/naviation/SideNavItem.js`:** L50-52 handle the proper conditional on whether we should show a sub nav menu.  If the property `hasSubMenu` is true AND the `subMenuItems` array has 0 items in it (here this would be `channelGroup` or `manageGroup` created in `application/Navigation.js`), then we do not render a sub nav menu.
3. **`common/component/naviation/SideNavSubmenu.js`:** L85-87 handles the proper conditional on whether we should show an item within a sub nav menu. This is where the `showOption` comes into play. If false (aka the user doesn't have the permission to view that page) we don't show that option.