### PR TITLE
Update to use new Jira Cloud APIs

### DIFF
--- a/alert-platform/build.gradle
+++ b/alert-platform/build.gradle
@@ -21,7 +21,7 @@ dependencies {
         api 'com.blackduck.integration:integration-rest:11.1.2'
         api 'com.blackduck.integration:integration-common:27.0.2'
         api 'com.blackduck.integration:blackduck-common:67.0.9'
-        api 'com.blackduck.integration:int-jira-common:5.0.1'
+        api 'com.blackduck.integration:int-jira-common:6.0.0'
 
         api 'com.google.cloud:libraries-bom:2.2.0'
         api 'com.google.oauth-client:google-oauth-client:1.34.1'

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/delegate/JiraIssueCommenter.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/delegate/JiraIssueCommenter.java
@@ -7,6 +7,7 @@
  */
 package com.blackduck.integration.alert.api.channel.jira.distribution.delegate;
 
+import com.blackduck.integration.jira.common.model.request.JiraRequestModel;
 import org.jetbrains.annotations.Nullable;
 
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.ProjectIssueModel;
@@ -15,9 +16,8 @@ import com.blackduck.integration.alert.api.channel.issue.tracker.send.IssueTrack
 import com.blackduck.integration.alert.api.channel.issue.tracker.send.IssueTrackerIssueResponseCreator;
 import com.blackduck.integration.alert.api.common.model.exception.AlertException;
 import com.blackduck.integration.exception.IntegrationException;
-import com.blackduck.integration.jira.common.model.request.IssueCommentRequestModel;
 
-public abstract class JiraIssueCommenter extends IssueTrackerIssueCommenter<String> {
+public abstract class JiraIssueCommenter<T extends JiraRequestModel> extends IssueTrackerIssueCommenter<String> {
 
     protected JiraIssueCommenter(IssueTrackerIssueResponseCreator issueResponseCreator) {
         super(issueResponseCreator);
@@ -26,13 +26,12 @@ public abstract class JiraIssueCommenter extends IssueTrackerIssueCommenter<Stri
     @Override
     protected final void addComment(String comment, ExistingIssueDetails<String> existingIssueDetails, @Nullable ProjectIssueModel source) throws AlertException {
         try {
-            IssueCommentRequestModel issueCommentRequestModel = new IssueCommentRequestModel(existingIssueDetails.getIssueKey(), comment);
-            addComment(issueCommentRequestModel);
+            addComment(createCommentModel(comment, existingIssueDetails));
         } catch (IntegrationException e) {
             throw new AlertException(String.format("Failed to add a comment in Jira. Issue Key: %s", existingIssueDetails.getIssueKey()), e);
         }
     }
 
-    protected abstract void addComment(IssueCommentRequestModel requestModel) throws IntegrationException;
-
+    protected abstract void addComment(T requestModel) throws IntegrationException;
+    protected abstract T createCommentModel(String comment, ExistingIssueDetails<String> existingIssueDetails) throws IntegrationException;
 }

--- a/api-channel-jira/src/test/java/com/blackduck/integration/alert/api/channel/jira/util/JiraCallbackUtilsTest.java
+++ b/api-channel-jira/src/test/java/com/blackduck/integration/alert/api/channel/jira/util/JiraCallbackUtilsTest.java
@@ -33,8 +33,8 @@ public class JiraCallbackUtilsTest {
 
     @Test
     void createUILinkFromIssueReturnsExpected() {
-        IssueFieldsComponent issueFieldsComponent = new IssueFieldsComponent(List.of(), null, null, "summary", "description", List.of(), null, List.of(), null, null, null, null);
-        IssueResponseModel responseModel = new IssueResponseModel("", "JP-1", ISSUE_URL, KEY, Map.of(), Map.of(), Map.of(), Map.of(), List.of(), null, null, null, null, null, issueFieldsComponent);
+        IssueFieldsComponent issueFieldsComponent = createIssueFieldsComponent("summary");
+        IssueResponseModel responseModel = createIssueResponseModel( "JP-1", KEY, ISSUE_URL, issueFieldsComponent);
         String output = JiraCallbackUtils.createUILink(responseModel);
 
         assertEquals(EXPECTED_UI_LINK, output);
@@ -46,5 +46,33 @@ public class JiraCallbackUtilsTest {
         String output = JiraCallbackUtils.createUILink(jiraSearcherResponseModel);
 
         assertEquals(EXPECTED_UI_LINK, output);
+    }
+
+    private IssueFieldsComponent createIssueFieldsComponent(String summary) {
+        return () -> summary;
+    }
+
+    private IssueResponseModel createIssueResponseModel(String id, String key, String self, IssueFieldsComponent issueFieldsComponent) {
+        return new IssueResponseModel() {
+            @Override
+            public String getId() {
+                return id;
+            }
+
+            @Override
+            public String getKey() {
+                return key;
+            }
+
+            @Override
+            public String getSelf() {
+                return self;
+            }
+
+            @Override
+            public IssueFieldsComponent getFields() {
+                return issueFieldsComponent;
+            }
+        };
     }
 }

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/action/JiraCloudGlobalFieldModelTestAction.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/action/JiraCloudGlobalFieldModelTestAction.java
@@ -60,7 +60,7 @@ public class JiraCloudGlobalFieldModelTestAction extends JiraGlobalFieldModelTes
         JiraCloudProperties jiraProperties = jiraCloudPropertiesFactory.createJiraProperties(fieldUtility);
         JiraCloudServiceFactory jiraCloudServiceFactory = jiraProperties.createJiraServicesCloudFactory(logger, gson);
         IssueSearchService issueSearchService = jiraCloudServiceFactory.createIssueSearchService();
-        IssueSearchResponseModel issueSearchResponseModel = issueSearchService.queryForIssuePage("", 0, 1);
+        IssueSearchResponseModel issueSearchResponseModel = issueSearchService.queryForIssuePage("", null, 1);
         return null != issueSearchResponseModel.getIssues();
     }
 

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/action/JiraCloudGlobalFieldModelTestAction.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/action/JiraCloudGlobalFieldModelTestAction.java
@@ -60,7 +60,9 @@ public class JiraCloudGlobalFieldModelTestAction extends JiraGlobalFieldModelTes
         JiraCloudProperties jiraProperties = jiraCloudPropertiesFactory.createJiraProperties(fieldUtility);
         JiraCloudServiceFactory jiraCloudServiceFactory = jiraProperties.createJiraServicesCloudFactory(logger, gson);
         IssueSearchService issueSearchService = jiraCloudServiceFactory.createIssueSearchService();
-        IssueSearchResponseModel issueSearchResponseModel = issueSearchService.queryForIssuePage("", null, 1);
+        // for jira cloud api v3 the jql query cannot be unbounded so use a JQL query with an or clause to guarantee
+        // returning results.
+        IssueSearchResponseModel issueSearchResponseModel = issueSearchService.queryForIssuePage("reporter IS NOT EMPTY OR reporter IS EMPTY order by created DESC", null, 1);
         return null != issueSearchResponseModel.getIssues();
     }
 

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/JiraCloudMessageSenderFactory.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/JiraCloudMessageSenderFactory.java
@@ -10,6 +10,7 @@ package com.blackduck.integration.alert.channel.jira.cloud.distribution;
 import java.util.Set;
 import java.util.UUID;
 
+import com.blackduck.integration.jira.common.cloud.builder.IssueRequestModelFieldsBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -97,7 +98,7 @@ public class JiraCloudMessageSenderFactory implements IssueTrackerMessageSenderF
         FieldService fieldService = jiraCloudServiceFactory.createFieldService();
 
         JiraCustomFieldResolver customFieldResolver = new JiraCustomFieldResolver(fieldService::getUserVisibleFields);
-        JiraIssueCreationRequestCreator issueCreationRequestCreator = new JiraIssueCreationRequestCreator(customFieldResolver);
+        JiraIssueCreationRequestCreator issueCreationRequestCreator = new JiraIssueCreationRequestCreator(customFieldResolver, IssueRequestModelFieldsBuilder::new);
         JiraErrorMessageUtility jiraErrorMessageUtility = new JiraErrorMessageUtility(gson, customFieldResolver);
 
         return createMessageSender(

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/JiraCloudQueryExecutor.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/JiraCloudQueryExecutor.java
@@ -54,7 +54,7 @@ public class JiraCloudQueryExecutor implements JqlQueryExecutor {
 
     private IssueSearchResponseModel queryForIssues(String jql, Integer maxResults) throws AlertException {
         try {
-            return issueSearchService.queryForIssuePage(jql, 0, maxResults);
+            return issueSearchService.queryForIssuePage(jql, null, maxResults);
         } catch (IntegrationException e) {
             throw new AlertException("Failed to query for Jira Cloud issues", e);
         }

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/delegate/JiraCloudIssueCommenter.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/delegate/JiraCloudIssueCommenter.java
@@ -7,14 +7,15 @@
  */
 package com.blackduck.integration.alert.channel.jira.cloud.distribution.delegate;
 
+import com.blackduck.integration.alert.api.channel.issue.tracker.search.ExistingIssueDetails;
 import com.blackduck.integration.alert.api.channel.issue.tracker.send.IssueTrackerIssueResponseCreator;
 import com.blackduck.integration.alert.api.channel.jira.distribution.delegate.JiraIssueCommenter;
 import com.blackduck.integration.alert.common.persistence.model.job.details.JiraCloudJobDetailsModel;
 import com.blackduck.integration.exception.IntegrationException;
 import com.blackduck.integration.jira.common.cloud.service.IssueService;
-import com.blackduck.integration.jira.common.model.request.IssueCommentRequestModel;
+import com.blackduck.integration.jira.common.cloud.model.IssueCommentRequestModel;
 
-public class JiraCloudIssueCommenter extends JiraIssueCommenter {
+public class JiraCloudIssueCommenter extends JiraIssueCommenter<IssueCommentRequestModel> {
     private final IssueService issueService;
     private final JiraCloudJobDetailsModel distributionDetails;
 
@@ -34,4 +35,8 @@ public class JiraCloudIssueCommenter extends JiraIssueCommenter {
         issueService.addComment(requestModel);
     }
 
+    @Override
+    protected IssueCommentRequestModel createCommentModel(String comment, ExistingIssueDetails<String> existingIssueDetails) throws IntegrationException {
+        return IssueCommentRequestModel.commentForIssue(existingIssueDetails.getIssueKey(), comment);
+    }
 }

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.blackduck.integration.jira.common.cloud.builder.IssueRequestModelFieldsBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,7 +93,7 @@ public class JiraCloudCommentEventHandler extends IssueTrackerCommentEventHandle
                 FieldService fieldService = jiraCloudServiceFactory.createFieldService();
 
                 JiraCustomFieldResolver customFieldResolver = new JiraCustomFieldResolver(fieldService::getUserVisibleFields);
-                JiraIssueCreationRequestCreator issueCreationRequestCreator = new JiraIssueCreationRequestCreator(customFieldResolver);
+                JiraIssueCreationRequestCreator issueCreationRequestCreator = new JiraIssueCreationRequestCreator(customFieldResolver, IssueRequestModelFieldsBuilder::new);
                 JiraErrorMessageUtility jiraErrorMessageUtility = new JiraErrorMessageUtility(gson, customFieldResolver);
 
                 IssueTrackerMessageSender<String> messageSender = messageSenderFactory.createMessageSender(

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandler.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.blackduck.integration.jira.common.cloud.builder.IssueRequestModelFieldsBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,7 +96,7 @@ public class JiraCloudCreateIssueEventHandler extends IssueTrackerCreateIssueEve
                 FieldService fieldService = jiraCloudServiceFactory.createFieldService();
 
                 JiraCustomFieldResolver customFieldResolver = new JiraCustomFieldResolver(fieldService::getUserVisibleFields);
-                JiraIssueCreationRequestCreator issueCreationRequestCreator = new JiraIssueCreationRequestCreator(customFieldResolver);
+                JiraIssueCreationRequestCreator issueCreationRequestCreator = new JiraIssueCreationRequestCreator(customFieldResolver, IssueRequestModelFieldsBuilder::new);
                 JiraErrorMessageUtility jiraErrorMessageUtility = new JiraErrorMessageUtility(gson, customFieldResolver);
 
                 IssueTrackerMessageSender<String> messageSender = messageSenderFactory.createMessageSender(

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandler.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.blackduck.integration.jira.common.cloud.builder.IssueRequestModelFieldsBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,7 +93,7 @@ public class JiraCloudTransitionEventHandler extends IssueTrackerTransitionEvent
                 FieldService fieldService = jiraCloudServiceFactory.createFieldService();
 
                 JiraCustomFieldResolver customFieldResolver = new JiraCustomFieldResolver(fieldService::getUserVisibleFields);
-                JiraIssueCreationRequestCreator issueCreationRequestCreator = new JiraIssueCreationRequestCreator(customFieldResolver);
+                JiraIssueCreationRequestCreator issueCreationRequestCreator = new JiraIssueCreationRequestCreator(customFieldResolver, IssueRequestModelFieldsBuilder::new);
                 JiraErrorMessageUtility jiraErrorMessageUtility = new JiraErrorMessageUtility(gson, customFieldResolver);
 
                 IssueTrackerMessageSender<String> messageSender = messageSenderFactory.createMessageSender(

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/task/JiraPropertyUpdateTask.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/task/JiraPropertyUpdateTask.java
@@ -40,7 +40,7 @@ public class JiraPropertyUpdateTask extends JiraTask {
             IssueSearchService issueSearchService = serviceFactory.createIssueSearchService();
             IssuePropertyService issuePropertyService = serviceFactory.createIssuePropertyService();
 
-            IssueSearchResponseModel responseModel = issueSearchService.queryForIssuePage(JQL_QUERY_FOR_ISSUE_PROPERTY_MIGRATION, 0, JQL_QUERY_MAX_RESULTS);
+            IssueSearchResponseModel responseModel = issueSearchService.queryForIssuePage(JQL_QUERY_FOR_ISSUE_PROPERTY_MIGRATION, null, JQL_QUERY_MAX_RESULTS);
             boolean foundIssuesForDefaultQuery = updateIssues(responseModel, issuePropertyService);
 
             if(!foundIssuesForDefaultQuery) {
@@ -49,7 +49,7 @@ public class JiraPropertyUpdateTask extends JiraTask {
                     if(StringUtils.isNotBlank(projectName)) {
                         logger.info("Querying issues for {} remaining project(s).  Querying issues for project: {}. ", projectNamesOrKeys.size(), projectName);
                         logger.debug("Remaining projects: {}", projectNamesOrKeys);
-                        responseModel = issueSearchService.queryForIssuePage(createProjectSpecificQuery(projectName), 0, JQL_QUERY_MAX_RESULTS);
+                        responseModel = issueSearchService.queryForIssuePage(createProjectSpecificQuery(projectName), null, JQL_QUERY_MAX_RESULTS);
                         boolean foundIssuesForProject = updateIssues(responseModel, issuePropertyService);
                         if (!foundIssuesForProject) {
                             // remove the key to no longer query for that project.

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/task/JiraPropertyUpdateTask.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/task/JiraPropertyUpdateTask.java
@@ -72,10 +72,10 @@ public class JiraPropertyUpdateTask extends JiraTask {
     }
 
     private boolean updateIssues(IssueSearchResponseModel responseModel, IssuePropertyService issuePropertyService) throws InterruptedException {
-        int totalIssues = responseModel.getTotal();
-        boolean foundIssues = totalIssues > 0;
+        boolean foundIssues = responseModel.getIssues() != null && responseModel.getIssues().isEmpty();
 
         if(foundIssues) {
+            int totalIssues = responseModel.getIssues().size();
             List<String> issueKeys = responseModel.getIssues().stream()
                     .map(IssueResponseModel::getKey)
                     .toList();

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/JiraCloudIssueCreatorTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/JiraCloudIssueCreatorTest.java
@@ -113,7 +113,7 @@ public class JiraCloudIssueCreatorTest {
             ))
         ));
         JiraCustomFieldResolver jiraCustomFieldResolver = new JiraCustomFieldResolver(() -> List.of());
-        JiraIssueCreationRequestCreator jiraIssueCreationRequestCreator = new JiraIssueCreationRequestCreator(jiraCustomFieldResolver);
+        JiraIssueCreationRequestCreator jiraIssueCreationRequestCreator = new JiraIssueCreationRequestCreator(jiraCustomFieldResolver, IssueRequestModelFieldsBuilder::new);
         IssueCategoryRetriever issueCategoryRetriever = new IssueCategoryRetriever();
 
         return new TestJiraCloudIssueCreator(jiraCloudJobDetailsModel, projectService, jiraIssueCreationRequestCreator, issueCategoryRetriever);

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandlerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandlerTest.java
@@ -42,8 +42,8 @@ import com.blackduck.integration.jira.common.cloud.service.IssueSearchService;
 import com.blackduck.integration.jira.common.cloud.service.IssueService;
 import com.blackduck.integration.jira.common.cloud.service.JiraCloudServiceFactory;
 import com.blackduck.integration.jira.common.cloud.service.ProjectService;
-import com.blackduck.integration.jira.common.model.request.IssueCommentRequestModel;
-import com.blackduck.integration.jira.common.model.response.IssueCommentResponseModel;
+import com.blackduck.integration.jira.common.cloud.model.IssueCommentRequestModel;
+import com.blackduck.integration.jira.common.cloud.model.IssueCommentResponseModel;
 import com.google.gson.Gson;
 
 class JiraCloudCommentEventHandlerTest {

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandlerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandlerTest.java
@@ -15,6 +15,10 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.blackduck.integration.jira.common.cloud.builder.AtlassianDocumentFormatModelBuilder;
+import com.blackduck.integration.jira.common.cloud.model.AtlassianDocumentFormatModel;
+import com.blackduck.integration.jira.common.cloud.model.JiraCloudIssueResponseModel;
+import com.blackduck.integration.jira.common.cloud.model.component.JiraCloudIssueFieldsComponent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -360,15 +364,18 @@ class JiraCloudCreateIssueEventHandlerTest {
         return new PageOfProjectsResponseModel(List.of(projectComponent));
     }
 
-    private IssueResponseModel createIssueResponseModel() {
+    private JiraCloudIssueResponseModel createIssueResponseModel() {
         String id = ISSUE_KEY;
-        IssueFieldsComponent issueFieldsComponent = new IssueFieldsComponent(List.of(), null, null, "summary", "description", List.of(), null, List.of(), null, null, null, null);
+        AtlassianDocumentFormatModelBuilder atlassianDocumentFormatModelBuilder = new AtlassianDocumentFormatModelBuilder();
+        atlassianDocumentFormatModelBuilder.addSingleParagraphTextNode("description");
+        AtlassianDocumentFormatModel descriptionModel = atlassianDocumentFormatModelBuilder.build();
+        JiraCloudIssueFieldsComponent issueFieldsComponent = new JiraCloudIssueFieldsComponent(List.of(), null, null, "summary", descriptionModel, List.of(), null, List.of(), null, null, null, null);
 
-        return new IssueResponseModel("", id, "", id, Map.of(), Map.of(), Map.of(), Map.of(), List.of(), null, null, null, null, null, issueFieldsComponent);
+        return new JiraCloudIssueResponseModel("", id, "", id, Map.of(), Map.of(), Map.of(), null, null, null, null, issueFieldsComponent);
     }
 
     private IssueSearchResponseModel createIssueSearchResponseModel() {
-        IssueResponseModel issueResponseModel = createIssueResponseModel();
+        JiraCloudIssueResponseModel issueResponseModel = createIssueResponseModel();
         return new IssueSearchResponseModel("", List.of(issueResponseModel), List.of(), null, null);
     }
 

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/model/TestIssueResponse.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/model/TestIssueResponse.java
@@ -7,25 +7,24 @@
  */
 package com.blackduck.integration.alert.channel.jira.cloud.model;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import com.blackduck.integration.jira.common.model.components.IdComponent;
+import com.blackduck.integration.jira.common.model.components.IssueFieldsComponent;
 import com.blackduck.integration.jira.common.model.response.IssueResponseModel;
 
-public class TestIssueResponse extends IssueResponseModel {
+public class TestIssueResponse implements IssueResponseModel {
     private final String id;
     private final String key;
-    private final List<IdComponent> transitions;
+    private final String self;
+    private final IssueFieldsComponent fields;
 
     public TestIssueResponse() {
-        this("1", "project-1", new ArrayList<>());
+        this("1", "project-1", "https://www.some-url.example.com/rest/api/3/issue/1", null);
     }
 
-    public TestIssueResponse(String id, String key, List<IdComponent> transitions) {
+    public TestIssueResponse(String id, String key, String self, IssueFieldsComponent fields) {
         this.id = id;
         this.key = key;
-        this.transitions = transitions;
+        this.self = self;
+        this.fields = fields;
     }
 
     @Override
@@ -39,7 +38,12 @@ public class TestIssueResponse extends IssueResponseModel {
     }
 
     @Override
-    public List<IdComponent> getTransitions() {
-        return transitions;
+    public String getSelf() {
+        return self;
+    }
+
+    @Override
+    public IssueFieldsComponent getFields() {
+        return fields;
     }
 }

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/JiraServerMessageSenderFactory.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/JiraServerMessageSenderFactory.java
@@ -10,6 +10,7 @@ package com.blackduck.integration.alert.channel.jira.server.distribution;
 import java.util.Set;
 import java.util.UUID;
 
+import com.blackduck.integration.jira.common.server.builder.IssueRequestModelFieldsBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -100,7 +101,7 @@ public class JiraServerMessageSenderFactory implements IssueTrackerMessageSender
 
         JiraServerQueryExecutor jiraServerQueryExecutor = new JiraServerQueryExecutor(issueSearchService);
         JiraCustomFieldResolver customFieldResolver = new JiraCustomFieldResolver(fieldService::getUserVisibleFields);
-        JiraIssueCreationRequestCreator issueCreationRequestCreator = new JiraIssueCreationRequestCreator(customFieldResolver);
+        JiraIssueCreationRequestCreator issueCreationRequestCreator = new JiraIssueCreationRequestCreator(customFieldResolver, IssueRequestModelFieldsBuilder::new);
         JiraErrorMessageUtility jiraErrorMessageUtility = new JiraErrorMessageUtility(gson, customFieldResolver);
 
         return createMessageSender(

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/delegate/JiraServerIssueCommenter.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/delegate/JiraServerIssueCommenter.java
@@ -7,14 +7,15 @@
  */
 package com.blackduck.integration.alert.channel.jira.server.distribution.delegate;
 
+import com.blackduck.integration.alert.api.channel.issue.tracker.search.ExistingIssueDetails;
 import com.blackduck.integration.alert.api.channel.issue.tracker.send.IssueTrackerIssueResponseCreator;
 import com.blackduck.integration.alert.api.channel.jira.distribution.delegate.JiraIssueCommenter;
 import com.blackduck.integration.alert.common.persistence.model.job.details.JiraServerJobDetailsModel;
 import com.blackduck.integration.exception.IntegrationException;
-import com.blackduck.integration.jira.common.model.request.IssueCommentRequestModel;
+import com.blackduck.integration.jira.common.server.model.IssueCommentRequestModel;
 import com.blackduck.integration.jira.common.server.service.IssueService;
 
-public class JiraServerIssueCommenter extends JiraIssueCommenter {
+public class JiraServerIssueCommenter extends JiraIssueCommenter<IssueCommentRequestModel> {
     private final IssueService issueService;
     private final JiraServerJobDetailsModel distributionDetails;
 
@@ -34,4 +35,8 @@ public class JiraServerIssueCommenter extends JiraIssueCommenter {
         issueService.addComment(requestModel);
     }
 
+    @Override
+    protected IssueCommentRequestModel createCommentModel(String comment, ExistingIssueDetails<String> existingIssueDetails) throws IntegrationException {
+        return new IssueCommentRequestModel(existingIssueDetails.getIssueKey(), comment);
+    }
 }

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandler.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.blackduck.integration.jira.common.server.builder.IssueRequestModelFieldsBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -90,7 +91,7 @@ public class JiraServerCommentEventHandler extends IssueTrackerCommentEventHandl
 
                 JiraServerQueryExecutor jiraServerQueryExecutor = new JiraServerQueryExecutor(issueSearchService);
                 JiraCustomFieldResolver customFieldResolver = new JiraCustomFieldResolver(fieldService::getUserVisibleFields);
-                JiraIssueCreationRequestCreator issueCreationRequestCreator = new JiraIssueCreationRequestCreator(customFieldResolver);
+                JiraIssueCreationRequestCreator issueCreationRequestCreator = new JiraIssueCreationRequestCreator(customFieldResolver, IssueRequestModelFieldsBuilder::new);
                 JiraErrorMessageUtility jiraErrorMessageUtility = new JiraErrorMessageUtility(gson, customFieldResolver);
 
                 IssueTrackerMessageSender<String> messageSender = jiraServerMessageSenderFactory.createMessageSender(

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.blackduck.integration.jira.common.server.builder.IssueRequestModelFieldsBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,7 +95,7 @@ public class JiraServerCreateIssueEventHandler extends IssueTrackerCreateIssueEv
                 FieldService fieldService = jiraServerServiceFactory.createFieldService();
 
                 JiraCustomFieldResolver customFieldResolver = new JiraCustomFieldResolver(fieldService::getUserVisibleFields);
-                JiraIssueCreationRequestCreator issueCreationRequestCreator = new JiraIssueCreationRequestCreator(customFieldResolver);
+                JiraIssueCreationRequestCreator issueCreationRequestCreator = new JiraIssueCreationRequestCreator(customFieldResolver, IssueRequestModelFieldsBuilder::new);
                 JiraErrorMessageUtility jiraErrorMessageUtility = new JiraErrorMessageUtility(gson, customFieldResolver);
 
                 IssueTrackerMessageSender<String> messageSender = jiraServerMessageSenderFactory.createMessageSender(

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandler.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.blackduck.integration.jira.common.server.builder.IssueRequestModelFieldsBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -90,7 +91,7 @@ public class JiraServerTransitionEventHandler extends IssueTrackerTransitionEven
                 FieldService fieldService = jiraServerServiceFactory.createFieldService();
 
                 JiraCustomFieldResolver customFieldResolver = new JiraCustomFieldResolver(fieldService::getUserVisibleFields);
-                JiraIssueCreationRequestCreator issueCreationRequestCreator = new JiraIssueCreationRequestCreator(customFieldResolver);
+                JiraIssueCreationRequestCreator issueCreationRequestCreator = new JiraIssueCreationRequestCreator(customFieldResolver, IssueRequestModelFieldsBuilder::new);
                 JiraErrorMessageUtility jiraErrorMessageUtility = new JiraErrorMessageUtility(gson, customFieldResolver);
 
                 IssueTrackerMessageSender<String> messageSender = jiraServerMessageSenderFactory.createMessageSender(

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/delegate/JiraServerIssueCreatorTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/delegate/JiraServerIssueCreatorTest.java
@@ -16,6 +16,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import java.util.List;
 import java.util.UUID;
 
+import com.blackduck.integration.jira.common.model.request.builder.IssueRequestModelFieldsMapBuilder;
+import com.blackduck.integration.jira.common.server.builder.IssueRequestModelFieldsBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,7 +41,6 @@ import com.blackduck.integration.alert.channel.jira.server.distribution.JiraServ
 import com.blackduck.integration.alert.common.message.model.LinkableItem;
 import com.blackduck.integration.alert.common.persistence.model.job.details.JiraServerJobDetailsModel;
 import com.blackduck.integration.exception.IntegrationException;
-import com.blackduck.integration.jira.common.cloud.builder.IssueRequestModelFieldsBuilder;
 import com.blackduck.integration.jira.common.model.components.ProjectComponent;
 import com.blackduck.integration.jira.common.server.model.IssueCreationRequestModel;
 import com.blackduck.integration.jira.common.server.service.IssueService;
@@ -66,7 +67,8 @@ public class JiraServerIssueCreatorTest {
     final IssueCreationModel simpleIssueCreationModel = IssueCreationModel.simple(TEST_TITLE, "description", List.of(), new LinkableItem("provider", "test-provider"));
 
 
-    @Mock IssueRequestModelFieldsBuilder mockFieldsBuilder;
+    @Mock
+    IssueRequestModelFieldsMapBuilder<IssueRequestModelFieldsBuilder> mockFieldsBuilder;
     @Mock IssueService mockIssueService;
     @Mock ProjectService mockProjectService;
     @Mock JiraIssueCreationRequestCreator mockJiraIssueCreationRequestCreator;

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandlerTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandlerTest.java
@@ -39,8 +39,8 @@ import com.blackduck.integration.alert.channel.jira.server.distribution.JiraServ
 import com.blackduck.integration.alert.common.persistence.model.job.details.JiraServerJobDetailsModel;
 import com.blackduck.integration.blackduck.service.BlackDuckServicesFactory;
 import com.blackduck.integration.exception.IntegrationException;
-import com.blackduck.integration.jira.common.model.request.IssueCommentRequestModel;
-import com.blackduck.integration.jira.common.model.response.IssueCommentResponseModel;
+import com.blackduck.integration.jira.common.server.model.IssueCommentRequestModel;
+import com.blackduck.integration.jira.common.server.model.IssueCommentResponseModel;
 import com.blackduck.integration.jira.common.server.service.FieldService;
 import com.blackduck.integration.jira.common.server.service.IssueSearchService;
 import com.blackduck.integration.jira.common.server.service.IssueService;

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandlerTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandlerTest.java
@@ -15,6 +15,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.blackduck.integration.jira.common.server.model.JiraServerIssueResponseModel;
+import com.blackduck.integration.jira.common.server.model.component.JiraServerIssueFieldsComponent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -367,11 +369,11 @@ class JiraServerCreateIssueEventHandlerTest {
         return new ProjectComponent("", "JP", ISSUE_KEY, "jiraProject", null, null, true, "");
     }
 
-    private IssueResponseModel createIssueResponseModel() {
+    private JiraServerIssueResponseModel createIssueResponseModel() {
         String id = ISSUE_KEY;
-        IssueFieldsComponent issueFieldsComponent = new IssueFieldsComponent(List.of(), null, null, "summary", "description", List.of(), null, List.of(), null, null, null, null);
+        JiraServerIssueFieldsComponent issueFieldsComponent = new JiraServerIssueFieldsComponent(List.of(), null, null, "summary", "description", List.of(), null, List.of(), null, null, null, null);
 
-        return new IssueResponseModel("", id, "", id, Map.of(), Map.of(), Map.of(), Map.of(), List.of(), null, null, null, null, null, issueFieldsComponent);
+        return new JiraServerIssueResponseModel("", id, "", id, Map.of(), Map.of(), Map.of(), Map.of(), List.of(), null, null, null, null, null, issueFieldsComponent);
     }
 
     private IssueSearchResponseModel createIssueSearchResponseModel() {

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/model/TestIssueResponse.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/model/TestIssueResponse.java
@@ -11,21 +11,24 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.blackduck.integration.jira.common.model.components.IdComponent;
+import com.blackduck.integration.jira.common.model.components.IssueFieldsComponent;
 import com.blackduck.integration.jira.common.model.response.IssueResponseModel;
 
-public class TestIssueResponse extends IssueResponseModel {
+public class TestIssueResponse implements IssueResponseModel {
     private final String id;
     private final String key;
-    private final List<IdComponent> transitions;
+    private final String self;
+    private final IssueFieldsComponent fields;
 
     public TestIssueResponse() {
-        this("1", "project-1", new ArrayList<>());
+        this("1", "project-1", "https://www.some-url.example.com/rest/api/3/issue/1", null);
     }
 
-    public TestIssueResponse(String id, String key, List<IdComponent> transitions) {
+    public TestIssueResponse(String id, String key, String self, IssueFieldsComponent fields) {
         this.id = id;
         this.key = key;
-        this.transitions = transitions;
+        this.self = self;
+        this.fields = fields;
     }
 
     @Override
@@ -39,7 +42,12 @@ public class TestIssueResponse extends IssueResponseModel {
     }
 
     @Override
-    public List<IdComponent> getTransitions() {
-        return transitions;
+    public String getSelf() {
+        return self;
+    }
+
+    @Override
+    public IssueFieldsComponent getFields() {
+        return fields;
     }
 }


### PR DESCRIPTION
Update Alert to use int-jira-common 6.0.0.  This is dependent upon the release of int-jira-common 6.0.0 which is blocked by the merge of this MR: https://github.com/blackducksoftware/int-jira-common/pull/64

Once that MR is merge int-jira-common 6.0.0 can be released and this is the changes to Alert to use the new APIs.

Since the communication issue with Jira Cloud was found while testing the timeout feature this change will be merged into the branch for the Jira Cloud timeout value. 

If we need to cherry pick the changes to create a different branch this MR can be used as a blueprint but the goal is to get the Jira Cloud timeout feature reviewed and merged into v8.3.0.