### PR TITLE
IALERT-3886: jira server timeout reorder

### DIFF
--- a/ui/src/main/js/page/channel/jira/server/JiraServerModal.js
+++ b/ui/src/main/js/page/channel/jira/server/JiraServerModal.js
@@ -226,18 +226,6 @@ const JiraServerModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMes
                     errorName={JIRA_SERVER_GLOBAL_FIELD_KEYS.url}
                     errorValue={error.fieldErrors.url}
                 />
-                <NumberInput
-                    id={JIRA_SERVER_GLOBAL_FIELD_KEYS.timeout}
-                    name={JIRA_SERVER_GLOBAL_FIELD_KEYS.timeout}
-                    label="Timeout"
-                    customDescription="The timeout in seconds for connections to the Jira server instance."
-                    required
-                    readOnly={readonly}
-                    onChange={FieldModelUtilities.handleTestChange(jiraServerModel, setJiraServerModel)}
-                    value={jiraServerModel[JIRA_SERVER_GLOBAL_FIELD_KEYS.timeout] || undefined}
-                    errorName={JIRA_SERVER_GLOBAL_FIELD_KEYS.timeout}
-                    errorValue={error.fieldErrors.timeout}
-                />
                 <RadioInput
                     id={JIRA_SERVER_GLOBAL_FIELD_KEYS.authorizationMethod}
                     name={JIRA_SERVER_GLOBAL_FIELD_KEYS.authorizationMethod}
@@ -296,6 +284,18 @@ const JiraServerModal = ({ data, isOpen, toggleModal, modalOptions, setStatusMes
                     />
                 )}
 
+                <NumberInput
+                    id={JIRA_SERVER_GLOBAL_FIELD_KEYS.timeout}
+                    name={JIRA_SERVER_GLOBAL_FIELD_KEYS.timeout}
+                    label="Timeout"
+                    customDescription="The timeout in seconds for connections to the Jira server instance."
+                    required
+                    readOnly={readonly}
+                    onChange={FieldModelUtilities.handleTestChange(jiraServerModel, setJiraServerModel)}
+                    value={jiraServerModel[JIRA_SERVER_GLOBAL_FIELD_KEYS.timeout] || undefined}
+                    errorName={JIRA_SERVER_GLOBAL_FIELD_KEYS.timeout}
+                    errorValue={error.fieldErrors.timeout}
+                />
                 <CheckboxInput
                     id={JIRA_SERVER_GLOBAL_FIELD_KEYS.disablePluginCheck}
                     name={JIRA_SERVER_GLOBAL_FIELD_KEYS.disablePluginCheck}


### PR DESCRIPTION
Timeout for Jira Server was in a different layout than other timeouts (Jira Cloud & Blackduck Provider) small change to just shuffle the UI elements around to come after the credentials.