### PR TITLE
IALERT-3898 - Fix description for Jira cloud

### DIFF
--- a/ui/src/main/js/page/channel/jira/cloud/JiraCloudGlobalConfiguration.js
+++ b/ui/src/main/js/page/channel/jira/cloud/JiraCloudGlobalConfiguration.js
@@ -95,7 +95,7 @@ const JiraCloudGlobalConfiguration = ({
                     id={JIRA_CLOUD_GLOBAL_FIELD_KEYS.timeout}
                     name={JIRA_CLOUD_GLOBAL_FIELD_KEYS.timeout}
                     label="Timeout"
-                    customDescription="The timeout in seconds for all connections to Jira Cloud.."
+                    description="The timeout in seconds for all connections to Jira Cloud."
                     required
                     readOnly={readonly}
                     onChange={FieldModelUtilities.handleChange(formData, setFormData)}


### PR DESCRIPTION
Description field placement was over arrow, and description ended with 2 periods:

<img width="976" height="194" alt="image" src="https://github.com/user-attachments/assets/0d246020-10b3-4402-9e1c-ac2ffce93f1c" />

Fixed:
<img width="357" height="138" alt="image" src="https://github.com/user-attachments/assets/12b65291-899c-418f-8826-3736466548ea" />
