### PR TITLE
IALERT-4027 - Make RabbitMQ so it can resume on restart

### DIFF
--- a/deployment/helm/blackduck-alert/templates/rabbitmq-headless.yaml
+++ b/deployment/helm/blackduck-alert/templates/rabbitmq-headless.yaml
@@ -1,0 +1,21 @@
+{{- if not .Values.rabbitmq.isExternal }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: alert
+    component: rabbitmq
+    name: {{ .Release.Name }}
+  name: {{ .Release.Name }}-rabbitmq-headless
+  namespace: {{ .Release.Namespace }}
+spec:
+  clusterIP: None
+  selector:
+    app: alert
+    component: rabbitmq
+    name: {{ .Release.Name }}
+  ports:
+  - name: amqp
+    port: {{ .Values.rabbitmq.port }}
+    targetPort: {{ .Values.rabbitmq.port }}
+{{- end }}

--- a/deployment/helm/blackduck-alert/templates/rabbitmq.yaml
+++ b/deployment/helm/blackduck-alert/templates/rabbitmq.yaml
@@ -77,6 +77,8 @@ spec:
         checksum/rabbitmq-config: {{ include (print $.Template.BasePath "/rabbitmq-config.yaml") . | sha256sum }}
       name: {{ .Release.Name }}-rabbitmq
     spec:
+      hostname: {{ .Release.Name }}-rabbitmq
+      subdomain: {{ .Release.Name }}-rabbitmq-headless
       containers:
       - env:
         {{- if .Values.rabbitmq.credential.secretName }}
@@ -98,6 +100,10 @@ spec:
             key: {{ required ".Values.rabbitmq.cluster.erlangCookie.cookieKey is missing." .Values.rabbitmq.cluster.erlangCookie.cookieKey }}
             name: {{ .Values.rabbitmq.cluster.erlangCookie.secretName }}
         {{- end }}
+        - name: RABBITMQ_USE_LONGNAME
+          value: "true"
+        - name: RABBITMQ_NODENAME
+          value: rabbit@{{ .Release.Name }}-rabbitmq.{{ .Release.Name }}-rabbitmq-headless.{{ .Release.Namespace }}.svc.cluster.local
         envFrom:
         - configMapRef:
             name: {{ .Release.Name}}-rabbitmq-config

--- a/deployment/helm/blackduck-alert/templates/rabbitmq.yaml
+++ b/deployment/helm/blackduck-alert/templates/rabbitmq.yaml
@@ -96,9 +96,9 @@ spec:
         {{- if .Values.rabbitmq.cluster.erlangCookie.secretName }}
         - name: RABBITMQ_ERLANG_COOKIE
           valueFrom:
-          secretKeyRef:
-            key: {{ required ".Values.rabbitmq.cluster.erlangCookie.cookieKey is missing." .Values.rabbitmq.cluster.erlangCookie.cookieKey }}
-            name: {{ .Values.rabbitmq.cluster.erlangCookie.secretName }}
+            secretKeyRef:
+              key: {{ required ".Values.rabbitmq.cluster.erlangCookie.cookieKey is missing." .Values.rabbitmq.cluster.erlangCookie.cookieKey }}
+              name: {{ .Values.rabbitmq.cluster.erlangCookie.secretName }}
         {{- end }}
         - name: RABBITMQ_USE_LONGNAME
           value: "true"


### PR DESCRIPTION
While doing verification for persistent queues for RabbitMQ using helm/kubernetes, it was found that when RabbitMQ was restarted with items in the queue, RabbitMQ did not continue processing the items in the queue. It was found that historically, the configuration for Alert helm deployments named the volume mount with a reference to the name of the pod, as it still is for the alert and postgres pod's:

```
# ls -ld /var/local-path-provisioner/pvc-*
drwx------ 19   70 root 4096 Mar  4 19:26 /var/local-path-provisioner/pvc-679793c4-cc1a-4e62-ba23-8547518d85a6_alert_alert-postgres
drwxrwxrwx  3 root root 4096 Mar  4 19:27 /var/local-path-provisioner/pvc-d6f59d9f-fee9-43aa-8633-d1f2f78461c2_alert_alert-pvc
```

The edit in this PR changes the RabbitMQ to be a static name, as shown below:

```
# ls -ld /var/local-path-provisioner/*rabbit*
drwxrwxrwx 4 root root 4096 Mar  4 19:24 /var/local-path-provisioner/alert-rabbitmq
```

After performing this change, a restart of RabbitMQ resulting in resuming of events in the queue.