### PR TITLE
IALERT-3971: fix unscheduling tasks when channel is deleted

### DIFF
--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/lifecycle/JiraPropertyTask.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/lifecycle/JiraPropertyTask.java
@@ -1,16 +1,11 @@
 package com.blackduck.integration.alert.api.channel.jira.lifecycle;
 
 import com.blackduck.integration.alert.api.channel.jira.JiraConstants;
-import com.blackduck.integration.alert.api.channel.jira.JiraIssueSearchProperties;
-import com.blackduck.integration.alert.api.task.ScheduledTask;
 import com.blackduck.integration.alert.api.task.TaskManager;
-import com.blackduck.integration.alert.api.task.TaskMetaData;
-import com.blackduck.integration.alert.api.task.TaskMetaDataProperty;
 import com.blackduck.integration.exception.IntegrationException;
 import com.blackduck.integration.jira.common.model.response.IssuePropertyResponseModel;
 import com.blackduck.integration.jira.common.rest.service.IssuePropertyService;
 import com.google.gson.Gson;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.TaskScheduler;

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/lifecycle/JiraSchedulingManager.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/lifecycle/JiraSchedulingManager.java
@@ -44,12 +44,12 @@ public class JiraSchedulingManager {
     public void unscheduleTasks(String configId) {
         logger.debug("Performing unscheduling jira tasks for config: id={}", configId);
 
-        List<JiraPropertyTask> tasks = taskManager.getTasksByClass(JiraPropertyTask.class)
+        List<JiraTask> tasks = taskManager.getTasksByClass(JiraTask.class)
                 .stream()
                 .filter(task -> task.getConfigId().equals(configId))
                 .toList();
 
-        for (JiraPropertyTask task : tasks) {
+        for (JiraTask task : tasks) {
             unscheduleTask(task);
         }
         logger.debug("Finished unscheduling jira tasks for config: id={}", configId);

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/lifecycle/JiraTask.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/lifecycle/JiraTask.java
@@ -14,6 +14,8 @@ import com.blackduck.integration.alert.api.task.TaskMetaData;
 import com.blackduck.integration.alert.api.task.TaskMetaDataProperty;
 import com.google.gson.Gson;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.TaskScheduler;
 
 import java.util.List;
@@ -21,15 +23,19 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public abstract class JiraTask extends ScheduledTask {
+    // if the task fails 120 consecutive times equaling to approximately being down for an hour consecutively then stop the task.
+    public static final int FAILURE_THRESHOLD = 120;
     protected static final int JQL_QUERY_MAX_RESULTS = 100;
     protected static final JiraIssueSearchProperties EMPTY_SEARCH_PROPERTIES = new JiraIssueSearchProperties(StringUtils.EMPTY,
             StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY,
             StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY);
+    private final Logger logger = LoggerFactory.getLogger(JiraTask.class);
     private final TaskManager taskManager;
     private final String taskName;
     private final String configId;
     private final String configName;
     private final Gson gson;
+    private int consecutiveFailures;
 
     protected JiraTask(TaskScheduler taskScheduler, TaskManager taskManager, String configId, String configName, String taskNameSuffix, Gson gson) {
         super(taskScheduler);
@@ -38,6 +44,7 @@ public abstract class JiraTask extends ScheduledTask {
         this.configName = configName;
         this.taskName = computeTaskName(taskNameSuffix);
         this.gson = gson;
+        this.consecutiveFailures = 0;
     }
 
     @Override
@@ -70,9 +77,31 @@ public abstract class JiraTask extends ScheduledTask {
         return Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
     }
 
+    public int getConsecutiveFailures() {
+        return consecutiveFailures;
+    }
+
     public void unScheduleTask() {
         taskManager.unScheduleTask(taskName);
         taskManager.unregisterTask(taskName);
+    }
+
+    protected void resetConsecutiveFailures() {
+        consecutiveFailures = 0;
+    }
+
+    protected void incrementConsecutiveFailures() {
+        consecutiveFailures++;
+    }
+
+    protected void checkThresholdAndIncrementFailures() {
+        if (consecutiveFailures >= FAILURE_THRESHOLD) {
+            logger.info("Jira Task {} has exceeded consecutive failure threshold of {}.", taskName, FAILURE_THRESHOLD);
+            unScheduleTask();
+        } else {
+            logger.info("Jira Task {} has failed {} out of the {} allowed.", taskName, consecutiveFailures, FAILURE_THRESHOLD);
+            incrementConsecutiveFailures();
+        }
     }
 
     private String computeTaskName(String taskNameSuffix) {

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/lifecycle/JiraTask.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/lifecycle/JiraTask.java
@@ -96,10 +96,10 @@ public abstract class JiraTask extends ScheduledTask {
 
     protected void checkThresholdAndIncrementFailures() {
         if (consecutiveFailures >= FAILURE_THRESHOLD) {
-            logger.info("Jira Task {} has exceeded consecutive failure threshold of {}.", taskName, FAILURE_THRESHOLD);
+            logger.error("Jira Task {} has exceeded consecutive failure threshold of {}.", taskName, FAILURE_THRESHOLD);
             unScheduleTask();
         } else {
-            logger.info("Jira Task {} has failed {} out of the {} allowed.", taskName, consecutiveFailures, FAILURE_THRESHOLD);
+            logger.error("Jira Task {} has failed {} out of the {} allowed.", taskName, consecutiveFailures, FAILURE_THRESHOLD);
             incrementConsecutiveFailures();
         }
     }

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/lifecycle/JiraTask.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/lifecycle/JiraTask.java
@@ -96,7 +96,7 @@ public abstract class JiraTask extends ScheduledTask {
 
     protected void checkThresholdAndIncrementFailures() {
         if (consecutiveFailures >= FAILURE_THRESHOLD) {
-            logger.error("Jira Task {} has exceeded consecutive failure threshold of {}.", taskName, FAILURE_THRESHOLD);
+            logger.error("Jira Task {} has exceeded consecutive failure threshold of {}; stopping task.", taskName, FAILURE_THRESHOLD);
             unScheduleTask();
         } else {
             logger.error("Jira Task {} has failed {} out of the {} allowed.", taskName, consecutiveFailures, FAILURE_THRESHOLD);

--- a/api-channel-jira/src/test/java/com/blackduck/integration/alert/api/channel/jira/JiraTaskTest.java
+++ b/api-channel-jira/src/test/java/com/blackduck/integration/alert/api/channel/jira/JiraTaskTest.java
@@ -1,0 +1,92 @@
+package com.blackduck.integration.alert.api.channel.jira;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.TaskScheduler;
+
+import com.blackduck.integration.alert.api.channel.jira.lifecycle.JiraTask;
+import com.blackduck.integration.alert.api.task.TaskManager;
+import com.google.gson.Gson;
+
+class JiraTaskTest {
+    private static final String CONFIG_ID = UUID.randomUUID().toString();
+    private static final String CONFIG_NAME = "Test Task Config";
+    private static final String TASK_NAME_SUFFIX = "Task name suffix";
+    private static final Gson GSON = new Gson();
+
+    @Test
+    void testExecuteTask() {
+        TestTask task = new TestTask(null, null, CONFIG_ID, CONFIG_NAME, TASK_NAME_SUFFIX, GSON, 0,0);
+        task.runTask();
+
+        Assertions.assertEquals(CONFIG_ID, task.getConfigId());
+        Assertions.assertEquals(CONFIG_NAME, task.getConfigName());
+        Assertions.assertTrue(task.getTaskName().contains(task.getClass().getSimpleName()));
+        Assertions.assertTrue(task.getTaskName().contains(TASK_NAME_SUFFIX));
+        Assertions.assertTrue(task.getTaskName().contains(CONFIG_ID));
+        Assertions.assertEquals(0, task.getConsecutiveFailures());
+    }
+
+    @Test
+    void testExecuteConsecutiveFailures() {
+        int expectedConsecutiveFailures = 10;
+        TestTask task = new TestTask(null, null, CONFIG_ID, CONFIG_NAME, TASK_NAME_SUFFIX, GSON, expectedConsecutiveFailures, expectedConsecutiveFailures+1);
+        for(int index = 0; index < expectedConsecutiveFailures; index++) {
+            task.runTask();
+        }
+        Assertions.assertEquals(expectedConsecutiveFailures, task.getConsecutiveFailures());
+    }
+
+    @Test
+    void testIncrementFailures() {
+        TestTask task = new TestTask(null, null, CONFIG_ID, CONFIG_NAME, TASK_NAME_SUFFIX, GSON, 1,2);
+        task.runTask();
+        Assertions.assertEquals(1, task.getConsecutiveFailures());
+    }
+
+    @Test
+    void testFailureReset() {
+        TestTask task = new TestTask(null, null, CONFIG_ID, CONFIG_NAME, TASK_NAME_SUFFIX, GSON, 1,1);
+        task.runTask();
+        Assertions.assertEquals(1, task.getConsecutiveFailures());
+        task.runTask();
+        Assertions.assertEquals(0, task.getConsecutiveFailures());
+    }
+
+    public static class TestTask extends JiraTask {
+        private final int expectedConsecutiveFailures;
+        private final int failuresBeforeReset;
+        public TestTask(
+            final TaskScheduler taskScheduler,
+            final TaskManager taskManager,
+            final String configId,
+            final String configName,
+            final String taskNameSuffix,
+            final Gson gson,
+            int expectedConsecutiveFailures,
+            int failuresBeforeReset
+        ) {
+            super(taskScheduler, taskManager, configId, configName, taskNameSuffix, gson);
+            this.expectedConsecutiveFailures = expectedConsecutiveFailures;
+            this.failuresBeforeReset = failuresBeforeReset;
+        }
+
+        @Override
+        public String scheduleCronExpression() {
+            return "";
+        }
+
+        @Override
+        public void runTask() {
+            if(getConsecutiveFailures() <= expectedConsecutiveFailures) {
+                checkThresholdAndIncrementFailures();
+            }
+
+            if(getConsecutiveFailures() > failuresBeforeReset) {
+                resetConsecutiveFailures();
+            }
+        }
+    }
+}

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/task/JiraPropertyUpdateTask.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/task/JiraPropertyUpdateTask.java
@@ -70,11 +70,14 @@ public class JiraPropertyUpdateTask extends JiraPropertyTask {
                 }
             }
             logger.info("Jira Cloud property migrator task ended.");
+            resetConsecutiveFailures();
         } catch (IntegrationException e) {
             logger.error("Error getting Jira Cloud Configuration.", e);
+            checkThresholdAndIncrementFailures();
         } catch (InterruptedException e) {
             logger.error("Error updating Jira Cloud issues with new property.", e);
             Thread.currentThread().interrupt();
+            checkThresholdAndIncrementFailures();
         }
     }
 

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/task/JiraSearchCommentUpdateTask.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/task/JiraSearchCommentUpdateTask.java
@@ -77,11 +77,14 @@ public class JiraSearchCommentUpdateTask extends JiraTask {
                 unScheduleTask();
             }
             logger.info("Jira Cloud search comment task ended.");
+            resetConsecutiveFailures();
         } catch (IntegrationException e) {
             logger.error("Error getting Jira Cloud Configuration.", e);
+            checkThresholdAndIncrementFailures();
         } catch (InterruptedException e) {
             logger.error("Error updating Jira Cloud issues with new search key comment.", e);
             Thread.currentThread().interrupt();
+            checkThresholdAndIncrementFailures();
         }
     }
 

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/task/JiraPropertyUpdateTask.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/task/JiraPropertyUpdateTask.java
@@ -70,11 +70,14 @@ public class JiraPropertyUpdateTask extends JiraPropertyTask {
                     unScheduleTask();
                 }
             }
+            resetConsecutiveFailures();
         } catch (IntegrationException e) {
             logger.error("Error getting Jira Server Configuration.", e);
+            checkThresholdAndIncrementFailures();
         } catch (InterruptedException e) {
             logger.error("Error updating Jira Server issues with new property.", e);
             Thread.currentThread().interrupt();
+            checkThresholdAndIncrementFailures();
         }
 
         logger.info("Jira Server property migrator task ended.");

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/task/JiraSearchCommentUpdateTask.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/task/JiraSearchCommentUpdateTask.java
@@ -73,11 +73,14 @@ public class JiraSearchCommentUpdateTask extends JiraTask {
                 // unschedule the task because the query returned no results
                 unScheduleTask();
             }
+            resetConsecutiveFailures();
         } catch (IntegrationException e) {
             logger.error("Error getting Jira Server Configuration.", e);
+            checkThresholdAndIncrementFailures();
         } catch (InterruptedException e) {
             logger.error("Error updating Jira Server issues with new search key comment.", e);
             Thread.currentThread().interrupt();
+            checkThresholdAndIncrementFailures();
         }
 
         logger.info("Jira Server search comment task ended.");


### PR DESCRIPTION
The task for adding comments to tickets was using a task manager that was looking for JiraPropertyTask classes.  The issue is that the commenting task extends JiraTask.  This is why the task would not end.  Changed the taskmanager to use JiraTask class to unschedule all the tasks for a channel. 

As a failsafe also added a threshold limit of 120 consecutive failures and keep track of the failures.  If the threshold is exceeded then there is a log.  Each time the task fails consecutively there is a log message to indicate the number of consecutive failures. This results in a task that executes for an hour with failures will unschedule the task.  As soon as the task completes without exceptions then the failure counter is reset to 0.  This allows the task to recover from intermittent networking issues or certificate issues communicating with the channel.  If the task completes successfully and finishes it's job it will un-schedule itself as usual.