### PR TITLE
IALERT-4002 - Tighten release version check to require numeric dot-se…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ version = '9.0.0-SNAPSHOT'
 
 ext.isSnapshot = project.version.endsWith('-SNAPSHOT')
 ext.isSIGQA = project.version.contains('-SIGQA')
-ext.isRelease = (!project.ext.isSnapshot && !project.ext.isSIGQA)
+ext.isRelease = (!project.ext.isSnapshot && !project.ext.isSIGQA && project.version ==~ /\d+(\.\d+)*/)
 
 if (project.ext.isSIGQA && System.env.HELM_SIGQA_REPOS != null) {
     helmArtifactoryRepos = System.env.HELM_SIGQA_REPOS.split(',').collect { it.trim() as String }


### PR DESCRIPTION
Update logic which flags a version as a release so it only supports a numeric period separated format. The regex reads as: 1 digit followed by zero or more occurrences of (a period followed by a digit)

Support versions include:
```
1
1.0
1.0.0
1.0.0.0
```