### PR TITLE
IALERT-3980: Issue Tracker distribution logging improvements

### DIFF
--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/IssueTrackerModelExtractor.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/IssueTrackerModelExtractor.java
@@ -12,6 +12,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.blackduck.integration.alert.api.channel.issue.tracker.convert.IssueTrackerMessageFormatter;
 import com.blackduck.integration.alert.api.channel.issue.tracker.convert.IssueTrackerSimpleMessageConverter;
 import com.blackduck.integration.alert.api.channel.issue.tracker.convert.ProjectIssueModelConverter;
@@ -29,6 +32,7 @@ import com.blackduck.integration.alert.api.processor.extract.model.SimpleMessage
 import com.blackduck.integration.alert.api.processor.extract.model.project.ProjectMessage;
 
 public class IssueTrackerModelExtractor<T extends Serializable> {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final IssueTrackerSimpleMessageConverter issueTrackerSimpleMessageConverter;
     private final ProjectIssueModelConverter projectIssueModelConverter;
     private final IssueTrackerSearcher<T> issueTrackerSearcher;
@@ -66,6 +70,7 @@ public class IssueTrackerModelExtractor<T extends Serializable> {
             return convertExistingIssue(existingIssueDetails.get(), projectIssueModel, searchResult.getRequiredOperation());
         } else {
             IssueCreationModel issueCreationModel = projectIssueModelConverter.toIssueCreationModel(projectIssueModel, jobName, searchResult.getSearchQuery());
+            logger.debug("Issue not found; creating new issue model with Alert Issue ID: {}", issueCreationModel.getAlertIssueId());
             return new IssueTrackerModelHolder<>(List.of(issueCreationModel), List.of(), List.of());
         }
     }
@@ -75,9 +80,11 @@ public class IssueTrackerModelExtractor<T extends Serializable> {
         List<IssueCommentModel<T>> commentModels = new ArrayList<>(1);
         if (ItemOperation.UPDATE.equals(requiredOperation) || ItemOperation.INFO.equals(requiredOperation)) {
             IssueCommentModel<T> projectIssueCommentModel = projectIssueModelConverter.toIssueCommentModel(existingIssueDetails, projectIssueModel);
+            logger.debug("Issue already exists; creating comment model with Alert Issue ID: {}", projectIssueCommentModel.getAlertIssueId());
             commentModels.add(projectIssueCommentModel);
         } else {
             IssueTransitionModel<T> projectIssueTransitionModel = projectIssueModelConverter.toIssueTransitionModel(existingIssueDetails, projectIssueModel, requiredOperation);
+            logger.debug("Issue already exists; creating transition model with Alert Issue ID: {}", projectIssueTransitionModel.getAlertIssueId());
             transitionModels.add(projectIssueTransitionModel);
         }
         return new IssueTrackerModelHolder<>(List.of(), transitionModels, commentModels);

--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/IssueTrackerModelExtractor.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/IssueTrackerModelExtractor.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import com.blackduck.integration.alert.api.channel.issue.tracker.convert.IssueTrackerMessageFormatter;
 import com.blackduck.integration.alert.api.channel.issue.tracker.convert.IssueTrackerSimpleMessageConverter;
 import com.blackduck.integration.alert.api.channel.issue.tracker.convert.ProjectIssueModelConverter;
+import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueActionModel;
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueCommentModel;
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueCreationModel;
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueTrackerModelHolder;
@@ -30,8 +31,11 @@ import com.blackduck.integration.alert.api.common.model.exception.AlertException
 import com.blackduck.integration.alert.common.enumeration.ItemOperation;
 import com.blackduck.integration.alert.api.processor.extract.model.SimpleMessage;
 import com.blackduck.integration.alert.api.processor.extract.model.project.ProjectMessage;
+import com.blackduck.integration.alert.common.message.model.LinkableItem;
 
 public class IssueTrackerModelExtractor<T extends Serializable> {
+    private static final String ISSUE_NOT_FOUND = "Issue not found";
+    private static final String ISSUE_FOUND = "Issue already exists";
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final IssueTrackerSimpleMessageConverter issueTrackerSimpleMessageConverter;
     private final ProjectIssueModelConverter projectIssueModelConverter;
@@ -70,7 +74,7 @@ public class IssueTrackerModelExtractor<T extends Serializable> {
             return convertExistingIssue(existingIssueDetails.get(), projectIssueModel, searchResult.getRequiredOperation());
         } else {
             IssueCreationModel issueCreationModel = projectIssueModelConverter.toIssueCreationModel(projectIssueModel, jobName, searchResult.getSearchQuery());
-            logger.debug("Issue not found; creating new issue model with Alert Issue ID: {}", issueCreationModel.getAlertIssueId());
+            logProjectIssueDetails(ISSUE_NOT_FOUND, issueCreationModel, projectIssueModel);
             return new IssueTrackerModelHolder<>(List.of(issueCreationModel), List.of(), List.of());
         }
     }
@@ -80,14 +84,30 @@ public class IssueTrackerModelExtractor<T extends Serializable> {
         List<IssueCommentModel<T>> commentModels = new ArrayList<>(1);
         if (ItemOperation.UPDATE.equals(requiredOperation) || ItemOperation.INFO.equals(requiredOperation)) {
             IssueCommentModel<T> projectIssueCommentModel = projectIssueModelConverter.toIssueCommentModel(existingIssueDetails, projectIssueModel);
-            logger.debug("Issue already exists; creating comment model with Alert Issue ID: {}", projectIssueCommentModel.getAlertIssueId());
+            logProjectIssueDetails(ISSUE_FOUND, projectIssueCommentModel, projectIssueModel);
             commentModels.add(projectIssueCommentModel);
         } else {
             IssueTransitionModel<T> projectIssueTransitionModel = projectIssueModelConverter.toIssueTransitionModel(existingIssueDetails, projectIssueModel, requiredOperation);
-            logger.debug("Issue already exists; creating transition model with Alert Issue ID: {}", projectIssueTransitionModel.getAlertIssueId());
+            logProjectIssueDetails(ISSUE_FOUND, projectIssueTransitionModel, projectIssueModel);
             transitionModels.add(projectIssueTransitionModel);
         }
         return new IssueTrackerModelHolder<>(List.of(), transitionModels, commentModels);
+    }
+
+    private void logProjectIssueDetails(String issueExistsMessage, IssueActionModel issueActionModel, ProjectIssueModel projectIssueModel) {
+        if (!logger.isDebugEnabled()) {
+            return;
+        }
+        String projectName = projectIssueModel.getProject().getValue();
+        String projectVersionLabelValue = projectIssueModel.getProjectVersion()
+            .map(LinkableItem::getValue)
+            .orElse("None");
+        String componentName = projectIssueModel.getBomComponentDetails().getComponent().getValue();
+        String componentVersionLabelValue = projectIssueModel.getBomComponentDetails().getComponentVersion()
+            .map(LinkableItem::getValue)
+            .orElse("None");
+        logger.debug("{}; Creating: {} with Alert Issue ID: {}. Project Issue Details; Black Duck Project: {}, Project Version: {}, Component: {}, Component Version: {}",
+            issueExistsMessage, issueActionModel.getClass().getSimpleName(), issueActionModel.getAlertIssueId(), projectName, projectVersionLabelValue, componentName, componentVersionLabelValue);
     }
 
 }

--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/IssueTrackerProcessor.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/IssueTrackerProcessor.java
@@ -43,7 +43,6 @@ public class IssueTrackerProcessor<T extends Serializable> implements IssueTrack
         logIssueTrackerMessages("Simple", simpleMessageHolder);
 
         for (ProjectMessage projectMessage : messages.getProjectMessages()) {
-            projectMessage.getBomComponents();
             IssueTrackerModelHolder<T> projectMessageHolder = modelExtractor.extractProjectMessageIssueModels(projectMessage, jobName);
             issueTrackerModels.add(projectMessageHolder);
             logIssueTrackerMessages("Project", projectMessageHolder);

--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/IssueTrackerProcessor.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/IssueTrackerProcessor.java
@@ -11,6 +11,9 @@ import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueTrackerModelHolder;
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueTrackerResponse;
 import com.blackduck.integration.alert.api.channel.issue.tracker.send.IssueTrackerAsyncMessageSender;
@@ -19,6 +22,7 @@ import com.blackduck.integration.alert.api.processor.extract.model.ProviderMessa
 import com.blackduck.integration.alert.api.processor.extract.model.project.ProjectMessage;
 
 public class IssueTrackerProcessor<T extends Serializable> implements IssueTrackerMessageProcessor<T> {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final IssueTrackerModelExtractor<T> modelExtractor;
     private final IssueTrackerAsyncMessageSender<IssueTrackerModelHolder<T>> messageSender;
 
@@ -32,15 +36,31 @@ public class IssueTrackerProcessor<T extends Serializable> implements IssueTrack
         List<IssueTrackerModelHolder<T>> issueTrackerModels = new LinkedList<>();
         IssueTrackerModelHolder<T> simpleMessageHolder = modelExtractor.extractSimpleMessageIssueModels(messages.getSimpleMessages(), jobName);
         issueTrackerModels.add(simpleMessageHolder);
+        logIssueTrackerMessages("Simple", simpleMessageHolder);
 
         for (ProjectMessage projectMessage : messages.getProjectMessages()) {
+            projectMessage.getBomComponents();
             IssueTrackerModelHolder<T> projectMessageHolder = modelExtractor.extractProjectMessageIssueModels(projectMessage, jobName);
             issueTrackerModels.add(projectMessageHolder);
+            logIssueTrackerMessages("Project", projectMessageHolder);
         }
 
         messageSender.sendAsyncMessages(issueTrackerModels);
 
         return new IssueTrackerResponse<>("Success", List.of());
+    }
+
+    private void logIssueTrackerMessages(String messageHolderType, IssueTrackerModelHolder<T> issueTrackerModels) {
+        if (!logger.isDebugEnabled()) {
+            return;
+        }
+        logger.debug("{} Message Counts for Job execution id: {}, for {} notifications. Creation: {}, Transition: {}, Comment: {}",
+            messageHolderType,
+            messageSender.getJobExecutionId(),
+            messageSender.getNotificationIds().size(),
+            issueTrackerModels.getIssueCreationModels().size(),
+            issueTrackerModels.getIssueTransitionModels().size(),
+            issueTrackerModels.getIssueCommentModels().size());
     }
 
 }

--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/IssueTrackerProcessor.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/IssueTrackerProcessor.java
@@ -10,12 +10,16 @@ package com.blackduck.integration.alert.api.channel.issue.tracker;
 import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueCommentModel;
+import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueCreationModel;
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueTrackerModelHolder;
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueTrackerResponse;
+import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueTransitionModel;
 import com.blackduck.integration.alert.api.channel.issue.tracker.send.IssueTrackerAsyncMessageSender;
 import com.blackduck.integration.alert.api.common.model.exception.AlertException;
 import com.blackduck.integration.alert.api.processor.extract.model.ProviderMessageHolder;
@@ -54,13 +58,28 @@ public class IssueTrackerProcessor<T extends Serializable> implements IssueTrack
         if (!logger.isDebugEnabled()) {
             return;
         }
-        logger.debug("{} Message Counts for Job execution id: {}, for {} notifications. Creation: {}, Transition: {}, Comment: {}",
+        List<String> creationModelAlertIds = issueTrackerModels.getIssueCreationModels().stream()
+                .map(IssueCreationModel::getAlertIssueId)
+                .map(UUID::toString)
+                .toList();
+        List<String> transitionModelAlertIds = issueTrackerModels.getIssueTransitionModels().stream()
+            .map(IssueTransitionModel::getAlertIssueId)
+            .map(UUID::toString)
+            .toList();
+        List<String> commentModelAlertIds = issueTrackerModels.getIssueCommentModels().stream()
+            .map(IssueCommentModel::getAlertIssueId)
+            .map(UUID::toString)
+            .toList();
+        logger.debug("{} Message Counts for Job execution id: {}, for {} notifications. Creation ({}): {}, Transition ({}): {}, Comment ({}): {}",
             messageHolderType,
             messageSender.getJobExecutionId(),
             messageSender.getNotificationIds().size(),
             issueTrackerModels.getIssueCreationModels().size(),
+            creationModelAlertIds.isEmpty() ? "None" : creationModelAlertIds,
             issueTrackerModels.getIssueTransitionModels().size(),
-            issueTrackerModels.getIssueCommentModels().size());
+            transitionModelAlertIds.isEmpty() ? "None" : transitionModelAlertIds,
+            issueTrackerModels.getIssueCommentModels().size(),
+            commentModelAlertIds.isEmpty() ? "None" : commentModelAlertIds);
     }
 
 }

--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/model/IssueActionModel.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/model/IssueActionModel.java
@@ -1,0 +1,25 @@
+/*
+ * blackduck-alert
+ *
+ * Copyright (c) 2026 Black Duck Software, Inc.
+ *
+ * Use subject to the terms and conditions of the Black Duck Software End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.blackduck.integration.alert.api.channel.issue.tracker.model;
+
+import java.util.UUID;
+
+import com.blackduck.integration.alert.api.common.model.AlertSerializableModel;
+
+public abstract class IssueActionModel extends AlertSerializableModel {
+
+    private final UUID alertIssueId;
+
+    protected IssueActionModel() {
+        this.alertIssueId = UUID.randomUUID();
+    }
+
+    public UUID getAlertIssueId() {
+        return alertIssueId;
+    }
+}

--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/model/IssueCommentModel.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/model/IssueCommentModel.java
@@ -14,10 +14,9 @@ import java.util.Optional;
 import org.jetbrains.annotations.Nullable;
 
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.ExistingIssueDetails;
-import com.blackduck.integration.alert.api.common.model.AlertSerializableModel;
 import com.blackduck.integration.jira.common.cloud.model.AtlassianDocumentFormatModel;
 
-public class IssueCommentModel<T extends Serializable> extends AlertSerializableModel {
+public class IssueCommentModel<T extends Serializable> extends IssueActionModel {
     private final ExistingIssueDetails<T> existingIssueDetails;
     private final List<String> comments;
     @Nullable

--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/model/IssueCreationModel.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/model/IssueCreationModel.java
@@ -12,11 +12,10 @@ import java.util.Optional;
 
 import org.jetbrains.annotations.Nullable;
 
-import com.blackduck.integration.alert.api.common.model.AlertSerializableModel;
 import com.blackduck.integration.alert.common.message.model.LinkableItem;
 import com.blackduck.integration.jira.common.cloud.model.AtlassianDocumentFormatModel;
 
-public class IssueCreationModel extends AlertSerializableModel {
+public class IssueCreationModel extends IssueActionModel {
     private static final long serialVersionUID = -3568919050386494416L;
     private final String queryString;
     private final String title;

--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/model/IssueTransitionModel.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/model/IssueTransitionModel.java
@@ -14,11 +14,10 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.ExistingIssueDetails;
-import com.blackduck.integration.alert.api.common.model.AlertSerializableModel;
 import com.blackduck.integration.alert.common.channel.issuetracker.enumeration.IssueOperation;
 import com.blackduck.integration.jira.common.cloud.model.AtlassianDocumentFormatModel;
 
-public class IssueTransitionModel<T extends Serializable> extends AlertSerializableModel {
+public class IssueTransitionModel<T extends Serializable> extends IssueActionModel {
     private final ExistingIssueDetails<T> existingIssueDetails;
     private final IssueOperation issueOperation;
     private final List<String> postTransitionComments;

--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerAsyncMessageSender.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerAsyncMessageSender.java
@@ -44,6 +44,14 @@ public class IssueTrackerAsyncMessageSender<T> implements AsyncMessageSender<T> 
         this.executingJobManager = executingJobManager;
     }
 
+    public UUID getJobExecutionId() {
+        return jobExecutionId;
+    }
+
+    public Set<Long> getNotificationIds() {
+        return notificationIds;
+    }
+
     public final void sendAsyncMessages(List<T> issueTrackerMessages) {
         List<AlertEvent> eventList = issueTrackerMessages.stream()
             .map(this::createAlertEvents)

--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerIssueCommenter.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerIssueCommenter.java
@@ -22,7 +22,7 @@ import com.blackduck.integration.alert.api.common.model.exception.AlertException
 import com.blackduck.integration.alert.common.channel.issuetracker.enumeration.IssueOperation;
 
 public abstract class IssueTrackerIssueCommenter<T extends Serializable> {
-    public static final String COMMENTING_DISABLED_MESSAGE = "Commenting on issues is disabled. Skipping.";
+    public static final String COMMENTING_DISABLED_MESSAGE = "Commenting on issues is disabled. Skipping. Alert Issue ID: {}";
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -34,12 +34,13 @@ public abstract class IssueTrackerIssueCommenter<T extends Serializable> {
 
     public final Optional<IssueTrackerIssueResponseModel<T>> commentOnIssue(IssueCommentModel<T> issueCommentModel) throws AlertException {
         if (!isCommentingEnabled()) {
-            logger.debug(COMMENTING_DISABLED_MESSAGE);
+            logger.debug(COMMENTING_DISABLED_MESSAGE, issueCommentModel.getAlertIssueId());
             return Optional.empty();
         }
 
         addComments(issueCommentModel);
         IssueTrackerIssueResponseModel<T> responseModel = issueResponseCreator.createIssueResponse(issueCommentModel.getSource().orElse(null), issueCommentModel.getExistingIssueDetails(), IssueOperation.UPDATE);
+        logger.debug("Commented on issue with Alert Issue ID: {}", issueCommentModel.getAlertIssueId());
         return Optional.of(responseModel);
     }
 
@@ -49,7 +50,7 @@ public abstract class IssueTrackerIssueCommenter<T extends Serializable> {
 
     protected void addComments(IssueCommentModel<T> issueCommentModel) throws AlertException {
         if (!isCommentingEnabled()) {
-            logger.debug(COMMENTING_DISABLED_MESSAGE);
+            logger.debug(COMMENTING_DISABLED_MESSAGE, issueCommentModel.getAlertIssueId());
             return;
         }
 

--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerIssueCreator.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerIssueCreator.java
@@ -54,7 +54,7 @@ public abstract class IssueTrackerIssueCreator<T extends Serializable> {
      */
     public final IssueTrackerIssueResponseModel<T> createIssueTrackerIssue(IssueCreationModel alertIssueCreationModel) throws AlertException {
         ExistingIssueDetails<T> createdIssueDetails = createIssueAndExtractDetails(alertIssueCreationModel);
-        logger.debug("Created new {} issue: {}", channelKey.getDisplayName(), createdIssueDetails);
+        logger.debug("Created new {} with Alert Issue ID: {}, Issue details: {}", channelKey.getDisplayName(), alertIssueCreationModel.getAlertIssueId(), createdIssueDetails);
 
         IssueTrackerCallbackInfo callbackInfo = null;
         Optional<ProjectIssueModel> optionalSource = alertIssueCreationModel.getSource();
@@ -84,6 +84,7 @@ public abstract class IssueTrackerIssueCreator<T extends Serializable> {
         postCreateComments.addFirst("This issue was automatically created by Alert.");
 
         IssueCommentModel<T> commentRequestModel = new IssueCommentModel<>(issueDetails, postCreateComments, projectSource);
+        logger.debug("Issue Creator: creating comment model with Alert Issue ID: {}", commentRequestModel.getAlertIssueId());
         commenter.commentOnIssue(commentRequestModel);
     }
 

--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerIssueCreator.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerIssueCreator.java
@@ -54,7 +54,7 @@ public abstract class IssueTrackerIssueCreator<T extends Serializable> {
      */
     public final IssueTrackerIssueResponseModel<T> createIssueTrackerIssue(IssueCreationModel alertIssueCreationModel) throws AlertException {
         ExistingIssueDetails<T> createdIssueDetails = createIssueAndExtractDetails(alertIssueCreationModel);
-        logger.debug("Created new {} with Alert Issue ID: {}, Issue details: {}", channelKey.getDisplayName(), alertIssueCreationModel.getAlertIssueId(), createdIssueDetails);
+        logger.debug("Created new {} issue with Alert Issue ID: {}, Issue details: {}", channelKey.getDisplayName(), alertIssueCreationModel.getAlertIssueId(), createdIssueDetails);
 
         IssueTrackerCallbackInfo callbackInfo = null;
         Optional<ProjectIssueModel> optionalSource = alertIssueCreationModel.getSource();
@@ -84,7 +84,7 @@ public abstract class IssueTrackerIssueCreator<T extends Serializable> {
         postCreateComments.addFirst("This issue was automatically created by Alert.");
 
         IssueCommentModel<T> commentRequestModel = new IssueCommentModel<>(issueDetails, postCreateComments, projectSource);
-        logger.debug("Issue Creator: creating comment model with Alert Issue ID: {}", commentRequestModel.getAlertIssueId());
+        logger.debug("Issue Creator for Alert Issue ID: {}, creating comment model with Alert Issue ID: {}", creationModel.getAlertIssueId(), commentRequestModel.getAlertIssueId());
         commenter.commentOnIssue(commentRequestModel);
     }
 

--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerIssueTransitioner.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerIssueTransitioner.java
@@ -70,7 +70,7 @@ public abstract class IssueTrackerIssueTransitioner<T extends Serializable> {
             null,
             issueTransitionModel.getAtlassianTransitionComments().orElse(null)
         );
-        logger.debug("Issue Transitioner: creating comment model with Alert Issue ID: {}", commentRequestModel.getAlertIssueId());
+        logger.debug("Issue Transitioner for Alert Issue ID: {}, creating comment model with Alert Issue ID: {}", issueTransitionModel.getAlertIssueId(), commentRequestModel.getAlertIssueId());
         commenter.commentOnIssue(commentRequestModel);
 
         return transitionResponse;

--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerIssueTransitioner.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/send/IssueTrackerIssueTransitioner.java
@@ -36,6 +36,7 @@ public abstract class IssueTrackerIssueTransitioner<T extends Serializable> {
     public final Optional<IssueTrackerIssueResponseModel<T>> transitionIssue(IssueTransitionModel<T> issueTransitionModel) throws AlertException {
         IssueOperation issueOperation = issueTransitionModel.getIssueOperation();
         ExistingIssueDetails<T> existingIssueDetails = issueTransitionModel.getExistingIssueDetails();
+        logger.debug("Attempting to transition issue with Alert Issue ID: {}", issueTransitionModel.getAlertIssueId());
 
         Optional<IssueTrackerIssueResponseModel<T>> transitionResponse = Optional.empty();
 
@@ -51,12 +52,15 @@ public abstract class IssueTrackerIssueTransitioner<T extends Serializable> {
                     existingIssueDetails,
                     issueOperation
                 );
+                logger.debug("Transitioned issue with Alert Issue ID: {}", issueTransitionModel.getAlertIssueId());
                 transitionResponse = Optional.of(transitionResponseModel);
             } else {
-                logger.debug("The issue is already in the status category that would result from this transition ({}). Issue Details: {}", transitionName, existingIssueDetails);
+                logger.debug("The issue is already in the status category that would result from this transition ({}). Alert Issue ID: {}, Issue Details: {}",
+                    transitionName, issueTransitionModel.getAlertIssueId(), existingIssueDetails);
             }
         } else {
-            logger.debug("No transition name was provided so no '{}' transition will be performed. Issue Details: {}", issueOperation.name(), existingIssueDetails);
+            logger.debug("No transition name was provided so no '{}' transition will be performed. Alert Issue ID: {}, Issue Details: {}",
+                issueOperation.name(), issueTransitionModel.getAlertIssueId(), existingIssueDetails);
         }
 
         IssueCommentModel<T> commentRequestModel = new IssueCommentModel<>(
@@ -66,6 +70,7 @@ public abstract class IssueTrackerIssueTransitioner<T extends Serializable> {
             null,
             issueTransitionModel.getAtlassianTransitionComments().orElse(null)
         );
+        logger.debug("Issue Transitioner: creating comment model with Alert Issue ID: {}", commentRequestModel.getAlertIssueId());
         commenter.commentOnIssue(commentRequestModel);
 
         return transitionResponse;
@@ -97,6 +102,7 @@ public abstract class IssueTrackerIssueTransitioner<T extends Serializable> {
             issueMissingTransitionException.getMessage()
         );
         IssueCommentModel<T> failureCommentRequestModel = new IssueCommentModel<>(existingIssueDetails, List.of(failureComment), null);
+        logger.debug("Issue Transitioner: creating comment model with Alert Issue ID: {}", failureCommentRequestModel.getAlertIssueId());
         try {
             commenter.commentOnIssue(failureCommentRequestModel);
         } catch (AlertException e) {

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/delegate/JiraIssueCreator.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/delegate/JiraIssueCreator.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.blackduck.integration.alert.api.channel.issue.tracker.callback.IssueTrackerCallbackInfoCreator;
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueBomComponentDetails;
@@ -49,6 +51,7 @@ import com.blackduck.integration.rest.exception.IntegrationRestException;
 public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<String> {
     private static final String FAILED_TO_CREATE_ISSUE_MESSAGE = "Failed to create an issue in Jira.";
 
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final JiraErrorMessageUtility jiraErrorMessageUtility;
     private final JiraIssueAlertPropertiesManager issuePropertiesManager;
     private final String issueCreatorDescriptorKey;
@@ -74,8 +77,12 @@ public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<Strin
     protected final ExistingIssueDetails<String> createIssueAndExtractDetails(IssueCreationModel alertIssueCreationModel) throws AlertException {
         Optional<ExistingIssueDetails<String>> existingIssue = doesIssueExist(alertIssueCreationModel);
         if (existingIssue.isPresent()) {
+            ExistingIssueDetails<String> existingIssueDetails = existingIssue.get();
+            logger.debug("Found existing Jira issue for Alert Issue ID: {}. Jira Issue Details: Jira ID: {} Jira Key: {}",
+                alertIssueCreationModel.getAlertIssueId(), existingIssueDetails.getIssueId(), existingIssueDetails.getIssueKey());
             return existingIssue.get();
         }
+        logger.debug("Did not discover existing Jira issues for Alert Issue ID: {}", alertIssueCreationModel.getAlertIssueId());
         ExistingIssueDetails<String> existingIssueDetails;
         MessageReplacementValues replacementValues = alertIssueCreationModel.getSource()
             .map(this::createCustomFieldReplacementValues)
@@ -85,6 +92,7 @@ public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<Strin
             ).build());
         T creationRequest = createIssueCreationRequest(alertIssueCreationModel, replacementValues);
         try {
+            logger.debug("Attempting to create new issue for Alert Issue ID: {}", alertIssueCreationModel.getAlertIssueId());
             IssueCreationResponseModel issueCreationResponseModel = createIssue(creationRequest);
             IssueResponseModel createdIssue = fetchIssue(issueCreationResponseModel.getKey());
             IssueFieldsComponent createdIssueFields = createdIssue.getFields();
@@ -121,6 +129,7 @@ public abstract class JiraIssueCreator<T> extends IssueTrackerIssueCreator<Strin
     }
 
     protected Optional<ExistingIssueDetails<String>> doesIssueExist(IssueCreationModel alertIssueCreationModel) {
+        logger.debug("Attempting to find existing Jira issues for Alert Issue ID: {}", alertIssueCreationModel.getAlertIssueId());
         String query = alertIssueCreationModel.getQueryString().orElse(null);
         if (StringUtils.isBlank(query)) {
             return Optional.empty();

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JiraExactIssueFinder.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JiraExactIssueFinder.java
@@ -81,7 +81,14 @@ public class JiraExactIssueFinder implements ExactIssueFinder<String> {
             concernType,
             policyName
         );
-        logger.debug("Searching for Jira issues with this Query: {}", jqlString);
+        String projectVersionLabelValue = projectIssueModel.getProjectVersion()
+            .map(LinkableItem::getValue)
+            .orElse(null);
+        String componentVersionLabelValue = bomComponent.getComponentVersion()
+            .map(LinkableItem::getValue)
+            .orElse(null);
+        logger.debug("Searching for Jira issues for Black Duck Project: {}, Project Version: {}, Component: {}, ComponentVersion: {}, with this JQL Query: {}",
+            project.getValue(), projectVersionLabelValue, bomComponent.getComponent().getValue(), componentVersionLabelValue, jqlString);
         List<ProjectIssueSearchResult<String>> searchResults;
         if(maxResults == Integer.MAX_VALUE) {
             searchResults = jqlQueryExecutor.executeQuery(jqlString)
@@ -94,6 +101,8 @@ public class JiraExactIssueFinder implements ExactIssueFinder<String> {
                     .map(jiraSearcherResponseModel -> searchResultCreator.createIssueResult(jiraSearcherResponseModel, projectIssueModel))
                     .toList();
         }
+        logger.debug("Found {} search results for Black Duck Project: {}, Project Version: {}, Component: {}, ComponentVersion: {}",
+            searchResults.size(), project.getValue(), projectVersionLabelValue, bomComponent.getComponent().getValue(), componentVersionLabelValue);
         return new IssueTrackerSearchResult<>(jqlString, searchResults);
     }
 

--- a/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JiraExactIssueFinder.java
+++ b/api-channel-jira/src/main/java/com/blackduck/integration/alert/api/channel/jira/distribution/search/JiraExactIssueFinder.java
@@ -83,12 +83,12 @@ public class JiraExactIssueFinder implements ExactIssueFinder<String> {
         );
         String projectVersionLabelValue = projectIssueModel.getProjectVersion()
             .map(LinkableItem::getValue)
-            .orElse(null);
+            .orElse("None");
         String componentVersionLabelValue = bomComponent.getComponentVersion()
             .map(LinkableItem::getValue)
-            .orElse(null);
-        logger.debug("Searching for Jira issues for Black Duck Project: {}, Project Version: {}, Component: {}, ComponentVersion: {}, with this JQL Query: {}",
-            project.getValue(), projectVersionLabelValue, bomComponent.getComponent().getValue(), componentVersionLabelValue, jqlString);
+            .orElse("None");
+        logger.debug("Searching for Jira issues for Black Duck Project: {}, Project Version: {}, Component: {}, Component Version: {}, Component Concern Type: {}, with this JQL Query: {}",
+            project.getValue(), projectVersionLabelValue, bomComponent.getComponent().getValue(), componentVersionLabelValue, concernType.name(), jqlString);
         List<ProjectIssueSearchResult<String>> searchResults;
         if(maxResults == Integer.MAX_VALUE) {
             searchResults = jqlQueryExecutor.executeQuery(jqlString)
@@ -101,8 +101,8 @@ public class JiraExactIssueFinder implements ExactIssueFinder<String> {
                     .map(jiraSearcherResponseModel -> searchResultCreator.createIssueResult(jiraSearcherResponseModel, projectIssueModel))
                     .toList();
         }
-        logger.debug("Found {} search results for Black Duck Project: {}, Project Version: {}, Component: {}, ComponentVersion: {}",
-            searchResults.size(), project.getValue(), projectVersionLabelValue, bomComponent.getComponent().getValue(), componentVersionLabelValue);
+        logger.debug("Found {} search results for Black Duck Project: {}, Project Version: {}, Component: {}, ComponentVersion: {}, Component Concern Type: {}",
+            searchResults.size(), project.getValue(), projectVersionLabelValue, bomComponent.getComponent().getValue(), componentVersionLabelValue, concernType.name());
         return new IssueTrackerSearchResult<>(jqlString, searchResults);
     }
 

--- a/api-distribution/src/main/java/com/blackduck/integration/alert/api/distribution/execution/ExecutingJobManager.java
+++ b/api-distribution/src/main/java/com/blackduck/integration/alert/api/distribution/execution/ExecutingJobManager.java
@@ -139,7 +139,7 @@ public class ExecutingJobManager {
     }
 
     public void incrementExpectedNotificationsSent(UUID jobExecutionId, int notificationCount) {
-        logger.debug("Incrementing sent notification count for job execution {} by {}", jobExecutionId, notificationCount);
+        logger.debug("Incrementing expected sent notification count for job execution {} by {}", jobExecutionId, notificationCount);
         Optional<ExecutingJob> executingJob = getExecutingJob(jobExecutionId);
         executingJob.ifPresent(execution -> execution.incrementExpectedNotificationsSent(notificationCount));
     }

--- a/api-processor/src/main/java/com/blackduck/integration/alert/api/processor/distribute/ProviderMessageDistributor.java
+++ b/api-processor/src/main/java/com/blackduck/integration/alert/api/processor/distribute/ProviderMessageDistributor.java
@@ -66,7 +66,7 @@ public class ProviderMessageDistributor {
         Set<Long> notificationIds = processedMessageHolder.extractAllNotificationIds();
         executingJobManager.incrementExpectedNotificationsSent(jobExecutionId, notificationIds.size());
         DistributionEvent event = new DistributionEvent(destinationKey, jobId, jobExecutionId, jobName, notificationIds, processedMessageHolder.toProviderMessageHolder());
-        logger.info("Sending {}. Event ID: {}. Job ID: {}. Destination: {}", EVENT_CLASS_NAME, event.getEventId(), jobId, destinationKey);
+        logger.info("Sending {}. Event ID: {}. Job ID: {}. Job Execution ID: {}. Destination: {}", EVENT_CLASS_NAME, event.getEventId(), jobId, event.getJobExecutionId(), destinationKey);
         if (logger.isDebugEnabled()) {
             String joinedIds = StringUtils.join(notificationIds, ", ");
             notificationLogger.debug("Creating event: {}. Job ID: {}. For notifications: {}", event.getEventId(), jobId, joinedIds);

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
 }
 
 mainClassName = 'com.blackduck.integration.alert.Application'
-version = '8.3.2'
+version = '8.3.2.1-SNAPSHOT'
 
 ext.isSnapshot = project.version.endsWith('-SNAPSHOT')
 ext.isSIGQA = project.version.contains('-SIGQA')

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandler.java
@@ -10,7 +10,6 @@ package com.blackduck.integration.alert.channel.jira.cloud.distribution.event;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import com.blackduck.integration.jira.common.cloud.builder.IssueRequestModelFieldsBuilder;
 import org.apache.commons.lang3.StringUtils;
@@ -114,10 +113,10 @@ public class JiraCloudCreateIssueEventHandler extends IssueTrackerCreateIssueEve
                 if (issueDoesNotExist) {
                     List<IssueTrackerIssueResponseModel<String>> responses = messageSender.sendMessage(creationModel);
                     postProcess(new IssueTrackerResponse<>("Success", responses));
-                    List<String> issueKeys = responses.stream()
-                        .map(IssueTrackerIssueResponseModel::getIssueId)
-                        .collect(Collectors.toList());
-                    logger.info("Created issues: {}", issueKeys);
+                    List<String> issuePairs = responses.stream()
+                        .map(response -> response.getIssueId() + " | " + response.getIssueKey())
+                        .toList();
+                    logger.info("Created issues (Issue ID | Issue Key): {}", issuePairs);
                 }
             } catch (AlertException ex) {
                 logger.error("Cannot create issue for job {}", jobId);

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/delegate/JiraServerCommentGenerator.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/delegate/JiraServerCommentGenerator.java
@@ -10,6 +10,9 @@ package com.blackduck.integration.alert.channel.jira.server.distribution.delegat
 import java.util.Set;
 import java.util.UUID;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.blackduck.integration.alert.api.channel.issue.tracker.event.IssueTrackerCommentEvent;
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueCommentModel;
 import com.blackduck.integration.alert.api.channel.issue.tracker.send.IssueTrackerCommentEventGenerator;
@@ -17,6 +20,7 @@ import com.blackduck.integration.alert.api.descriptor.JiraServerChannelKey;
 import com.blackduck.integration.alert.channel.jira.server.distribution.event.JiraServerCommentEvent;
 
 public class JiraServerCommentGenerator implements IssueTrackerCommentEventGenerator<String> {
+    private Logger logger = LoggerFactory.getLogger(getClass());
     private final JiraServerChannelKey channelKey;
     private final UUID jobExecutionId;
     private final UUID jobId;
@@ -31,6 +35,7 @@ public class JiraServerCommentGenerator implements IssueTrackerCommentEventGener
 
     @Override
     public IssueTrackerCommentEvent<String> generateEvent(IssueCommentModel<String> model) {
+        logger.debug("Generate Jira Server Comment Event for Alert Issue ID {}. Job Execution ID: {}", model.getAlertIssueId(), jobExecutionId);
         return new JiraServerCommentEvent(IssueTrackerCommentEvent.createDefaultEventDestination(channelKey), jobExecutionId, jobId, notificationIds, model);
     }
 }

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/delegate/JiraServerCreateEventGenerator.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/delegate/JiraServerCreateEventGenerator.java
@@ -10,6 +10,9 @@ package com.blackduck.integration.alert.channel.jira.server.distribution.delegat
 import java.util.Set;
 import java.util.UUID;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.blackduck.integration.alert.api.channel.issue.tracker.event.IssueTrackerCreateIssueEvent;
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueCreationModel;
 import com.blackduck.integration.alert.api.channel.issue.tracker.send.IssueTrackerCreationEventGenerator;
@@ -17,6 +20,7 @@ import com.blackduck.integration.alert.api.descriptor.JiraServerChannelKey;
 import com.blackduck.integration.alert.channel.jira.server.distribution.event.JiraServerCreateIssueEvent;
 
 public class JiraServerCreateEventGenerator implements IssueTrackerCreationEventGenerator {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final JiraServerChannelKey channelKey;
     private final UUID jobExecutionId;
     private final UUID jobId;
@@ -31,6 +35,7 @@ public class JiraServerCreateEventGenerator implements IssueTrackerCreationEvent
 
     @Override
     public IssueTrackerCreateIssueEvent generateEvent(IssueCreationModel model) {
+        logger.debug("Generate Jira Server Create Event for Alert Issue ID {}. Job Execution ID: {}", model.getAlertIssueId(), jobExecutionId);
         return new JiraServerCreateIssueEvent(IssueTrackerCreateIssueEvent.createDefaultEventDestination(channelKey), jobExecutionId, jobId, notificationIds, model);
     }
 }

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/delegate/JiraServerIssueCreator.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/delegate/JiraServerIssueCreator.java
@@ -121,12 +121,16 @@ public class JiraServerIssueCreator extends JiraIssueCreator<IssueCreationReques
 
     @Override
     protected IssueCreationResponseModel createIssue(IssueCreationRequestModel alertIssueCreationModel) throws IntegrationException {
-        return issueService.createIssue(alertIssueCreationModel);
+        IssueCreationResponseModel issueCreationResponseModel = issueService.createIssue(alertIssueCreationModel);
+        logger.debug("Created Jira Server issue with ID: {} and Key: {}", issueCreationResponseModel.getId(), issueCreationResponseModel.getKey());
+        return issueCreationResponseModel;
     }
 
     @Override
     protected IssueResponseModel fetchIssue(String issueIdOrKey) throws IntegrationException {
-        return issueService.getIssue(issueIdOrKey);
+        IssueResponseModel issueResponseModel = issueService.getIssue(issueIdOrKey);
+        logger.debug("Fetched Jira Server issue with ID: {}", issueResponseModel.getId());
+        return issueResponseModel;
     }
 
     @Override

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/delegate/JiraServerTransitionGenerator.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/delegate/JiraServerTransitionGenerator.java
@@ -10,6 +10,9 @@ package com.blackduck.integration.alert.channel.jira.server.distribution.delegat
 import java.util.Set;
 import java.util.UUID;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.blackduck.integration.alert.api.channel.issue.tracker.event.IssueTrackerTransitionIssueEvent;
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueTransitionModel;
 import com.blackduck.integration.alert.api.channel.issue.tracker.send.IssueTrackerTransitionEventGenerator;
@@ -17,6 +20,7 @@ import com.blackduck.integration.alert.api.descriptor.JiraServerChannelKey;
 import com.blackduck.integration.alert.channel.jira.server.distribution.event.JiraServerTransitionEvent;
 
 public class JiraServerTransitionGenerator implements IssueTrackerTransitionEventGenerator<String> {
+    private Logger logger = LoggerFactory.getLogger(getClass());
     private final JiraServerChannelKey channelKey;
     private final UUID jobExecutionId;
     private final UUID jobId;
@@ -31,6 +35,7 @@ public class JiraServerTransitionGenerator implements IssueTrackerTransitionEven
 
     @Override
     public IssueTrackerTransitionIssueEvent<String> generateEvent(IssueTransitionModel<String> model) {
+        logger.debug("Generate Jira Server Transition Event for Alert Issue ID {}. Job Execution ID: {}", model.getAlertIssueId(), jobExecutionId);
         return new JiraServerTransitionEvent(
             IssueTrackerTransitionIssueEvent.createDefaultEventDestination(channelKey),
             jobExecutionId,

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandler.java
@@ -73,6 +73,7 @@ public class JiraServerCommentEventHandler extends IssueTrackerCommentEventHandl
     public void handleEvent(JiraServerCommentEvent event) {
         UUID jobId = event.getJobId();
         Optional<JiraServerJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(event.getJobId());
+        logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), event.getCommentModel().getAlertIssueId());
         if (details.isPresent()) {
             try {
                 JiraServerProperties jiraProperties = jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jobId);

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
@@ -10,7 +10,6 @@ package com.blackduck.integration.alert.channel.jira.server.distribution.event;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import com.blackduck.integration.jira.common.server.builder.IssueRequestModelFieldsBuilder;
 import org.apache.commons.lang3.StringUtils;
@@ -113,10 +112,10 @@ public class JiraServerCreateIssueEventHandler extends IssueTrackerCreateIssueEv
                 if (issueDoesNotExist) {
                     List<IssueTrackerIssueResponseModel<String>> responses = messageSender.sendMessage(creationModel);
                     postProcess(new IssueTrackerResponse<>("Success", responses));
-                    List<String> issueKeys = responses.stream()
-                        .map(IssueTrackerIssueResponseModel::getIssueId)
-                        .collect(Collectors.toList());
-                    logger.info("Created issues: {}", issueKeys);
+                    List<String> issuePairs = responses.stream()
+                        .map(response -> response.getIssueId() + " | " + response.getIssueKey())
+                        .toList();
+                    logger.info("Created issues (Issue ID | Issue Key): {}", issuePairs);
                 } else {
                     logger.debug("Issue already exists for query: {}", jqlQuery);
                 }

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
@@ -75,6 +75,7 @@ public class JiraServerCreateIssueEventHandler extends IssueTrackerCreateIssueEv
     public synchronized void handleEvent(IssueTrackerCreateIssueEvent event) {
         UUID jobId = event.getJobId();
         IssueCreationModel creationModel = event.getCreationModel();
+        logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), creationModel.getAlertIssueId());
         Optional<JiraServerJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(jobId);
         if (details.isPresent()) {
             try {

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandler.java
@@ -73,6 +73,7 @@ public class JiraServerTransitionEventHandler extends IssueTrackerTransitionEven
     public void handleEvent(JiraServerTransitionEvent event) {
         UUID jobId = event.getJobId();
         Optional<JiraServerJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(event.getJobId());
+        logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), event.getTransitionModel().getAlertIssueId());
         if (details.isPresent()) {
             try {
                 JiraServerProperties jiraProperties = jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jobId);

--- a/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/issue/BlackDuckIssueTrackerCallbackEventHandler.java
+++ b/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/issue/BlackDuckIssueTrackerCallbackEventHandler.java
@@ -47,7 +47,7 @@ public class BlackDuckIssueTrackerCallbackEventHandler implements AlertEventHand
     @Override
     public void handle(IssueTrackerCallbackEvent event) {
         String eventId = event.getEventId();
-        logger.debug("Handling issue-tracker callback event with id '{}'", eventId);
+        logger.debug("Handling issue-tracker callback event with id '{}' for issue key: {}", eventId, event.getIssueKey());
 
         IssueTrackerCallbackInfo callbackInfo = event.getCallbackInfo();
         Optional<BlackDuckServicesFactory> optionalBlackDuckServicesFactory = createBlackDuckProperties(callbackInfo.getProviderConfigId())
@@ -61,7 +61,7 @@ public class BlackDuckIssueTrackerCallbackEventHandler implements AlertEventHand
             BlackDuckProviderIssueModel issueModel = createBlackDuckIssueModel(event);
             createOrUpdateBlackDuckIssue(blackDuckProviderIssueHandler, issueModel, callbackInfo);
         }
-        logger.debug("Finished handling issue-tracker callback event with id '{}'", eventId);
+        logger.debug("Finished handling issue-tracker callback event with id '{}' for issue key: {}", eventId, event.getIssueKey());
     }
 
     private Optional<BlackDuckProperties> createBlackDuckProperties(Long providerConfigId) {

--- a/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/issue/BlackDuckProviderIssueHandler.java
+++ b/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/issue/BlackDuckProviderIssueHandler.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.blackduck.integration.alert.provider.blackduck.processor.message.util.BlackDuckMessageLinkUtils;
 import com.blackduck.integration.blackduck.api.generated.view.ProjectVersionIssuesView;
@@ -31,6 +33,7 @@ import com.blackduck.integration.rest.body.StringBodyContent;
 import com.google.gson.Gson;
 
 public class BlackDuckProviderIssueHandler {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final Gson gson;
     private final BlackDuckApiClient blackDuckApiClient;
     private final IssueService issueService;
@@ -48,6 +51,7 @@ public class BlackDuckProviderIssueHandler {
         IssueRequest issueRequestModel = createIssueRequestModel(issueModel);
 
         if (optionalExistingIssue.isPresent()) {
+            logger.debug("Updating existing issue-tracker callback request for issue key: {}", issueRequestModel.getIssueId());
             ProjectVersionIssuesView existingIssue = optionalExistingIssue.get();
             issueRequestModel.setIssueDescription(existingIssue.getIssueDescription());
             issueRequestModel.setIssueCreatedAt(existingIssue.getIssueCreatedAt());
@@ -57,6 +61,7 @@ public class BlackDuckProviderIssueHandler {
             HttpUrl requestUri = existingIssue.getHref();
             performRequest(requestUri, HttpMethod.PUT, issueRequestModel);
         } else if (null != bomComponentVersionIssuesUrl) {
+            logger.debug("Creating new issue-tracker callback request for issue key: {}", issueRequestModel.getIssueId());
             issueRequestModel.setIssueCreatedAt(currentDate);
             issueRequestModel.setIssueUpdatedAt(null);
 


### PR DESCRIPTION
The changes in this MR are targeted at increasing the debug logging around issue tracker distribution, mainly focused towards Jira Server distributions.

To accomplish this I've created a new class: 
IssueActionModel which is an abstract class that the other issue type models will extend allowing them to expose an `alertIssueId` UUID that is created whenever a new object is constructed. This is implemented by:
- IssueCreationModel
- IssueTransitionModel
- IssueCommentModel

An "Alert Issue ID" is logged throughout the issue tracker distribution process. This ID is an internal ID used only for tracking and debugging purposes and has no direct correlation to Issue IDs or Issue Keys which are specific to issue tracker channels. Using this ID we are able to correlate certain notifications to either batches of notifications that have been processed, or to individual messages being distributed. 

Additionally, some logging has been included around issue tracker callback links back to BlackDuck SCA.

Some additional logging has also been included in areas where IDs were available previously but not logged. 