### PR TITLE
IALERT-3993: Remove c3p0 dependency

### DIFF
--- a/alert-database/build.gradle
+++ b/alert-database/build.gradle
@@ -19,11 +19,6 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     runtimeOnly 'org.liquibase:liquibase-core'
 
-    // Connection Pool
-    // https://www.baeldung.com/hibernate-c3p0
-    // https://www.codejava.net/frameworks/hibernate/solved-jdbcconnectionexception-unable-to-acquire-jdbc-connection-with-hibernate-and-mysql
-    runtimeOnly 'org.hibernate.orm:hibernate-c3p0'
-
     // Deprecated for removal in 8.0.0. We still need the h2 jar bundled for use in the docker-entrypoint to upgrade a pre 6.0.0 database.
     runtimeOnly 'com.h2database:h2'
 

--- a/alert-database/src/main/resources/hibernate.properties
+++ b/alert-database/src/main/resources/hibernate.properties
@@ -1,5 +1,0 @@
-# C3P0 DB Connection Pool
-hibernate.c3p0.min_size=5
-hibernate.c3p0.max_size=20
-hibernate.c3p0.timeout=300
-hibernate.c3p0.acquire_increment=5

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ ext {
 }
 
 mainClassName = 'com.blackduck.integration.alert.Application'
-version = '9.0.0-SNAPSHOT-MC'
+version = '9.0.0-SNAPSHOT'
 
 ext.isSnapshot = project.version.endsWith('-SNAPSHOT')
 ext.isSIGQA = project.version.contains('-SIGQA')

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ ext {
 }
 
 mainClassName = 'com.blackduck.integration.alert.Application'
-version = '9.0.0-SNAPSHOT'
+version = '9.0.0-SNAPSHOT-MC'
 
 ext.isSnapshot = project.version.endsWith('-SNAPSHOT')
 ext.isSIGQA = project.version.contains('-SIGQA')


### PR DESCRIPTION
The dependency on c3p0 is no longer required with the versions of Spring and Hibernate we now use. We are using Hikari for management of our JDBC connections and now longer depend on c3p0. 