### PR TITLE
IALERT-3998: Remove h2 dependency

### DIFF
--- a/alert-database/build.gradle
+++ b/alert-database/build.gradle
@@ -19,9 +19,6 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     runtimeOnly 'org.liquibase:liquibase-core'
 
-    // Deprecated for removal in 8.0.0. We still need the h2 jar bundled for use in the docker-entrypoint to upgrade a pre 6.0.0 database.
-    runtimeOnly 'com.h2database:h2'
-
     testImplementation project(':test-common')
     testImplementation 'com.blackduck.integration:blackduck-common'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ ext {
 }
 
 mainClassName = 'com.blackduck.integration.alert.Application'
-version = '9.0.0-SNAPSHOT'
+version = '9.0.0-SNAPSHOT-MC'
 
 ext.isSnapshot = project.version.endsWith('-SNAPSHOT')
 ext.isSIGQA = project.version.contains('-SIGQA')
@@ -241,7 +241,6 @@ distributions {
     boot {
         contents {
             from("$project.buildDir/libs/liquibase") {
-                include 'h2*.jar'
                 include 'liquibase-core*.jar'
                 include 'logback-*.jar'
                 include 'slf4j-api*.jar'

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ ext {
 }
 
 mainClassName = 'com.blackduck.integration.alert.Application'
-version = '9.0.0-SNAPSHOT-MC'
+version = '9.0.0-SNAPSHOT'
 
 ext.isSnapshot = project.version.endsWith('-SNAPSHOT')
 ext.isSIGQA = project.version.contains('-SIGQA')

--- a/buildSrc/buildTasks.gradle
+++ b/buildSrc/buildTasks.gradle
@@ -8,7 +8,7 @@ def findJar(Object... prefixes) {
 }
 
 task copyToLib(type: Copy, dependsOn: [compileJava]) {
-    from findJar('h2', 'liquibase', 'logback-classic', 'logback-core', 'slf4j-api', 'snakeyaml')
+    from findJar('liquibase', 'logback-classic', 'logback-core', 'slf4j-api', 'snakeyaml')
     into "${project.buildDir}/libs/liquibase"
 }
 

--- a/docker/blackduck-alert/docker-entrypoint.sh
+++ b/docker/blackduck-alert/docker-entrypoint.sh
@@ -230,19 +230,6 @@ importDockerHubServerCertificate() {
     fi
 }
 
-liquibaseChangelockReset() {
-  logIt "Begin releasing liquibase changeloglock."
-  "${JAVA_HOME}/bin/java" -cp "${ALERT_TAR_HOME}/lib/liquibase/*" \
-      liquibase.integration.commandline.Main \
-      --url="jdbc:h2:file:${alertDatabaseDir}" \
-      --username="sa" \
-      --password="" \
-      --driver="org.h2.Driver" \
-      --changeLogFile="${upgradeResourcesDir}/release-locks-changelog.xml" \
-      releaseLocks
-  logIt "End releasing liquibase changeloglock."
-}
-
 liquibaseChangelockResetPostgres() {
   logIt "Begin releasing Postgres liquibase changeloglock."
 
@@ -354,60 +341,6 @@ validatePostgresDatabase() {
     validateAlertDBExists
     psql "${alertDatabaseConfig}" -c '\dt ALERT.*' | grep -q 'field_values'
     checkStatus $? "Creating Alert postgres database tables"
-}
-
-postgresPrepare600Upgrade() {
-    logIt "Determining if preparation for 6.0.0 upgrade is necessary..."
-    if psql "${alertDatabaseConfig}" -c 'SELECT COUNT(CONTEXT) FROM Alert.Config_Contexts;' | grep -q '2';
-    then
-        logIt "Alert postgres database is initialized."
-    else
-        logIt "Preparing the old Alert database to be upgraded to 6.0.0..."
-        if [ -f "${ALERT_DATA_DIR}/alertdb.mv.db" ];
-        then
-            logIt "A previous database existed."
-            liquibaseChangelockReset
-            logIt "Clearing old checksums for offline upgrade..."
-            "${JAVA_HOME}/bin/java" -cp "${ALERT_TAR_HOME}/lib/liquibase/*" \
-            liquibase.integration.commandline.Main \
-            --url="jdbc:h2:file:${alertDatabaseDir}" \
-            --username="sa" \
-            --password="" \
-            --driver="org.h2.Driver" \
-            --changeLogFile="${upgradeResourcesDir}/changelog-master.xml" \
-            clearCheckSums
-
-            logIt "Upgrading old database to 5.3.0 so that it can be properly exported..."
-            "${JAVA_HOME}/bin/java" -cp "${ALERT_TAR_HOME}/lib/liquibase/*" \
-            liquibase.integration.commandline.Main \
-            --url="jdbc:h2:file:${alertDatabaseDir}" \
-            --username="sa" \
-            --password="" \
-            --driver="org.h2.Driver" \
-            --changeLogFile="${upgradeResourcesDir}/changelog-master.xml" \
-            update
-
-            logIt "Creating temp directory for data migration..."
-            mkdir -m 766 ${ALERT_DATA_DIR}/temp
-
-            logIt "Exporting data from old database..."
-            "${JAVA_HOME}/bin/java" -cp "${ALERT_TAR_HOME}/lib/liquibase/*" \
-            org.h2.tools.RunScript \
-            -url "jdbc:h2:${alertDatabaseDir}" \
-            -user "sa" \
-            -password "" \
-            -driver "org.h2.Driver" \
-            -script ${upgradeResourcesDir}/export_h2_tables.sql
-
-            chmod 766 ${ALERT_DATA_DIR}/temp/*
-
-            logIt "Importing data from old database into new database..."
-            psql "${alertDatabaseConfig}" -f ${upgradeResourcesDir}/import_postgres_tables.sql
-            checkStatus $? "Running ${upgradeResourcesDir}/import_postgres_tables.sql"
-        else
-            logIt "No previous database existed."
-        fi
-    fi
 }
 
 createPostgresExtensions() {
@@ -547,9 +480,7 @@ importBlackDuckSystemCertificateIntoKeystore
 importDockerHubServerCertificate
 createPostgresDatabase
 validatePostgresDatabase
-postgresPrepare600Upgrade
 createPostgresExtensions
-liquibaseChangelockReset
 liquibaseChangelockResetPostgres
 
 if [ -f "$truststoreFile" ];


### PR DESCRIPTION
Prior to 6.0.0 Alert depended on an H2 database for it's storage before switching to Postgres. The only usage of H2 remaining has been for migrations from old versions of Alert. As we are now moving to Alert 9.0.0 we are far beyond the old supported migration path. 

As a part of the 9.0.0 dependency cleanup, this MR is removing the H2 dependency and it's usages. This MR removes the dependency in our build.gradle as well as it's usages in the docker-entrypoint file.