### PR TITLE
IALERT-3972 - Latest version for PG upgrades to address vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ ext {
     moduleName = 'com.blackduck.integration.alert.main'
 
     // This version is also in src/test/resources/spring-test.properties for the test jdbc connection
-    postgresContainerVersionMigration = '15.8'
+    postgresContainerVersionMigration = '15.17'
     postgresContainerVersionCurrent = '16.13'
 
     // Docker Variables


### PR DESCRIPTION
This was missed during the main work for the ticket, but surfaced during the security review. 

This updates the minor version of PG installed for upgrades. We support upgrades from -1 version, and PG continues updating minor versions for security fixes. As it is supported, we need to update this version as well as the main (current) version we are running.