### PR TITLE
Update .gitignore to exclude .npmrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ sonar-project.properties
 .scannerwork/
 /coverage/
 **/data
+**/.npmrc


### PR DESCRIPTION
Update .gitignore to exclude any instance of .npmrc to ensure internal url's are not exposed.