### PR TITLE
IALERT-4055 - Force version of Apache Tomcat to patched version

### DIFF
--- a/alert-platform/build.gradle
+++ b/alert-platform/build.gradle
@@ -32,6 +32,11 @@ dependencies {
         api 'org.javassist:javassist:3.29.2-GA'
         api 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
 
+        // Spring Boot 3.5.16 manages 10.1.55 with strictly; 10.1.57 contains security fixes.
+        // Enforced via resolutionStrategy.force in root build.gradle allprojects block.
+        api "org.apache.tomcat.embed:tomcat-embed-core:${rootProject.ext.tomcatVersion}"
+        api "org.apache.tomcat:tomcat-annotations-api:${rootProject.ext.tomcatVersion}"
+
         api "org.opensaml:opensaml-core:4.3.0"
         api "org.opensaml:opensaml-saml-api:4.3.0"
         api "org.opensaml:opensaml-saml-impl:4.3.0"

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,10 @@ allprojects {
     configurations {
         all {
             exclude group: 'com.blackducksoftware.bdio', module: 'bdio2'
+
+            /* Spring is no longer patching the 3.5 line of Spring Boot, but Apache Tomcat
+               has critical & high vulnerabilities it has addressed in newer releases.
+               Because of the this, force the Apache Tomcat version to the patched version */
             resolutionStrategy {
                 force "org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}"
                 force "org.apache.tomcat:tomcat-annotations-api:${tomcatVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ plugins {
 }
 
 ext {
+    tomcatVersion = '10.1.57'
+
     userID = 'id -u'.execute().text.trim()
     groupID = 'id -g'.execute().text.trim()
 
@@ -111,6 +113,10 @@ allprojects {
     configurations {
         all {
             exclude group: 'com.blackducksoftware.bdio', module: 'bdio2'
+            resolutionStrategy {
+                force "org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}"
+                force "org.apache.tomcat:tomcat-annotations-api:${tomcatVersion}"
+            }
         }
     }
     // disable the test task when running the alert server to speed up startup time.


### PR DESCRIPTION
- Apache Tomcat has 2 high vulns. We are vulnerable to them.
- Apache Tomcat comes into Alert via spring-boot. We are on the 3.5 line of spring boot, and on the latest version on the 3.5 line. 
- Apache Tomcat has released a fix for the issues. Spring is no longer patching the 3.5 line.

This MR forces Gradle to get the patched version of the Apache Tomcat dependencies.