### PR TITLE
IALERT-4054: Issue tracker logging improvements

### DIFF
--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/callback/ProviderCallbackIssueTrackerResponsePostProcessor.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/callback/ProviderCallbackIssueTrackerResponsePostProcessor.java
@@ -10,8 +10,9 @@ package com.blackduck.integration.alert.api.channel.issue.tracker.callback;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -23,6 +24,7 @@ import com.blackduck.integration.alert.common.channel.issuetracker.IssueTrackerC
 
 @Component
 public class ProviderCallbackIssueTrackerResponsePostProcessor implements IssueTrackerResponsePostProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final EventManager eventManager;
 
     @Autowired
@@ -38,23 +40,30 @@ public class ProviderCallbackIssueTrackerResponsePostProcessor implements IssueT
 
     private <T extends Serializable> List<IssueTrackerCallbackEvent> createCallbackEvents(IssueTrackerResponse<T> issueTrackerResponse) {
         return issueTrackerResponse.getUpdatedIssues()
-                   .stream()
-                   .map(this::createProviderCallbackEvent)
-                   .flatMap(Optional::stream)
-                   .collect(Collectors.toList());
+            .stream()
+            .map(this::createProviderCallbackEvent)
+            .flatMap(Optional::stream)
+            .toList();
     }
 
     private <T extends Serializable> Optional<IssueTrackerCallbackEvent> createProviderCallbackEvent(IssueTrackerIssueResponseModel<T> issueResponseModel) {
         return issueResponseModel.getCallbackInfo()
-                   .map(callbackInfo ->
-                            new IssueTrackerCallbackEvent(
-                                callbackInfo,
-                                issueResponseModel.getIssueKey(),
-                                issueResponseModel.getIssueLink(),
-                                issueResponseModel.getIssueOperation(),
-                                issueResponseModel.getIssueTitle()
-                            )
-                   );
+            .map(callbackInfo -> {
+                logger.debug(
+                    "Creating issue tracker callback event: issue key: [{}], issue operation: [{}], issue title: [{}], link: [{}]",
+                    issueResponseModel.getIssueKey(),
+                    issueResponseModel.getIssueOperation(),
+                    issueResponseModel.getIssueTitle(),
+                    issueResponseModel.getIssueLink()
+                );
+                return new IssueTrackerCallbackEvent(
+                    callbackInfo,
+                    issueResponseModel.getIssueKey(),
+                    issueResponseModel.getIssueLink(),
+                    issueResponseModel.getIssueOperation(),
+                    issueResponseModel.getIssueTitle()
+                );
+            });
     }
 
 }

--- a/api-processor/src/main/java/com/blackduck/integration/alert/api/processor/mapping/JobNotificationMapper2.java
+++ b/api-processor/src/main/java/com/blackduck/integration/alert/api/processor/mapping/JobNotificationMapper2.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -27,6 +29,7 @@ import com.blackduck.integration.alert.common.rest.model.AlertPagedDetails;
 
 @Component
 public class JobNotificationMapper2 {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final ProcessingJobAccessor2 processingJobAccessor;
     private final JobNotificationMappingAccessor jobNotificationMappingAccessor;
 
@@ -83,6 +86,8 @@ public class JobNotificationMapper2 {
             pageNumber,
             pageSize
         );
+
+        boolean anyMapped = false;
         while (jobs.getCurrentPage() <= jobs.getTotalPages()) {
             List<JobToNotificationMappingModel> mappings = new LinkedList<>();
             for (SimpleFilteredDistributionJobResponseModel job : jobs.getModels()) {
@@ -91,7 +96,10 @@ public class JobNotificationMapper2 {
                 }
             }
             if (!mappings.isEmpty()) {
+                anyMapped = true;
                 jobNotificationMappingAccessor.addJobMappings(mappings);
+                mappings.forEach(mapping ->
+                    logger.debug("Notification [{}] mapped to job {} [correlationId: {}]", mapping.getNotificationId(), mapping.getJobId(), correlationId));
             }
             pageNumber++;
             jobs = processingJobAccessor.getMatchingEnabledJobsForNotifications(
@@ -100,5 +108,28 @@ public class JobNotificationMapper2 {
                 pageSize
             );
         }
+
+        if (!anyMapped && logger.isDebugEnabled()) {
+            String additionalNotificationContext = getAdditionalNotificationContext(filteredDistributionJobRequestModel);
+            logger.debug(
+                "Notification [{}] matched no enabled distribution jobs [correlationId: {}, project: {}, version: {}, types: {}{}]",
+                filteredDistributionJobRequestModel.getNotificationId().map(Object::toString).orElse("unknown"),
+                correlationId,
+                projectName,
+                projectVersionName,
+                filteredDistributionJobRequestModel.getNotificationTypes(),
+                additionalNotificationContext
+            );
+        }
+    }
+
+    private String getAdditionalNotificationContext(final FilteredDistributionJobRequestModel filteredDistributionJobRequestModel) {
+        String additionalNotificationContext = "";
+        if (!filteredDistributionJobRequestModel.getPolicyNames().isEmpty()) {
+            additionalNotificationContext = ", policy names: " + filteredDistributionJobRequestModel.getPolicyNames();
+        } else if (!filteredDistributionJobRequestModel.getVulnerabilitySeverities().isEmpty()) {
+            additionalNotificationContext = ", vulnerability severities: " + filteredDistributionJobRequestModel.getVulnerabilitySeverities();
+        }
+        return additionalNotificationContext;
     }
 }

--- a/api-processor/src/main/java/com/blackduck/integration/alert/api/processor/mapping/JobNotificationMapper2.java
+++ b/api-processor/src/main/java/com/blackduck/integration/alert/api/processor/mapping/JobNotificationMapper2.java
@@ -98,8 +98,10 @@ public class JobNotificationMapper2 {
             if (!mappings.isEmpty()) {
                 anyMapped = true;
                 jobNotificationMappingAccessor.addJobMappings(mappings);
-                mappings.forEach(mapping ->
-                    logger.debug("Notification [{}] mapped to job {} [correlationId: {}]", mapping.getNotificationId(), mapping.getJobId(), correlationId));
+                if (logger.isDebugEnabled()) {
+                    mappings.forEach(mapping ->
+                        logger.debug("Notification [{}] mapped to job {} [correlationId: {}]", mapping.getNotificationId(), mapping.getJobId(), correlationId));
+                }
             }
             pageNumber++;
             jobs = processingJobAccessor.getMatchingEnabledJobsForNotifications(

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
@@ -115,7 +115,7 @@ public class JiraCloudCommentEventHandler extends IssueTrackerCommentEventHandle
                 logger.error("Cause: ", ex);
             }
         } else {
-            logger.error("No Jira Cloud job found with id {}", jobId);
+            logger.error("No Jira Cloud job found with id {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
         }
     }
 

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
@@ -115,7 +115,7 @@ public class JiraCloudCommentEventHandler extends IssueTrackerCommentEventHandle
                 logger.error("Cause: ", ex);
             }
         } else {
-            logger.error("No Jira Cloud job found with id {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
+            logger.error("No Jira Cloud job found with job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
         }
     }
 

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.blackduck.integration.jira.common.cloud.builder.IssueRequestModelFieldsBuilder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,6 +75,8 @@ public class JiraCloudCommentEventHandler extends IssueTrackerCommentEventHandle
     @Override
     public void handleEvent(JiraCloudCommentEvent event) {
         UUID jobId = event.getJobId();
+        IssueCommentModel<String> commentModel = event.getCommentModel();
+        logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), commentModel.getAlertIssueId());
         Optional<JiraCloudJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(jobId);
         if (details.isPresent()) {
             try {
@@ -105,11 +108,11 @@ public class JiraCloudCommentEventHandler extends IssueTrackerCommentEventHandle
                     jiraErrorMessageUtility,
                     jiraCloudQueryExecutor
                 );
-                IssueCommentModel<String> commentModel = event.getCommentModel();
                 List<IssueTrackerIssueResponseModel<String>> responses = messageSender.sendMessage(commentModel);
                 postProcess(new IssueTrackerResponse<>("Success", responses));
             } catch (AlertException ex) {
-                logger.error("Cannot comment on issue for job {}", jobId);
+                logger.error("Cannot comment on issue for job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
+                logger.error("Cause: ", ex);
             }
         } else {
             logger.error("No Jira Cloud job found with id {}", jobId);

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandler.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.blackduck.integration.jira.common.cloud.builder.IssueRequestModelFieldsBuilder;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,6 +77,7 @@ public class JiraCloudCreateIssueEventHandler extends IssueTrackerCreateIssueEve
     public synchronized void handleEvent(IssueTrackerCreateIssueEvent event) {
         UUID jobId = event.getJobId();
         IssueCreationModel creationModel = event.getCreationModel();
+        logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), creationModel.getAlertIssueId());
         Optional<JiraCloudJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(event.getJobId());
         if (details.isPresent()) {
             try {
@@ -116,15 +118,17 @@ public class JiraCloudCreateIssueEventHandler extends IssueTrackerCreateIssueEve
                     List<String> issuePairs = responses.stream()
                         .map(response -> response.getIssueId() + " | " + response.getIssueKey())
                         .toList();
-                    logger.info("Created issues (Issue ID | Issue Key): {}", issuePairs);
+                    logger.info("Created issues for Alert Issue ID: {}, (Issue ID | Issue Key): {}", creationModel.getAlertIssueId(), issuePairs);
+                } else {
+                    logger.debug("Issue already exists. Alert Issue ID: {}, JQL query: {}", creationModel.getAlertIssueId(), jqlQuery);
                 }
             } catch (AlertException ex) {
-                logger.error("Cannot create issue for job {}", jobId);
+                logger.error("Cannot create issue for job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
                 logger.error("Query: {}", creationModel.getQueryString());
                 logger.error("Cause: ", ex);
             }
         } else {
-            logger.error("No Jira Cloud job found with id {}", jobId);
+            logger.error("No Jira Cloud job found with job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
         }
     }
 

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandler.java
@@ -115,7 +115,7 @@ public class JiraCloudTransitionEventHandler extends IssueTrackerTransitionEvent
                 logger.error("Cause: ", ex);
             }
         } else {
-            logger.error("No Jira Cloud job found with id {}", jobId);
+            logger.error("No Jira Cloud job found with job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
         }
     }
 }

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandler.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.blackduck.integration.jira.common.cloud.builder.IssueRequestModelFieldsBuilder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,6 +75,8 @@ public class JiraCloudTransitionEventHandler extends IssueTrackerTransitionEvent
     @Override
     public void handleEvent(JiraCloudTransitionEvent event) {
         UUID jobId = event.getJobId();
+        IssueTransitionModel<String> transitionModel = event.getTransitionModel();
+        logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), transitionModel.getAlertIssueId());
         Optional<JiraCloudJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(event.getJobId());
         if (details.isPresent()) {
             try {
@@ -105,11 +108,11 @@ public class JiraCloudTransitionEventHandler extends IssueTrackerTransitionEvent
                     jiraErrorMessageUtility,
                     jiraCloudQueryExecutor
                 );
-                IssueTransitionModel<String> commentModel = event.getTransitionModel();
-                List<IssueTrackerIssueResponseModel<String>> responses = messageSender.sendMessage(commentModel);
+                List<IssueTrackerIssueResponseModel<String>> responses = messageSender.sendMessage(transitionModel);
                 postProcess(new IssueTrackerResponse<>("Success", responses));
             } catch (AlertException ex) {
-                logger.error("Cannot transition issue for job {}", jobId);
+                logger.error("Cannot transition issue for job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
+                logger.error("Cause: ", ex);
             }
         } else {
             logger.error("No Jira Cloud job found with id {}", jobId);

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandler.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.blackduck.integration.jira.common.server.builder.IssueRequestModelFieldsBuilder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,8 +73,9 @@ public class JiraServerCommentEventHandler extends IssueTrackerCommentEventHandl
     @Override
     public void handleEvent(JiraServerCommentEvent event) {
         UUID jobId = event.getJobId();
+        IssueCommentModel<String> commentModel = event.getCommentModel();
+        logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), commentModel.getAlertIssueId());
         Optional<JiraServerJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(event.getJobId());
-        logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), event.getCommentModel().getAlertIssueId());
         if (details.isPresent()) {
             try {
                 JiraServerProperties jiraProperties = jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jobId);
@@ -104,11 +106,10 @@ public class JiraServerCommentEventHandler extends IssueTrackerCommentEventHandl
                     jiraErrorMessageUtility,
                     jiraServerQueryExecutor
                 );
-                IssueCommentModel<String> commentModel = event.getCommentModel();
                 List<IssueTrackerIssueResponseModel<String>> responses = messageSender.sendMessage(commentModel);
                 postProcess(new IssueTrackerResponse<>("Success", responses));
             } catch (AlertException ex) {
-                logger.error("Cannot comment on issue for job {}", jobId);
+                logger.error("Cannot comment on issue for job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
                 logger.error("Cause: ", ex);
             }
         } else {

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandler.java
@@ -113,7 +113,7 @@ public class JiraServerCommentEventHandler extends IssueTrackerCommentEventHandl
                 logger.error("Cause: ", ex);
             }
         } else {
-            logger.error("No Jira Server job found with id {}", jobId);
+            logger.error("No Jira Server job found with job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
         }
     }
 }

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.blackduck.integration.jira.common.server.builder.IssueRequestModelFieldsBuilder;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -116,17 +117,17 @@ public class JiraServerCreateIssueEventHandler extends IssueTrackerCreateIssueEv
                     List<String> issuePairs = responses.stream()
                         .map(response -> response.getIssueId() + " | " + response.getIssueKey())
                         .toList();
-                    logger.info("Created issues (Issue ID | Issue Key): {}", issuePairs);
+                    logger.info("Created issues for Alert Issue ID: {}, (Issue ID | Issue Key): {}", creationModel.getAlertIssueId(), issuePairs);
                 } else {
-                    logger.debug("Issue already exists for query: {}", jqlQuery);
+                    logger.debug("Issue already exists. Alert Issue ID: {}, JQL query: {}", creationModel.getAlertIssueId(), jqlQuery);
                 }
             } catch (AlertException ex) {
-                logger.error("Cannot create issue for job {}", jobId);
+                logger.error("Cannot create issue for job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
                 logger.error("Query: {}", creationModel.getQueryString());
                 logger.error("Cause: ", ex);
             }
         } else {
-            logger.error("No Jira Server job found with id {}", jobId);
+            logger.error("No Jira Server job found with job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
         }
     }
 

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandler.java
@@ -113,7 +113,7 @@ public class JiraServerTransitionEventHandler extends IssueTrackerTransitionEven
                 logger.error("Cause: ", ex);
             }
         } else {
-            logger.error("No Jira Server job found with id {}", jobId);
+            logger.error("No Jira Server job found with job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
         }
     }
 }

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandler.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.blackduck.integration.jira.common.server.builder.IssueRequestModelFieldsBuilder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,8 +73,9 @@ public class JiraServerTransitionEventHandler extends IssueTrackerTransitionEven
     @Override
     public void handleEvent(JiraServerTransitionEvent event) {
         UUID jobId = event.getJobId();
+        IssueTransitionModel<String> transitionModel = event.getTransitionModel();
+        logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), transitionModel.getAlertIssueId());
         Optional<JiraServerJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(event.getJobId());
-        logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), event.getTransitionModel().getAlertIssueId());
         if (details.isPresent()) {
             try {
                 JiraServerProperties jiraProperties = jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jobId);
@@ -104,11 +106,11 @@ public class JiraServerTransitionEventHandler extends IssueTrackerTransitionEven
                     jiraErrorMessageUtility,
                     jiraServerQueryExecutor
                 );
-                IssueTransitionModel<String> transitionModel = event.getTransitionModel();
                 List<IssueTrackerIssueResponseModel<String>> responses = messageSender.sendMessage(transitionModel);
                 postProcess(new IssueTrackerResponse<>("Success", responses));
             } catch (AlertException ex) {
-                logger.error("Cannot transition issue for job {}", jobId);
+                logger.error("Cannot transition issue for job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
+                logger.error("Cause: ", ex);
             }
         } else {
             logger.error("No Jira Server job found with id {}", jobId);

--- a/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/issue/BlackDuckIssueTrackerCallbackEventHandler.java
+++ b/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/issue/BlackDuckIssueTrackerCallbackEventHandler.java
@@ -53,7 +53,7 @@ public class BlackDuckIssueTrackerCallbackEventHandler implements AlertEventHand
         String eventId = event.getEventId();
         IssueTrackerCallbackInfo callbackInfo = event.getCallbackInfo();
         logger.debug(
-            "Start handling issue-tracker callback. event id: '{}', issue key: {}, issue summary: {} provider id: {}, project-version URL: {}, Callback URL: {}",
+            "Start handling issue-tracker callback. event id: '{}', issue key: {}, issue summary: {}, provider id: {}, project-version URL: {}, callback URL: {}",
             eventId,
             event.getIssueKey(),
             event.getIssueSummary(),
@@ -102,7 +102,7 @@ public class BlackDuckIssueTrackerCallbackEventHandler implements AlertEventHand
             blackDuckProviderIssueHandler.createOrUpdateBlackDuckIssue(issueModel, callbackInfo.getCallbackUrl(), callbackInfo.getBlackDuckProjectVersionUrl());
         } catch (IntegrationException e) {
             logger.debug(
-                "An error occurred while trying to map an issue to a Black Duck project/version. issue key: {}, issue summary: {}, provider id: {}, project-version URL: {}, Callback URL: {}",
+                "An error occurred while trying to map an issue to a Black Duck project/version. issue key: {}, issue summary: {}, provider id: {}, project-version URL: {}, callback URL: {}",
                 issueModel.getKey(),
                 issueModel.getSummary(),
                 callbackInfo.getProviderConfigId(),

--- a/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/issue/BlackDuckIssueTrackerCallbackEventHandler.java
+++ b/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/issue/BlackDuckIssueTrackerCallbackEventHandler.java
@@ -38,7 +38,11 @@ public class BlackDuckIssueTrackerCallbackEventHandler implements AlertEventHand
     private final BlackDuckPropertiesFactory blackDuckPropertiesFactory;
     private final ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor;
 
-    public BlackDuckIssueTrackerCallbackEventHandler(Gson gson, BlackDuckPropertiesFactory blackDuckPropertiesFactory, ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor) {
+    public BlackDuckIssueTrackerCallbackEventHandler(
+        Gson gson,
+        BlackDuckPropertiesFactory blackDuckPropertiesFactory,
+        ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor
+    ) {
         this.gson = gson;
         this.blackDuckPropertiesFactory = blackDuckPropertiesFactory;
         this.configurationModelConfigurationAccessor = configurationModelConfigurationAccessor;
@@ -47,11 +51,19 @@ public class BlackDuckIssueTrackerCallbackEventHandler implements AlertEventHand
     @Override
     public void handle(IssueTrackerCallbackEvent event) {
         String eventId = event.getEventId();
-        logger.debug("Handling issue-tracker callback event with id '{}' for issue key: {}", eventId, event.getIssueKey());
-
         IssueTrackerCallbackInfo callbackInfo = event.getCallbackInfo();
+        logger.debug(
+            "Start handling issue-tracker callback. event id: '{}', issue key: {}, issue summary: {} provider id: {}, project-version URL: {}, Callback URL: {}",
+            eventId,
+            event.getIssueKey(),
+            event.getIssueSummary(),
+            callbackInfo.getProviderConfigId(),
+            callbackInfo.getBlackDuckProjectVersionUrl(),
+            callbackInfo.getCallbackUrl()
+        );
+
         Optional<BlackDuckServicesFactory> optionalBlackDuckServicesFactory = createBlackDuckProperties(callbackInfo.getProviderConfigId())
-                                                                                  .flatMap(this::createBlackDuckServicesFactory);
+            .flatMap(this::createBlackDuckServicesFactory);
         if (optionalBlackDuckServicesFactory.isPresent()) {
             BlackDuckServicesFactory blackDuckServicesFactory = optionalBlackDuckServicesFactory.get();
             BlackDuckApiClient blackDuckApiClient = blackDuckServicesFactory.getBlackDuckApiClient();
@@ -61,12 +73,12 @@ public class BlackDuckIssueTrackerCallbackEventHandler implements AlertEventHand
             BlackDuckProviderIssueModel issueModel = createBlackDuckIssueModel(event);
             createOrUpdateBlackDuckIssue(blackDuckProviderIssueHandler, issueModel, callbackInfo);
         }
-        logger.debug("Finished handling issue-tracker callback event with id '{}' for issue key: {}", eventId, event.getIssueKey());
+        logger.debug("Finished handling issue-tracker callback. event id: '{}', issue key: {}", eventId, event.getIssueKey());
     }
 
     private Optional<BlackDuckProperties> createBlackDuckProperties(Long providerConfigId) {
         return configurationModelConfigurationAccessor.getConfigurationById(providerConfigId)
-                   .map(blackDuckPropertiesFactory::createProperties);
+            .map(blackDuckPropertiesFactory::createProperties);
     }
 
     private Optional<BlackDuckServicesFactory> createBlackDuckServicesFactory(BlackDuckProperties blackDuckProperties) {
@@ -81,11 +93,23 @@ public class BlackDuckIssueTrackerCallbackEventHandler implements AlertEventHand
         }
     }
 
-    private void createOrUpdateBlackDuckIssue(BlackDuckProviderIssueHandler blackDuckProviderIssueHandler, BlackDuckProviderIssueModel issueModel, IssueTrackerCallbackInfo callbackInfo) {
+    private void createOrUpdateBlackDuckIssue(
+        BlackDuckProviderIssueHandler blackDuckProviderIssueHandler,
+        BlackDuckProviderIssueModel issueModel,
+        IssueTrackerCallbackInfo callbackInfo
+    ) {
         try {
             blackDuckProviderIssueHandler.createOrUpdateBlackDuckIssue(issueModel, callbackInfo.getCallbackUrl(), callbackInfo.getBlackDuckProjectVersionUrl());
         } catch (IntegrationException e) {
-            logger.error("Failed to create or update Black Duck issue: {}", issueModel, e);
+            logger.debug(
+                "An error occurred while trying to map an issue to a Black Duck project/version. issue key: {}, issue summary: {}, provider id: {}, project-version URL: {}, Callback URL: {}",
+                issueModel.getKey(),
+                issueModel.getSummary(),
+                callbackInfo.getProviderConfigId(),
+                callbackInfo.getBlackDuckProjectVersionUrl(),
+                callbackInfo.getCallbackUrl()
+            );
+            logger.error("Failed to create or update Black Duck project/version. issue key: {}", issueModel.getKey(), e);
         }
     }
 
@@ -95,15 +119,11 @@ public class BlackDuckIssueTrackerCallbackEventHandler implements AlertEventHand
     }
 
     private String mapOperationToAlertStatus(IssueOperation issueOperation) {
-        switch (issueOperation) {
-            case OPEN:
-            case UPDATE:
-                return "Created by Alert";
-            case RESOLVE:
-                return "Resolved by Alert";
-            default:
-                return "Unknown";
-        }
+        return switch (issueOperation) {
+            case OPEN, UPDATE -> "Created by Alert";
+            case RESOLVE -> "Resolved by Alert";
+            default -> "Unknown";
+        };
     }
 
 }


### PR DESCRIPTION
The purpose of this change is to improve the observability across notification processing and issue tracker distribution. The goals were to log mappings between notifications and jobs and to throw a special message if no notifications were mapped. Secondly to aid triaging issue tracker failures relevant IDs and context were added to issue tracker event handlers.

Samples of log messages:
JobNotificationMapper2
```
DEBUG - Notification [10042] mapped to job a3f1c2d4-... [correlationId: 9e8b7c6a-...]
DEBUG - Notification [10042] matched no enabled distribution jobs [correlationId: 9e8b7c6a-..., project: my-project, version: 1.0.0, types: [VULNERABILITY], severities: [HIGH, CRITICAL]]
DEBUG - Notification [10043] matched no enabled distribution jobs [correlationId: 9e8b7c6a-..., project: my-project, version: 1.0.0, types: [POLICY_OVERRIDE], policy names: [No LGPL Policy]]
```

ProviderCallbackIssueTrackerResponsePostProcessor                                                                                                                                                                                  
```
DEBUG - Creating issue tracker callback event: issue key: [PROJ-101], issue operation: [OPEN], issue title: [Alert - Vulnerability: CVE-2024-1234 in my-project 1.0.0], link: [https://jira.example.com/browse/PROJ-101]           
```
                                                                                               
BlackDuckIssueTrackerCallbackEventHandler
```
DEBUG - Start handling issue-tracker callback. event id: 'evt-uuid-...', issue key: PROJ-101, issue summary: Alert - Vulnerability: CVE-2024-1234 in my-project 1.0.0 provider id: 7, project-version URL:https://blackduck.example.com/api/projects/abc.../versions/def.../components, Callback URL: https://blackduck.example.com/api/projects/abc.../versions/def.../components/xyz.../issues
```                                                                                                                                     

JiraCloudCommentEventHandler
```
DEBUG - Begin Handle Event: JiraCloudCommentEventHandler for Alert Issue ID: alert-issue-uuid-...
ERROR - Cannot comment on issue for job id: a3f1c2d4-..., Alert Issue ID: alert-issue-uuid-...
ERROR - Cause: <exception stack trace>
```

JiraCloudCreateIssueEventHandler
```
DEBUG - Begin Handle Event: JiraCloudCreateIssueEventHandler for Alert Issue ID: alert-issue-uuid-...
INFO - Created issues for Alert Issue ID: alert-issue-uuid-..., (Issue ID | Issue Key): [10001 | PROJ-101]
DEBUG - Issue already exists. Alert Issue ID: alert-issue-uuid-..., JQL query: project = PROJ AND summary ~ "CVE-2024-1234"
ERROR - Cannot create issue for job id: a3f1c2d4-..., Alert Issue ID: alert-issue-uuid-...
ERROR - No Jira Cloud job found with job id: a3f1c2d4-..., Alert Issue ID: alert-issue-uuid-...
```

JiraCloudTransitionEventHandler
```
DEBUG - Begin Handle Event: JiraCloudTransitionEventHandler for Alert Issue ID: alert-issue-uuid-...                                                                                                                               
ERROR - Cannot transition issue for job id: a3f1c2d4-..., Alert Issue ID: alert-issue-uuid-...                                                                                                                                     
ERROR - Cause: <exception stack trace>  
```

The following Jira Server channels have the same log changes as those for Jira Cloud
JiraServerCommentEventHandler  
JiraServerCreateIssueEventHandler
JiraServerTransitionEventHandler
