### PR TITLE
IALERT-4057: Fix audit failure handling for issue trackers

### DIFF
--- a/api-distribution/src/main/java/com/blackduck/integration/alert/api/distribution/JobSubTaskEventHandler.java
+++ b/api-distribution/src/main/java/com/blackduck/integration/alert/api/distribution/JobSubTaskEventHandler.java
@@ -11,6 +11,9 @@ import java.time.Instant;
 import java.util.UUID;
 import java.util.function.Predicate;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.blackduck.integration.alert.api.common.model.exception.AlertException;
 import com.blackduck.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJob;
@@ -23,6 +26,7 @@ import com.blackduck.integration.alert.common.enumeration.AuditEntryStatus;
 import com.blackduck.integration.alert.common.persistence.util.AuditStackTraceUtil;
 
 public abstract class JobSubTaskEventHandler<T extends JobSubTaskEvent> implements AlertEventHandler<T> {
+    private final Logger logger = LoggerFactory.getLogger(JobSubTaskEventHandler.class);
     private final EventManager eventManager;
     private final JobStage jobStage;
     private final ExecutingJobManager executingJobManager;
@@ -58,8 +62,23 @@ public abstract class JobSubTaskEventHandler<T extends JobSubTaskEvent> implemen
                 exception.getMessage(),
                 AuditStackTraceUtil.createStackTraceString(exception)
             ));
+        } catch (Exception exception) {
+            handleUnknownException(exception, jobExecutionId, event);
         }
     }
 
     protected abstract void handleEvent(T event) throws AlertException;
+
+    protected void handleUnknownException(Exception e, UUID jobExecutionId, T event) {
+        logger.error("An unexpected error occurred while handling the following issue tracker event: {}.", event.getEventId(), e);
+        executingJobManager.endStage(jobExecutionId, jobStage, Instant.now());
+        executingJobManager.incrementSentNotificationCount(jobExecutionId, event.getNotificationIds().size());
+        eventManager.sendEvent(new AuditFailedEvent(
+            event.getJobExecutionId(),
+            event.getJobId(),
+            event.getNotificationIds(),
+            "An unexpected error occurred during issue tracker distribution. Please refer to the logs for more details.",
+            AuditStackTraceUtil.createStackTraceString(e)
+        ));
+    }
 }

--- a/api-distribution/src/main/java/com/blackduck/integration/alert/api/distribution/JobSubTaskEventHandler.java
+++ b/api-distribution/src/main/java/com/blackduck/integration/alert/api/distribution/JobSubTaskEventHandler.java
@@ -26,7 +26,7 @@ import com.blackduck.integration.alert.common.enumeration.AuditEntryStatus;
 import com.blackduck.integration.alert.common.persistence.util.AuditStackTraceUtil;
 
 public abstract class JobSubTaskEventHandler<T extends JobSubTaskEvent> implements AlertEventHandler<T> {
-    private final Logger logger = LoggerFactory.getLogger(JobSubTaskEventHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final EventManager eventManager;
     private final JobStage jobStage;
     private final ExecutingJobManager executingJobManager;

--- a/api-distribution/src/test/java/com/blackduck/integration/alert/api/distribution/JobSubTaskEventHandlerTest.java
+++ b/api-distribution/src/test/java/com/blackduck/integration/alert/api/distribution/JobSubTaskEventHandlerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.blackduck.integration.alert.api.common.model.exception.AlertException;
+import com.blackduck.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJob;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.blackduck.integration.alert.api.distribution.execution.JobStage;
@@ -47,7 +48,6 @@ class JobSubTaskEventHandlerTest {
     @Test
     void testHandleEvent() {
         String destination = "destination";
-        UUID parentEventId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
@@ -73,9 +73,7 @@ class JobSubTaskEventHandlerTest {
 
     @Test
     void testHandleExceptionEvent() {
-
         String destination = "destination";
-        UUID parentEventId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
@@ -92,7 +90,6 @@ class JobSubTaskEventHandlerTest {
     @Test
     void testHandleEventCountToZero() {
         String destination = "destination";
-        UUID parentEventId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
@@ -102,6 +99,23 @@ class JobSubTaskEventHandlerTest {
         handler.handle(event);
 
         assertTrue(handler.wasHandlerCalled());
+    }
+
+    @Test
+    void testHandleUnknownException() {
+        String destination = "destination";
+        UUID jobExecutionId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L);
+
+        TestHandler handler = new TestHandler(eventManager, executingJobManager);
+        handler.setShouldThrowRuntimeException(true);
+
+        TestEvent event = new TestEvent(destination, jobExecutionId, jobId, notificationIds);
+        handler.handle(event);
+
+        assertTrue(handler.wasHandlerCalled(), "Handler should have been called before the exception was thrown");
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
     }
 
     private static class TestEvent extends JobSubTaskEvent {
@@ -115,6 +129,7 @@ class JobSubTaskEventHandlerTest {
     private static class TestHandler extends JobSubTaskEventHandler<TestEvent> {
         private boolean handlerCalled = false;
         private boolean shouldThrowException = false;
+        private boolean shouldThrowRuntimeException = false;
 
         protected TestHandler(
             EventManager eventManager,
@@ -130,6 +145,9 @@ class JobSubTaskEventHandlerTest {
             if (shouldThrowException) {
                 throw new AlertException("Test handler throws exception");
             }
+            if (shouldThrowRuntimeException) {
+                throw new RuntimeException("Test handler throws unexpected runtime exception");
+            }
         }
 
         public boolean wasHandlerCalled() {
@@ -142,6 +160,10 @@ class JobSubTaskEventHandlerTest {
 
         public void setShouldThrowException(boolean shouldThrowException) {
             this.shouldThrowException = shouldThrowException;
+        }
+
+        public void setShouldThrowRuntimeException(boolean shouldThrowRuntimeException) {
+            this.shouldThrowRuntimeException = shouldThrowRuntimeException;
         }
     }
 }

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
@@ -73,7 +73,7 @@ public class JiraCloudCommentEventHandler extends IssueTrackerCommentEventHandle
     }
 
     @Override
-    public void handleEvent(JiraCloudCommentEvent event) {
+    public void handleEvent(JiraCloudCommentEvent event) throws AlertException {
         UUID jobId = event.getJobId();
         IssueCommentModel<String> commentModel = event.getCommentModel();
         logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), commentModel.getAlertIssueId());
@@ -113,9 +113,12 @@ public class JiraCloudCommentEventHandler extends IssueTrackerCommentEventHandle
             } catch (AlertException ex) {
                 logger.error("Cannot comment on issue for job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
                 logger.error("Cause: ", ex);
+                throw ex;
             }
         } else {
-            logger.error("No Jira Cloud job found with job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
+            String errorMessage = String.format("No Jira Cloud job found with job id: %s, Alert Issue ID: %s", jobId, commentModel.getAlertIssueId());
+            logger.error(errorMessage);
+            throw new AlertException(errorMessage);
         }
     }
 

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
@@ -113,6 +113,7 @@ public class JiraCloudCommentEventHandler extends IssueTrackerCommentEventHandle
             } catch (AlertException ex) {
                 logger.error("Cannot comment on issue for job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
                 logger.error("Cause: ", ex);
+                // Re-throw the error so the base class can publish an AuditFailedEvent with detailed error information.
                 throw ex;
             }
         } else {

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandler.java
@@ -126,6 +126,7 @@ public class JiraCloudCreateIssueEventHandler extends IssueTrackerCreateIssueEve
                 logger.error("Cannot create issue for job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
                 logger.error("Query: {}", creationModel.getQueryString());
                 logger.error("Cause: ", ex);
+                // Re-throw the error so the base class can publish an AuditFailedEvent with detailed error information.
                 throw ex;
             }
         } else {

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandler.java
@@ -74,7 +74,7 @@ public class JiraCloudCreateIssueEventHandler extends IssueTrackerCreateIssueEve
     }
 
     @Override
-    public synchronized void handleEvent(IssueTrackerCreateIssueEvent event) {
+    public synchronized void handleEvent(IssueTrackerCreateIssueEvent event) throws AlertException {
         UUID jobId = event.getJobId();
         IssueCreationModel creationModel = event.getCreationModel();
         logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), creationModel.getAlertIssueId());
@@ -126,9 +126,12 @@ public class JiraCloudCreateIssueEventHandler extends IssueTrackerCreateIssueEve
                 logger.error("Cannot create issue for job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
                 logger.error("Query: {}", creationModel.getQueryString());
                 logger.error("Cause: ", ex);
+                throw ex;
             }
         } else {
-            logger.error("No Jira Cloud job found with job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
+            String errorMessage = String.format("No Jira Cloud job found with job id: %s, Alert Issue ID: %s", jobId, creationModel.getAlertIssueId());
+            logger.error(errorMessage);
+            throw new AlertException(errorMessage);
         }
     }
 

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandler.java
@@ -113,6 +113,7 @@ public class JiraCloudTransitionEventHandler extends IssueTrackerTransitionEvent
             } catch (AlertException ex) {
                 logger.error("Cannot transition issue for job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
                 logger.error("Cause: ", ex);
+                // Re-throw the error so the base class can publish an AuditFailedEvent with detailed error information.
                 throw ex;
             }
         } else {

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandler.java
@@ -73,7 +73,7 @@ public class JiraCloudTransitionEventHandler extends IssueTrackerTransitionEvent
     }
 
     @Override
-    public void handleEvent(JiraCloudTransitionEvent event) {
+    public void handleEvent(JiraCloudTransitionEvent event) throws AlertException {
         UUID jobId = event.getJobId();
         IssueTransitionModel<String> transitionModel = event.getTransitionModel();
         logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), transitionModel.getAlertIssueId());
@@ -113,9 +113,12 @@ public class JiraCloudTransitionEventHandler extends IssueTrackerTransitionEvent
             } catch (AlertException ex) {
                 logger.error("Cannot transition issue for job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
                 logger.error("Cause: ", ex);
+                throw ex;
             }
         } else {
-            logger.error("No Jira Cloud job found with job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
+            String errorMessage = String.format("No Jira Cloud job found with job id: %s, Alert Issue ID: %s", jobId, transitionModel.getAlertIssueId());
+            logger.error(errorMessage);
+            throw new AlertException(errorMessage);
         }
     }
 }

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandlerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandlerTest.java
@@ -27,7 +27,10 @@ import com.blackduck.integration.alert.api.channel.issue.tracker.search.Existing
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.IssueCategoryRetriever;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueCategory;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueStatus;
+import com.blackduck.integration.alert.api.common.model.exception.AlertConfigurationException;
+import com.blackduck.integration.alert.api.common.model.exception.AlertException;
 import com.blackduck.integration.alert.api.descriptor.model.ChannelKeys;
+import com.blackduck.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.blackduck.integration.alert.api.event.EventManager;
 import com.blackduck.integration.alert.channel.jira.cloud.JiraCloudProperties;
@@ -101,6 +104,52 @@ class JiraCloudCommentEventHandlerTest {
         );
         handler.handle(event);
         assertEquals(0, issueCounter.get());
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
+    }
+
+    @Test
+    void handleEventExceptionSendsAuditFailedEvent() throws Exception {
+        UUID jobExecutionId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
+
+        JiraCloudPropertiesFactory propertiesFactory = Mockito.mock(JiraCloudPropertiesFactory.class);
+        Mockito.when(propertiesFactory.createJiraProperties()).thenThrow(new AlertConfigurationException("Simulated connection failure"));
+
+        IssueTrackerCallbackInfoCreator callbackInfoCreator = new IssueTrackerCallbackInfoCreator();
+        IssueCategoryRetriever issueCategoryRetriever = new IssueCategoryRetriever();
+        JiraCloudMessageSenderFactory messageSenderFactory = new JiraCloudMessageSenderFactory(
+            gson,
+            ChannelKeys.JIRA_CLOUD,
+            propertiesFactory,
+            callbackInfoCreator,
+            issueCategoryRetriever,
+            eventManager,
+            executingJobManager
+        );
+        JobDetailsAccessor<JiraCloudJobDetailsModel> jobDetailsAccessor = jobId1 -> Optional.of(createJobDetails(jobId));
+
+        JiraCloudCommentEventHandler handler = new JiraCloudCommentEventHandler(
+            eventManager,
+            gson,
+            propertiesFactory,
+            messageSenderFactory,
+            jobDetailsAccessor,
+            responsePostProcessor,
+            executingJobManager
+        );
+        ExistingIssueDetails<String> existingIssueDetails = new ExistingIssueDetails<>("id", "key", "summary", "link", IssueStatus.UNKNOWN, IssueCategory.BOM);
+        IssueCommentModel<String> model = new IssueCommentModel<>(existingIssueDetails, List.of("A comment"), null);
+        JiraCloudCommentEvent event = new JiraCloudCommentEvent(
+            IssueTrackerCommentEvent.createDefaultEventDestination(ChannelKeys.JIRA_CLOUD),
+            jobExecutionId,
+            jobId,
+            notificationIds,
+            model
+        );
+
+        handler.handle(event);
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
     }
 
     @Test

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandlerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandlerTest.java
@@ -28,7 +28,6 @@ import com.blackduck.integration.alert.api.channel.issue.tracker.search.IssueCat
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueCategory;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueStatus;
 import com.blackduck.integration.alert.api.common.model.exception.AlertConfigurationException;
-import com.blackduck.integration.alert.api.common.model.exception.AlertException;
 import com.blackduck.integration.alert.api.descriptor.model.ChannelKeys;
 import com.blackduck.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJobManager;

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventListenerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventListenerTest.java
@@ -35,7 +35,7 @@ class JiraCloudCommentEventListenerTest {
     private final Gson gson = BlackDuckServicesFactory.createDefaultGson();
 
     @Test
-    void onMessageTest() {
+    void onMessageTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -74,7 +74,7 @@ class JiraCloudCommentEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsFinishedTest() {
+    void onMessageJobWithRemainingEventsFinishedTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -114,7 +114,7 @@ class JiraCloudCommentEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsTest() {
+    void onMessageJobWithRemainingEventsTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandlerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandlerTest.java
@@ -15,10 +15,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.blackduck.integration.jira.common.cloud.builder.AtlassianDocumentFormatModelBuilder;
-import com.blackduck.integration.jira.common.cloud.model.AtlassianDocumentFormatModel;
-import com.blackduck.integration.jira.common.cloud.model.JiraCloudIssueResponseModel;
-import com.blackduck.integration.jira.common.cloud.model.component.JiraCloudIssueFieldsComponent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -31,9 +27,16 @@ import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueBomC
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueCreationModel;
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.ProjectIssueModel;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.IssueCategoryRetriever;
+import com.blackduck.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.blackduck.integration.alert.api.descriptor.model.ChannelKeys;
+import com.blackduck.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.blackduck.integration.alert.api.event.EventManager;
+
+import com.blackduck.integration.jira.common.cloud.builder.AtlassianDocumentFormatModelBuilder;
+import com.blackduck.integration.jira.common.cloud.model.AtlassianDocumentFormatModel;
+import com.blackduck.integration.jira.common.cloud.model.JiraCloudIssueResponseModel;
+import com.blackduck.integration.jira.common.cloud.model.component.JiraCloudIssueFieldsComponent;
 import com.blackduck.integration.alert.api.processor.extract.model.ProviderDetails;
 import com.blackduck.integration.alert.channel.jira.cloud.JiraCloudProperties;
 import com.blackduck.integration.alert.channel.jira.cloud.JiraCloudPropertiesFactory;
@@ -52,10 +55,8 @@ import com.blackduck.integration.jira.common.cloud.service.IssueSearchService;
 import com.blackduck.integration.jira.common.cloud.service.IssueService;
 import com.blackduck.integration.jira.common.cloud.service.JiraCloudServiceFactory;
 import com.blackduck.integration.jira.common.cloud.service.ProjectService;
-import com.blackduck.integration.jira.common.model.components.IssueFieldsComponent;
 import com.blackduck.integration.jira.common.model.components.ProjectComponent;
 import com.blackduck.integration.jira.common.model.response.IssueCreationResponseModel;
-import com.blackduck.integration.jira.common.model.response.IssueResponseModel;
 import com.blackduck.integration.jira.common.model.response.PageOfProjectsResponseModel;
 import com.blackduck.integration.jira.common.rest.service.IssuePropertyService;
 import com.google.gson.Gson;
@@ -125,6 +126,55 @@ class JiraCloudCreateIssueEventHandlerTest {
         );
 
         handler.handle(event);
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
+    }
+
+    @Test
+    void handleEventExceptionSendsAuditFailedEvent() throws Exception {
+        UUID jobExecutionId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
+
+        JiraCloudJobDetailsModel jobDetailsModel = createJobDetails(jobId);
+
+        JiraCloudPropertiesFactory propertiesFactory = Mockito.mock(JiraCloudPropertiesFactory.class);
+        Mockito.when(propertiesFactory.createJiraProperties()).thenThrow(new AlertConfigurationException("Simulated connection failure"));
+
+        IssueTrackerCallbackInfoCreator callbackInfoCreator = new IssueTrackerCallbackInfoCreator();
+        IssueCategoryRetriever issueCategoryRetriever = new IssueCategoryRetriever();
+        JiraCloudMessageSenderFactory messageSenderFactory = new JiraCloudMessageSenderFactory(
+            gson,
+            ChannelKeys.JIRA_CLOUD,
+            propertiesFactory,
+            callbackInfoCreator,
+            issueCategoryRetriever,
+            eventManager,
+            executingJobManager
+        );
+
+        jobDetailsAccessor.saveJiraCloudJobDetails(jobId, jobDetailsModel);
+        JiraCloudCreateIssueEventHandler handler = new JiraCloudCreateIssueEventHandler(
+            eventManager,
+            gson,
+            propertiesFactory,
+            messageSenderFactory,
+            jobDetailsAccessor,
+            responsePostProcessor,
+            executingJobManager
+        );
+
+        LinkableItem provider = new LinkableItem("provider", "test-provider");
+        IssueCreationModel issueCreationModel = IssueCreationModel.simple("title", "description", List.of(), provider);
+        JiraCloudCreateIssueEvent event = new JiraCloudCreateIssueEvent(
+            IssueTrackerCreateIssueEvent.createDefaultEventDestination(ChannelKeys.JIRA_CLOUD),
+            jobExecutionId,
+            jobId,
+            notificationIds,
+            issueCreationModel
+        );
+
+        handler.handle(event);
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
     }
 
     @Test
@@ -368,7 +418,20 @@ class JiraCloudCreateIssueEventHandlerTest {
         AtlassianDocumentFormatModelBuilder atlassianDocumentFormatModelBuilder = new AtlassianDocumentFormatModelBuilder();
         atlassianDocumentFormatModelBuilder.addSingleParagraphTextNode("description");
         AtlassianDocumentFormatModel descriptionModel = atlassianDocumentFormatModelBuilder.build();
-        JiraCloudIssueFieldsComponent issueFieldsComponent = new JiraCloudIssueFieldsComponent(List.of(), null, null, "summary", descriptionModel, List.of(), null, List.of(), null, null, null, null);
+        JiraCloudIssueFieldsComponent issueFieldsComponent = new JiraCloudIssueFieldsComponent(
+            List.of(),
+            null,
+            null,
+            "summary",
+            descriptionModel,
+            List.of(),
+            null,
+            List.of(),
+            null,
+            null,
+            null,
+            null
+        );
 
         return new JiraCloudIssueResponseModel("", id, "", id, Map.of(), Map.of(), Map.of(), null, null, null, null, issueFieldsComponent);
     }

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventListenerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventListenerTest.java
@@ -35,7 +35,7 @@ class JiraCloudCreateIssueEventListenerTest {
     private final Gson gson = BlackDuckServicesFactory.createDefaultGson();
 
     @Test
-    void onMessageTest() {
+    void onMessageTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -75,7 +75,7 @@ class JiraCloudCreateIssueEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsFinishedTest() {
+    void onMessageJobWithRemainingEventsFinishedTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -116,7 +116,7 @@ class JiraCloudCreateIssueEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsTest() {
+    void onMessageJobWithRemainingEventsTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandlerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandlerTest.java
@@ -28,7 +28,9 @@ import com.blackduck.integration.alert.api.channel.issue.tracker.search.Existing
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.IssueCategoryRetriever;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueCategory;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueStatus;
+import com.blackduck.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.blackduck.integration.alert.api.descriptor.model.ChannelKeys;
+import com.blackduck.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.blackduck.integration.alert.api.event.EventManager;
 import com.blackduck.integration.alert.channel.jira.cloud.JiraCloudProperties;
@@ -107,6 +109,52 @@ class JiraCloudTransitionEventHandlerTest {
         );
         handler.handle(event);
         assertEquals(0, issueCounter.get());
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
+    }
+
+    @Test
+    void handleEventExceptionSendsAuditFailedEvent() throws Exception {
+        UUID jobExecutionId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
+
+        JiraCloudPropertiesFactory propertiesFactory = Mockito.mock(JiraCloudPropertiesFactory.class);
+        Mockito.when(propertiesFactory.createJiraProperties()).thenThrow(new AlertConfigurationException("Simulated connection failure"));
+
+        IssueTrackerCallbackInfoCreator callbackInfoCreator = new IssueTrackerCallbackInfoCreator();
+        IssueCategoryRetriever issueCategoryRetriever = new IssueCategoryRetriever();
+        JiraCloudMessageSenderFactory messageSenderFactory = new JiraCloudMessageSenderFactory(
+            gson,
+            ChannelKeys.JIRA_CLOUD,
+            propertiesFactory,
+            callbackInfoCreator,
+            issueCategoryRetriever,
+            eventManager,
+            executingJobManager
+        );
+        JobDetailsAccessor<JiraCloudJobDetailsModel> jobDetailsAccessor = jobId1 -> Optional.of(createJobDetails(jobId));
+
+        JiraCloudTransitionEventHandler handler = new JiraCloudTransitionEventHandler(
+            eventManager,
+            gson,
+            propertiesFactory,
+            messageSenderFactory,
+            jobDetailsAccessor,
+            responsePostProcessor,
+            executingJobManager
+        );
+        ExistingIssueDetails<String> existingIssueDetails = new ExistingIssueDetails<>("id", "key", "summary", "link", IssueStatus.UNKNOWN, IssueCategory.BOM);
+        IssueTransitionModel<String> model = new IssueTransitionModel<>(existingIssueDetails, IssueOperation.RESOLVE, List.of(), null);
+        JiraCloudTransitionEvent event = new JiraCloudTransitionEvent(
+            IssueTrackerTransitionIssueEvent.createDefaultEventDestination(ChannelKeys.JIRA_CLOUD),
+            jobExecutionId,
+            jobId,
+            notificationIds,
+            model
+        );
+
+        handler.handle(event);
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
     }
 
     @Test

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventListenerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventListenerTest.java
@@ -36,7 +36,7 @@ class JiraCloudTransitionEventListenerTest {
     private final Gson gson = BlackDuckServicesFactory.createDefaultGson();
 
     @Test
-    void onMessageTest() {
+    void onMessageTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -75,7 +75,7 @@ class JiraCloudTransitionEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsFinishedTest() {
+    void onMessageJobWithRemainingEventsFinishedTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -115,7 +115,7 @@ class JiraCloudTransitionEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsTest() {
+    void onMessageJobWithRemainingEventsTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandler.java
@@ -71,7 +71,7 @@ public class JiraServerCommentEventHandler extends IssueTrackerCommentEventHandl
     }
 
     @Override
-    public void handleEvent(JiraServerCommentEvent event) {
+    public void handleEvent(JiraServerCommentEvent event) throws AlertException {
         UUID jobId = event.getJobId();
         IssueCommentModel<String> commentModel = event.getCommentModel();
         logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), commentModel.getAlertIssueId());
@@ -111,9 +111,12 @@ public class JiraServerCommentEventHandler extends IssueTrackerCommentEventHandl
             } catch (AlertException ex) {
                 logger.error("Cannot comment on issue for job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
                 logger.error("Cause: ", ex);
+                throw ex;
             }
         } else {
-            logger.error("No Jira Server job found with job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
+            String errorMessage = String.format("No Jira Server job found with job id: %s, Alert Issue ID: %s", jobId, commentModel.getAlertIssueId());
+            logger.error(errorMessage);
+            throw new AlertException(errorMessage);
         }
     }
 }

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandler.java
@@ -111,6 +111,7 @@ public class JiraServerCommentEventHandler extends IssueTrackerCommentEventHandl
             } catch (AlertException ex) {
                 logger.error("Cannot comment on issue for job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
                 logger.error("Cause: ", ex);
+                // Re-throw the error so the base class can publish an AuditFailedEvent with detailed error information.
                 throw ex;
             }
         } else {

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
@@ -125,6 +125,7 @@ public class JiraServerCreateIssueEventHandler extends IssueTrackerCreateIssueEv
                 logger.error("Cannot create issue for job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
                 logger.error("Query: {}", creationModel.getQueryString());
                 logger.error("Cause: ", ex);
+                // Re-throw the error so the base class can publish an AuditFailedEvent with detailed error information.
                 throw ex;
             }
         } else {

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
@@ -73,7 +73,7 @@ public class JiraServerCreateIssueEventHandler extends IssueTrackerCreateIssueEv
     }
 
     @Override
-    public synchronized void handleEvent(IssueTrackerCreateIssueEvent event) {
+    public synchronized void handleEvent(IssueTrackerCreateIssueEvent event) throws AlertException {
         UUID jobId = event.getJobId();
         IssueCreationModel creationModel = event.getCreationModel();
         logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), creationModel.getAlertIssueId());
@@ -125,9 +125,12 @@ public class JiraServerCreateIssueEventHandler extends IssueTrackerCreateIssueEv
                 logger.error("Cannot create issue for job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
                 logger.error("Query: {}", creationModel.getQueryString());
                 logger.error("Cause: ", ex);
+                throw ex;
             }
         } else {
-            logger.error("No Jira Server job found with job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
+            String errorMessage = String.format("No Jira Server job found with job id: %s, Alert Issue ID: %s", jobId, creationModel.getAlertIssueId());
+            logger.error(errorMessage);
+            throw new AlertException(errorMessage);
         }
     }
 

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandler.java
@@ -111,6 +111,7 @@ public class JiraServerTransitionEventHandler extends IssueTrackerTransitionEven
             } catch (AlertException ex) {
                 logger.error("Cannot transition issue for job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
                 logger.error("Cause: ", ex);
+                // Re-throw the error so the base class can publish an AuditFailedEvent with detailed error information.
                 throw ex;
             }
         } else {

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandler.java
@@ -71,7 +71,7 @@ public class JiraServerTransitionEventHandler extends IssueTrackerTransitionEven
     }
 
     @Override
-    public void handleEvent(JiraServerTransitionEvent event) {
+    public void handleEvent(JiraServerTransitionEvent event) throws AlertException {
         UUID jobId = event.getJobId();
         IssueTransitionModel<String> transitionModel = event.getTransitionModel();
         logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), transitionModel.getAlertIssueId());
@@ -111,9 +111,12 @@ public class JiraServerTransitionEventHandler extends IssueTrackerTransitionEven
             } catch (AlertException ex) {
                 logger.error("Cannot transition issue for job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
                 logger.error("Cause: ", ex);
+                throw ex;
             }
         } else {
-            logger.error("No Jira Server job found with job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
+            String errorMessage = String.format("No Jira Server job found with job id: %s, Alert Issue ID: %s", jobId, transitionModel.getAlertIssueId());
+            logger.error(errorMessage);
+            throw new AlertException(errorMessage);
         }
     }
 }

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandlerTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandlerTest.java
@@ -27,7 +27,9 @@ import com.blackduck.integration.alert.api.channel.issue.tracker.search.Existing
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.IssueCategoryRetriever;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueCategory;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueStatus;
+import com.blackduck.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.blackduck.integration.alert.api.descriptor.model.ChannelKeys;
+import com.blackduck.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.blackduck.integration.alert.api.event.EventManager;
 import com.blackduck.integration.alert.channel.jira.server.JiraServerProperties;
@@ -113,6 +115,54 @@ class JiraServerCommentEventHandlerTest {
         );
         handler.handle(event);
         assertEquals(0, issueCounter.get());
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
+    }
+
+    @Test
+    void handleEventExceptionSendsAuditFailedEvent() throws Exception {
+        UUID jobExecutionId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
+
+        JiraServerJobDetailsModel jobDetailsModel = createJobDetails(jobId);
+
+        JiraServerPropertiesFactory propertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
+        Mockito.when(propertiesFactory.createJiraPropertiesWithJobId(jobId)).thenThrow(new AlertConfigurationException("Simulated connection failure"));
+
+        IssueTrackerCallbackInfoCreator callbackInfoCreator = new IssueTrackerCallbackInfoCreator();
+        IssueCategoryRetriever issueCategoryRetriever = new IssueCategoryRetriever();
+        JiraServerMessageSenderFactory messageSenderFactory = new JiraServerMessageSenderFactory(
+            gson,
+            ChannelKeys.JIRA_SERVER,
+            propertiesFactory,
+            callbackInfoCreator,
+            issueCategoryRetriever,
+            eventManager,
+            executingJobManager
+        );
+
+        jobDetailsAccessor.saveConcreteJobDetails(jobId, jobDetailsModel);
+        JiraServerCommentEventHandler handler = new JiraServerCommentEventHandler(
+            eventManager,
+            gson,
+            propertiesFactory,
+            messageSenderFactory,
+            jobDetailsAccessor,
+            responsePostProcessor,
+            executingJobManager
+        );
+        ExistingIssueDetails<String> existingIssueDetails = new ExistingIssueDetails<>("id", "key", "summary", "link", IssueStatus.UNKNOWN, IssueCategory.BOM);
+        IssueCommentModel<String> model = new IssueCommentModel<>(existingIssueDetails, List.of("A comment"), null);
+        JiraServerCommentEvent event = new JiraServerCommentEvent(
+            IssueTrackerCommentEvent.createDefaultEventDestination(ChannelKeys.JIRA_SERVER),
+            jobExecutionId,
+            jobId,
+            notificationIds,
+            model
+        );
+
+        handler.handle(event);
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
     }
 
     @Test

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventListenerTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventListenerTest.java
@@ -35,7 +35,7 @@ class JiraServerCommentEventListenerTest {
     private final Gson gson = BlackDuckServicesFactory.createDefaultGson();
 
     @Test
-    void onMessageTest() {
+    void onMessageTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -74,7 +74,7 @@ class JiraServerCommentEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsFinishedTest() {
+    void onMessageJobWithRemainingEventsFinishedTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -114,7 +114,7 @@ class JiraServerCommentEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsTest() {
+    void onMessageJobWithRemainingEventsTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandlerTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandlerTest.java
@@ -29,7 +29,9 @@ import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueBomC
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueCreationModel;
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.ProjectIssueModel;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.IssueCategoryRetriever;
+import com.blackduck.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.blackduck.integration.alert.api.descriptor.model.ChannelKeys;
+import com.blackduck.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.blackduck.integration.alert.api.event.EventManager;
 import com.blackduck.integration.alert.api.processor.extract.model.ProviderDetails;
@@ -127,6 +129,55 @@ class JiraServerCreateIssueEventHandlerTest {
 
         handler.handle(event);
         assertEquals(0, issueCounter.get());
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
+    }
+
+    @Test
+    void handleEventExceptionSendsAuditFailedEvent() throws Exception {
+        UUID jobExecutionId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
+
+        JiraServerJobDetailsModel jobDetailsModel = createJobDetails(jobId);
+
+        JiraServerPropertiesFactory propertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
+        Mockito.when(propertiesFactory.createJiraPropertiesWithJobId(jobId)).thenThrow(new AlertConfigurationException("Simulated connection failure"));
+
+        IssueTrackerCallbackInfoCreator callbackInfoCreator = new IssueTrackerCallbackInfoCreator();
+        IssueCategoryRetriever issueCategoryRetriever = new IssueCategoryRetriever();
+        JiraServerMessageSenderFactory messageSenderFactory = new JiraServerMessageSenderFactory(
+            gson,
+            ChannelKeys.JIRA_SERVER,
+            propertiesFactory,
+            callbackInfoCreator,
+            issueCategoryRetriever,
+            eventManager,
+            executingJobManager
+        );
+
+        jobDetailsAccessor.saveConcreteJobDetails(jobId, jobDetailsModel);
+        JiraServerCreateIssueEventHandler handler = new JiraServerCreateIssueEventHandler(
+            eventManager,
+            gson,
+            propertiesFactory,
+            messageSenderFactory,
+            jobDetailsAccessor,
+            responsePostProcessor,
+            executingJobManager
+        );
+
+        LinkableItem provider = new LinkableItem("provider", "test-provider");
+        IssueCreationModel issueCreationModel = IssueCreationModel.simple("title", "description", List.of(), provider);
+        JiraServerCreateIssueEvent event = new JiraServerCreateIssueEvent(
+            IssueTrackerCreateIssueEvent.createDefaultEventDestination(ChannelKeys.JIRA_SERVER),
+            jobExecutionId,
+            jobId,
+            notificationIds,
+            issueCreationModel
+        );
+
+        handler.handle(event);
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
     }
 
     @Test

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventListenerTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventListenerTest.java
@@ -35,7 +35,7 @@ class JiraServerCreateIssueEventListenerTest {
     private final Gson gson = BlackDuckServicesFactory.createDefaultGson();
 
     @Test
-    void onMessageTestJob() {
+    void onMessageTestJob() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -75,7 +75,7 @@ class JiraServerCreateIssueEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsFinishedTest() {
+    void onMessageJobWithRemainingEventsFinishedTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -116,7 +116,7 @@ class JiraServerCreateIssueEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsTest() {
+    void onMessageJobWithRemainingEventsTest() throws Exception {
 
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandlerTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandlerTest.java
@@ -28,7 +28,9 @@ import com.blackduck.integration.alert.api.channel.issue.tracker.search.Existing
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.IssueCategoryRetriever;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueCategory;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueStatus;
+import com.blackduck.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.blackduck.integration.alert.api.descriptor.model.ChannelKeys;
+import com.blackduck.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.blackduck.integration.alert.api.event.EventManager;
 import com.blackduck.integration.alert.channel.jira.server.JiraServerProperties;
@@ -118,6 +120,54 @@ class JiraServerTransitionEventHandlerTest {
         );
         handler.handle(event);
         assertEquals(0, issueCounter.get());
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
+    }
+
+    @Test
+    void handleEventExceptionSendsAuditFailedEvent() throws Exception {
+        UUID jobExecutionId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
+
+        JiraServerJobDetailsModel jobDetailsModel = createJobDetails(jobId);
+
+        JiraServerPropertiesFactory propertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
+        Mockito.when(propertiesFactory.createJiraPropertiesWithJobId(jobId)).thenThrow(new AlertConfigurationException("Simulated connection failure"));
+
+        IssueTrackerCallbackInfoCreator callbackInfoCreator = new IssueTrackerCallbackInfoCreator();
+        IssueCategoryRetriever issueCategoryRetriever = new IssueCategoryRetriever();
+        JiraServerMessageSenderFactory messageSenderFactory = new JiraServerMessageSenderFactory(
+            gson,
+            ChannelKeys.JIRA_SERVER,
+            propertiesFactory,
+            callbackInfoCreator,
+            issueCategoryRetriever,
+            eventManager,
+            executingJobManager
+        );
+
+        jobDetailsAccessor.saveConcreteJobDetails(jobId, jobDetailsModel);
+        JiraServerTransitionEventHandler handler = new JiraServerTransitionEventHandler(
+            eventManager,
+            gson,
+            propertiesFactory,
+            messageSenderFactory,
+            jobDetailsAccessor,
+            responsePostProcessor,
+            executingJobManager
+        );
+        ExistingIssueDetails<String> existingIssueDetails = new ExistingIssueDetails<>("id", "key", "summary", "link", IssueStatus.UNKNOWN, IssueCategory.BOM);
+        IssueTransitionModel<String> model = new IssueTransitionModel<>(existingIssueDetails, IssueOperation.RESOLVE, List.of(), null);
+        JiraServerTransitionEvent event = new JiraServerTransitionEvent(
+            IssueTrackerTransitionIssueEvent.createDefaultEventDestination(ChannelKeys.JIRA_SERVER),
+            jobExecutionId,
+            jobId,
+            notificationIds,
+            model
+        );
+
+        handler.handle(event);
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
     }
 
     @Test

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventListenerTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventListenerTest.java
@@ -36,7 +36,7 @@ class JiraServerTransitionEventListenerTest {
     private final Gson gson = BlackDuckServicesFactory.createDefaultGson();
 
     @Test
-    void onMessageTest() {
+    void onMessageTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -75,7 +75,7 @@ class JiraServerTransitionEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsFinishedTest() {
+    void onMessageJobWithRemainingEventsFinishedTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -115,7 +115,7 @@ class JiraServerTransitionEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsTest() {
+    void onMessageJobWithRemainingEventsTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);


### PR DESCRIPTION
This branch fixes a bug where Jira Cloud and Jira Server event handlers silently swallowed `AlertException` errors, preventing failures from being recorded in the Audit Failed table. 

The fix propagates exceptions from all six handlers for Jira Cloud and Jira Server (create/comment/transition)  up to the `JobSubTaskEventHandler` base class, which catches `AlertException` and publishes an `AuditFailedEvent`. This error can then be used in the Failed Audit table to either replay events that failed due to timeouts, or to inspect errors that may have occurred. 

I have also added a comment for each handler explaining the double log scenario. A second log is not produced, but we use the stack trace and error message by the upstream base class for audit messaging. 

