### PR TITLE
IALERT-4060: Migrate Function Components from defaultProps to Parameter Defaults

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "blackduck-alert",
-    "version": "9.0.0-SIGQA1",
+    "version": "9.0.0-SIGQA2-SNAPSHOT",
     "description": "Alert UI",
     "keywords": [
         "blackduck",

--- a/ui/src/main/js/common/component/CollapsiblePane.js
+++ b/ui/src/main/js/common/component/CollapsiblePane.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Button from 'common/component/button/Button';
 
-const CollapsiblePane = ({ children, id, title, expanded, isDisabled }) => {
+const CollapsiblePane = ({ children, id = 'collapsiblePaneId', title, expanded = false, isDisabled = false }) => {
     const [isExpanded, setIsExpanded] = useState(expanded);
 
     function toggleCollapsiblePane() {
@@ -24,12 +24,6 @@ const CollapsiblePane = ({ children, id, title, expanded, isDisabled }) => {
             </div>
         </div>
     );
-};
-
-CollapsiblePane.defaultProps = {
-    id: 'collapsiblePaneId',
-    isDisabled: false,
-    expanded: false
 };
 
 CollapsiblePane.propTypes = {

--- a/ui/src/main/js/common/component/CollapsiblePane.js
+++ b/ui/src/main/js/common/component/CollapsiblePane.js
@@ -2,7 +2,13 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Button from 'common/component/button/Button';
 
-const CollapsiblePane = ({ children, id = 'collapsiblePaneId', title, expanded = false, isDisabled = false }) => {
+const CollapsiblePane = ({
+    children,
+    id = 'collapsiblePaneId',
+    title,
+    expanded = false,
+    isDisabled = false
+}) => {
     const [isExpanded, setIsExpanded] = useState(expanded);
 
     function toggleCollapsiblePane() {

--- a/ui/src/main/js/common/component/FadeField.js
+++ b/ui/src/main/js/common/component/FadeField.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
-const FadeField = ({ timeout, children }) => {
+const FadeField = ({ timeout = 5000, children }) => {
     const [showChildren, setShowChildren] = useState(true);
     const [removeChildren, setRemoveChildren] = useState(false);
 
@@ -30,11 +30,6 @@ const FadeField = ({ timeout, children }) => {
 FadeField.propTypes = {
     children: PropTypes.any,
     timeout: PropTypes.number
-};
-
-FadeField.defaultProps = {
-    children: null,
-    timeout: 5000
 };
 
 export default FadeField;

--- a/ui/src/main/js/common/component/FadeField.js
+++ b/ui/src/main/js/common/component/FadeField.js
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
-const FadeField = ({ timeout = 5000, children }) => {
+const FadeField = ({
+    timeout = 5000,
+    children
+}) => {
     const [showChildren, setShowChildren] = useState(true);
     const [removeChildren, setRemoveChildren] = useState(false);
 

--- a/ui/src/main/js/common/component/LabelValuePair.js
+++ b/ui/src/main/js/common/component/LabelValuePair.js
@@ -18,7 +18,7 @@ const useStyles = createUseStyles({
     }
 });
 
-const LabelValuePair = ({ label, seperator, value, icon }) => {
+const LabelValuePair = ({ label, seperator = ':', value, icon }) => {
     const classes = useStyles();
     const displayLabel = `${label}${seperator}`;
 
@@ -33,10 +33,6 @@ const LabelValuePair = ({ label, seperator, value, icon }) => {
             <span>{value}</span>
         </div>
     );
-};
-
-LabelValuePair.defaultProps = {
-    seperator: ':'
 };
 
 LabelValuePair.propTypes = {

--- a/ui/src/main/js/common/component/LabelValuePair.js
+++ b/ui/src/main/js/common/component/LabelValuePair.js
@@ -18,7 +18,12 @@ const useStyles = createUseStyles({
     }
 });
 
-const LabelValuePair = ({ label, seperator = ':', value, icon }) => {
+const LabelValuePair = ({
+    label,
+    seperator = ':',
+    value,
+    icon
+}) => {
     const classes = useStyles();
     const displayLabel = `${label}${seperator}`;
 

--- a/ui/src/main/js/common/component/MessageFormatter.js
+++ b/ui/src/main/js/common/component/MessageFormatter.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { NavLink } from 'react-router-dom';
 
 const MessageFormatter = ({
-    id, errorIsDetailed, message
+    id = 'messageFormatterId', errorIsDetailed = false, message = null
 }) => {
     const determineDisplayMessage = () => {
         if (!message) {
@@ -44,12 +44,6 @@ MessageFormatter.propTypes = {
     id: PropTypes.string,
     errorIsDetailed: PropTypes.bool,
     message: PropTypes.string
-};
-
-MessageFormatter.defaultProps = {
-    id: 'messageFormatterId',
-    errorIsDetailed: false,
-    message: null
 };
 
 export default MessageFormatter;

--- a/ui/src/main/js/common/component/MessageFormatter.js
+++ b/ui/src/main/js/common/component/MessageFormatter.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import { NavLink } from 'react-router-dom';
 
 const MessageFormatter = ({
-    id = 'messageFormatterId', errorIsDetailed = false, message = null
+    id = 'messageFormatterId',
+    errorIsDetailed = false,
+    message = null
 }) => {
     const determineDisplayMessage = () => {
         if (!message) {

--- a/ui/src/main/js/common/component/StatusMessage.js
+++ b/ui/src/main/js/common/component/StatusMessage.js
@@ -5,7 +5,7 @@ import FadeField from 'common/component/FadeField';
 import MessageFormatter from 'common/component/MessageFormatter';
 
 const StatusMessage = ({
-    id, errorMessage, actionMessage, errorIsDetailed
+    id = 'statusMessageId', errorMessage, actionMessage, errorIsDetailed = false
 }) => {
     const [showError, setShowError] = useState(false);
     const [showMessage, setShowMessage] = useState(false);
@@ -68,13 +68,6 @@ StatusMessage.propTypes = {
     errorMessage: PropTypes.string,
     errorIsDetailed: PropTypes.bool,
     actionMessage: PropTypes.string
-};
-
-StatusMessage.defaultProps = {
-    id: 'statusMessageId',
-    errorMessage: null,
-    errorIsDetailed: false,
-    actionMessage: null
 };
 
 export default StatusMessage;

--- a/ui/src/main/js/common/component/StatusMessage.js
+++ b/ui/src/main/js/common/component/StatusMessage.js
@@ -5,7 +5,10 @@ import FadeField from 'common/component/FadeField';
 import MessageFormatter from 'common/component/MessageFormatter';
 
 const StatusMessage = ({
-    id = 'statusMessageId', errorMessage, actionMessage, errorIsDetailed = false
+    id = 'statusMessageId',
+    errorMessage,
+    actionMessage,
+    errorIsDetailed = false
 }) => {
     const [showError, setShowError] = useState(false);
     const [showMessage, setShowMessage] = useState(false);

--- a/ui/src/main/js/common/component/SystemMessage.js
+++ b/ui/src/main/js/common/component/SystemMessage.js
@@ -28,7 +28,7 @@ const useStyles = createUseStyles((theme) => ({
     }
 }));
 
-const SystemMessage = ({ createdAt, content, severity, id }) => {
+const SystemMessage = ({ createdAt, content, severity = 'INFO', id = 'systemMessageId' }) => {
     const classes = useStyles();
 
     function getIcon(messageSeverity) {
@@ -62,13 +62,6 @@ SystemMessage.propTypes = {
     severity: PropTypes.string,
     createdAt: PropTypes.string,
     content: PropTypes.string
-};
-
-SystemMessage.defaultProps = {
-    id: 'systemMessageId',
-    severity: 'INFO',
-    createdAt: '',
-    content: ''
 };
 
 export default SystemMessage;

--- a/ui/src/main/js/common/component/SystemMessage.js
+++ b/ui/src/main/js/common/component/SystemMessage.js
@@ -28,7 +28,12 @@ const useStyles = createUseStyles((theme) => ({
     }
 }));
 
-const SystemMessage = ({ createdAt, content, severity = 'INFO', id = 'systemMessageId' }) => {
+const SystemMessage = ({
+    createdAt,
+    content,
+    severity = 'INFO',
+    id = 'systemMessageId'
+}) => {
     const classes = useStyles();
 
     function getIcon(messageSeverity) {

--- a/ui/src/main/js/common/component/button/Button.js
+++ b/ui/src/main/js/common/component/button/Button.js
@@ -118,7 +118,7 @@ const useStyles = createUseStyles((theme) => ({
     }
 }));
 
-const Button = ({ id, icon, type = 'button', isDisabled, onClick, role, buttonStyle = 'default', title, text, showLoader }) => {
+const Button = ({ id, icon, type = 'button', isDisabled = false, onClick, role, buttonStyle = 'default', title, text, showLoader }) => {
     const classes = useStyles();
     const btnClass = classNames(classes.button, {
         [classes.delete]: buttonStyle === 'delete',
@@ -153,11 +153,6 @@ const Button = ({ id, icon, type = 'button', isDisabled, onClick, role, buttonSt
             )}
         </button>
     );
-};
-
-Button.defaultProps = {
-    isDisabled: false,
-    type: 'button'
 };
 
 Button.propTypes = {

--- a/ui/src/main/js/common/component/button/Button.js
+++ b/ui/src/main/js/common/component/button/Button.js
@@ -118,7 +118,18 @@ const useStyles = createUseStyles((theme) => ({
     }
 }));
 
-const Button = ({ id, icon, type = 'button', isDisabled = false, onClick, role, buttonStyle = 'default', title, text, showLoader }) => {
+const Button = ({
+    id,
+    icon,
+    type = 'button',
+    isDisabled = false,
+    onClick,
+    role,
+    buttonStyle = 'default',
+    title,
+    text,
+    showLoader
+}) => {
     const classes = useStyles();
     const btnClass = classNames(classes.button, {
         [classes.delete]: buttonStyle === 'delete',

--- a/ui/src/main/js/common/component/button/ConfigButtons.js
+++ b/ui/src/main/js/common/component/button/ConfigButtons.js
@@ -20,7 +20,7 @@ const useStyles = createUseStyles((theme) => ({
     }
 }));
 
-const TestButton = ({ includeTest, testId, onTestClick, testLabel, isTestDisabled }) => {
+const TestButton = ({ includeTest, testId = 'testButton', onTestClick, testLabel = 'Test Configuration', isTestDisabled }) => {
     if (includeTest) {
         return (
             <Button
@@ -43,7 +43,7 @@ TestButton.propTypes = {
     isTestDisabled: PropTypes.bool
 };
 
-const SaveButton = ({ includeSave, submitId, submitLabel, isSaveDisabled }) => {
+const SaveButton = ({ includeSave = true, submitId = 'submitButton', submitLabel = 'Save', isSaveDisabled }) => {
     if (includeSave) {
         return (
             <Button
@@ -65,7 +65,7 @@ SaveButton.propTypes = {
     isSaveDisabled: PropTypes.bool
 };
 
-const CancelButton = ({ includeCancel, cancelId, onCancelClick, cancelLabel }) => {
+const CancelButton = ({ includeCancel, cancelId = 'cancelButton', onCancelClick, cancelLabel = 'Cancel' }) => {
     if (includeCancel) {
         return (
             <Button id={cancelId} onClick={onCancelClick} text={cancelLabel} buttonStyle="actionSecondary" />
@@ -81,7 +81,7 @@ CancelButton.propTypes = {
     cancelLabel: PropTypes.string
 };
 
-const DeleteButton = ({ includeDelete, deleteId, handleDelete, deleteLabel, isDeleteDisabled }) => {
+const DeleteButton = ({ includeDelete, deleteId = 'deleteButton', handleDelete, deleteLabel = 'Delete', isDeleteDisabled }) => {
     if (includeDelete) {
         return (
             <Button
@@ -106,9 +106,9 @@ DeleteButton.propTypes = {
 
 const ConfigButtons = ({
     cancelId, submitId, testId, deleteId, includeCancel, includeSave,
-    includeTest, includeDelete, onCancelClick, onTestClick, onDeleteClick,
+    includeTest, includeDelete, onCancelClick, onTestClick, onDeleteClick = () => true,
     performingAction, submitLabel, testLabel, cancelLabel, deleteLabel,
-    confirmDeleteTitle, confirmDeleteMessage, isSaveDisabled,
+    confirmDeleteTitle = 'Confirm Delete', confirmDeleteMessage = 'Are you sure you want to delete?', isSaveDisabled,
     isDeleteDisabled, isTestDisabled
 }) => {
     const classes = useStyles();
@@ -207,27 +207,6 @@ ConfigButtons.propTypes = {
     isSaveDisabled: PropTypes.bool,
     isDeleteDisabled: PropTypes.bool,
     isTestDisabled: PropTypes.bool
-};
-
-ConfigButtons.defaultProps = {
-    cancelId: 'cancelButton',
-    submitId: 'submitButton',
-    testId: 'testButton',
-    deleteId: 'deleteButton',
-    includeCancel: false,
-    includeSave: true,
-    includeTest: false,
-    includeDelete: false,
-    performingAction: false,
-    onCancelClick: () => true,
-    onTestClick: (evt) => true,
-    onDeleteClick: () => true,
-    submitLabel: 'Save',
-    testLabel: 'Test Configuration',
-    deleteLabel: 'Delete',
-    cancelLabel: 'Cancel',
-    confirmDeleteTitle: 'Confirm Delete',
-    confirmDeleteMessage: 'Are you sure you want to delete?'
 };
 
 export default ConfigButtons;

--- a/ui/src/main/js/common/component/button/ConfigButtons.js
+++ b/ui/src/main/js/common/component/button/ConfigButtons.js
@@ -20,7 +20,13 @@ const useStyles = createUseStyles((theme) => ({
     }
 }));
 
-const TestButton = ({ includeTest, testId = 'testButton', onTestClick, testLabel = 'Test Configuration', isTestDisabled }) => {
+const TestButton = ({
+    includeTest,
+    testId = 'testButton',
+    onTestClick,
+    testLabel = 'Test Configuration',
+    isTestDisabled
+}) => {
     if (includeTest) {
         return (
             <Button
@@ -43,7 +49,12 @@ TestButton.propTypes = {
     isTestDisabled: PropTypes.bool
 };
 
-const SaveButton = ({ includeSave = true, submitId = 'submitButton', submitLabel = 'Save', isSaveDisabled }) => {
+const SaveButton = ({
+    includeSave = true,
+    submitId = 'submitButton',
+    submitLabel = 'Save',
+    isSaveDisabled
+}) => {
     if (includeSave) {
         return (
             <Button
@@ -65,7 +76,12 @@ SaveButton.propTypes = {
     isSaveDisabled: PropTypes.bool
 };
 
-const CancelButton = ({ includeCancel, cancelId = 'cancelButton', onCancelClick, cancelLabel = 'Cancel' }) => {
+const CancelButton = ({
+    includeCancel,
+    cancelId = 'cancelButton',
+    onCancelClick,
+    cancelLabel = 'Cancel'
+}) => {
     if (includeCancel) {
         return (
             <Button id={cancelId} onClick={onCancelClick} text={cancelLabel} buttonStyle="actionSecondary" />
@@ -81,7 +97,13 @@ CancelButton.propTypes = {
     cancelLabel: PropTypes.string
 };
 
-const DeleteButton = ({ includeDelete, deleteId = 'deleteButton', handleDelete, deleteLabel = 'Delete', isDeleteDisabled }) => {
+const DeleteButton = ({
+    includeDelete,
+    deleteId = 'deleteButton',
+    handleDelete,
+    deleteLabel = 'Delete',
+    isDeleteDisabled
+}) => {
     if (includeDelete) {
         return (
             <Button
@@ -105,11 +127,27 @@ DeleteButton.propTypes = {
 };
 
 const ConfigButtons = ({
-    cancelId, submitId, testId, deleteId, includeCancel, includeSave,
-    includeTest, includeDelete, onCancelClick, onTestClick, onDeleteClick = () => true,
-    performingAction, submitLabel, testLabel, cancelLabel, deleteLabel,
-    confirmDeleteTitle = 'Confirm Delete', confirmDeleteMessage = 'Are you sure you want to delete?', isSaveDisabled,
-    isDeleteDisabled, isTestDisabled
+    cancelId,
+    submitId,
+    testId,
+    deleteId,
+    includeCancel,
+    includeSave,
+    includeTest,
+    includeDelete,
+    onCancelClick,
+    onTestClick,
+    onDeleteClick = () => true,
+    performingAction,
+    submitLabel,
+    testLabel,
+    cancelLabel,
+    deleteLabel,
+    confirmDeleteTitle = 'Confirm Delete',
+    confirmDeleteMessage = 'Are you sure you want to delete?',
+    isSaveDisabled,
+    isDeleteDisabled,
+    isTestDisabled
 }) => {
     const classes = useStyles();
     const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);

--- a/ui/src/main/js/common/component/button/IconButton.js
+++ b/ui/src/main/js/common/component/button/IconButton.js
@@ -21,7 +21,7 @@ const useStyles = createUseStyles({
     }
 });
 
-const IconButton = ({ id, type, onClick, role, title, icon, disabled }) => {
+const IconButton = ({ id, type = 'button', onClick, role, title, icon, disabled }) => {
     const classes = useStyles();
     return (
         <button
@@ -37,10 +37,6 @@ const IconButton = ({ id, type, onClick, role, title, icon, disabled }) => {
             <FontAwesomeIcon icon={icon} />
         </button>
     );
-};
-
-IconButton.defaultProps = {
-    type: 'button'
 };
 
 IconButton.propTypes = {

--- a/ui/src/main/js/common/component/button/IconButton.js
+++ b/ui/src/main/js/common/component/button/IconButton.js
@@ -21,7 +21,15 @@ const useStyles = createUseStyles({
     }
 });
 
-const IconButton = ({ id, type = 'button', onClick, role, title, icon, disabled }) => {
+const IconButton = ({
+    id,
+    type = 'button',
+    onClick,
+    role,
+    title,
+    icon,
+    disabled
+}) => {
     const classes = useStyles();
     return (
         <button

--- a/ui/src/main/js/common/component/button/PaginationButton.js
+++ b/ui/src/main/js/common/component/button/PaginationButton.js
@@ -33,7 +33,7 @@ const useStyles = createUseStyles((theme) => ({
     }
 }));
 
-const PaginationButton = ({ id, type, onClick, role, title, pageNumber, isActive }) => {
+const PaginationButton = ({ id, type = 'button', onClick, role, title, pageNumber, isActive }) => {
     const classes = useStyles();
 
     const paginationBtnClass = useMemo(() => classNames(classes.paginationBtn, {
@@ -54,10 +54,6 @@ const PaginationButton = ({ id, type, onClick, role, title, pageNumber, isActive
             {pageNumber}
         </button>
     );
-};
-
-PaginationButton.defaultProps = {
-    type: 'button'
 };
 
 PaginationButton.propTypes = {

--- a/ui/src/main/js/common/component/button/PaginationButton.js
+++ b/ui/src/main/js/common/component/button/PaginationButton.js
@@ -33,7 +33,15 @@ const useStyles = createUseStyles((theme) => ({
     }
 }));
 
-const PaginationButton = ({ id, type = 'button', onClick, role, title, pageNumber, isActive }) => {
+const PaginationButton = ({
+    id,
+    type = 'button',
+    onClick,
+    role,
+    title,
+    pageNumber,
+    isActive
+}) => {
     const classes = useStyles();
 
     const paginationBtnClass = useMemo(() => classNames(classes.paginationBtn, {

--- a/ui/src/main/js/common/component/descriptor/DescriptorOption.js
+++ b/ui/src/main/js/common/component/descriptor/DescriptorOption.js
@@ -15,8 +15,4 @@ DescriptorOption.propTypes = {
     style: PropTypes.object
 };
 
-DescriptorOption.defaultProps = {
-    style: {}
-};
-
 export default DescriptorOption;

--- a/ui/src/main/js/common/component/input/BaseInput.js
+++ b/ui/src/main/js/common/component/input/BaseInput.js
@@ -30,8 +30,9 @@ const useStyles = createUseStyles((theme) => ({
 }));
 
 const BaseInput = ({
-    id, errorValue, name, onChange, readOnly, value, placeholder,
-    isDisabled, width, type, min, max
+    id = 'BaseInputId', errorValue = LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
+    name = 'name', onChange = () => true, readOnly, value = '', placeholder,
+    isDisabled, width = '100%', type = 'text', min, max
 }) => {
     const classes = useStyles({ width });
     const inputClass = classNames(classes.input, {
@@ -69,18 +70,6 @@ BaseInput.propTypes = {
     max: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     type: PropTypes.string
-};
-
-BaseInput.defaultProps = {
-    id: 'BaseInputId',
-    name: 'name',
-    onChange: () => true,
-    readOnly: false,
-    value: '',
-    errorValue: LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
-    isDisabled: false,
-    width: '100%',
-    type: 'text'
 };
 
 export default BaseInput;

--- a/ui/src/main/js/common/component/input/BaseInput.js
+++ b/ui/src/main/js/common/component/input/BaseInput.js
@@ -30,9 +30,18 @@ const useStyles = createUseStyles((theme) => ({
 }));
 
 const BaseInput = ({
-    id = 'BaseInputId', errorValue = LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
-    name = 'name', onChange = () => true, readOnly, value = '', placeholder,
-    isDisabled, width = '100%', type = 'text', min, max
+    id = 'BaseInputId',
+    errorValue = LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
+    name = 'name',
+    onChange = () => true,
+    readOnly,
+    value = '',
+    placeholder,
+    isDisabled,
+    width = '100%',
+    type = 'text',
+    min,
+    max
 }) => {
     const classes = useStyles({ width });
     const inputClass = classNames(classes.input, {

--- a/ui/src/main/js/common/component/input/CheckboxInput.js
+++ b/ui/src/main/js/common/component/input/CheckboxInput.js
@@ -28,7 +28,13 @@ const useStyles = createUseStyles((theme) => ({
 }));
 
 const CheckboxInput = ({
-    id, fieldDescription, errorName, errorValue, isChecked, label, name, onChange, readOnly, required, tooltipDescription, checkboxValueLabel, checkboxValueDescription
+    id = 'checkboxInputId', isChecked = false, label, name = 'name', 
+    onChange = () => true, readOnly, fieldDescription,
+    checkboxValueLabel, checkboxValueDescription,
+    errorName = LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
+    errorValue = LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
+    required = LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
+    tooltipDescription = LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT
 }) => {
     const classes = useStyles();
     const inputClass = classNames(classes.input, {
@@ -82,18 +88,6 @@ CheckboxInput.propTypes = {
     tooltipDescription: PropTypes.string,
     checkboxValueLabel: PropTypes.string,
     checkboxValueDescription: PropTypes.string
-};
-
-CheckboxInput.defaultProps = {
-    id: 'checkboxInputId',
-    isChecked: false,
-    name: 'name',
-    onChange: () => true,
-    readOnly: false,
-    tooltipDescription: LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
-    errorName: LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
-    errorValue: LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
-    required: LabelFieldPropertyDefaults.REQUIRED_DEFAULT
 };
 
 export default CheckboxInput;

--- a/ui/src/main/js/common/component/input/CheckboxInput.js
+++ b/ui/src/main/js/common/component/input/CheckboxInput.js
@@ -28,9 +28,15 @@ const useStyles = createUseStyles((theme) => ({
 }));
 
 const CheckboxInput = ({
-    id = 'checkboxInputId', isChecked = false, label, name = 'name', 
-    onChange = () => true, readOnly, fieldDescription,
-    checkboxValueLabel, checkboxValueDescription,
+    id = 'checkboxInputId',
+    isChecked = false,
+    label,
+    name = 'name', 
+    onChange = () => true,
+    readOnly,
+    fieldDescription,
+    checkboxValueLabel,
+    checkboxValueDescription,
     errorName = LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
     errorValue = LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
     required = LabelFieldPropertyDefaults.REQUIRED_DEFAULT,

--- a/ui/src/main/js/common/component/input/DynamicSelectInput.js
+++ b/ui/src/main/js/common/component/input/DynamicSelectInput.js
@@ -21,24 +21,24 @@ const useStyles = createUseStyles({
 
 const DynamicSelectInput = ({
     onChange,
-    id,
-    name,
+    id = 'dynamicSelectInputId',
+    name = 'dynamicSelectInputId',
     width = '100%',
-    options,
-    searchable,
-    placeholder,
-    value,
-    removeSelected,
+    options = [],
+    searchable = false,
+    placeholder = 'Choose a value',
+    value = [],
+    removeSelected = false,
     multiSelect,
     readOnly,
-    clearable,
+    clearable = true,
     onFocus,
     fieldDescription,
-    tooltipDescription,
+    tooltipDescription = LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
     label,
-    errorName,
-    errorValue,
-    required,
+    errorName = LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
+    errorValue = LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
+    required = LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
     creatable,
     maxMenuHeight,
     customVal,
@@ -212,26 +212,6 @@ DynamicSelectInput.propTypes = {
     customVal: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     customSelect: PropTypes.element,
     width: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
-
-DynamicSelectInput.defaultProps = {
-    id: 'dynamicSelectInputId',
-    name: 'dynamicSelectInputId',
-    value: [],
-    placeholder: 'Choose a value',
-    options: [],
-    searchable: false,
-    removeSelected: false,
-    readOnly: false,
-    multiSelect: false,
-    clearable: true,
-    onFocus: () => null,
-    tooltipDescription: LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
-    errorName: LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
-    errorValue: LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
-    required: LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
-    creatable: false,
-    customSelect: null
 };
 
 export default DynamicSelectInput;

--- a/ui/src/main/js/common/component/input/EndpointSelectField.js
+++ b/ui/src/main/js/common/component/input/EndpointSelectField.js
@@ -8,30 +8,30 @@ import { LabelFieldPropertyDefaults } from './field/LabeledField';
 
 // TODO Remove currentConfig and requiredRelatedFields
 const EndpointSelectField = ({
-    id,
-    clearable,
+    id = 'endpointSelectFieldId',
+    clearable = true,
     convertDataToOptions,
     createRequestBody,
     csrfToken,
-    currentConfig,
+    currentConfig = null,
     endpoint,
-    errorName,
-    errorValue,
+    errorName = LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
+    errorValue = LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
     fieldDescription,
     fieldKey,
     label,
-    multiSelect,
+    multiSelect = false,
     onChange,
-    placeholder,
-    readOnly,
+    placeholder = 'Choose a value',
+    readOnly = false,
     readOptionsRequest,
-    removeSelected,
-    required,
-    requiredRelatedFields,
-    searchable,
+    removeSelected = false,
+    required = LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
+    requiredRelatedFields = [],
+    searchable = false,
     selectSpacingClass,
-    tooltipDescription,
-    value,
+    tooltipDescription = LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
+    value = [],
     customVal
 }) => {
     const [options, setOptions] = useState([]);
@@ -127,27 +127,6 @@ EndpointSelectField.propTypes = {
     readOptionsRequest: PropTypes.func,
     convertDataToOptions: PropTypes.func,
     customVal: PropTypes.oneOfType([PropTypes.array, PropTypes.object])
-};
-
-EndpointSelectField.defaultProps = {
-    id: 'endpointSelectFieldId',
-    clearable: true,
-    currentConfig: {},
-    multiSelect: false,
-    placeholder: 'Choose a value',
-    readOnly: false,
-    removeSelected: false,
-    requiredRelatedFields: [],
-    searchable: false,
-    selectSpacingClass: 'col-sm-8',
-    value: [],
-    createRequestBody: null,
-    readOptionsRequest: null,
-    convertDataToOptions: null,
-    tooltipDescription: LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
-    errorName: LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
-    errorValue: LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
-    required: LabelFieldPropertyDefaults.REQUIRED_DEFAULT
 };
 
 export default EndpointSelectField;

--- a/ui/src/main/js/common/component/input/NumberInput.js
+++ b/ui/src/main/js/common/component/input/NumberInput.js
@@ -4,8 +4,20 @@ import LabeledField, { LabelFieldPropertyDefaults } from 'common/component/input
 import BaseInput from 'common/component/input/BaseInput';
 
 const NumberInput = ({
-    readOnly, id, name, value, onChange, label, errorName,
-    errorValue, required, tooltipDescription, minimumValue, maximumValue, width, fieldDescription
+    readOnly = false,
+    id = 'numberInputId',
+    name = 'name',
+    value = '',
+    onChange = () => true,
+    label,
+    errorName = LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
+    errorValue = LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
+    required = LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
+    tooltipDescription = LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
+    minimumValue = 0,
+    maximumValue = Number.MAX_SAFE_INTEGER,
+    width,
+    fieldDescription
 }) => {
     const onChangeHandler = readOnly ? null : onChange;
 
@@ -49,20 +61,6 @@ NumberInput.propTypes = {
     minimumValue: PropTypes.number,
     maximumValue: PropTypes.number,
     width: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-};
-
-NumberInput.defaultProps = {
-    id: 'numberInputId',
-    value: '',
-    readOnly: false,
-    name: 'name',
-    onChange: () => true,
-    tooltipDescription: LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
-    errorName: LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
-    errorValue: LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
-    required: LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
-    minimumValue: 0,
-    maximumValue: Number.MAX_SAFE_INTEGER
 };
 
 export default NumberInput;

--- a/ui/src/main/js/common/component/input/PasswordInput.js
+++ b/ui/src/main/js/common/component/input/PasswordInput.js
@@ -4,8 +4,20 @@ import LabeledField, { LabelFieldPropertyDefaults } from 'common/component/input
 import BaseInput from 'common/component/input/BaseInput';
 
 const PasswordInput = ({
-    id, errorName, errorValue, isSet, label, fieldDescription,
-    name, onChange, readOnly, required, value, placeholder, tooltipDescription, isDisabled
+    id = 'passwordInputId',
+    errorName = LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
+    errorValue = LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
+    isSet = false,
+    label,
+    fieldDescription,
+    name = 'name',
+    onChange = () => true,
+    readOnly = false,
+    required = LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
+    value = '',
+    placeholder,
+    tooltipDescription = LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
+    isDisabled = false
 }) => {
     const placeholderText = (isSet) ? '***********' : null;
     const onChangeHandler = readOnly ? null : onChange;
@@ -51,20 +63,6 @@ PasswordInput.propTypes = {
     tooltipDescription: PropTypes.string,
     isDisabled: PropTypes.bool,
     placeholder: PropTypes.string
-};
-
-PasswordInput.defaultProps = {
-    id: 'passwordInputId',
-    isSet: false,
-    value: '',
-    readOnly: false,
-    name: 'name',
-    onChange: () => true,
-    errorName: LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
-    errorValue: LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
-    tooltipDescription: LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
-    required: LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
-    isDisabled: false
 };
 
 export default PasswordInput;

--- a/ui/src/main/js/common/component/input/RadioInput.js
+++ b/ui/src/main/js/common/component/input/RadioInput.js
@@ -21,8 +21,19 @@ const useStyles = createUseStyles({
 });
 
 const RadioInput = ({
-    id, fieldDescription, errorName, errorValue, label, name, onChange, readOnly,
-    required, radioOptions, checked, isInModal, tooltipDescription
+    id = 'checkboxInputId',
+    fieldDescription,
+    errorName = LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
+    errorValue = LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
+    label,
+    name = 'name',
+    onChange = () => true,
+    readOnly = false,
+    required = LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
+    radioOptions,
+    checked,
+    isInModal = false,
+    tooltipDescription = LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT
 }) => {
     const classes = useStyles();
 
@@ -78,18 +89,6 @@ RadioInput.propTypes = {
     readOnly: PropTypes.bool,
     required: PropTypes.bool,
     radioOptions: PropTypes.array
-};
-
-RadioInput.defaultProps = {
-    id: 'checkboxInputId',
-    name: 'name',
-    onChange: () => true,
-    readOnly: false,
-    isInModal: false,
-    tooltipDescription: LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
-    errorName: LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
-    errorValue: LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
-    required: LabelFieldPropertyDefaults.REQUIRED_DEFAULT
 };
 
 export default RadioInput;

--- a/ui/src/main/js/common/component/input/TextArea.js
+++ b/ui/src/main/js/common/component/input/TextArea.js
@@ -30,8 +30,19 @@ const useStyles = createUseStyles((theme) => ({
 }));
 
 const TextArea = ({
-    id, errorName, errorValue, label, name, onChange, readOnly, required,
-    value, tooltipDescription, isDisabled, rows, fieldDescription
+    id = 'textAreaId',
+    errorName = LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
+    errorValue = LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
+    label,
+    name = 'name',
+    onChange = () => true,
+    readOnly = false,
+    required = LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
+    value = '',
+    tooltipDescription = LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
+    isDisabled = false,
+    rows = 8,
+    fieldDescription
 }) => {
     const classes = useStyles();
     const onChangeHandler = readOnly ? null : onChange;
@@ -70,20 +81,6 @@ TextArea.propTypes = {
     fieldDescription: PropTypes.string,
     isDisabled: PropTypes.bool,
     rows: PropTypes.number
-};
-
-TextArea.defaultProps = {
-    id: 'textAreaId',
-    name: 'name',
-    onChange: () => true,
-    readOnly: false,
-    value: '',
-    errorName: LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
-    errorValue: LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
-    tooltipDescription: LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
-    required: LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
-    isDisabled: false,
-    rows: 8
 };
 
 export default TextArea;

--- a/ui/src/main/js/common/component/input/TextInput.js
+++ b/ui/src/main/js/common/component/input/TextInput.js
@@ -4,9 +4,19 @@ import LabeledField, { LabelFieldPropertyDefaults } from 'common/component/input
 import BaseInput from 'common/component/input/BaseInput';
 
 const TextInput = ({
-    id, errorName, errorValue, label,
-    name, onChange, readOnly, required, value,
-    placeholder, tooltipDescription, isDisabled, fieldDescription
+    id = 'textInputId',
+    errorName = LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
+    errorValue = LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
+    label,
+    name = 'name',
+    onChange = () => true,
+    readOnly = false,
+    required = LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
+    value = '',
+    placeholder,
+    tooltipDescription = LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
+    isDisabled = false,
+    fieldDescription
 }) => (
     <LabeledField
         id={id}
@@ -46,19 +56,6 @@ TextInput.propTypes = {
     tooltipDescription: PropTypes.string,
     fieldDescription: PropTypes.string,
     isDisabled: PropTypes.bool
-};
-
-TextInput.defaultProps = {
-    id: 'textInputId',
-    name: 'name',
-    onChange: () => true,
-    readOnly: false,
-    value: '',
-    tooltipDescription: LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
-    errorName: LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
-    errorValue: LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
-    required: LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
-    isDisabled: false
 };
 
 export default TextInput;

--- a/ui/src/main/js/common/component/input/field/ButtonField.js
+++ b/ui/src/main/js/common/component/input/field/ButtonField.js
@@ -5,18 +5,18 @@ import StatusMessage from 'common/component/StatusMessage';
 import Button from 'common/component/button/Button';
 
 const ButtonField = ({
-    id,
+    id = 'endpointButtonFieldId',
     buttonLabel,
-    tooltipDescription,
+    tooltipDescription = LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
     fieldDescription,
-    fieldError,
+    fieldError = LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
     fieldKey,
     label,
-    readOnly,
+    readOnly = false,
     onSendClick,
-    required,
+    required = LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
     success,
-    statusMessage
+    statusMessage = 'Success'
 }) => {
     const [progress, setProgress] = useState(false);
 
@@ -58,15 +58,6 @@ ButtonField.propTypes = {
     statusMessage: PropTypes.string,
     fieldDescription: PropTypes.string,
     tooltipDescription: PropTypes.string
-};
-
-ButtonField.defaultProps = {
-    id: 'endpointButtonFieldId',
-    readOnly: false,
-    tooltipDescription: LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
-    fieldError: LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
-    required: LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
-    statusMessage: 'Success'
 };
 
 export default ButtonField;

--- a/ui/src/main/js/common/component/input/field/EndpointButtonField.js
+++ b/ui/src/main/js/common/component/input/field/EndpointButtonField.js
@@ -8,25 +8,25 @@ import * as HTTPErrorUtils from 'common/util/httpErrorUtilities';
 import Button from 'common/component/button/Button';
 
 const EndpointButtonField = ({
-    id,
+    id = 'endpointButtonFieldId',
     buttonLabel,
     csrfToken,
     currentConfig,
-    tooltipDescription,
+    tooltipDescription = LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
     fieldDescription,
     endpoint,
-    errorValue,
+    errorValue = LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
     fieldKey,
-    fields,
+    fields = [],
     label,
-    name,
+    name = '',
     onChange,
-    readOnly,
-    required,
-    requiredRelatedFields,
-    statusMessage,
+    readOnly = false,
+    required = LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
+    requiredRelatedFields = [],
+    statusMessage = 'Success',
     successBox,
-    value
+    value = false
 }) => {
     const [showModal, setShowModal] = useState(false);
     const [fieldError, setFieldError] = useState(errorValue);
@@ -135,19 +135,6 @@ EndpointButtonField.propTypes = {
     errorValue: PropTypes.object,
     label: PropTypes.string.isRequired,
     required: PropTypes.bool
-};
-
-EndpointButtonField.defaultProps = {
-    id: 'endpointButtonFieldId',
-    fields: [],
-    name: '',
-    readOnly: false,
-    requiredRelatedFields: [],
-    statusMessage: 'Success',
-    value: false,
-    tooltipDescription: LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
-    errorValue: LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
-    required: LabelFieldPropertyDefaults.REQUIRED_DEFAULT
 };
 
 export default EndpointButtonField;

--- a/ui/src/main/js/common/component/input/field/LabeledField.js
+++ b/ui/src/main/js/common/component/input/field/LabeledField.js
@@ -88,7 +88,15 @@ const useStyles = createUseStyles((theme) => ({
 }));
 
 const LabeledField = ({
-    id, children, tooltipDescription, errorName, errorValue, label, required, fieldDescription, isDisabled
+    id = 'labeledFieldId',
+    children,
+    tooltipDescription,
+    errorName,
+    errorValue,
+    label,
+    required = LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
+    fieldDescription,
+    isDisabled
 }) => {
     const classes = useStyles();
     const [showTooltip, setShowTooltip] = useState(false);
@@ -157,15 +165,6 @@ LabeledField.propTypes = {
     required: PropTypes.bool,
     isDisabled: PropTypes.bool,
     fieldDescription: PropTypes.string
-};
-
-LabeledField.defaultProps = {
-    id: 'labeledFieldId',
-    children: null,
-    tooltipDescription: LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
-    errorName: LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
-    errorValue: LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
-    required: LabelFieldPropertyDefaults.REQUIRED_DEFAULT
 };
 
 export default LabeledField;

--- a/ui/src/main/js/common/component/input/field/ReadOnlyField.js
+++ b/ui/src/main/js/common/component/input/field/ReadOnlyField.js
@@ -13,7 +13,16 @@ const useStyles = createUseStyles({
 });
 
 const ReadOnlyField = ({
-    id, alt, tooltipDescription, errorName, errorValue, label, required, url, value, fieldDescription
+    id = 'readOnlyFieldId',
+    alt = '',
+    tooltipDescription = LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
+    errorName = LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
+    errorValue = LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
+    label,
+    required = LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
+    url = '',
+    value = '',
+    fieldDescription
 }) => {
     const classes = useStyles();
     const altValue = alt || url;
@@ -46,17 +55,6 @@ ReadOnlyField.propTypes = {
     errorValue: PropTypes.object,
     label: PropTypes.string.isRequired,
     required: PropTypes.bool
-};
-
-ReadOnlyField.defaultProps = {
-    id: 'readOnlyFieldId',
-    value: '',
-    url: '',
-    alt: '',
-    tooltipDescription: LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
-    errorName: LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
-    errorValue: LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
-    required: LabelFieldPropertyDefaults.REQUIRED_DEFAULT
 };
 
 export default ReadOnlyField;

--- a/ui/src/main/js/common/component/input/field/UploadFileButtonField.js
+++ b/ui/src/main/js/common/component/input/field/UploadFileButtonField.js
@@ -30,24 +30,28 @@ const useStyles = createUseStyles((theme) => ({
 }));
 
 const UploadFileButtonField = ({
-    id,
+    id = 'uploadFileButtonFieldId',
     accept,
     capture,
     buttonLabel,
     csrfToken,
-    tooltipDescription,
+    tooltipDescription = LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
     endpoint,
-    errorValue,
+    errorValue = LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
     fieldKey,
     label,
-    name,
-    readOnly,
-    required,
-    statusMessage,
-    permissions,
-    onChange,
-    customEndpoint,
-    value,
+    name = '',
+    readOnly = false,
+    required = LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
+    statusMessage = 'Upload Metadata File Success',
+    permissions = {
+        read: true,
+        write: true,
+        delete: true
+    },
+    onChange = () => {},
+    customEndpoint = '',
+    value = '',
     valueToCheckFileExistsOnChange
 }) => {
     const classes = useStyles();
@@ -213,27 +217,6 @@ UploadFileButtonField.propTypes = {
     customEndpoint: PropTypes.string,
     value: PropTypes.any,
     valueToCheckFileExistsOnChange: PropTypes.any
-};
-
-UploadFileButtonField.defaultProps = {
-    id: 'uploadFileButtonFieldId',
-    accept: null,
-    capture: null,
-    name: '',
-    readOnly: false,
-    statusMessage: 'Upload Metadata File Success',
-    tooltipDescription: LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
-    errorValue: LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
-    required: LabelFieldPropertyDefaults.REQUIRED_DEFAULT,
-    permissions: {
-        read: true,
-        write: true,
-        delete: true
-    },
-    onChange: () => {},
-    customEndpoint: '',
-    value: '',
-    valueToCheckFileExistsOnChange: ''
 };
 
 export default UploadFileButtonField;

--- a/ui/src/main/js/common/component/input/mapping/FieldMappingRow.js
+++ b/ui/src/main/js/common/component/input/mapping/FieldMappingRow.js
@@ -32,12 +32,12 @@ const useStyles = createUseStyles((theme) => ({
 
 const FieldMappingRow = ({
     index,
-    leftSide,
-    rightSide,
+    leftSide = '',
+    rightSide = '',
     setMapping,
     deleteRow,
-    mappingSymbol,
-    readonly
+    mappingSymbol = ' = ',
+    readonly = false
 }) => {
     const classes = useStyles();
     const [currentLeftSide, setCurrentLeftSide] = useState(leftSide);
@@ -95,13 +95,6 @@ FieldMappingRow.propTypes = {
     rightSide: PropTypes.string,
     mappingSymbol: PropTypes.any,
     readonly: PropTypes.bool
-};
-
-FieldMappingRow.defaultProps = {
-    leftSide: '',
-    rightSide: '',
-    mappingSymbol: ' = ',
-    readonly: false
 };
 
 export default FieldMappingRow;

--- a/ui/src/main/js/common/component/input/mapping/FluidFieldMappingField.js
+++ b/ui/src/main/js/common/component/input/mapping/FluidFieldMappingField.js
@@ -24,15 +24,15 @@ const useStyles = createUseStyles((theme) => ({
 }));
 
 const FluidFieldMappingField = ({
-    id,
+    id = 'fieldMappingFieldId',
     buttonLabel,
     description,
     value,
     setValue,
     errorName,
     errorValue,
-    readonly,
-    required
+    readonly = false,
+    required = LabelFieldPropertyDefaults.REQUIRED_DEFAULT
 }) => {
     const classes = useStyles();
     const [fieldMappings, setFieldMappings] = useState([]);
@@ -111,15 +111,6 @@ FluidFieldMappingField.propTypes = {
     errorValue: PropTypes.object,
     readonly: PropTypes.bool,
     required: PropTypes.bool
-};
-
-FluidFieldMappingField.defaultProps = {
-    id: 'fieldMappingFieldId',
-    readonly: false,
-    description: LabelFieldPropertyDefaults.DESCRIPTION_DEFAULT,
-    errorName: LabelFieldPropertyDefaults.ERROR_NAME_DEFAULT,
-    errorValue: LabelFieldPropertyDefaults.ERROR_VALUE_DEFAULT,
-    required: LabelFieldPropertyDefaults.REQUIRED_DEFAULT
 };
 
 export default FluidFieldMappingField;

--- a/ui/src/main/js/common/component/modal/Modal.js
+++ b/ui/src/main/js/common/component/modal/Modal.js
@@ -65,7 +65,7 @@ const useStyles = createUseStyles((theme) => ({
 }));
 
 const Modal = ({
-    isOpen, size, title, closeModal, children, handleCancel, handleSubmit,
+    isOpen, size = 'md', title, closeModal, children, handleCancel, handleSubmit,
     handleTest, submitText, testText, showLoader, notification, showNotification, buttonStyle,
     disableSubmit, submitTitle, noOverflow
 }) => {
@@ -118,10 +118,6 @@ const Modal = ({
         </div>,
         modalRoot
     );
-};
-
-Modal.defaultProps = {
-    size: 'md'
 };
 
 Modal.propTypes = {

--- a/ui/src/main/js/common/component/modal/Modal.js
+++ b/ui/src/main/js/common/component/modal/Modal.js
@@ -65,9 +65,23 @@ const useStyles = createUseStyles((theme) => ({
 }));
 
 const Modal = ({
-    isOpen, size = 'md', title, closeModal, children, handleCancel, handleSubmit,
-    handleTest, submitText, testText, showLoader, notification, showNotification, buttonStyle,
-    disableSubmit, submitTitle, noOverflow
+    isOpen,
+    size = 'md',
+    title,
+    closeModal,
+    children,
+    handleCancel,
+    handleSubmit,
+    handleTest,
+    submitText,
+    testText,
+    showLoader,
+    notification,
+    showNotification,
+    buttonStyle,
+    disableSubmit,
+    submitTitle,
+    noOverflow
 }) => {
     const classes = useStyles();
 

--- a/ui/src/main/js/common/component/navigation/PageHeader.js
+++ b/ui/src/main/js/common/component/navigation/PageHeader.js
@@ -65,7 +65,7 @@ const useStyles = createUseStyles((theme) => ({
     }
 }));
 
-const PageHeader = ({ title, description, icon, lastUpdated }) => {
+const PageHeader = ({ title, description = '', icon, lastUpdated }) => {
     const classes = useStyles();
 
     return (
@@ -101,11 +101,6 @@ PageHeader.propTypes = {
     description: PropTypes.string,
     icon: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
     lastUpdated: PropTypes.string
-};
-
-PageHeader.defaultProps = {
-    description: '',
-    lastUpdated: null
 };
 
 export default PageHeader;

--- a/ui/src/main/js/common/component/navigation/PageHeader.js
+++ b/ui/src/main/js/common/component/navigation/PageHeader.js
@@ -65,7 +65,12 @@ const useStyles = createUseStyles((theme) => ({
     }
 }));
 
-const PageHeader = ({ title, description = '', icon, lastUpdated }) => {
+const PageHeader = ({
+    title,
+    description = '',
+    icon,
+    lastUpdated
+}) => {
     const classes = useStyles();
 
     return (

--- a/ui/src/main/js/common/component/navigation/Pagination.js
+++ b/ui/src/main/js/common/component/navigation/Pagination.js
@@ -60,7 +60,13 @@ function getDisplayPages(currentPage, totalPages) {
     return links;
 }
 
-const Pagination = ({ data, onPage }) => {
+const Pagination = ({
+    data = {
+        currentPage: 0,
+        totalPages: 1
+    },
+    onPage
+}) => {
     const classes = useStyles();
     const { currentPage, totalPages } = data;
 
@@ -106,13 +112,6 @@ const Pagination = ({ data, onPage }) => {
             <IconButton icon="angle-double-right" onClick={handleEndPageClick} />
         </div>
     );
-};
-
-Pagination.defaultProps = {
-    data: {
-        currentPage: 0,
-        totalPages: 1
-    }
 };
 
 Pagination.propTypes = {

--- a/ui/src/main/js/common/component/table/EmptyTableView.js
+++ b/ui/src/main/js/common/component/table/EmptyTableView.js
@@ -10,7 +10,11 @@ const useStyles = createUseStyles({
     }
 });
 
-const EmptyTableView = ({ emptyTableConfig }) => {
+const EmptyTableView = ({
+    emptyTableConfig = {
+        message: 'There are no records to display for this table.'
+    }
+}) => {
     const classes = useStyles();
 
     return (
@@ -18,12 +22,6 @@ const EmptyTableView = ({ emptyTableConfig }) => {
             {emptyTableConfig?.message}
         </div>
     );
-};
-
-EmptyTableView.defaultProps = {
-    emptyTableConfig: {
-        message: 'There are no records to display for this table.'
-    }
 };
 
 EmptyTableView.propTypes = {

--- a/ui/src/main/js/common/configuration/global/CommonGlobalConfigurationForm.js
+++ b/ui/src/main/js/common/configuration/global/CommonGlobalConfigurationForm.js
@@ -10,20 +10,20 @@ import StatusMessage from 'common/component/StatusMessage';
 const CommonGlobalConfigurationForm = ({
     formData,
     setFormData,
-    testFormData,
-    setTestFormData,
+    testFormData = {},
+    setTestFormData = () => null,
     csrfToken,
     setErrors,
-    displaySave,
-    displayTest,
-    displayDelete,
-    displayCancel,
+    displaySave = true,
+    displayTest = true,
+    displayDelete = true,
+    displayCancel = false,
     children,
     testFields,
-    buttonIdPrefix,
-    afterSuccessfulSave,
+    buttonIdPrefix = 'common-form',
+    afterSuccessfulSave = () => null,
     retrieveData,
-    readonly,
+    readonly = false,
     errorHandler,
     deleteLabel
 }) => {
@@ -221,19 +221,6 @@ CommonGlobalConfigurationForm.propTypes = {
     readonly: PropTypes.bool,
     errorHandler: PropTypes.object.isRequired,
     deleteLabel: PropTypes.string
-};
-
-CommonGlobalConfigurationForm.defaultProps = {
-    displaySave: true,
-    displayTest: true,
-    displayDelete: true,
-    displayCancel: false,
-    testFields: null,
-    testFormData: {},
-    setTestFormData: () => null,
-    buttonIdPrefix: 'common-form',
-    afterSuccessfulSave: () => null,
-    readonly: false
 };
 
 export default CommonGlobalConfigurationForm;

--- a/ui/src/main/js/common/configuration/global/GlobalTestModal.js
+++ b/ui/src/main/js/common/configuration/global/GlobalTestModal.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Modal from 'common/component/modal/Modal';
 
 const GlobalTestModal = ({
-    children, showTestModal, handleTest, handleCancel, performingAction,
+    children, showTestModal, handleTest, handleCancel, performingAction = false,
     modalSubmitText, disableTestModalSubmit, testModalButtonTitle, testModalTitle
 }) => (
     <Modal
@@ -32,10 +32,6 @@ GlobalTestModal.propTypes = {
     testModalButtonTitle: PropTypes.string,
     disableTestModalSubmit: PropTypes.bool,
     performingAction: PropTypes.bool
-};
-
-GlobalTestModal.defaultProps = {
-    performingAction: false
 };
 
 export default GlobalTestModal;

--- a/ui/src/main/js/common/configuration/global/GlobalTestModal.js
+++ b/ui/src/main/js/common/configuration/global/GlobalTestModal.js
@@ -3,8 +3,15 @@ import PropTypes from 'prop-types';
 import Modal from 'common/component/modal/Modal';
 
 const GlobalTestModal = ({
-    children, showTestModal, handleTest, handleCancel, performingAction = false,
-    modalSubmitText, disableTestModalSubmit, testModalButtonTitle, testModalTitle
+    children,
+    showTestModal,
+    handleTest,
+    handleCancel,
+    performingAction = false,
+    modalSubmitText,
+    disableTestModalSubmit,
+    testModalButtonTitle,
+    testModalTitle
 }) => (
     <Modal
         isOpen={showTestModal}

--- a/ui/src/main/js/common/configuration/global/concrete/ConcreteConfigurationForm.js
+++ b/ui/src/main/js/common/configuration/global/concrete/ConcreteConfigurationForm.js
@@ -7,7 +7,7 @@ import StatusMessage from 'common/component/StatusMessage';
 
 const ConcreteConfigurationForm = ({
     formDataId,
-    clearTestForm,
+    clearTestForm = () => null,
     setErrors,
     getRequest,
     deleteRequest,
@@ -15,27 +15,27 @@ const ConcreteConfigurationForm = ({
     createRequest,
     validateRequest,
     testRequest,
-    displaySave,
-    displayTest,
-    displayDelete,
-    displayCancel,
+    displaySave = true,
+    displayTest = true,
+    displayDelete = true,
+    displayCancel = false,
     children,
     testFields,
     testModalTitle,
-    buttonIdPrefix,
-    afterSuccessfulSave,
-    readonly,
+    buttonIdPrefix = 'common-form',
+    afterSuccessfulSave = () => null,
+    readonly = false,
     errorHandler,
     cancelLabel,
     deleteLabel,
     submitLabel,
     testLabel,
     testButtonClicked,
-    postDeleteAction,
+    postDeleteAction = () => {},
     disableTestModalSubmit,
     modalSubmitText,
     testModalButtonTitle,
-    ignoreValidation,
+    ignoreValidation = false,
     isSaveDisabled,
     isDeleteDisabled
 }) => {
@@ -259,22 +259,6 @@ ConcreteConfigurationForm.propTypes = {
     isSaveDisabled: PropTypes.bool,
     isDeleteDisabled: PropTypes.bool,
     ignoreValidation: PropTypes.bool
-};
-
-ConcreteConfigurationForm.defaultProps = {
-    testRequest: () => null,
-    displaySave: true,
-    displayTest: true,
-    displayDelete: true,
-    displayCancel: false,
-    formDataId: null,
-    testFields: null,
-    clearTestForm: () => null,
-    buttonIdPrefix: 'common-form',
-    afterSuccessfulSave: () => null,
-    readonly: false,
-    postDeleteAction: () => {},
-    ignoreValidation: false
 };
 
 export default ConcreteConfigurationForm;

--- a/ui/src/main/js/page/distribution/CommonDistributionConfigurationForm.js
+++ b/ui/src/main/js/page/distribution/CommonDistributionConfigurationForm.js
@@ -9,18 +9,18 @@ import StatusMessage from 'common/component/StatusMessage';
 const CommonDistributionConfigurationForm = ({
     formData,
     setFormData,
-    setTestFormData,
+    setTestFormData = () => null,
     csrfToken,
     setErrors,
-    displaySave,
-    displayTest,
-    displayDelete,
+    displaySave = true,
+    displayTest = true,
+    displayDelete = false,
     isSaveDisabled,
     isTestDisabled,
     children,
     testFields,
-    buttonIdPrefix,
-    afterSuccessfulSave,
+    buttonIdPrefix = 'common-form',
+    afterSuccessfulSave = () => null,
     retrieveData,
     createDataToSend,
     createDataToTest,
@@ -220,18 +220,6 @@ CommonDistributionConfigurationForm.propTypes = {
     createDataToSend: PropTypes.func,
     createDataToTest: PropTypes.func,
     errorHandler: PropTypes.object.isRequired
-};
-
-CommonDistributionConfigurationForm.defaultProps = {
-    displaySave: true,
-    displayTest: true,
-    displayDelete: false,
-    testFields: null,
-    setTestFormData: () => null,
-    buttonIdPrefix: 'common-form',
-    afterSuccessfulSave: () => null,
-    createDataToSend: null,
-    createDataToTest: null
 };
 
 export default CommonDistributionConfigurationForm;

--- a/ui/src/main/js/page/settings/standalone/SettingsEncryptionConfiguration.js
+++ b/ui/src/main/js/page/settings/standalone/SettingsEncryptionConfiguration.js
@@ -10,7 +10,7 @@ import ReadOnlyField from 'common/component/input/field/ReadOnlyField';
 import FormCard from 'common/component/FormCard';
 
 const SettingsEncryptionConfiguration = ({
-    csrfToken, errorHandler, readonly, displaySave
+    csrfToken, errorHandler, readonly = false, displaySave = true
 }) => {
     const encryptionRequestUrl = `${ConfigurationRequestBuilder.ENCRYPTION_API_URL}`;
 
@@ -94,11 +94,6 @@ SettingsEncryptionConfiguration.propTypes = {
     // Pass this in for now while we have all descriptors in global state, otherwise retrieve this in this component
     readonly: PropTypes.bool,
     displaySave: PropTypes.bool
-};
-
-SettingsEncryptionConfiguration.defaultProps = {
-    readonly: false,
-    displaySave: true
 };
 
 export default SettingsEncryptionConfiguration;

--- a/ui/src/main/js/page/settings/standalone/SettingsEncryptionConfiguration.js
+++ b/ui/src/main/js/page/settings/standalone/SettingsEncryptionConfiguration.js
@@ -10,7 +10,10 @@ import ReadOnlyField from 'common/component/input/field/ReadOnlyField';
 import FormCard from 'common/component/FormCard';
 
 const SettingsEncryptionConfiguration = ({
-    csrfToken, errorHandler, readonly = false, displaySave = true
+    csrfToken,
+    errorHandler,
+    readonly = false,
+    displaySave = true
 }) => {
     const encryptionRequestUrl = `${ConfigurationRequestBuilder.ENCRYPTION_API_URL}`;
 

--- a/ui/src/main/js/page/settings/standalone/SettingsProxyConfiguration.js
+++ b/ui/src/main/js/page/settings/standalone/SettingsProxyConfiguration.js
@@ -12,7 +12,12 @@ import DynamicSelectInput from 'common/component/input/DynamicSelectInput';
 import FormCard from 'common/component/FormCard';
 
 const SettingsProxyConfiguration = ({
-    csrfToken, errorHandler, readOnly, displayTest, displaySave, displayDelete
+    csrfToken,
+    errorHandler,
+    readOnly = false,
+    displayTest = true,
+    displaySave = true,
+    displayDelete = true
 }) => {
     const proxyRequestUrl = `${ConfigurationRequestBuilder.PROXY_API_URL}`;
 
@@ -142,13 +147,6 @@ SettingsProxyConfiguration.propTypes = {
     displayTest: PropTypes.bool,
     displaySave: PropTypes.bool,
     displayDelete: PropTypes.bool
-};
-
-SettingsProxyConfiguration.defaultProps = {
-    readOnly: false,
-    displayTest: true,
-    displaySave: true,
-    displayDelete: true
 };
 
 export default SettingsProxyConfiguration;


### PR DESCRIPTION
### Summary
This PR modernizes React function components by replacing defaultProps with parameter defaults in component signatures. Behavior was preserved where defaults are required, while redundant legacy null-style defaults were removed where they had no practical effect.

### Why
- Aligns with current React best practices for function components
- Keeps defaults close to component inputs for readability
- Removes legacy defaultProps usage consistently across UI components

### Example change
**Before:**
```
const TextInput = ({ id, name, value, onChange, readOnly }) => (/* ... */);

TextInput.defaultProps = {
    id: 'textInputId',
    name: 'name',
    value: '',
    onChange: () => true,
    readOnly: false
};
```

**After:**
```
const TextInput = ({
    id = 'textInputId',
    name = 'name',
    value = '',
    onChange = () => true,
    readOnly = false
}) => (/* ... */);
```