### PR TITLE
IALERT-4059: (UI) Filter by Project Issues

### DIFF
--- a/ui/src/main/js/common/component/input/DynamicSelectInput.js
+++ b/ui/src/main/js/common/component/input/DynamicSelectInput.js
@@ -42,7 +42,8 @@ const DynamicSelectInput = ({
     creatable,
     maxMenuHeight,
     customVal,
-    customSelect
+    customSelect,
+    menuPlacement = 'auto'
 }) => {
     const classes = useStyles({ width });
     const selectedOptions = options.filter((option) => value.includes(option.value));
@@ -142,7 +143,7 @@ const DynamicSelectInput = ({
             isDisabled={readOnly}
             noOptionsMessage={() => 'No options available'}
             onFocus={onFocus}
-            menuPlacement="auto"
+            menuPlacement={menuPlacement}
             maxMenuHeight={maxMenuHeight || 250}
             styles={selectStyles}
         />
@@ -211,7 +212,8 @@ DynamicSelectInput.propTypes = {
     tooltipDescription: PropTypes.string,
     customVal: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     customSelect: PropTypes.element,
-    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    menuPlacement: PropTypes.oneOf(['auto', 'top', 'bottom'])
 };
 
 export default DynamicSelectInput;

--- a/ui/src/main/js/common/component/table/Table.js
+++ b/ui/src/main/js/common/component/table/Table.js
@@ -65,7 +65,7 @@ const Table = ({
                 <TableSkeleton />
             )}
 
-            { (!tableData || tableData?.length === 0) && (
+            { (!isLoading &&(!tableData || tableData?.length === 0)) && (
                 <EmptyTableView emptyTableConfig={emptyTableConfig} />
             )}
 

--- a/ui/src/main/js/common/component/table/Table.js
+++ b/ui/src/main/js/common/component/table/Table.js
@@ -65,7 +65,7 @@ const Table = ({
                 <TableSkeleton />
             )}
 
-            { (!isLoading &&(!tableData || tableData?.length === 0)) && (
+            { (!isLoading && (!tableData || tableData?.length === 0)) && (
                 <EmptyTableView emptyTableConfig={emptyTableConfig} />
             )}
 

--- a/ui/src/main/js/page/distribution/DistributionConfigurationForm.js
+++ b/ui/src/main/js/page/distribution/DistributionConfigurationForm.js
@@ -327,6 +327,13 @@ const DistributionConfigurationForm = ({
         });
     };
 
+    const handleProjectSelectChange = (selectedOptions) => FieldModelUtilities.handleChange(providerModel, setProviderModel)({
+        target: {
+            name: DISTRIBUTION_COMMON_FIELD_KEYS.configuredProjects,
+            value: selectedOptions || []
+        }
+    });
+
     function getProjectValues(data) {
         if (data.some((project) => 'label' in project)) {
             return data;
@@ -512,7 +519,15 @@ const DistributionConfigurationForm = ({
                                 errorValue={errors.fieldErrors[DISTRIBUTION_COMMON_FIELD_KEYS.configuredProjects]}
                                 customSelect={(
                                     <>
-                                        <div className="typeAheadField">
+                                        <div
+                                            className="typeAheadField"
+                                            onClick={(event) => {
+                                                if (event.target.closest('[data-project-remove="true"]') || event.target.closest('[data-project-clear="true"]')) {
+                                                    return;
+                                                }
+                                                setShowProjectSelectModal(true);
+                                            }}
+                                        >
                                             <Select
                                                 noOptionsMessage={() => null}
                                                 openMenuOnClick={false}
@@ -521,7 +536,16 @@ const DistributionConfigurationForm = ({
                                                 value={getProjectValues(FieldModelUtilities.getFieldModelValues(providerModel, DISTRIBUTION_COMMON_FIELD_KEYS.configuredProjects))}
                                                 isMulti
                                                 isClearable
+                                                onChange={(newValue, { action }) => {
+                                                    if (action === 'clear') {
+                                                        handleProjectSelectChange([]);
+                                                    }
+                                                }}
                                                 styles={{
+                                                    control: (base) => ({
+                                                        ...base,
+                                                        cursor: 'pointer'
+                                                    }),
                                                     dropdownIndicator: (base) => ({
                                                         ...base,
                                                         padding: '12px'
@@ -540,9 +564,29 @@ const DistributionConfigurationForm = ({
                                                             <FontAwesomeIcon icon="plus" onClick={() => setShowProjectSelectModal(true)} />
                                                         </components.DropdownIndicator>
                                                     ),
+                                                    ClearIndicator: ({ ...props }) => (
+                                                        <components.ClearIndicator
+                                                            {...props}
+                                                            innerProps={{
+                                                                ...props.innerProps,
+                                                                'data-project-clear': 'true'
+                                                            }}
+                                                        />
+                                                    ),
                                                     MultiValueRemove: ({ ...props }) => (
                                                         <components.MultiValueRemove
                                                             {...props}
+                                                            innerProps={{
+                                                                ...props.innerProps,
+                                                                'data-project-remove': 'true',
+                                                                onMouseDown: (event) => {
+                                                                    event.stopPropagation();
+                                                                },
+                                                                onClick: (event) => {
+                                                                    event.stopPropagation();
+                                                                    removeSelectedProject(props.data);
+                                                                }
+                                                            }}
                                                         >
                                                             <FontAwesomeIcon
                                                                 icon="times"

--- a/ui/src/main/js/page/distribution/DistributionConfigurationForm.js
+++ b/ui/src/main/js/page/distribution/DistributionConfigurationForm.js
@@ -665,6 +665,7 @@ const DistributionConfigurationForm = ({
                         value={FieldModelUtilities.getFieldModelValues(channelModel, DISTRIBUTION_COMMON_FIELD_KEYS.channelName)}
                         errorName={FieldModelUtilities.createFieldModelErrorKey(DISTRIBUTION_COMMON_FIELD_KEYS.channelName)}
                         errorValue={errors.fieldErrors[DISTRIBUTION_COMMON_FIELD_KEYS.channelName]}
+                        menuPlacement="top"
                     />
                     {renderChannelFields()}
                 </CommonDistributionConfigurationForm>

--- a/ui/src/main/js/page/distribution/ProjectSelectModal.js
+++ b/ui/src/main/js/page/distribution/ProjectSelectModal.js
@@ -87,7 +87,7 @@ export default function ProjectSelectModal({ isOpen, handleClose, csrfToken, pro
                                 setSelected(newSelected);
                                 return;
                             }
-                            
+
                             if (selectedProjectNames.includes(rowData.name)) {
                                 setSelected(selected.filter((project) => project.value !== rowData.href));
                             } else {
@@ -121,5 +121,11 @@ ProjectSelectModal.propTypes = {
     csrfToken: PropTypes.string,
     projectRequestBody: PropTypes.func,
     handleSubmit: PropTypes.func,
-    formData: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
+    formData: PropTypes.oneOfType([
+        PropTypes.array, 
+        PropTypes.shape({
+            label: PropTypes.string,
+            value: PropTypes.string
+        })
+    ])
 };

--- a/ui/src/main/js/page/distribution/ProjectSelectModal.js
+++ b/ui/src/main/js/page/distribution/ProjectSelectModal.js
@@ -79,7 +79,15 @@ export default function ProjectSelectModal({ isOpen, handleClose, csrfToken, pro
                             setSearchTerm(newSearchTerm);
                         }}
                         selected={selectedProjectNames}
-                        onSelected={(rowID, rowData) => {
+                        onSelected={(rowIDOrAllIDs, rowData) => {
+                            if (!rowData) {
+                                const newSelected = (data?.models || [])
+                                    .filter((m) => rowIDOrAllIDs.includes(m.name))
+                                    .map((m) => ({ label: m.name, value: m.href }));
+                                setSelected(newSelected);
+                                return;
+                            }
+                            
                             if (selectedProjectNames.includes(rowData.name)) {
                                 setSelected(selected.filter((project) => project.value !== rowData.href));
                             } else {
@@ -113,5 +121,5 @@ ProjectSelectModal.propTypes = {
     csrfToken: PropTypes.string,
     projectRequestBody: PropTypes.func,
     handleSubmit: PropTypes.func,
-    formData: PropTypes.oneOf([PropTypes.object, PropTypes.array])
+    formData: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
 };


### PR DESCRIPTION
## Description
This fix is for the Distribution Configuration's "Filter by Project", Project's field. The bugs identified:
- A user should be able to click the entire field to open the modal (requested improvement)
- A console error for the prop type being passed to the modal was incorrect (bug)
- A user could not select all on the table without the screen throwing a console error (bug)
- The table loader AND it's error message would show at the same time (bug)
- The "Channel" dropdown opens off screen

All four of these were fixed via:
- Adjust the entire field to be clickable by the user as well as a11y compliant
- Adjust the prop types for `formData` in the `ProjectSelectModal` to accept arrays or objects. Depending on what is selected will be what is passed in.
- Adjust the `onSelect` function for the `ProjectSelectModal` table to account for an array of all project ID's
- Adjust the table error message to only show after the table has finished loading it's data.
- Adjust the menuPlacement to open above for this particular dropdown


https://github.com/user-attachments/assets/91c1e4e5-da2c-48e6-8645-5f856c2fefe9

<img width="1728" height="869" alt="Screenshot 2026-08-13 at 12 22 53 PM" src="https://github.com/user-attachments/assets/979fc26f-cab6-407c-98f1-a9e9c31255a9" />