### PR TITLE
IALERT-4064: Bug: Add protections to prevent DB constraint issues if attempting to save a notification that already exists by content ID

### DIFF
--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessor.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessor.java
@@ -72,7 +72,7 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
         if (notifications.isEmpty()) {
             return List.of();
         }
-        
+
         // Prefetch all content IDs in a batch to determine if duplicates exist when performing in-memory filtering.
         Set<String> allBatchContentIds = notifications.stream()
             .map(AlertNotificationModel::getContentId)
@@ -113,6 +113,8 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
         if (contentIdsToSave.isEmpty()) {
             return List.of();
         }
+        // Native query insert bypasses Hibernate's identity management. As a result, the in-memory NotificationEntities do not have their ID populated.
+        // A fetch is required to ensure the correct notifications are returned with the correct IDs.
         return notificationContentRepository.findByContentIdIn(contentIdsToSave)
             .stream()
             .map(this::toModel)

--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessor.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessor.java
@@ -9,6 +9,7 @@ package com.blackduck.integration.alert.database.job.api;
 
 import java.time.OffsetDateTime;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -70,9 +71,13 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
     public List<AlertNotificationModel> saveAllNotifications(Collection<AlertNotificationModel> notifications) {
         List<NotificationEntity> entitiesToSave = new LinkedList<>();
 
+        Set<String> contentIdsToSave = new HashSet<>();
         for (AlertNotificationModel model : notifications) {
             if (notificationContentRepository.existsByContentId(model.getContentId())) {
                 logger.info("Notification already exists for provider: {} contentId: {}", model.getProviderConfigId(), model.getContentId());
+                logger.debug("Content: {}", model.getContent());
+            } else if (!contentIdsToSave.add(model.getContentId())) {
+                logger.info("Duplicate notification in batch for provider: {}, contentId: {}", model.getProviderConfigId(), model.getContentId());
                 logger.debug("Content: {}", model.getContent());
             } else {
                 entitiesToSave.add(fromModel(model));
@@ -82,14 +87,14 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
         return notificationContentRepository.saveAllAndFlush(entitiesToSave)
             .stream()
             .map(this::toModel)
-            .collect(Collectors.toList());
+            .toList();
     }
 
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
     public List<AlertNotificationModel> saveAllNotificationsInBatch(final UUID batchId, final Collection<AlertNotificationModel> notifications) {
         List<AlertNotificationModel> models = saveAllNotifications(notifications);
-        if(!models.isEmpty()) {
+        if (!models.isEmpty()) {
             List<NotificationBatchEntity> batchDataList = models.stream()
                 .map(notification -> new NotificationBatchEntity(notification.getProviderConfigId(), batchId, notification.getId()))
                 .toList();
@@ -186,10 +191,10 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
         String sortingField = "createdAt";
         // We can only modify the query for the fields that exist in NotificationContent
         if (StringUtils.isNotBlank(sortField) && "createdAt".equalsIgnoreCase(sortField)
-                || "provider".equalsIgnoreCase(sortField)
-                || COLUMN_NAME_PROVIDER_CREATION_TIME.equalsIgnoreCase(sortField)
-                || "notificationType".equalsIgnoreCase(sortField)
-                || "content".equalsIgnoreCase(sortField)) {
+            || "provider".equalsIgnoreCase(sortField)
+            || COLUMN_NAME_PROVIDER_CREATION_TIME.equalsIgnoreCase(sortField)
+            || "notificationType".equalsIgnoreCase(sortField)
+            || "content".equalsIgnoreCase(sortField)) {
             sortingField = sortField;
             sortQuery = true;
         }
@@ -271,11 +276,11 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
         Sort.Order sortingOrder = Sort.Order.asc(COLUMN_NAME_PROVIDER_CREATION_TIME);
         PageRequest pageRequest = PageRequest.of(currentPage, pageSize, Sort.by(sortingOrder));
         Page<AlertNotificationModel> pageOfNotifications = notificationContentRepository.findNotMappedAndNotProcessedNotifications(
-                        providerConfigId,
-                        batchId,
-                        pageRequest
-                )
-                .map(this::toModel);
+                providerConfigId,
+                batchId,
+                pageRequest
+            )
+            .map(this::toModel);
         List<AlertNotificationModel> alertNotificationModels = pageOfNotifications.getContent();
         return new AlertPagedModel<>(pageOfNotifications.getTotalPages(), currentPage, pageSize, alertNotificationModels);
     }
@@ -284,9 +289,9 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
     @Transactional
     public void setNotificationsMapping(List<AlertNotificationModel> notifications) {
         Set<Long> notificationIds = notifications
-                .stream()
-                .map(AlertNotificationModel::getId)
-                .collect(Collectors.toSet());
+            .stream()
+            .map(AlertNotificationModel::getId)
+            .collect(Collectors.toSet());
         setNotificationsMappingById(notificationIds);
     }
 
@@ -299,7 +304,7 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
 
     @Override
     @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
-    public boolean hasMoreNotificationsToMap(long providerConfigId,  UUID batchId) {
+    public boolean hasMoreNotificationsToMap(long providerConfigId, UUID batchId) {
         return notificationContentRepository.existsByProviderConfigIdAndMappingToJobsFalse(providerConfigId, batchId);
     }
 

--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessor.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessor.java
@@ -84,7 +84,24 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
             }
         }
 
-        return notificationContentRepository.saveAllAndFlush(entitiesToSave)
+        for (NotificationEntity entity : entitiesToSave) {
+            notificationContentRepository.saveIgnoreContentIdConflict(
+                entity.getCreatedAt(),
+                entity.getProvider(),
+                entity.getProviderConfigId(),
+                entity.getProviderCreationTime(),
+                entity.getNotificationType(),
+                entity.getContent(),
+                entity.getProcessed(),
+                entity.getContentId(),
+                entity.isMappingToJobs()
+            );
+        }
+
+        if (contentIdsToSave.isEmpty()) {
+            return List.of();
+        }
+        return notificationContentRepository.findByContentIdIn(contentIdsToSave)
             .stream()
             .map(this::toModel)
             .toList();

--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessor.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessor.java
@@ -8,9 +8,9 @@
 package com.blackduck.integration.alert.database.job.api;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -69,7 +69,7 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
     public List<AlertNotificationModel> saveAllNotifications(Collection<AlertNotificationModel> notifications) {
-        List<NotificationEntity> entitiesToSave = new LinkedList<>();
+        List<NotificationEntity> entitiesToSave = new ArrayList<>();
 
         Set<String> contentIdsToSave = new HashSet<>();
         for (AlertNotificationModel model : notifications) {

--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessor.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessor.java
@@ -69,11 +69,23 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
     public List<AlertNotificationModel> saveAllNotifications(Collection<AlertNotificationModel> notifications) {
-        List<NotificationEntity> entitiesToSave = new ArrayList<>();
+        if (notifications.isEmpty()) {
+            return List.of();
+        }
+        
+        // Prefetch all content IDs in a batch to determine if duplicates exist when performing in-memory filtering.
+        Set<String> allBatchContentIds = notifications.stream()
+            .map(AlertNotificationModel::getContentId)
+            .collect(Collectors.toSet());
+        Set<String> existingContentIds = notificationContentRepository.findByContentIdIn(allBatchContentIds)
+            .stream()
+            .map(NotificationEntity::getContentId)
+            .collect(Collectors.toSet());
 
+        List<NotificationEntity> entitiesToSave = new ArrayList<>();
         Set<String> contentIdsToSave = new HashSet<>();
         for (AlertNotificationModel model : notifications) {
-            if (notificationContentRepository.existsByContentId(model.getContentId())) {
+            if (existingContentIds.contains(model.getContentId())) {
                 logger.info("Notification already exists for provider: {} contentId: {}", model.getProviderConfigId(), model.getContentId());
                 logger.debug("Content: {}", model.getContent());
             } else if (!contentIdsToSave.add(model.getContentId())) {

--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/notification/NotificationContentRepository.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/notification/NotificationContentRepository.java
@@ -8,6 +8,7 @@
 package com.blackduck.integration.alert.database.notification;
 
 import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -93,7 +94,7 @@ public interface NotificationContentRepository extends JpaRepository<Notificatio
 
     long countByProviderConfigIdAndNotificationType(long providerConfigId, String notificationType);
 
-    @Query(value ="SELECT entity FROM NotificationEntity entity"
+    @Query(value = "SELECT entity FROM NotificationEntity entity"
         + " INNER JOIN NotificationBatchEntity batch ON entity.id = batch.notificationId"
         + " WHERE batch.batchId = :batchId"
         + " AND entity.providerConfigId = :providerId"
@@ -111,20 +112,20 @@ public interface NotificationContentRepository extends JpaRepository<Notificatio
         + " AND entity.processed = false"
         + ") THEN true ELSE false END"
         + " FROM NotificationEntity entity")
-    boolean existsByProviderConfigIdAndMappingToJobsFalse(@Param("providerId") long providerConfigId, @Param("batchId")  UUID batchId);
+    boolean existsByProviderConfigIdAndMappingToJobsFalse(@Param("providerId") long providerConfigId, @Param("batchId") UUID batchId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE NotificationEntity entity "
-            + "SET entity.mappingToJobs = true "
-            + "WHERE entity.id IN :notificationIds"
+        + "SET entity.mappingToJobs = true "
+        + "WHERE entity.id IN :notificationIds"
     )
     void setMappingToJobsByIds(@Param("notificationIds") Set<Long> notificationIds);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE NotificationEntity entity "
-            + "SET entity.mappingToJobs = false "
-            + "WHERE entity.providerConfigId = :providerConfigId "
-            + "AND entity.processed = false"
+        + "SET entity.mappingToJobs = false "
+        + "WHERE entity.providerConfigId = :providerConfigId "
+        + "AND entity.processed = false"
     )
     void setMappingToJobsFalseWhenProcessedFalse(@Param("providerConfigId") long providerConfigId);
 
@@ -134,4 +135,27 @@ public interface NotificationContentRepository extends JpaRepository<Notificatio
         + " GROUP BY DATE_TRUNC('hour', entity.createdAt)"
         + " ORDER BY DATE_TRUNC('hour', entity.createdAt) ")
     List<NotificationCountsPerHour> findNotificationCountsPerHourByProviderConfigId(@Param("providerConfigId") long providerConfigId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        value = "INSERT INTO alert.raw_notification_content "
+            + "(created_at, provider, provider_config_id, provider_creation_time, notification_type, content, processed, content_id, mapping_to_jobs) "
+            + "VALUES (:createdAt, :provider, :providerConfigId, :providerCreationTime, :notificationType, :content, :processed, :contentId, :mappingToJobs) "
+            + "ON CONFLICT (content_id) DO NOTHING",
+        nativeQuery = true
+    )
+    void saveIgnoreContentIdConflict(
+        @Param("createdAt") OffsetDateTime createdAt,
+        @Param("provider") String provider,
+        @Param("providerConfigId") Long providerConfigId,
+        @Param("providerCreationTime") OffsetDateTime providerCreationTime,
+        @Param("notificationType") String notificationType,
+        @Param("content") String content,
+        @Param("processed") boolean processed,
+        @Param("contentId") String contentId,
+        @Param("mappingToJobs") boolean mappingToJobs
+    );
+
+    List<NotificationEntity> findByContentIdIn(Collection<String> contentIds);
 }
+

--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/notification/NotificationEntity.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/notification/NotificationEntity.java
@@ -31,7 +31,7 @@ import jakarta.persistence.Table;
 public class NotificationEntity extends BaseEntity implements DatabaseEntity {
     @Id
     @GeneratedValue(generator = "alert.raw_notification_content_id_seq_generator", strategy = GenerationType.SEQUENCE)
-    @SequenceGenerator(name = "alert.raw_notification_content_id_seq_generator", sequenceName = "alert.raw_notification_content_id_seq")
+    @SequenceGenerator(name = "alert.raw_notification_content_id_seq_generator", sequenceName = "alert.raw_notification_content_id_seq", allocationSize = 1)
     @Column(name = "id")
     private Long id;
     @Column(name = "created_at")
@@ -49,7 +49,7 @@ public class NotificationEntity extends BaseEntity implements DatabaseEntity {
     @Column(name = "processed")
     private boolean processed;
 
-    @Column(name = "content_id")
+    @Column(name = "content_id", nullable = false, unique = true)
     private String contentId;
 
     @Column(name = "mapping_to_jobs")
@@ -59,7 +59,7 @@ public class NotificationEntity extends BaseEntity implements DatabaseEntity {
     private final List<AuditNotificationRelation> auditNotificationRelations = new ArrayList<>();
 
     @OneToMany(cascade = CascadeType.ALL)
-    @JoinColumn(name = "notification_id", referencedColumnName = "id",  insertable = false, updatable = false)
+    @JoinColumn(name = "notification_id", referencedColumnName = "id", insertable = false, updatable = false)
     private List<NotificationBatchEntity> notificationBatches = new ArrayList<>();
 
     public NotificationEntity() {

--- a/alert-database/src/main/resources/liquibase/9.0.0/raw-notification-content-sequence-increment.xml
+++ b/alert-database/src/main/resources/liquibase/9.0.0/raw-notification-content-sequence-increment.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
-    <include file="jira-cloud-job-details-remove-comments.xml" relativeToChangelogFile="true"/>
-    <include file="jira-server-job-details-remove-comments.xml" relativeToChangelogFile="true"/>
-    <include file="raw-notification-content-sequence-increment.xml" relativeToChangelogFile="true"/>
+    <changeSet author="martinch" id="raw-notification-content-sequence-increment">
+        <alterSequence schemaName="alert"
+                       sequenceName="raw_notification_content_id_seq"
+                       incrementBy="1"
+        />
+    </changeSet>
 </databaseChangeLog>

--- a/alert-database/src/main/resources/scripts/init_alert_db.sql
+++ b/alert-database/src/main/resources/scripts/init_alert_db.sql
@@ -320,5 +320,8 @@ ALTER SEQUENCE alert.descriptor_configs_id_seq INCREMENT 50;
 ALTER SEQUENCE alert.field_values_id_seq INCREMENT 50;
 ALTER SEQUENCE alert.provider_projects_id_seq INCREMENT 50;
 ALTER SEQUENCE alert.provider_users_id_seq INCREMENT 50;
-ALTER SEQUENCE alert.raw_notification_content_id_seq INCREMENT 50;
 ALTER SEQUENCE alert.system_messages_id_seq INCREMENT 50;
+
+-- raw_notification_content is inserted using native PSQL query rather than hibernate.
+ALTER SEQUENCE alert.raw_notification_content_id_seq INCREMENT 1;
+

--- a/alert-database/src/test/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessorTest.java
+++ b/alert-database/src/test/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessorTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.mockito.verification.VerificationMode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -126,17 +127,7 @@ class DefaultNotificationAccessorTest {
         AlertNotificationModel testAlertNotificationModel = alertNotificationModelList.get(0);
         testExpectedAlertNotificationModel(expectedAlertNotificationModel, testAlertNotificationModel);
 
-        Mockito.verify(notificationContentRepository, Mockito.times(1)).saveIgnoreContentIdConflict(
-            Mockito.any(OffsetDateTime.class),
-            Mockito.anyString(),
-            Mockito.any(Long.class),
-            Mockito.any(OffsetDateTime.class),
-            Mockito.anyString(),
-            Mockito.anyString(),
-            Mockito.anyBoolean(),
-            Mockito.anyString(),
-            Mockito.anyBoolean()
-        );
+        verifySaveIgnoreContentIdConflict(notificationContentRepository, Mockito.times(1));
     }
 
     @Test
@@ -200,17 +191,7 @@ class DefaultNotificationAccessorTest {
 
         assertEquals(1, result.size(), "Only the first occurrence of a duplicate contentId should be saved");
 
-        Mockito.verify(notificationContentRepository, Mockito.times(1)).saveIgnoreContentIdConflict(
-            Mockito.any(OffsetDateTime.class),
-            Mockito.anyString(),
-            Mockito.any(Long.class),
-            Mockito.any(OffsetDateTime.class),
-            Mockito.anyString(),
-            Mockito.anyString(),
-            Mockito.anyBoolean(),
-            Mockito.anyString(),
-            Mockito.anyBoolean()
-        );
+        verifySaveIgnoreContentIdConflict(notificationContentRepository, Mockito.times(1));
     }
 
     @Test
@@ -241,17 +222,7 @@ class DefaultNotificationAccessorTest {
 
         assertTrue(result.isEmpty(), "Notifications already in the database should not be saved again");
 
-        Mockito.verify(notificationContentRepository, Mockito.never()).saveIgnoreContentIdConflict(
-            Mockito.any(OffsetDateTime.class),
-            Mockito.anyString(),
-            Mockito.any(Long.class),
-            Mockito.any(OffsetDateTime.class),
-            Mockito.anyString(),
-            Mockito.anyString(),
-            Mockito.anyBoolean(),
-            Mockito.anyString(),
-            Mockito.anyBoolean()
-        );
+        verifySaveIgnoreContentIdConflict(notificationContentRepository, Mockito.never());
     }
 
     @Test
@@ -262,17 +233,7 @@ class DefaultNotificationAccessorTest {
         List<AlertNotificationModel> alertNotificationModelList = notificationManager.saveAllNotifications(new ArrayList<>());
 
         assertTrue(alertNotificationModelList.isEmpty());
-        Mockito.verify(notificationContentRepository, Mockito.never()).saveIgnoreContentIdConflict(
-            Mockito.any(OffsetDateTime.class),
-            Mockito.anyString(),
-            Mockito.any(Long.class),
-            Mockito.any(OffsetDateTime.class),
-            Mockito.anyString(),
-            Mockito.anyString(),
-            Mockito.anyBoolean(),
-            Mockito.anyString(),
-            Mockito.anyBoolean()
-        );
+        verifySaveIgnoreContentIdConflict(notificationContentRepository, Mockito.never());
         Mockito.verify(notificationContentRepository, Mockito.never()).findByContentIdIn(Mockito.any());
     }
 
@@ -714,6 +675,20 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.existsByProcessedFalse()).thenReturn(Boolean.TRUE);
         DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, null, notificationBatchRepository);
         assertTrue(notificationManager.hasMoreNotificationsToProcess());
+    }
+
+    private void verifySaveIgnoreContentIdConflict(NotificationContentRepository repository, VerificationMode mode) {
+        Mockito.verify(repository, mode).saveIgnoreContentIdConflict(
+            Mockito.any(OffsetDateTime.class),
+            Mockito.anyString(),
+            Mockito.any(Long.class),
+            Mockito.any(OffsetDateTime.class),
+            Mockito.anyString(),
+            Mockito.anyString(),
+            Mockito.anyBoolean(),
+            Mockito.anyString(),
+            Mockito.anyBoolean()
+        );
     }
 
     private void testExpectedAlertNotificationModel(AlertNotificationModel expected, AlertNotificationModel actual) {

--- a/alert-database/src/test/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessorTest.java
+++ b/alert-database/src/test/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessorTest.java
@@ -18,6 +18,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import org.mockito.ArgumentCaptor;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -113,12 +115,117 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.saveAllAndFlush(Mockito.any())).thenReturn(List.of(notificationEntity));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         List<AlertNotificationModel> alertNotificationModelList = notificationManager.saveAllNotifications(List.of(alertNotificationModel));
 
         assertEquals(1, alertNotificationModelList.size());
         AlertNotificationModel testAlertNotificationModel = alertNotificationModelList.get(0);
         testExpectedAlertNotificationModel(expectedAlertNotificationModel, testAlertNotificationModel);
+    }
+
+    @Test
+    void saveAllNotificationsWithDuplicateContentIdInBatchTest() {
+        OffsetDateTime createdAt = DateUtils.createCurrentDateTimestamp();
+        OffsetDateTime providerCreationTime = createdAt.minusSeconds(10);
+
+        AlertNotificationModel firstOccurrence = new AlertNotificationModel(
+            null,
+            providerConfigId,
+            provider,
+            providerConfigName,
+            notificationType,
+            content,
+            createdAt,
+            providerCreationTime,
+            false,
+            contentId,
+            false
+        );
+        AlertNotificationModel duplicateOccurrence = new AlertNotificationModel(
+            null,
+            providerConfigId,
+            provider,
+            providerConfigName,
+            notificationType,
+            content,
+            createdAt,
+            providerCreationTime,
+            false,
+            contentId,
+            false
+        );
+        NotificationEntity savedEntity = new NotificationEntity(
+            id,
+            createdAt,
+            provider,
+            providerConfigId,
+            providerCreationTime,
+            notificationType,
+            content,
+            false,
+            contentId,
+            false
+        );
+
+        NotificationContentRepository notificationContentRepository = Mockito.mock(NotificationContentRepository.class);
+        ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
+
+        Mockito.when(notificationContentRepository.existsByContentId(contentId)).thenReturn(false);
+        Mockito.when(notificationContentRepository.saveAllAndFlush(Mockito.any())).thenReturn(List.of(savedEntity));
+        Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(createConfigurationModel()));
+
+        DefaultNotificationAccessor defaultNotificationAccessor = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
+        List<AlertNotificationModel> result = defaultNotificationAccessor.saveAllNotifications(List.of(firstOccurrence, duplicateOccurrence));
+
+        assertEquals(1, result.size(), "Only the first occurrence of a duplicate contentId should be saved");
+
+        ArgumentCaptor<List<NotificationEntity>> saveCaptor = ArgumentCaptor.captor();
+        Mockito.verify(notificationContentRepository).saveAllAndFlush(saveCaptor.capture());
+        assertEquals(1, saveCaptor.getValue().size(), "Only one entity should be passed to saveAllAndFlush when the batch contains a duplicate contentId");
+    }
+
+    @Test
+    void saveAllNotificationsSkipsNotificationAlreadyInDatabaseTest() {
+        OffsetDateTime createdAt = DateUtils.createCurrentDateTimestamp();
+        OffsetDateTime providerCreationTime = createdAt.minusSeconds(10);
+
+        AlertNotificationModel alreadyPersistedModel = new AlertNotificationModel(
+            null,
+            providerConfigId,
+            provider,
+            providerConfigName,
+            notificationType,
+            content,
+            createdAt,
+            providerCreationTime,
+            false,
+            contentId,
+            false
+        );
+
+        NotificationContentRepository notificationContentRepository = Mockito.mock(NotificationContentRepository.class);
+
+        Mockito.when(notificationContentRepository.existsByContentId(contentId)).thenReturn(true);
+        Mockito.when(notificationContentRepository.saveAllAndFlush(Mockito.any())).thenReturn(List.of());
+
+        DefaultNotificationAccessor defaultNotificationAccessor = new DefaultNotificationAccessor(notificationContentRepository, null, null, notificationBatchRepository);
+        List<AlertNotificationModel> result = defaultNotificationAccessor.saveAllNotifications(List.of(alreadyPersistedModel));
+
+        assertTrue(result.isEmpty(), "Notifications already in the database should not be saved again");
+
+        ArgumentCaptor<List<NotificationEntity>> saveCaptor = ArgumentCaptor.captor();
+        Mockito.verify(notificationContentRepository).saveAllAndFlush(saveCaptor.capture());
+        assertTrue(saveCaptor.getValue().isEmpty(), "No entities should be passed to saveAllAndFlush when all notifications already exist in the database");
     }
 
     @Test
@@ -158,7 +265,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.findAllSentNotifications(Mockito.any())).thenReturn(allSentNotifications);
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         Page<AlertNotificationModel> alertNotificationModelPage = notificationManager.findAll(pageRequest, Boolean.TRUE);
 
         assertEquals(1, alertNotificationModelPage.getTotalPages());
@@ -191,7 +303,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
         Mockito.when(notificationContentRepository.findAll(pageRequest)).thenReturn(allSentNotifications);
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         Page<AlertNotificationModel> alertNotificationModelPage = notificationManager.findAll(pageRequest, Boolean.FALSE);
 
         assertEquals(1, alertNotificationModelPage.getTotalPages());
@@ -226,7 +343,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
         Mockito.when(notificationContentRepository.findMatchingNotification(Mockito.any(), Mockito.any())).thenReturn(notificationEntityPage);
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         Page<AlertNotificationModel> alertNotificationModelPage = notificationManager.findAllWithSearch(searchTerm, pageRequest, Boolean.TRUE);
         Page<AlertNotificationModel> alertNotificationModelPageShowNotificationsFalse = notificationManager.findAllWithSearch(searchTerm, pageRequest, Boolean.FALSE);
 
@@ -261,7 +383,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.findAllByIdInOrderByProviderCreationTimeAsc(Mockito.any())).thenReturn(List.of(notificationEntity1));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         List<AlertNotificationModel> alertNotificationModelList = notificationManager.findByIds(List.of(1L));
 
         assertEquals(1, alertNotificationModelList.size());
@@ -291,7 +418,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.findById(Mockito.any())).thenReturn(Optional.of(notificationEntity));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         Optional<AlertNotificationModel> alertNotificationModel = notificationManager.findById(1L);
 
         assertTrue(alertNotificationModel.isPresent());
@@ -320,8 +452,14 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.findByCreatedAtBetween(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(new PageImpl<>(List.of(notificationEntity)));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
-        List<AlertNotificationModel> alertNotificationModelList = notificationManager.findByCreatedAtBetween(DateUtils.createCurrentDateTimestamp(),
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
+        List<AlertNotificationModel> alertNotificationModelList = notificationManager.findByCreatedAtBetween(
+                DateUtils.createCurrentDateTimestamp(),
                 DateUtils.createCurrentDateTimestamp(),
                 AlertPagedModel.DEFAULT_PAGE_NUMBER, AlertPagedModel.DEFAULT_PAGE_SIZE
             )
@@ -354,7 +492,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.findByCreatedAtBefore(Mockito.any())).thenReturn(List.of(notificationEntity));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         List<AlertNotificationModel> alertNotificationModelList = notificationManager.findByCreatedAtBefore(DateUtils.createCurrentDateTimestamp());
 
         assertEquals(1, alertNotificationModelList.size());
@@ -384,7 +527,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.findByCreatedAtBefore(Mockito.any())).thenReturn(List.of(notificationEntity));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         List<AlertNotificationModel> alertNotificationModelList = notificationManager.findByCreatedAtBeforeDayOffset(1);
 
         assertEquals(1, alertNotificationModelList.size());
@@ -404,7 +552,12 @@ class DefaultNotificationAccessorTest {
         AuditNotificationRepository auditNotificationRepository = Mockito.mock(AuditNotificationRepository.class);
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, auditEntryRepository, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            auditEntryRepository,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         PageRequest pageRequest = notificationManager.getPageRequestForNotifications(pageNumber, pageSize, sortField, sortOrder);
 
         assertEquals(pageNumber, pageRequest.getPageNumber());
@@ -434,7 +587,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.findByProcessedFalseOrderByProviderCreationTimeAsc(Mockito.any())).thenReturn(pageOfNotificationEntities);
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         AlertPagedModel<AlertNotificationModel> model = notificationManager.getFirstPageOfNotificationsNotProcessed(100);
 
         List<AlertNotificationModel> alertNotificationModelList = model.getModels();
@@ -444,7 +602,8 @@ class DefaultNotificationAccessorTest {
 
     @Test
     void setNotificationsProcessedTest() {
-        AlertNotificationModel alertNotificationModel = new AlertNotificationModel(null,
+        AlertNotificationModel alertNotificationModel = new AlertNotificationModel(
+            null,
             providerConfigId,
             provider,
             providerConfigName,
@@ -460,7 +619,12 @@ class DefaultNotificationAccessorTest {
         NotificationContentRepository notificationContentRepository = Mockito.mock(NotificationContentRepository.class);
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         notificationManager.setNotificationsProcessed(List.of(alertNotificationModel));
 
         Mockito.verify(notificationContentRepository).setProcessedByIds(Mockito.any());
@@ -489,7 +653,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.findAllById(Mockito.any())).thenReturn(List.of(notificationEntity));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         notificationManager.setNotificationsProcessedById(notificationIds);
 
         Mockito.verify(notificationContentRepository).setProcessedByIds(Mockito.any());

--- a/alert-database/src/test/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessorTest.java
+++ b/alert-database/src/test/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessorTest.java
@@ -18,8 +18,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-import org.mockito.ArgumentCaptor;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -112,7 +110,8 @@ class DefaultNotificationAccessorTest {
         NotificationContentRepository notificationContentRepository = Mockito.mock(NotificationContentRepository.class);
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
 
-        Mockito.when(notificationContentRepository.saveAllAndFlush(Mockito.any())).thenReturn(List.of(notificationEntity));
+        Mockito.when(notificationContentRepository.existsByContentId(contentId)).thenReturn(false);
+        Mockito.when(notificationContentRepository.findByContentIdIn(Mockito.any())).thenReturn(List.of(notificationEntity));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
         DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
@@ -126,6 +125,18 @@ class DefaultNotificationAccessorTest {
         assertEquals(1, alertNotificationModelList.size());
         AlertNotificationModel testAlertNotificationModel = alertNotificationModelList.get(0);
         testExpectedAlertNotificationModel(expectedAlertNotificationModel, testAlertNotificationModel);
+
+        Mockito.verify(notificationContentRepository, Mockito.times(1)).saveIgnoreContentIdConflict(
+            Mockito.any(OffsetDateTime.class),
+            Mockito.anyString(),
+            Mockito.any(Long.class),
+            Mockito.any(OffsetDateTime.class),
+            Mockito.anyString(),
+            Mockito.anyString(),
+            Mockito.anyBoolean(),
+            Mockito.anyString(),
+            Mockito.anyBoolean()
+        );
     }
 
     @Test
@@ -176,7 +187,7 @@ class DefaultNotificationAccessorTest {
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
 
         Mockito.when(notificationContentRepository.existsByContentId(contentId)).thenReturn(false);
-        Mockito.when(notificationContentRepository.saveAllAndFlush(Mockito.any())).thenReturn(List.of(savedEntity));
+        Mockito.when(notificationContentRepository.findByContentIdIn(Mockito.any())).thenReturn(List.of(savedEntity));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(createConfigurationModel()));
 
         DefaultNotificationAccessor defaultNotificationAccessor = new DefaultNotificationAccessor(
@@ -189,9 +200,17 @@ class DefaultNotificationAccessorTest {
 
         assertEquals(1, result.size(), "Only the first occurrence of a duplicate contentId should be saved");
 
-        ArgumentCaptor<List<NotificationEntity>> saveCaptor = ArgumentCaptor.captor();
-        Mockito.verify(notificationContentRepository).saveAllAndFlush(saveCaptor.capture());
-        assertEquals(1, saveCaptor.getValue().size(), "Only one entity should be passed to saveAllAndFlush when the batch contains a duplicate contentId");
+        Mockito.verify(notificationContentRepository, Mockito.times(1)).saveIgnoreContentIdConflict(
+            Mockito.any(OffsetDateTime.class),
+            Mockito.anyString(),
+            Mockito.any(Long.class),
+            Mockito.any(OffsetDateTime.class),
+            Mockito.anyString(),
+            Mockito.anyString(),
+            Mockito.anyBoolean(),
+            Mockito.anyString(),
+            Mockito.anyBoolean()
+        );
     }
 
     @Test
@@ -216,28 +235,45 @@ class DefaultNotificationAccessorTest {
         NotificationContentRepository notificationContentRepository = Mockito.mock(NotificationContentRepository.class);
 
         Mockito.when(notificationContentRepository.existsByContentId(contentId)).thenReturn(true);
-        Mockito.when(notificationContentRepository.saveAllAndFlush(Mockito.any())).thenReturn(List.of());
 
         DefaultNotificationAccessor defaultNotificationAccessor = new DefaultNotificationAccessor(notificationContentRepository, null, null, notificationBatchRepository);
         List<AlertNotificationModel> result = defaultNotificationAccessor.saveAllNotifications(List.of(alreadyPersistedModel));
 
         assertTrue(result.isEmpty(), "Notifications already in the database should not be saved again");
 
-        ArgumentCaptor<List<NotificationEntity>> saveCaptor = ArgumentCaptor.captor();
-        Mockito.verify(notificationContentRepository).saveAllAndFlush(saveCaptor.capture());
-        assertTrue(saveCaptor.getValue().isEmpty(), "No entities should be passed to saveAllAndFlush when all notifications already exist in the database");
+        Mockito.verify(notificationContentRepository, Mockito.never()).saveIgnoreContentIdConflict(
+            Mockito.any(OffsetDateTime.class),
+            Mockito.anyString(),
+            Mockito.any(Long.class),
+            Mockito.any(OffsetDateTime.class),
+            Mockito.anyString(),
+            Mockito.anyString(),
+            Mockito.anyBoolean(),
+            Mockito.anyString(),
+            Mockito.anyBoolean()
+        );
     }
 
     @Test
     void saveAllNotificationsEmptyModelListTest() {
         NotificationContentRepository notificationContentRepository = Mockito.mock(NotificationContentRepository.class);
 
-        Mockito.when(notificationContentRepository.saveAll(Mockito.any())).thenReturn(new ArrayList<>());
-
         DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, null, notificationBatchRepository);
         List<AlertNotificationModel> alertNotificationModelList = notificationManager.saveAllNotifications(new ArrayList<>());
 
         assertTrue(alertNotificationModelList.isEmpty());
+        Mockito.verify(notificationContentRepository, Mockito.never()).saveIgnoreContentIdConflict(
+            Mockito.any(OffsetDateTime.class),
+            Mockito.anyString(),
+            Mockito.any(Long.class),
+            Mockito.any(OffsetDateTime.class),
+            Mockito.anyString(),
+            Mockito.anyString(),
+            Mockito.anyBoolean(),
+            Mockito.anyString(),
+            Mockito.anyBoolean()
+        );
+        Mockito.verify(notificationContentRepository, Mockito.never()).findByContentIdIn(Mockito.any());
     }
 
     @Test

--- a/alert-database/src/test/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessorTest.java
+++ b/alert-database/src/test/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessorTest.java
@@ -111,8 +111,10 @@ class DefaultNotificationAccessorTest {
         NotificationContentRepository notificationContentRepository = Mockito.mock(NotificationContentRepository.class);
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
 
-        Mockito.when(notificationContentRepository.existsByContentId(contentId)).thenReturn(false);
-        Mockito.when(notificationContentRepository.findByContentIdIn(Mockito.any())).thenReturn(List.of(notificationEntity));
+        // First call: prefetch returns empty (notification does not yet exist); second call: post-save retrieve returns the saved entity
+        Mockito.when(notificationContentRepository.findByContentIdIn(Mockito.any()))
+            .thenReturn(List.of())
+            .thenReturn(List.of(notificationEntity));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
         DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
@@ -177,8 +179,10 @@ class DefaultNotificationAccessorTest {
         NotificationContentRepository notificationContentRepository = Mockito.mock(NotificationContentRepository.class);
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
 
-        Mockito.when(notificationContentRepository.existsByContentId(contentId)).thenReturn(false);
-        Mockito.when(notificationContentRepository.findByContentIdIn(Mockito.any())).thenReturn(List.of(savedEntity));
+        // First call: prefetch returns empty (neither occurrence exists yet); second call: post-save retrieve returns the saved entity
+        Mockito.when(notificationContentRepository.findByContentIdIn(Mockito.any()))
+            .thenReturn(List.of())
+            .thenReturn(List.of(savedEntity));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(createConfigurationModel()));
 
         DefaultNotificationAccessor defaultNotificationAccessor = new DefaultNotificationAccessor(
@@ -213,9 +217,23 @@ class DefaultNotificationAccessorTest {
             false
         );
 
+        NotificationEntity existingEntity = new NotificationEntity(
+            id,
+            createdAt,
+            provider,
+            providerConfigId,
+            providerCreationTime,
+            notificationType,
+            content,
+            false,
+            contentId,
+            false
+        );
+
         NotificationContentRepository notificationContentRepository = Mockito.mock(NotificationContentRepository.class);
 
-        Mockito.when(notificationContentRepository.existsByContentId(contentId)).thenReturn(true);
+        // Prefetch returns the existing entity, causing the in-memory filter to skip it
+        Mockito.when(notificationContentRepository.findByContentIdIn(Mockito.any())).thenReturn(List.of(existingEntity));
 
         DefaultNotificationAccessor defaultNotificationAccessor = new DefaultNotificationAccessor(notificationContentRepository, null, null, notificationBatchRepository);
         List<AlertNotificationModel> result = defaultNotificationAccessor.saveAllNotifications(List.of(alreadyPersistedModel));

--- a/api-distribution/src/test/java/com/blackduck/integration/alert/api/distribution/mock/MockNotificationContentRepository.java
+++ b/api-distribution/src/test/java/com/blackduck/integration/alert/api/distribution/mock/MockNotificationContentRepository.java
@@ -8,6 +8,7 @@
 package com.blackduck.integration.alert.api.distribution.mock;
 
 import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
@@ -32,6 +33,7 @@ import com.blackduck.integration.alert.test.common.database.MockRepositoryContai
 
 public class MockNotificationContentRepository extends MockRepositoryContainer<Long, NotificationEntity> implements NotificationContentRepository {
     private final MockNotificationBatchRepository mockNotificationBatchRepository;
+
     public MockNotificationContentRepository(final Function<NotificationEntity, Long> idGenerator) {
         super(idGenerator);
         mockNotificationBatchRepository = new MockNotificationBatchRepository();
@@ -202,7 +204,7 @@ public class MockNotificationContentRepository extends MockRepositoryContainer<L
     }
 
     @Override
-    public Page<NotificationEntity> findNotMappedAndNotProcessedNotifications(long providerConfigId, UUID batchId,  Pageable pageable) {
+    public Page<NotificationEntity> findNotMappedAndNotProcessedNotifications(long providerConfigId, UUID batchId, Pageable pageable) {
         Set<Long> notificationsInBatch = mockNotificationBatchRepository.findAll().stream()
             .filter(entity -> entity.getBatchId().equals(batchId))
             .map(NotificationBatchEntity::getNotificationId)
@@ -212,12 +214,12 @@ public class MockNotificationContentRepository extends MockRepositoryContainer<L
         Predicate<NotificationEntity> notProcessed = Predicate.not(NotificationEntity::getProcessed);
         Predicate<NotificationEntity> providerConfigIdEqual = notificationEntity -> notificationEntity.getProviderConfigId().equals(providerConfigId);
         List<NotificationEntity> notifications = findAll().stream()
-                .sorted(Comparator.comparing(NotificationEntity::getProviderCreationTime))
-                .filter(providerConfigIdEqual)
-                .filter(notificationInBatch)
-                .filter(mappingFalse)
-                .filter(notProcessed)
-                .toList();
+            .sorted(Comparator.comparing(NotificationEntity::getProviderCreationTime))
+            .filter(providerConfigIdEqual)
+            .filter(notificationInBatch)
+            .filter(mappingFalse)
+            .filter(notProcessed)
+            .toList();
         int pageSize = pageable.getPageSize();
         int pageNumber = pageable.getPageNumber();
         List<List<NotificationEntity>> partitionedLists = ListUtils.partition(notifications, pageSize);
@@ -235,14 +237,14 @@ public class MockNotificationContentRepository extends MockRepositoryContainer<L
         Predicate<NotificationEntity> notMapped = Predicate.not(NotificationEntity::isMappingToJobs);
         Predicate<NotificationEntity> providerAndMappingToJobsFalse = providerConfigIdEqual.and(notMapped);
         return findAll()
-                .stream()
-                .anyMatch(providerAndMappingToJobsFalse);
+            .stream()
+            .anyMatch(providerAndMappingToJobsFalse);
     }
 
     @Override
     public void setMappingToJobsByIds(Set<Long> notificationIds) {
         findAllById(notificationIds)
-                .forEach(NotificationEntity::setMappingToJobsToTrue);
+            .forEach(NotificationEntity::setMappingToJobsToTrue);
     }
 
     @Override
@@ -253,27 +255,29 @@ public class MockNotificationContentRepository extends MockRepositoryContainer<L
         Predicate<NotificationEntity> providerMappingAndProcessedFalse = providerConfigIdEqual.and(notMapped).and(notProcessed);
 
         List<NotificationEntity> entities = findAll().stream()
-                .filter(providerMappingAndProcessedFalse)
-                .toList();
+            .filter(providerMappingAndProcessedFalse)
+            .toList();
 
         List<NotificationEntity> updatedEntities = entities.stream()
-                .map(this::setMappingAndProcessedToFalse)
-                .toList();
+            .map(this::setMappingAndProcessedToFalse)
+            .toList();
 
         saveAll(updatedEntities);
     }
 
     private NotificationEntity setMappingAndProcessedToFalse(NotificationEntity entity) {
-        return new NotificationEntity(entity.getId(),
-                entity.getCreatedAt(),
-                entity.getProvider(),
-                entity.getProviderConfigId(),
-                entity.getProviderCreationTime(),
-                entity.getNotificationType(),
-                entity.getContent(),
-                false,
-                entity.getContentId(),
-                false);
+        return new NotificationEntity(
+            entity.getId(),
+            entity.getCreatedAt(),
+            entity.getProvider(),
+            entity.getProviderConfigId(),
+            entity.getProviderCreationTime(),
+            entity.getNotificationType(),
+            entity.getContent(),
+            false,
+            entity.getContentId(),
+            false
+        );
     }
 
     @Override
@@ -285,6 +289,30 @@ public class MockNotificationContentRepository extends MockRepositoryContainer<L
         return notificationsPerHourMap.entrySet().stream()
             .map(entry -> new NotificationCountsPerHour(entry.getKey(), entry.getValue()))
             .sorted(Comparator.comparing(NotificationCountsPerHour::getAccumulationHour))
+            .toList();
+    }
+
+    @Override
+    public void saveIgnoreContentIdConflict(
+        final OffsetDateTime createdAt,
+        final String provider,
+        final Long providerConfigId,
+        final OffsetDateTime providerCreationTime,
+        final String notificationType,
+        final String content,
+        final boolean processed,
+        final String contentId,
+        final boolean mappingToJobs
+    ) {
+        if (!existsByContentId(contentId)) {
+            super.save(new NotificationEntity(createdAt, provider, providerConfigId, providerCreationTime, notificationType, content, processed, contentId, mappingToJobs));
+        }
+    }
+
+    @Override
+    public List<NotificationEntity> findByContentIdIn(final Collection<String> contentIds) {
+        return findAll().stream()
+            .filter(entity -> contentIds.contains(entity.getContentId()))
             .toList();
     }
 }

--- a/src/test/java/com/blackduck/integration/alert/NotificationAccessorTestIT.java
+++ b/src/test/java/com/blackduck/integration/alert/NotificationAccessorTestIT.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -526,14 +527,17 @@ class NotificationAccessorTestIT {
     }
 
     private AlertNotificationModel createNotificationModelWithContentId(OffsetDateTime createdAt, String contentId) {
+        // Truncate to microseconds to match PostgreSQL TIMESTAMP WITH TIME ZONE precision.
+        // Without this, some systems with only microsecond precision will result in tests failures.
+        OffsetDateTime microsCreatedAt = createdAt.truncatedTo(ChronoUnit.MICROS);
         return new AlertNotificationModel(
             providerConfigModel.getConfigurationId(),
             "provider",
             "providerConfigName",
             NOTIFICATION_TYPE,
             "{content: \"content is here...\"}",
-            createdAt,
-            createdAt,
+            microsCreatedAt,
+            microsCreatedAt,
             false,
             contentId,
             false

--- a/src/test/java/com/blackduck/integration/alert/NotificationAccessorTestIT.java
+++ b/src/test/java/com/blackduck/integration/alert/NotificationAccessorTestIT.java
@@ -290,7 +290,12 @@ class NotificationAccessorTestIT {
         notificationManager.saveAllNotifications(List.of(entityToFind1));
         notificationManager.saveAllNotifications(List.of(entityToFind2));
 
-        List<AlertNotificationModel> foundList = notificationManager.findByCreatedAtBetween(startDate, endDate, AlertPagedModel.DEFAULT_PAGE_NUMBER, AlertPagedModel.DEFAULT_PAGE_SIZE).getModels();
+        List<AlertNotificationModel> foundList = notificationManager.findByCreatedAtBetween(
+            startDate,
+            endDate,
+            AlertPagedModel.DEFAULT_PAGE_NUMBER,
+            AlertPagedModel.DEFAULT_PAGE_SIZE
+        ).getModels();
 
         assertEquals(2, foundList.size());
         assertNotificationModel(entityToFind1, foundList.get(0));
@@ -310,7 +315,12 @@ class NotificationAccessorTestIT {
         entity = createNotificationModel(createdAtLater);
         notificationManager.saveAllNotifications(List.of(entity));
 
-        List<AlertNotificationModel> foundList = notificationManager.findByCreatedAtBetween(startDate, endDate, AlertPagedModel.DEFAULT_PAGE_NUMBER, AlertPagedModel.DEFAULT_PAGE_SIZE).getModels();
+        List<AlertNotificationModel> foundList = notificationManager.findByCreatedAtBetween(
+            startDate,
+            endDate,
+            AlertPagedModel.DEFAULT_PAGE_NUMBER,
+            AlertPagedModel.DEFAULT_PAGE_SIZE
+        ).getModels();
 
         assertTrue(foundList.isEmpty());
     }
@@ -381,6 +391,36 @@ class NotificationAccessorTestIT {
     }
 
     @Test
+    void testSaveSkipsDuplicateContentIdInBatch() {
+        String sharedContentId = "duplicate-content-id-" + UUID.randomUUID();
+        OffsetDateTime createdAt = DateUtils.createCurrentDateTimestamp();
+
+        AlertNotificationModel firstOccurrence = createNotificationModelWithContentId(createdAt, sharedContentId);
+        AlertNotificationModel duplicateOccurrence = createNotificationModelWithContentId(createdAt, sharedContentId);
+
+        List<AlertNotificationModel> savedModels = notificationManager.saveAllNotifications(List.of(firstOccurrence, duplicateOccurrence));
+
+        assertEquals(1, savedModels.size(), "Only the first occurrence of a duplicate contentId in a batch should be saved");
+        assertEquals(1, notificationContentRepository.count(), "Only one row should exist in the database after saving a batch with a duplicate contentId");
+    }
+
+    @Test
+    void testSaveSkipsNotificationAlreadyInDatabase() {
+        String sharedContentId = "existing-content-id-" + UUID.randomUUID();
+        OffsetDateTime createdAt = DateUtils.createCurrentDateTimestamp();
+
+        AlertNotificationModel original = createNotificationModelWithContentId(createdAt, sharedContentId);
+        List<AlertNotificationModel> firstSave = notificationManager.saveAllNotifications(List.of(original));
+        assertEquals(1, firstSave.size(), "First save should persist the notification");
+
+        AlertNotificationModel duplicate = createNotificationModelWithContentId(createdAt, sharedContentId);
+        List<AlertNotificationModel> secondSave = notificationManager.saveAllNotifications(List.of(duplicate));
+
+        assertTrue(secondSave.isEmpty(), "Saving a notification whose contentId already exists in the database should return an empty list");
+        assertEquals(1, notificationContentRepository.count(), "The database should still contain only one notification after a duplicate save attempt");
+    }
+
+    @Test
     void testDeleteNotification() {
         AlertNotificationModel notificationEntity = createNotificationModel();
         AlertNotificationModel savedModel = notificationManager.saveAllNotifications(List.of(notificationEntity)).get(0);
@@ -423,7 +463,16 @@ class NotificationAccessorTestIT {
         assertTrue(alertNotificationModelTest.get().getProcessed());
     }
 
+    private AlertNotificationModel createNotificationModel() {
+        OffsetDateTime createdAt = DateUtils.createCurrentDateTimestamp();
+        return createNotificationModel(createdAt);
+    }
+
     private AlertNotificationModel createNotificationModel(OffsetDateTime createdAt) {
+        return createNotificationModelWithContentId(createdAt, String.format("content-id-%s", UUID.randomUUID()));
+    }
+
+    private AlertNotificationModel createNotificationModelWithContentId(OffsetDateTime createdAt, String contentId) {
         return new AlertNotificationModel(
             providerConfigModel.getConfigurationId(),
             "provider",
@@ -433,18 +482,20 @@ class NotificationAccessorTestIT {
             createdAt,
             createdAt,
             false,
-            String.format("content-id-%s", UUID.randomUUID()),
+            contentId,
             false
         );
     }
 
-    private AlertNotificationModel createNotificationModel() {
-        OffsetDateTime createdAt = DateUtils.createCurrentDateTimestamp();
-        return createNotificationModel(createdAt);
-    }
-
     private NotificationEntity createNotificationContent(OffsetDateTime createdAt) {
-        MockNotificationContent mockedNotificationContent = new MockNotificationContent(createdAt, "provider", createdAt, NOTIFICATION_TYPE, "{content: \"content is here...\"}", providerConfigModel.getConfigurationId());
+        MockNotificationContent mockedNotificationContent = new MockNotificationContent(
+            createdAt,
+            "provider",
+            createdAt,
+            NOTIFICATION_TYPE,
+            "{content: \"content is here...\"}",
+            providerConfigModel.getConfigurationId()
+        );
         return mockedNotificationContent.createEntity();
     }
 

--- a/src/test/java/com/blackduck/integration/alert/NotificationAccessorTestIT.java
+++ b/src/test/java/com/blackduck/integration/alert/NotificationAccessorTestIT.java
@@ -120,7 +120,6 @@ class NotificationAccessorTestIT {
 
     private void cleanDB() {
         notificationContentRepository.deleteAllInBatch();
-        notificationContentRepository.deleteAllInBatch();
         auditNotificationRepository.deleteAllInBatch();
         auditEntryRepository.deleteAllInBatch();
         descriptorConfigRepository.deleteAllInBatch();
@@ -390,6 +389,9 @@ class NotificationAccessorTestIT {
         assertEquals(notification1.getCreatedAt(), remainingNotification.getCreatedAt());
     }
 
+    /**
+     * Verifies that only the first occurrence of a duplicate {@code contentId} within a single batch is persisted.
+     */
     @Test
     void testSaveSkipsDuplicateContentIdInBatch() {
         String sharedContentId = "duplicate-content-id-" + UUID.randomUUID();
@@ -404,6 +406,9 @@ class NotificationAccessorTestIT {
         assertEquals(1, notificationContentRepository.count(), "Only one row should exist in the database after saving a batch with a duplicate contentId");
     }
 
+    /**
+     * Verifies that a notification whose {@code contentId} already exists in the database is not persisted again.
+     */
     @Test
     void testSaveSkipsNotificationAlreadyInDatabase() {
         String sharedContentId = "existing-content-id-" + UUID.randomUUID();
@@ -418,6 +423,54 @@ class NotificationAccessorTestIT {
 
         assertTrue(secondSave.isEmpty(), "Saving a notification whose contentId already exists in the database should return an empty list");
         assertEquals(1, notificationContentRepository.count(), "The database should still contain only one notification after a duplicate save attempt");
+    }
+
+    /**
+     * Verifies that {@link DefaultNotificationAccessor#saveAllNotifications} correctly handles a batch
+     * containing all three deduplication scenarios simultaneously:
+     * <ul>
+     *   <li>Notifications whose {@code contentId} is new — these should be persisted and returned.</li>
+     *   <li>Notifications whose {@code contentId} already exists in the database — these should be silently skipped.</li>
+     *   <li>Notifications whose {@code contentId} appears more than once within the same batch — only the first
+     *       occurrence should be persisted; subsequent duplicates should be filtered.</li>
+     * </ul>
+     */
+    @Test
+    void testSaveMixedBatchContentIds() {
+        OffsetDateTime createdAt = DateUtils.createCurrentDateTimestamp();
+
+        // Save 2 notifications so they already exist in the database
+        String existingContentId1 = "existing-1-" + UUID.randomUUID();
+        String existingContentId2 = "existing-2-" + UUID.randomUUID();
+        notificationManager.saveAllNotifications(List.of(
+            createNotificationModelWithContentId(createdAt, existingContentId1),
+            createNotificationModelWithContentId(createdAt, existingContentId2)
+        ));
+
+        // Build a mixed batch:
+        // - 2 new unique notifications (should be saved)
+        // - 2 already in the database (should be skipped)
+        // - 1 in-batch duplicate of a new notification (should be skipped)
+        String newContentId1 = "new-1-" + UUID.randomUUID();
+        String newContentId2 = "new-2-" + UUID.randomUUID();
+        List<AlertNotificationModel> mixedBatch = List.of(
+            createNotificationModelWithContentId(createdAt, newContentId1),
+            createNotificationModelWithContentId(createdAt, newContentId2),
+            createNotificationModelWithContentId(createdAt, existingContentId1),
+            createNotificationModelWithContentId(createdAt, existingContentId2),
+            createNotificationModelWithContentId(createdAt, newContentId1)
+        );
+
+        List<AlertNotificationModel> savedModels = notificationManager.saveAllNotifications(mixedBatch);
+
+        assertEquals(2, savedModels.size(), "Only the 2 new unique notifications should be returned when saving.");
+        assertEquals(4, notificationContentRepository.count(), "The database should contain 2 pre-existing + 2 new notifications.");
+
+        List<String> savedContentIds = savedModels.stream()
+            .map(AlertNotificationModel::getContentId)
+            .toList();
+        assertTrue(savedContentIds.contains(newContentId1), "The first new notification should be in the returned list");
+        assertTrue(savedContentIds.contains(newContentId2), "The second new notification should be in the returned list");
     }
 
     @Test

--- a/src/test/java/com/blackduck/integration/alert/database/notification/NotificationContentRepositoryTestIT.java
+++ b/src/test/java/com/blackduck/integration/alert/database/notification/NotificationContentRepositoryTestIT.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
@@ -36,6 +37,7 @@ import com.blackduck.integration.alert.test.common.TestTags;
 import com.blackduck.integration.alert.util.AlertIntegrationTest;
 import com.blackduck.integration.blackduck.api.manual.enumeration.NotificationType;
 
+@Transactional
 @AlertIntegrationTest
 @Tag(TestTags.DEFAULT_INTEGRATION)
 class NotificationContentRepositoryTestIT {
@@ -56,7 +58,6 @@ class NotificationContentRepositoryTestIT {
     }
 
     @Test
-    @Transactional
     void findByProcessedFalseOrderByProviderCreationTimeAscTestIT() {
         // Create provider config (required for FK constraint)
         DescriptorConfigEntity providerConfig = createProviderConfig();
@@ -94,7 +95,6 @@ class NotificationContentRepositoryTestIT {
     }
 
     @Test
-    @Transactional
     void countByProcessedTest() {
         DescriptorConfigEntity providerConfig = createProviderConfig();
         Long providerConfigId = providerConfig.getId();
@@ -107,6 +107,99 @@ class NotificationContentRepositoryTestIT {
 
         assertEquals(1, notificationContentRepository.countByProcessed(true));
         assertEquals(2, notificationContentRepository.countByProcessed(false));
+    }
+
+    @Test
+    void saveIgnoreContentIdConflictInsertsNewNotificationTest() {
+        DescriptorConfigEntity providerConfig = createProviderConfig();
+        String contentId = String.format("content-id-%s", UUID.randomUUID());
+
+        saveNotificationWithContentId(providerConfig.getId(), contentId);
+
+        assertEquals(1, notificationContentRepository.count(), "A new notification with a unique contentId should be inserted");
+    }
+
+    @Test
+    void saveIgnoreContentIdConflictIgnoresDuplicateContentIdTest() {
+        DescriptorConfigEntity providerConfig = createProviderConfig();
+        String contentId = String.format("content-id-%s", UUID.randomUUID());
+
+        saveNotificationWithContentId(providerConfig.getId(), contentId);
+        saveNotificationWithContentId(providerConfig.getId(), contentId);
+
+        assertEquals(1, notificationContentRepository.count(), "A duplicate contentId not produce a second row");
+    }
+
+    @Test
+    void saveIgnoreContentIdConflictSequentialIdIncrementTest() {
+        DescriptorConfigEntity providerConfig = createProviderConfig();
+        int numberOfNotifications = 5;
+        List<String> contentIds = new ArrayList<>();
+        for (int i = 0; i < numberOfNotifications; i++) {
+            String contentId = String.format("content-id-%s", UUID.randomUUID());
+            contentIds.add(contentId);
+            saveNotificationWithContentId(providerConfig.getId(), contentId);
+        }
+
+        List<NotificationEntity> savedNotificationEntities = notificationContentRepository.findByContentIdIn(contentIds);
+        savedNotificationEntities.sort(Comparator.comparing(NotificationEntity::getId));
+
+        assertEquals(numberOfNotifications, savedNotificationEntities.size());
+        long firstId = savedNotificationEntities.get(0).getId();
+        for (int i = 0; i < savedNotificationEntities.size(); i++) {
+            assertEquals(firstId + i, savedNotificationEntities.get(i).getId(), "Notification IDs should be sequential starting from the first inserted ID");
+        }
+    }
+
+    @Test
+    void findByContentIdInReturnsMatchingEntitiesTest() {
+        DescriptorConfigEntity providerConfig = createProviderConfig();
+        OffsetDateTime now = OffsetDateTime.now();
+
+        NotificationEntity first = createNotification(providerConfig.getId(), now);
+        NotificationEntity second = createNotification(providerConfig.getId(), now);
+        notificationContentRepository.saveAll(List.of(first, second));
+
+        List<NotificationEntity> result = notificationContentRepository.findByContentIdIn(List.of(first.getContentId(), second.getContentId()));
+
+        assertEquals(2, result.size(), "Both saved notifications should be returned when queried by their contentIds");
+    }
+
+    @Test
+    void findByContentIdInReturnsEmptyWhenNoMatchesTest() {
+        List<NotificationEntity> result = notificationContentRepository.findByContentIdIn(
+            List.of(String.format("non-existent-content-id-%s", UUID.randomUUID()), String.format("non-existent-content-id-%s", UUID.randomUUID()))
+        );
+
+        assertTrue(result.isEmpty(), "No entities should be returned when none of the contentIds exist in the database");
+    }
+
+    @Test
+    void findByContentIdInReturnsSubsetForPartialMatchesTest() {
+        DescriptorConfigEntity providerConfig = createProviderConfig();
+        NotificationEntity saved = createNotification(providerConfig.getId(), OffsetDateTime.now());
+        notificationContentRepository.save(saved);
+
+        List<NotificationEntity> result = notificationContentRepository.findByContentIdIn(
+            List.of(saved.getContentId(), String.format("non-existent-content-id-%s", UUID.randomUUID()))
+        );
+
+        assertEquals(1, result.size(), "Only the notification with a matching contentId should be returned");
+        assertEquals(saved.getContentId(), result.get(0).getContentId(), "The returned entity should match the saved contentId");
+    }
+
+    private void saveNotificationWithContentId(Long providerConfigId, String contentId) {
+        notificationContentRepository.saveIgnoreContentIdConflict(
+            OffsetDateTime.now(),
+            BLACK_DUCK_PROVIDER_KEY.getUniversalKey(),
+            providerConfigId,
+            OffsetDateTime.now(),
+            NotificationType.VULNERABILITY.name(),
+            "{\"content\": {}}",
+            false,
+            contentId,
+            false
+        );
     }
 
     private DescriptorConfigEntity createProviderConfig() {

--- a/src/test/java/com/blackduck/integration/alert/database/notification/NotificationContentRepositoryTestIT.java
+++ b/src/test/java/com/blackduck/integration/alert/database/notification/NotificationContentRepositoryTestIT.java
@@ -127,7 +127,7 @@ class NotificationContentRepositoryTestIT {
         saveNotificationWithContentId(providerConfig.getId(), contentId);
         saveNotificationWithContentId(providerConfig.getId(), contentId);
 
-        assertEquals(1, notificationContentRepository.count(), "A duplicate contentId not produce a second row");
+        assertEquals(1, notificationContentRepository.count(), "A duplicate contentId should not produce a second row");
     }
 
     @Test


### PR DESCRIPTION
This MR fixes a bug where the same Black Duck notification could be persisted multiple times to alert.raw_notification_content resulting in a DB constraint violation. This likely occurred when the same content_id appeared more than once within a single batch, or when a subsequent batch arrived containing a content_id that had already been saved.

To address the issue we've taken a two phase approach to handle de-duplication:
- In memory deduplication using a Set to filter duplicates within a batch of notifications before sending to the DB.
- Database level deduplication to include a native insert using an ON CONFLICT DO NOTHING clause as added safety.

Supporting the Database changes required a number of changes to move to a native query as typically writes in Alert were managed using JPA's save/saveAll methods. As these methods do not support custom clauses, additional changes were required to handle sequencing IDs in the raw_notification_content. To support this, I have added a new changelog as well as a change to our init database script to set increment to go by 1 rather than the previous 50 allocated and managed through Hibernate.

Some Alert specific details:
- Alert will grab batches of notifications 200 at a time and write them into the Alert database. 
- When Alert determines the next window of notifications to fetch it will use the time of the last notification in Black Duck.
- For auditing and logging reasons, Alert is doing validation to determine whether notifications exist in the database before calling the save. This logging is vital when tracking and auditing notifications from Black Duck.
- content_id is a hash created using the user-notification href from Black Duck. It is representative of the notification that we receive and therefore not a true unique identifier. This is used to determine if notifications have already been persisted when processing. Some users will re-play their notifications from Black Duck and this functionality ensures we do not write duplicate values into the database when multiple accumulations occur. 

Notable File Changes:
DefaultNotificationAccessor:
- Replaced `saveAllAndFlush` with a per-entity saveIgnoreContentIdConflict loop, guarded by an in-memory Set to skip within batch duplicates.
- Added helper method findByContentIdIn to find all saved rows by the list of contentIds.

NotificationContentRepository:
- Added a native SQL statement to perform insert for notifications with the added "ON CONFLICT (content_id) DO NOTHING.
- Added JPA query to perform bulk lookup of entities by content ID.

NotificationEntity
- Added marker parameters to the column for "contentId" to better describe the constraints that is implemented for this column in JDBC.
- Changed the allocation size to be consistent with the new increment value for situations where save or saveAll are called using the legacy JPA method.

liquibase files:
- Changed the increment for existing customers to use 1 rather than the hibernate default 50. This ensures clients get the new number on an upgrade scenario.

init_alert_db.sql:
- Changed the increment for fresh installs.


