### PR TITLE
IALERT-4058: Surface Audit Failure Stacktraces to Users

### DIFF
--- a/ui/src/main/js/common/component/table/Table.js
+++ b/ui/src/main/js/common/component/table/Table.js
@@ -34,7 +34,7 @@ const useStyles = createUseStyles((theme) => ({
 const Table = ({
     columns, multiSelect, selected, onSelected, disableSelectOptions, tableData, handleSearchChange,
     searchBarPlaceholder, tableActions, onToggle, active, onSort, sortConfig, data, onPage, emptyTableConfig,
-    defaultSearchValue, onPageSize, showPageSize, pageSize, cellId, isLoading
+    defaultSearchValue, onPageSize, showPageSize, pageSize, cellId, isLoading, ExpandableContent, isExpandable
 }) => {
     const classes = useStyles();
 
@@ -82,6 +82,7 @@ const Table = ({
                             sortConfig={sortConfig}
                             disableSelectOptions={disableSelectOptions}
                             cellId={cellId}
+                            hasExpandableContent={!!ExpandableContent}
                         />
                         <TableBody
                             columns={columns}
@@ -91,6 +92,8 @@ const Table = ({
                             onSelected={onSelected}
                             disableSelectOptions={disableSelectOptions}
                             cellId={cellId}
+                            ExpandableContent={ExpandableContent}
+                            isExpandable={isExpandable}
                         />
                     </table>
 
@@ -134,7 +137,9 @@ Table.propTypes = {
     defaultSearchValue: PropTypes.string,
     pageSize: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     cellId: PropTypes.string,
-    isLoading: PropTypes.bool
+    isLoading: PropTypes.bool,
+    ExpandableContent: PropTypes.func,
+    isExpandable: PropTypes.func
 };
 
 export default Table;

--- a/ui/src/main/js/common/component/table/TableBody.js
+++ b/ui/src/main/js/common/component/table/TableBody.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import MultiSelectCell from 'common/component/table/cell/MultiSelectCell';
 import WrapperCell from 'common/component/table/cell/WrapperCell';
 import { createUseStyles } from 'react-jss';
@@ -14,50 +15,170 @@ const useStyles = createUseStyles((theme) => ({
         '& > :first-child': {
             paddingLeft: '35px'
         }
+    },
+    nonMultiSelectExpandable: {
+        '& > :nth-child(2)': {
+            paddingLeft: '35px'
+        }
+    },
+    rowExpander: {
+        cursor: 'pointer',
+        '&:hover': {
+            backgroundColor: theme.colors.white.darkWhite
+        }
+    },
+    rowExpanded: {
+        cursor: 'pointer',
+        backgroundColor: theme.colors.white.darkWhite
+    },
+    expandIconCell: {
+        width: '40px',
+        paddingLeft: '12px'
+    },
+    expandIconPlaceholder: {
+        width: '40px'
+    },
+    expandedContentRow: {
+        borderBottom: `1px solid ${theme.colors.grey.lighterGrey}`
+    },
+    expandedContentCell: {
+        padding: '16px 24px',
+        overflowWrap: 'break-word',
+        wordBreak: 'break-word',
+        maxWidth: 0
     }
 }));
 
-const TableBody = ({ columns, multiSelect, tableData, selected, onSelected, disableSelectOptions, cellId }) => {
+const ACTION_ELEMENTS = ['button', 'a'];
+
+function isAction(element) {
+    return ACTION_ELEMENTS.some(tag => element.closest(tag));
+}
+
+function ExpandedContentCell({ data, expandedRows, rowIndex, isExpandable, ExpandableContent }) {
     const classes = useStyles();
 
-    const tableRowClass = classNames(classes.tableRow, {
-        [classes.nonMultiSelect]: !multiSelect
-    });
+    if (!ExpandableContent) {
+        return null;
+    }
+
+    if (isExpandable(data)) {
+        const isExpanded = expandedRows.includes(rowIndex);
+        return (
+            <td className={classes.expandIconCell}>
+                <FontAwesomeIcon
+                    icon={isExpanded ? 'chevron-down' : 'chevron-right'}
+                    size="sm"
+                    fixedWidth
+                />
+            </td>
+        );
+    }
+
+    return <td className={classes.expandIconPlaceholder} />;
+}
+
+ExpandedContentCell.propTypes = {
+    data: PropTypes.object,
+    expandedRows: PropTypes.arrayOf(PropTypes.number),
+    rowIndex: PropTypes.number,
+    isExpandable: PropTypes.func,
+    ExpandableContent: PropTypes.func
+};
+
+const TableBody = ({ columns, multiSelect, tableData, selected, onSelected, disableSelectOptions, cellId, ExpandableContent, isExpandable }) => {
+    const classes = useStyles();
+    const [expandedRows, setExpandedRows] = useState([]);
+
+    const totalColumns = columns.length + (multiSelect ? 1 : 0) + (ExpandableContent ? 1 : 0);
+
+    useEffect(() => {
+        setExpandedRows([]);
+    }, [tableData]);
+
+    function isRowExpanded(rowIndex) {
+        return expandedRows.includes(rowIndex);
+    }
+
+    function handleRowExpander(rowIndex) {
+        if (isRowExpanded(rowIndex)) {
+            setExpandedRows(prev => prev.filter(i => i !== rowIndex));
+        } else {
+            setExpandedRows(prev => [...prev, rowIndex]);
+        }
+    }
+
+    function handleRowClick(event, rowData, rowIndex) {
+        if (isExpandable?.(rowData) && !isAction(event.target)) {
+            handleRowExpander(rowIndex);
+        }
+    }
 
     return (
         <tbody>
-            {tableData?.map((rowData, rowIndex) => (
-                <tr key={`${rowIndex}-table-row`} className={tableRowClass}>
-                    {multiSelect && (
-                        <MultiSelectCell
-                            data={rowData}
-                            selected={selected}
-                            onSelected={onSelected}
-                            disableSelectOptions={disableSelectOptions}
-                            cellId={cellId}
-                        />
-                    )}
+            {tableData?.map((rowData, rowIndex) => {
+                const expandable = isExpandable?.(rowData);
+                const expanded = isRowExpanded(rowIndex);
 
-                    { columns.map((col, colIndex) => {
-                        const columnKey = `${col.key}-${rowIndex}-${colIndex}`;
-                        if (col.customCell) {
-                            const CustomCell = col.customCell;
+                const tableRowClass = classNames(classes.tableRow, {
+                    [classes.nonMultiSelect]: !multiSelect && !ExpandableContent,
+                    [classes.nonMultiSelectExpandable]: !multiSelect && ExpandableContent,
+                    [classes.rowExpander]: expandable && !expanded,
+                    [classes.rowExpanded]: expandable && expanded
+                });
 
-                            return (
-                                <WrapperCell key={columnKey} settings={col.settings}>
-                                    <CustomCell id={col.key} data={rowData} settings={col.settings} customCallback={col.customCallback} />
-                                </WrapperCell>
-                            );
-                        }
+                return (
+                    <React.Fragment key={`${rowIndex}-table-row`}>
+                        <tr
+                            className={tableRowClass}
+                            onClick={event => handleRowClick(event, rowData, rowIndex)}
+                        >
+                            <ExpandedContentCell
+                                data={rowData}
+                                rowIndex={rowIndex}
+                                expandedRows={expandedRows}
+                                isExpandable={isExpandable}
+                                ExpandableContent={ExpandableContent}
+                            />
 
-                        return (
-                            <WrapperCell key={columnKey} datakey={col.key}>
-                                {rowData[col.key] ?? '\u2014'}
-                            </WrapperCell>
-                        );
-                    })}
-                </tr>
-            ))}
+                            {multiSelect && (
+                                <MultiSelectCell
+                                    data={rowData}
+                                    selected={selected}
+                                    onSelected={onSelected}
+                                    disableSelectOptions={disableSelectOptions}
+                                    cellId={cellId}
+                                />
+                            )}
+
+                            {columns.map((col, colIndex) => {
+                                const columnKey = `${col.key}-${rowIndex}-${colIndex}`;
+                                if (col.customCell) {
+                                    const CustomCell = col.customCell;
+                                    return (
+                                        <WrapperCell key={columnKey} settings={col.settings}>
+                                            <CustomCell id={col.key} data={rowData} settings={col.settings} customCallback={col.customCallback} />
+                                        </WrapperCell>
+                                    );
+                                }
+                                return (
+                                    <WrapperCell key={columnKey} datakey={col.key}>
+                                        {rowData[col.key] ?? '—'}
+                                    </WrapperCell>
+                                );
+                            })}
+                        </tr>
+
+                        {expanded && (
+                            <tr className={classes.expandedContentRow}>
+                                <td className={classes.expandedContentCell} colSpan={totalColumns}>
+                                    {ExpandableContent(rowData)}
+                                </td>
+                            </tr>
+                        )}
+                    </React.Fragment>
+                );
+            })}
         </tbody>
     );
 };
@@ -73,7 +194,9 @@ TableBody.propTypes = {
     onSelected: PropTypes.func,
     tableData: PropTypes.arrayOf(PropTypes.object),
     disableSelectOptions: PropTypes.object,
-    cellId: PropTypes.string
+    cellId: PropTypes.string,
+    ExpandableContent: PropTypes.func,
+    isExpandable: PropTypes.func
 };
 
 export default TableBody;

--- a/ui/src/main/js/common/component/table/TableBody.js
+++ b/ui/src/main/js/common/component/table/TableBody.js
@@ -49,10 +49,10 @@ const useStyles = createUseStyles((theme) => ({
     }
 }));
 
-const ACTION_ELEMENTS = ['button', 'a'];
+const ACTION_ELEMENTS = ['button', 'a', 'input', 'select', 'textarea', 'label'];
 
 function isAction(element) {
-    return ACTION_ELEMENTS.some(tag => element.closest(tag));
+    return element?.closest ? ACTION_ELEMENTS.some(tag => element.closest(tag)) : false;
 }
 
 function ExpandedContentCell({ data, expandedRows, rowIndex, isExpandable, ExpandableContent }) {
@@ -62,7 +62,7 @@ function ExpandedContentCell({ data, expandedRows, rowIndex, isExpandable, Expan
         return null;
     }
 
-    if (isExpandable(data)) {
+    if (isExpandable?.(data)) {
         const isExpanded = expandedRows.includes(rowIndex);
         return (
             <td className={classes.expandIconCell}>
@@ -131,7 +131,19 @@ const TableBody = ({ columns, multiSelect, tableData, selected, onSelected, disa
                     <React.Fragment key={`${rowIndex}-table-row`}>
                         <tr
                             className={tableRowClass}
+                            role={expandable ? 'button' : undefined}
+                            tabIndex={expandable ? 0 : undefined}
+                            aria-expanded={expandable ? expanded : undefined}
                             onClick={event => handleRowClick(event, rowData, rowIndex)}
+                            onKeyDown={(event) => {
+                                 if (!expandable || isAction(event.target)) {
+                                     return;
+                                 }
+                                 if (event.key === 'Enter' || event.key === ' ') {
+                                     event.preventDefault();
+                                     handleRowExpander(rowIndex);
+                                 }
+                             }}
                         >
                             <ExpandedContentCell
                                 data={rowData}

--- a/ui/src/main/js/common/component/table/TableHeader.js
+++ b/ui/src/main/js/common/component/table/TableHeader.js
@@ -20,20 +20,29 @@ const useStyles = createUseStyles((theme) => ({
         '& > tr > :first-child': {
             paddingLeft: '30px'
         }
+    },
+    nonMultiSelectExpandable: {
+        '& > tr > :nth-child(2)': {
+            paddingLeft: '30px'
+        }
+    },
+    expandIconHeader: {
+        width: '40px'
     }
 }));
 
-const TableHeader = ({ columns, multiSelect, selected, onSelected, tableData, onSort, sortConfig, disableSelectOptions, cellId }) => {
+const TableHeader = ({ columns, multiSelect, selected, onSelected, tableData, onSort, sortConfig, disableSelectOptions, cellId, hasExpandableContent }) => {
     const classes = useStyles();
 
     const tableHeadClass = classNames(classes.tableHead, {
-        [classes.nonMultiSelect]: !multiSelect
+        [classes.nonMultiSelect]: !multiSelect && !hasExpandableContent,
+        [classes.nonMultiSelectExpandable]: !multiSelect && hasExpandableContent
     });
 
     return (
         <thead className={tableHeadClass}>
             <tr>
-                { multiSelect && (
+                {multiSelect && (
                     <MultiSelectHeaderCell
                         selected={selected}
                         onSelected={onSelected}
@@ -43,7 +52,9 @@ const TableHeader = ({ columns, multiSelect, selected, onSelected, tableData, on
                     />
                 )}
 
-                { columns.map((column) => (
+                {hasExpandableContent && <th className={classes.expandIconHeader} />}
+
+                {columns.map((column) => (
                     <TableHeaderCell
                         key={column.key}
                         label={column.label}
@@ -75,7 +86,8 @@ TableHeader.propTypes = {
         direction: PropTypes.string
     }),
     disableSelectOptions: PropTypes.object,
-    cellId: PropTypes.string
+    cellId: PropTypes.string,
+    hasExpandableContent: PropTypes.bool
 };
 
 export default TableHeader;

--- a/ui/src/main/js/common/component/table/TableHeader.js
+++ b/ui/src/main/js/common/component/table/TableHeader.js
@@ -52,7 +52,9 @@ const TableHeader = ({ columns, multiSelect, selected, onSelected, tableData, on
                     />
                 )}
 
-                {hasExpandableContent && <th className={classes.expandIconHeader} />}
+                {hasExpandableContent && 
+                    <th className={classes.expandIconHeader} aria-hidden="true" />
+                }
 
                 {columns.map((column) => (
                     <TableHeaderCell

--- a/ui/src/main/js/common/component/table/cell/WrapperCell.js
+++ b/ui/src/main/js/common/component/table/cell/WrapperCell.js
@@ -21,7 +21,7 @@ const useStyles = createUseStyles({
     }
 });
 
-const WrapperCell = ({ children, settings, colSpan }) => {
+const WrapperCell = ({ children, settings }) => {
     const classes = useStyles();
     const cellStyle = classNames(classes.wrapperCell, {
         [classes.right]: settings?.alignment === 'right',
@@ -29,7 +29,7 @@ const WrapperCell = ({ children, settings, colSpan }) => {
     });
 
     return (
-        <td className={cellStyle} colSpan={colSpan}>
+        <td className={cellStyle}>
             {children}
         </td>
     );
@@ -37,8 +37,7 @@ const WrapperCell = ({ children, settings, colSpan }) => {
 
 WrapperCell.propTypes = {
     settings: PropTypes.object,
-    children: PropTypes.any,
-    colSpan: PropTypes.number
+    children: PropTypes.any
 };
 
 export default WrapperCell;

--- a/ui/src/main/js/common/component/table/cell/WrapperCell.js
+++ b/ui/src/main/js/common/component/table/cell/WrapperCell.js
@@ -21,7 +21,7 @@ const useStyles = createUseStyles({
     }
 });
 
-const WrapperCell = ({ children, settings }) => {
+const WrapperCell = ({ children, settings, colSpan }) => {
     const classes = useStyles();
     const cellStyle = classNames(classes.wrapperCell, {
         [classes.right]: settings?.alignment === 'right',
@@ -29,7 +29,7 @@ const WrapperCell = ({ children, settings }) => {
     });
 
     return (
-        <td className={cellStyle}>
+        <td className={cellStyle} colSpan={colSpan}>
             {children}
         </td>
     );
@@ -37,7 +37,8 @@ const WrapperCell = ({ children, settings }) => {
 
 WrapperCell.propTypes = {
     settings: PropTypes.object,
-    children: PropTypes.any
+    children: PropTypes.any,
+    colSpan: PropTypes.number
 };
 
 export default WrapperCell;

--- a/ui/src/main/js/page/audit/DistributionTable.js
+++ b/ui/src/main/js/page/audit/DistributionTable.js
@@ -69,10 +69,14 @@ function CopyStacktraceButton({ stackTrace }) {
     const [copied, setCopied] = useState(false);
 
     function handleCopy() {
-        navigator.clipboard.writeText(stackTrace).then(() => {
-            setCopied(true);
-            setTimeout(() => setCopied(false), 2000);
-        });
+        navigator.clipboard.writeText(stackTrace)
+            .then(() => {
+                setCopied(true);
+                setTimeout(() => setCopied(false), 2000);
+            })
+            .catch(() => {
+                // Clipboard can fail due to permissions / insecure context.
+            });
     }
 
     return (

--- a/ui/src/main/js/page/audit/DistributionTable.js
+++ b/ui/src/main/js/page/audit/DistributionTable.js
@@ -19,7 +19,7 @@ const useStyles = createUseStyles(theme => ({
     },
     errorTitle: {
         fontWeight: 'bold',
-        color: 'red',
+        color: theme.status.error.text,
         paddingBottom: '4px'
     },
     copyButtonWrapper: {
@@ -121,19 +121,21 @@ const DistributionTable = ({ data }) => {
         }
     }];
 
-    function getExpandableRowContent(data) {
+    function getExpandableRowContent(rowData) {
         return (
             <div className={classes.expandedContentCell}>
-                <div className={classes.errorTitle}>{data.errorMessage}</div>
-                <TextArea
-                    sizeClass="col-sm-12"
-                    label=""
-                    readOnly
-                    name="notificationContent"
-                    value={data.errorStackTrace || ''}
-                />
-                {data.errorStackTrace && (
-                    <CopyStacktraceButton stackTrace={data.errorStackTrace} />
+                <div className={classes.errorTitle}>{rowData.errorMessage}</div>
+                {rowData.errorStackTrace && (
+                    <>
+                        <TextArea
+                            sizeClass="col-sm-12"
+                            label=""
+                            readOnly
+                            name="notificationContent"
+                            value={rowData.errorStackTrace || ''}
+                        />
+                        <CopyStacktraceButton stackTrace={rowData.errorStackTrace} />
+                    </>
                 )}
             </div>
         );
@@ -144,7 +146,7 @@ const DistributionTable = ({ data }) => {
             tableData={data?.jobs}
             columns={COLUMNS}
             emptyTableConfig={emptyTableConfig}
-            isExpandable={rowData => !!rowData}
+            isExpandable={rowData => !!(rowData.errorMessage || rowData.errorStackTrace)}
             ExpandableContent={getExpandableRowContent}
         />
     );
@@ -152,7 +154,7 @@ const DistributionTable = ({ data }) => {
 
 DistributionTable.propTypes = {
     data: PropTypes.shape({
-        jobs: PropTypes.object,
+        jobs: PropTypes.arrayOf(PropTypes.object),
         id: PropTypes.string
     })
 };

--- a/ui/src/main/js/page/audit/DistributionTable.js
+++ b/ui/src/main/js/page/audit/DistributionTable.js
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { createUseStyles } from 'react-jss';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Table from 'common/component/table/Table';
 import EventTypeCell from 'page/audit/EventTypeCell';
 import DistributionLastSentCell from 'page/audit/DistributionLastSentCell';
@@ -9,7 +11,91 @@ const emptyTableConfig = {
     message: 'There are no records to display for this table.'
 };
 
+const useStyles = createUseStyles(theme => ({
+    expandedContentCell: {
+        display: 'flex',
+        flexDirection: 'column'
+    },
+    errorTitle: {
+        fontWeight: 'bold',
+        color: 'red'
+    },
+    stackTrace: {
+        display: '-webkit-box',
+        '-webkit-line-clamp': 3,
+        '-webkit-box-orient': 'vertical',
+        overflow: 'hidden'
+    },
+    copyButtonWrapper: {
+        position: 'relative',
+        alignSelf: 'flex-end',
+        margin: ['8px', '8px', 0]
+    },
+    copyButton: {
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '6px',
+        padding: 0,
+        color: theme.colors.grey.default,
+        background: 'none',
+        border: 'none',
+        cursor: 'pointer',
+        fontSize: '13px',
+        '&:hover': {
+            color: theme.colors.grey.darkerGrey
+        }
+    },
+    copiedButton: {
+        color: theme.colors.status.success.text
+    },
+    tooltip: {
+        position: 'absolute',
+        bottom: 'calc(100% + 6px)',
+        right: 0,
+        padding: ['3px', '8px'],
+        borderRadius: '4px',
+        backgroundColor: theme.colors.grey.darkerGrey,
+        color: theme.colors.white.default,
+        fontSize: '12px',
+        whiteSpace: 'nowrap',
+        pointerEvents: 'none',
+        opacity: 1,
+        transition: 'opacity 0.2s ease'
+    }
+}));
+
+function CopyStacktraceButton({ stackTrace }) {
+    const classes = useStyles();
+    const [copied, setCopied] = useState(false);
+
+    function handleCopy() {
+        navigator.clipboard.writeText(stackTrace).then(() => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        });
+    }
+
+    return (
+        <div className={classes.copyButtonWrapper}>
+            {copied && <div className={classes.tooltip}>Copied stacktrace!</div>}
+            <button
+                type="button"
+                className={`${classes.copyButton}${copied ? ` ${classes.copiedButton}` : ''}`}
+                onClick={handleCopy}
+            >
+                <FontAwesomeIcon icon={copied ? 'check' : 'copy'} size="sm" />
+                Copy Stacktrace
+            </button>
+        </div>
+    );
+}
+
+CopyStacktraceButton.propTypes = {
+    stackTrace: PropTypes.string
+};
+
 const DistributionTable = ({ data }) => {
+    const classes = useStyles();
     const COLUMNS = [{
         key: 'name',
         label: 'Distribution Job',
@@ -26,7 +112,6 @@ const DistributionTable = ({ data }) => {
         customCell: DistributionLastSentCell
     }, {
         key: 'refreshJob',
-        label: 'Refresh',
         sortable: false,
         customCell: RefreshFailureCell,
         settings: {
@@ -36,11 +121,25 @@ const DistributionTable = ({ data }) => {
         }
     }];
 
+    function getExpandableRowContent(data) {
+        return (
+            <div className={classes.expandedContentCell}>
+                <div className={classes.errorTitle}>{data.errorMessage}</div>
+                <div className={classes.stackTrace}>{data.errorStackTrace}</div>
+                {data.errorStackTrace && (
+                    <CopyStacktraceButton stackTrace={data.errorStackTrace} />
+                )}
+            </div>
+        );
+    }
+
     return (
         <Table
             tableData={data?.jobs}
             columns={COLUMNS}
             emptyTableConfig={emptyTableConfig}
+            isExpandable={rowData => !!rowData}
+            ExpandableContent={getExpandableRowContent}
         />
     );
 };

--- a/ui/src/main/js/page/audit/DistributionTable.js
+++ b/ui/src/main/js/page/audit/DistributionTable.js
@@ -130,7 +130,7 @@ const DistributionTable = ({ data }) => {
                     label=""
                     readOnly
                     name="notificationContent"
-                    value={data.errorStackTrace}
+                    value={data.errorStackTrace || ''}
                 />
                 {data.errorStackTrace && (
                     <CopyStacktraceButton stackTrace={data.errorStackTrace} />

--- a/ui/src/main/js/page/audit/DistributionTable.js
+++ b/ui/src/main/js/page/audit/DistributionTable.js
@@ -19,7 +19,7 @@ const useStyles = createUseStyles(theme => ({
     },
     errorTitle: {
         fontWeight: 'bold',
-        color: theme.status.error.text,
+        color: theme.colors.status.error.text,
         paddingBottom: '4px'
     },
     copyButtonWrapper: {
@@ -122,16 +122,18 @@ const DistributionTable = ({ data }) => {
     }];
 
     function getExpandableRowContent(rowData) {
+        const stackTraceId = `${rowData.id}-stacktrace-error`;
         return (
             <div className={classes.expandedContentCell}>
                 <div className={classes.errorTitle}>{rowData.errorMessage}</div>
                 {rowData.errorStackTrace && (
                     <>
                         <TextArea
+                            id={stackTraceId}
                             sizeClass="col-sm-12"
                             label=""
                             readOnly
-                            name="notificationContent"
+                            name={stackTraceId}
                             value={rowData.errorStackTrace || ''}
                         />
                         <CopyStacktraceButton stackTrace={rowData.errorStackTrace} />

--- a/ui/src/main/js/page/audit/DistributionTable.js
+++ b/ui/src/main/js/page/audit/DistributionTable.js
@@ -6,6 +6,7 @@ import Table from 'common/component/table/Table';
 import EventTypeCell from 'page/audit/EventTypeCell';
 import DistributionLastSentCell from 'page/audit/DistributionLastSentCell';
 import RefreshFailureCell from 'page/audit/RefreshFailureCell';
+import TextArea from 'common/component/input/TextArea';
 
 const emptyTableConfig = {
     message: 'There are no records to display for this table.'
@@ -18,13 +19,8 @@ const useStyles = createUseStyles(theme => ({
     },
     errorTitle: {
         fontWeight: 'bold',
-        color: 'red'
-    },
-    stackTrace: {
-        display: '-webkit-box',
-        '-webkit-line-clamp': 3,
-        '-webkit-box-orient': 'vertical',
-        overflow: 'hidden'
+        color: 'red',
+        paddingBottom: '4px'
     },
     copyButtonWrapper: {
         position: 'relative',
@@ -129,7 +125,13 @@ const DistributionTable = ({ data }) => {
         return (
             <div className={classes.expandedContentCell}>
                 <div className={classes.errorTitle}>{data.errorMessage}</div>
-                <div className={classes.stackTrace}>{data.errorStackTrace}</div>
+                <TextArea
+                    sizeClass="col-sm-12"
+                    label=""
+                    readOnly
+                    name="notificationContent"
+                    value={data.errorStackTrace}
+                />
                 {data.errorStackTrace && (
                     <CopyStacktraceButton stackTrace={data.errorStackTrace} />
                 )}


### PR DESCRIPTION
## Overview
This ticket called to surface the errors to users coming from audit failure jobs. I believe this functionality existed in the past but was lost within the many upgrades we've done to the UI.

## Technical Overview
Within the Audit Failure > Job Details modal, we show which distribution job fails. There is more granularity to that failure contained within the response payload. When this data exists, the user can click on the row within the table and expand more content below that row. The content that is contained within that row is the error title and error stacktrace.  These stacktraces can be massive, so we limit the view to only show 8 lines (via the TextArea component) but allow the user to copy the entire stacktrace to their clipboard. 
  
## Demo
https://github.com/user-attachments/assets/d4278efd-3d48-4f00-92f5-1e26143bfdaf




