### PR TITLE
IALERT-3979: Issue tracker reliability and various notification fixes

### DIFF
--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessor.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessor.java
@@ -8,8 +8,9 @@
 package com.blackduck.integration.alert.database.job.api;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -68,28 +69,63 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
     public List<AlertNotificationModel> saveAllNotifications(Collection<AlertNotificationModel> notifications) {
-        List<NotificationEntity> entitiesToSave = new LinkedList<>();
+        if (notifications.isEmpty()) {
+            return List.of();
+        }
 
+        // Prefetch all content IDs in a batch to determine if duplicates exist when performing in-memory filtering.
+        Set<String> allBatchContentIds = notifications.stream()
+            .map(AlertNotificationModel::getContentId)
+            .collect(Collectors.toSet());
+        Set<String> existingContentIds = notificationContentRepository.findByContentIdIn(allBatchContentIds)
+            .stream()
+            .map(NotificationEntity::getContentId)
+            .collect(Collectors.toSet());
+
+        List<NotificationEntity> entitiesToSave = new ArrayList<>();
+        Set<String> contentIdsToSave = new HashSet<>();
         for (AlertNotificationModel model : notifications) {
-            if (notificationContentRepository.existsByContentId(model.getContentId())) {
+            if (existingContentIds.contains(model.getContentId())) {
                 logger.info("Notification already exists for provider: {} contentId: {}", model.getProviderConfigId(), model.getContentId());
+                logger.debug("Content: {}", model.getContent());
+            } else if (!contentIdsToSave.add(model.getContentId())) {
+                logger.info("Duplicate notification in batch for provider: {}, contentId: {}", model.getProviderConfigId(), model.getContentId());
                 logger.debug("Content: {}", model.getContent());
             } else {
                 entitiesToSave.add(fromModel(model));
             }
         }
 
-        return notificationContentRepository.saveAllAndFlush(entitiesToSave)
+        for (NotificationEntity entity : entitiesToSave) {
+            notificationContentRepository.saveIgnoreContentIdConflict(
+                entity.getCreatedAt(),
+                entity.getProvider(),
+                entity.getProviderConfigId(),
+                entity.getProviderCreationTime(),
+                entity.getNotificationType(),
+                entity.getContent(),
+                entity.getProcessed(),
+                entity.getContentId(),
+                entity.isMappingToJobs()
+            );
+        }
+
+        if (contentIdsToSave.isEmpty()) {
+            return List.of();
+        }
+        // Native query insert bypasses Hibernate's identity management. As a result, the in-memory NotificationEntities do not have their ID populated.
+        // A fetch is required to ensure the correct notifications are returned with the correct IDs.
+        return notificationContentRepository.findByContentIdIn(contentIdsToSave)
             .stream()
             .map(this::toModel)
-            .collect(Collectors.toList());
+            .toList();
     }
 
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
     public List<AlertNotificationModel> saveAllNotificationsInBatch(final UUID batchId, final Collection<AlertNotificationModel> notifications) {
         List<AlertNotificationModel> models = saveAllNotifications(notifications);
-        if(!models.isEmpty()) {
+        if (!models.isEmpty()) {
             List<NotificationBatchEntity> batchDataList = models.stream()
                 .map(notification -> new NotificationBatchEntity(notification.getProviderConfigId(), batchId, notification.getId()))
                 .toList();
@@ -186,10 +222,10 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
         String sortingField = "createdAt";
         // We can only modify the query for the fields that exist in NotificationContent
         if (StringUtils.isNotBlank(sortField) && "createdAt".equalsIgnoreCase(sortField)
-                || "provider".equalsIgnoreCase(sortField)
-                || COLUMN_NAME_PROVIDER_CREATION_TIME.equalsIgnoreCase(sortField)
-                || "notificationType".equalsIgnoreCase(sortField)
-                || "content".equalsIgnoreCase(sortField)) {
+            || "provider".equalsIgnoreCase(sortField)
+            || COLUMN_NAME_PROVIDER_CREATION_TIME.equalsIgnoreCase(sortField)
+            || "notificationType".equalsIgnoreCase(sortField)
+            || "content".equalsIgnoreCase(sortField)) {
             sortingField = sortField;
             sortQuery = true;
         }
@@ -271,11 +307,11 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
         Sort.Order sortingOrder = Sort.Order.asc(COLUMN_NAME_PROVIDER_CREATION_TIME);
         PageRequest pageRequest = PageRequest.of(currentPage, pageSize, Sort.by(sortingOrder));
         Page<AlertNotificationModel> pageOfNotifications = notificationContentRepository.findNotMappedAndNotProcessedNotifications(
-                        providerConfigId,
-                        batchId,
-                        pageRequest
-                )
-                .map(this::toModel);
+                providerConfigId,
+                batchId,
+                pageRequest
+            )
+            .map(this::toModel);
         List<AlertNotificationModel> alertNotificationModels = pageOfNotifications.getContent();
         return new AlertPagedModel<>(pageOfNotifications.getTotalPages(), currentPage, pageSize, alertNotificationModels);
     }
@@ -284,9 +320,9 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
     @Transactional
     public void setNotificationsMapping(List<AlertNotificationModel> notifications) {
         Set<Long> notificationIds = notifications
-                .stream()
-                .map(AlertNotificationModel::getId)
-                .collect(Collectors.toSet());
+            .stream()
+            .map(AlertNotificationModel::getId)
+            .collect(Collectors.toSet());
         setNotificationsMappingById(notificationIds);
     }
 
@@ -299,7 +335,7 @@ public class DefaultNotificationAccessor implements NotificationAccessor {
 
     @Override
     @Transactional(readOnly = true, isolation = Isolation.READ_COMMITTED)
-    public boolean hasMoreNotificationsToMap(long providerConfigId,  UUID batchId) {
+    public boolean hasMoreNotificationsToMap(long providerConfigId, UUID batchId) {
         return notificationContentRepository.existsByProviderConfigIdAndMappingToJobsFalse(providerConfigId, batchId);
     }
 

--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/notification/NotificationContentRepository.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/notification/NotificationContentRepository.java
@@ -8,6 +8,7 @@
 package com.blackduck.integration.alert.database.notification;
 
 import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -93,7 +94,7 @@ public interface NotificationContentRepository extends JpaRepository<Notificatio
 
     long countByProviderConfigIdAndNotificationType(long providerConfigId, String notificationType);
 
-    @Query(value ="SELECT entity FROM NotificationEntity entity"
+    @Query(value = "SELECT entity FROM NotificationEntity entity"
         + " INNER JOIN NotificationBatchEntity batch ON entity.id = batch.notificationId"
         + " WHERE batch.batchId = :batchId"
         + " AND entity.providerConfigId = :providerId"
@@ -111,20 +112,20 @@ public interface NotificationContentRepository extends JpaRepository<Notificatio
         + " AND entity.processed = false"
         + ") THEN true ELSE false END"
         + " FROM NotificationEntity entity")
-    boolean existsByProviderConfigIdAndMappingToJobsFalse(@Param("providerId") long providerConfigId, @Param("batchId")  UUID batchId);
+    boolean existsByProviderConfigIdAndMappingToJobsFalse(@Param("providerId") long providerConfigId, @Param("batchId") UUID batchId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE NotificationEntity entity "
-            + "SET entity.mappingToJobs = true "
-            + "WHERE entity.id IN :notificationIds"
+        + "SET entity.mappingToJobs = true "
+        + "WHERE entity.id IN :notificationIds"
     )
     void setMappingToJobsByIds(@Param("notificationIds") Set<Long> notificationIds);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE NotificationEntity entity "
-            + "SET entity.mappingToJobs = false "
-            + "WHERE entity.providerConfigId = :providerConfigId "
-            + "AND entity.processed = false"
+        + "SET entity.mappingToJobs = false "
+        + "WHERE entity.providerConfigId = :providerConfigId "
+        + "AND entity.processed = false"
     )
     void setMappingToJobsFalseWhenProcessedFalse(@Param("providerConfigId") long providerConfigId);
 
@@ -134,4 +135,27 @@ public interface NotificationContentRepository extends JpaRepository<Notificatio
         + " GROUP BY DATE_TRUNC('hour', entity.createdAt)"
         + " ORDER BY DATE_TRUNC('hour', entity.createdAt) ")
     List<NotificationCountsPerHour> findNotificationCountsPerHourByProviderConfigId(@Param("providerConfigId") long providerConfigId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        value = "INSERT INTO alert.raw_notification_content "
+            + "(created_at, provider, provider_config_id, provider_creation_time, notification_type, content, processed, content_id, mapping_to_jobs) "
+            + "VALUES (:createdAt, :provider, :providerConfigId, :providerCreationTime, :notificationType, :content, :processed, :contentId, :mappingToJobs) "
+            + "ON CONFLICT (content_id) DO NOTHING",
+        nativeQuery = true
+    )
+    void saveIgnoreContentIdConflict(
+        @Param("createdAt") OffsetDateTime createdAt,
+        @Param("provider") String provider,
+        @Param("providerConfigId") Long providerConfigId,
+        @Param("providerCreationTime") OffsetDateTime providerCreationTime,
+        @Param("notificationType") String notificationType,
+        @Param("content") String content,
+        @Param("processed") boolean processed,
+        @Param("contentId") String contentId,
+        @Param("mappingToJobs") boolean mappingToJobs
+    );
+
+    List<NotificationEntity> findByContentIdIn(Collection<String> contentIds);
 }
+

--- a/alert-database/src/main/java/com/blackduck/integration/alert/database/notification/NotificationEntity.java
+++ b/alert-database/src/main/java/com/blackduck/integration/alert/database/notification/NotificationEntity.java
@@ -31,7 +31,7 @@ import jakarta.persistence.Table;
 public class NotificationEntity extends BaseEntity implements DatabaseEntity {
     @Id
     @GeneratedValue(generator = "alert.raw_notification_content_id_seq_generator", strategy = GenerationType.SEQUENCE)
-    @SequenceGenerator(name = "alert.raw_notification_content_id_seq_generator", sequenceName = "alert.raw_notification_content_id_seq")
+    @SequenceGenerator(name = "alert.raw_notification_content_id_seq_generator", sequenceName = "alert.raw_notification_content_id_seq", allocationSize = 1)
     @Column(name = "id")
     private Long id;
     @Column(name = "created_at")
@@ -49,7 +49,7 @@ public class NotificationEntity extends BaseEntity implements DatabaseEntity {
     @Column(name = "processed")
     private boolean processed;
 
-    @Column(name = "content_id")
+    @Column(name = "content_id", nullable = false, unique = true)
     private String contentId;
 
     @Column(name = "mapping_to_jobs")
@@ -59,7 +59,7 @@ public class NotificationEntity extends BaseEntity implements DatabaseEntity {
     private final List<AuditNotificationRelation> auditNotificationRelations = new ArrayList<>();
 
     @OneToMany(cascade = CascadeType.ALL)
-    @JoinColumn(name = "notification_id", referencedColumnName = "id",  insertable = false, updatable = false)
+    @JoinColumn(name = "notification_id", referencedColumnName = "id", insertable = false, updatable = false)
     private List<NotificationBatchEntity> notificationBatches = new ArrayList<>();
 
     public NotificationEntity() {

--- a/alert-database/src/main/resources/liquibase/9.0.0/raw-notification-content-sequence-increment.xml
+++ b/alert-database/src/main/resources/liquibase/9.0.0/raw-notification-content-sequence-increment.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
-    <include file="jira-cloud-job-details-remove-comments.xml" relativeToChangelogFile="true"/>
-    <include file="jira-server-job-details-remove-comments.xml" relativeToChangelogFile="true"/>
-    <include file="raw-notification-content-sequence-increment.xml" relativeToChangelogFile="true"/>
+    <changeSet author="martinch" id="raw-notification-content-sequence-increment">
+        <alterSequence schemaName="alert"
+                       sequenceName="raw_notification_content_id_seq"
+                       incrementBy="1"
+        />
+    </changeSet>
 </databaseChangeLog>

--- a/alert-database/src/main/resources/scripts/init_alert_db.sql
+++ b/alert-database/src/main/resources/scripts/init_alert_db.sql
@@ -320,5 +320,8 @@ ALTER SEQUENCE alert.descriptor_configs_id_seq INCREMENT 50;
 ALTER SEQUENCE alert.field_values_id_seq INCREMENT 50;
 ALTER SEQUENCE alert.provider_projects_id_seq INCREMENT 50;
 ALTER SEQUENCE alert.provider_users_id_seq INCREMENT 50;
-ALTER SEQUENCE alert.raw_notification_content_id_seq INCREMENT 50;
 ALTER SEQUENCE alert.system_messages_id_seq INCREMENT 50;
+
+-- raw_notification_content is inserted using native PSQL query rather than hibernate.
+ALTER SEQUENCE alert.raw_notification_content_id_seq INCREMENT 1;
+

--- a/alert-database/src/test/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessorTest.java
+++ b/alert-database/src/test/java/com/blackduck/integration/alert/database/job/api/DefaultNotificationAccessorTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.mockito.verification.VerificationMode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -110,27 +111,148 @@ class DefaultNotificationAccessorTest {
         NotificationContentRepository notificationContentRepository = Mockito.mock(NotificationContentRepository.class);
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
 
-        Mockito.when(notificationContentRepository.saveAllAndFlush(Mockito.any())).thenReturn(List.of(notificationEntity));
+        // First call: prefetch returns empty (notification does not yet exist); second call: post-save retrieve returns the saved entity
+        Mockito.when(notificationContentRepository.findByContentIdIn(Mockito.any()))
+            .thenReturn(List.of())
+            .thenReturn(List.of(notificationEntity));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         List<AlertNotificationModel> alertNotificationModelList = notificationManager.saveAllNotifications(List.of(alertNotificationModel));
 
         assertEquals(1, alertNotificationModelList.size());
         AlertNotificationModel testAlertNotificationModel = alertNotificationModelList.get(0);
         testExpectedAlertNotificationModel(expectedAlertNotificationModel, testAlertNotificationModel);
+
+        verifySaveIgnoreContentIdConflict(notificationContentRepository, Mockito.times(1));
+    }
+
+    @Test
+    void saveAllNotificationsWithDuplicateContentIdInBatchTest() {
+        OffsetDateTime createdAt = DateUtils.createCurrentDateTimestamp();
+        OffsetDateTime providerCreationTime = createdAt.minusSeconds(10);
+
+        AlertNotificationModel firstOccurrence = new AlertNotificationModel(
+            null,
+            providerConfigId,
+            provider,
+            providerConfigName,
+            notificationType,
+            content,
+            createdAt,
+            providerCreationTime,
+            false,
+            contentId,
+            false
+        );
+        AlertNotificationModel duplicateOccurrence = new AlertNotificationModel(
+            null,
+            providerConfigId,
+            provider,
+            providerConfigName,
+            notificationType,
+            content,
+            createdAt,
+            providerCreationTime,
+            false,
+            contentId,
+            false
+        );
+        NotificationEntity savedEntity = new NotificationEntity(
+            id,
+            createdAt,
+            provider,
+            providerConfigId,
+            providerCreationTime,
+            notificationType,
+            content,
+            false,
+            contentId,
+            false
+        );
+
+        NotificationContentRepository notificationContentRepository = Mockito.mock(NotificationContentRepository.class);
+        ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
+
+        // First call: prefetch returns empty (neither occurrence exists yet); second call: post-save retrieve returns the saved entity
+        Mockito.when(notificationContentRepository.findByContentIdIn(Mockito.any()))
+            .thenReturn(List.of())
+            .thenReturn(List.of(savedEntity));
+        Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(createConfigurationModel()));
+
+        DefaultNotificationAccessor defaultNotificationAccessor = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
+        List<AlertNotificationModel> result = defaultNotificationAccessor.saveAllNotifications(List.of(firstOccurrence, duplicateOccurrence));
+
+        assertEquals(1, result.size(), "Only the first occurrence of a duplicate contentId should be saved");
+
+        verifySaveIgnoreContentIdConflict(notificationContentRepository, Mockito.times(1));
+    }
+
+    @Test
+    void saveAllNotificationsSkipsNotificationAlreadyInDatabaseTest() {
+        OffsetDateTime createdAt = DateUtils.createCurrentDateTimestamp();
+        OffsetDateTime providerCreationTime = createdAt.minusSeconds(10);
+
+        AlertNotificationModel alreadyPersistedModel = new AlertNotificationModel(
+            null,
+            providerConfigId,
+            provider,
+            providerConfigName,
+            notificationType,
+            content,
+            createdAt,
+            providerCreationTime,
+            false,
+            contentId,
+            false
+        );
+
+        NotificationEntity existingEntity = new NotificationEntity(
+            id,
+            createdAt,
+            provider,
+            providerConfigId,
+            providerCreationTime,
+            notificationType,
+            content,
+            false,
+            contentId,
+            false
+        );
+
+        NotificationContentRepository notificationContentRepository = Mockito.mock(NotificationContentRepository.class);
+
+        // Prefetch returns the existing entity, causing the in-memory filter to skip it
+        Mockito.when(notificationContentRepository.findByContentIdIn(Mockito.any())).thenReturn(List.of(existingEntity));
+
+        DefaultNotificationAccessor defaultNotificationAccessor = new DefaultNotificationAccessor(notificationContentRepository, null, null, notificationBatchRepository);
+        List<AlertNotificationModel> result = defaultNotificationAccessor.saveAllNotifications(List.of(alreadyPersistedModel));
+
+        assertTrue(result.isEmpty(), "Notifications already in the database should not be saved again");
+
+        verifySaveIgnoreContentIdConflict(notificationContentRepository, Mockito.never());
     }
 
     @Test
     void saveAllNotificationsEmptyModelListTest() {
         NotificationContentRepository notificationContentRepository = Mockito.mock(NotificationContentRepository.class);
 
-        Mockito.when(notificationContentRepository.saveAll(Mockito.any())).thenReturn(new ArrayList<>());
-
         DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, null, notificationBatchRepository);
         List<AlertNotificationModel> alertNotificationModelList = notificationManager.saveAllNotifications(new ArrayList<>());
 
         assertTrue(alertNotificationModelList.isEmpty());
+        verifySaveIgnoreContentIdConflict(notificationContentRepository, Mockito.never());
+        Mockito.verify(notificationContentRepository, Mockito.never()).findByContentIdIn(Mockito.any());
     }
 
     @Test
@@ -158,7 +280,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.findAllSentNotifications(Mockito.any())).thenReturn(allSentNotifications);
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         Page<AlertNotificationModel> alertNotificationModelPage = notificationManager.findAll(pageRequest, Boolean.TRUE);
 
         assertEquals(1, alertNotificationModelPage.getTotalPages());
@@ -191,7 +318,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
         Mockito.when(notificationContentRepository.findAll(pageRequest)).thenReturn(allSentNotifications);
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         Page<AlertNotificationModel> alertNotificationModelPage = notificationManager.findAll(pageRequest, Boolean.FALSE);
 
         assertEquals(1, alertNotificationModelPage.getTotalPages());
@@ -226,7 +358,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
         Mockito.when(notificationContentRepository.findMatchingNotification(Mockito.any(), Mockito.any())).thenReturn(notificationEntityPage);
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         Page<AlertNotificationModel> alertNotificationModelPage = notificationManager.findAllWithSearch(searchTerm, pageRequest, Boolean.TRUE);
         Page<AlertNotificationModel> alertNotificationModelPageShowNotificationsFalse = notificationManager.findAllWithSearch(searchTerm, pageRequest, Boolean.FALSE);
 
@@ -261,7 +398,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.findAllByIdInOrderByProviderCreationTimeAsc(Mockito.any())).thenReturn(List.of(notificationEntity1));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         List<AlertNotificationModel> alertNotificationModelList = notificationManager.findByIds(List.of(1L));
 
         assertEquals(1, alertNotificationModelList.size());
@@ -291,7 +433,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.findById(Mockito.any())).thenReturn(Optional.of(notificationEntity));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         Optional<AlertNotificationModel> alertNotificationModel = notificationManager.findById(1L);
 
         assertTrue(alertNotificationModel.isPresent());
@@ -320,8 +467,14 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.findByCreatedAtBetween(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(new PageImpl<>(List.of(notificationEntity)));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
-        List<AlertNotificationModel> alertNotificationModelList = notificationManager.findByCreatedAtBetween(DateUtils.createCurrentDateTimestamp(),
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
+        List<AlertNotificationModel> alertNotificationModelList = notificationManager.findByCreatedAtBetween(
+                DateUtils.createCurrentDateTimestamp(),
                 DateUtils.createCurrentDateTimestamp(),
                 AlertPagedModel.DEFAULT_PAGE_NUMBER, AlertPagedModel.DEFAULT_PAGE_SIZE
             )
@@ -354,7 +507,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.findByCreatedAtBefore(Mockito.any())).thenReturn(List.of(notificationEntity));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         List<AlertNotificationModel> alertNotificationModelList = notificationManager.findByCreatedAtBefore(DateUtils.createCurrentDateTimestamp());
 
         assertEquals(1, alertNotificationModelList.size());
@@ -384,7 +542,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.findByCreatedAtBefore(Mockito.any())).thenReturn(List.of(notificationEntity));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         List<AlertNotificationModel> alertNotificationModelList = notificationManager.findByCreatedAtBeforeDayOffset(1);
 
         assertEquals(1, alertNotificationModelList.size());
@@ -404,7 +567,12 @@ class DefaultNotificationAccessorTest {
         AuditNotificationRepository auditNotificationRepository = Mockito.mock(AuditNotificationRepository.class);
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, auditEntryRepository, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            auditEntryRepository,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         PageRequest pageRequest = notificationManager.getPageRequestForNotifications(pageNumber, pageSize, sortField, sortOrder);
 
         assertEquals(pageNumber, pageRequest.getPageNumber());
@@ -434,7 +602,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.findByProcessedFalseOrderByProviderCreationTimeAsc(Mockito.any())).thenReturn(pageOfNotificationEntities);
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         AlertPagedModel<AlertNotificationModel> model = notificationManager.getFirstPageOfNotificationsNotProcessed(100);
 
         List<AlertNotificationModel> alertNotificationModelList = model.getModels();
@@ -444,7 +617,8 @@ class DefaultNotificationAccessorTest {
 
     @Test
     void setNotificationsProcessedTest() {
-        AlertNotificationModel alertNotificationModel = new AlertNotificationModel(null,
+        AlertNotificationModel alertNotificationModel = new AlertNotificationModel(
+            null,
             providerConfigId,
             provider,
             providerConfigName,
@@ -460,7 +634,12 @@ class DefaultNotificationAccessorTest {
         NotificationContentRepository notificationContentRepository = Mockito.mock(NotificationContentRepository.class);
         ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor = Mockito.mock(ConfigurationModelConfigurationAccessor.class);
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         notificationManager.setNotificationsProcessed(List.of(alertNotificationModel));
 
         Mockito.verify(notificationContentRepository).setProcessedByIds(Mockito.any());
@@ -489,7 +668,12 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.findAllById(Mockito.any())).thenReturn(List.of(notificationEntity));
         Mockito.when(configurationModelConfigurationAccessor.getConfigurationById(Mockito.any())).thenReturn(Optional.of(configurationModel));
 
-        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, configurationModelConfigurationAccessor, notificationBatchRepository);
+        DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(
+            notificationContentRepository,
+            null,
+            configurationModelConfigurationAccessor,
+            notificationBatchRepository
+        );
         notificationManager.setNotificationsProcessedById(notificationIds);
 
         Mockito.verify(notificationContentRepository).setProcessedByIds(Mockito.any());
@@ -509,6 +693,20 @@ class DefaultNotificationAccessorTest {
         Mockito.when(notificationContentRepository.existsByProcessedFalse()).thenReturn(Boolean.TRUE);
         DefaultNotificationAccessor notificationManager = new DefaultNotificationAccessor(notificationContentRepository, null, null, notificationBatchRepository);
         assertTrue(notificationManager.hasMoreNotificationsToProcess());
+    }
+
+    private void verifySaveIgnoreContentIdConflict(NotificationContentRepository repository, VerificationMode mode) {
+        Mockito.verify(repository, mode).saveIgnoreContentIdConflict(
+            Mockito.any(OffsetDateTime.class),
+            Mockito.anyString(),
+            Mockito.any(Long.class),
+            Mockito.any(OffsetDateTime.class),
+            Mockito.anyString(),
+            Mockito.anyString(),
+            Mockito.anyBoolean(),
+            Mockito.anyString(),
+            Mockito.anyBoolean()
+        );
     }
 
     private void testExpectedAlertNotificationModel(AlertNotificationModel expected, AlertNotificationModel actual) {

--- a/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/callback/ProviderCallbackIssueTrackerResponsePostProcessor.java
+++ b/api-channel-issue-tracker/src/main/java/com/blackduck/integration/alert/api/channel/issue/tracker/callback/ProviderCallbackIssueTrackerResponsePostProcessor.java
@@ -10,8 +10,9 @@ package com.blackduck.integration.alert.api.channel.issue.tracker.callback;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -23,6 +24,7 @@ import com.blackduck.integration.alert.common.channel.issuetracker.IssueTrackerC
 
 @Component
 public class ProviderCallbackIssueTrackerResponsePostProcessor implements IssueTrackerResponsePostProcessor {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final EventManager eventManager;
 
     @Autowired
@@ -38,23 +40,30 @@ public class ProviderCallbackIssueTrackerResponsePostProcessor implements IssueT
 
     private <T extends Serializable> List<IssueTrackerCallbackEvent> createCallbackEvents(IssueTrackerResponse<T> issueTrackerResponse) {
         return issueTrackerResponse.getUpdatedIssues()
-                   .stream()
-                   .map(this::createProviderCallbackEvent)
-                   .flatMap(Optional::stream)
-                   .collect(Collectors.toList());
+            .stream()
+            .map(this::createProviderCallbackEvent)
+            .flatMap(Optional::stream)
+            .toList();
     }
 
     private <T extends Serializable> Optional<IssueTrackerCallbackEvent> createProviderCallbackEvent(IssueTrackerIssueResponseModel<T> issueResponseModel) {
         return issueResponseModel.getCallbackInfo()
-                   .map(callbackInfo ->
-                            new IssueTrackerCallbackEvent(
-                                callbackInfo,
-                                issueResponseModel.getIssueKey(),
-                                issueResponseModel.getIssueLink(),
-                                issueResponseModel.getIssueOperation(),
-                                issueResponseModel.getIssueTitle()
-                            )
-                   );
+            .map(callbackInfo -> {
+                logger.debug(
+                    "Creating issue tracker callback event: issue key: [{}], issue operation: [{}], issue title: [{}], link: [{}]",
+                    issueResponseModel.getIssueKey(),
+                    issueResponseModel.getIssueOperation(),
+                    issueResponseModel.getIssueTitle(),
+                    issueResponseModel.getIssueLink()
+                );
+                return new IssueTrackerCallbackEvent(
+                    callbackInfo,
+                    issueResponseModel.getIssueKey(),
+                    issueResponseModel.getIssueLink(),
+                    issueResponseModel.getIssueOperation(),
+                    issueResponseModel.getIssueTitle()
+                );
+            });
     }
 
 }

--- a/api-distribution/src/main/java/com/blackduck/integration/alert/api/distribution/JobSubTaskEventHandler.java
+++ b/api-distribution/src/main/java/com/blackduck/integration/alert/api/distribution/JobSubTaskEventHandler.java
@@ -11,6 +11,9 @@ import java.time.Instant;
 import java.util.UUID;
 import java.util.function.Predicate;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.blackduck.integration.alert.api.common.model.exception.AlertException;
 import com.blackduck.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJob;
@@ -23,6 +26,7 @@ import com.blackduck.integration.alert.common.enumeration.AuditEntryStatus;
 import com.blackduck.integration.alert.common.persistence.util.AuditStackTraceUtil;
 
 public abstract class JobSubTaskEventHandler<T extends JobSubTaskEvent> implements AlertEventHandler<T> {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final EventManager eventManager;
     private final JobStage jobStage;
     private final ExecutingJobManager executingJobManager;
@@ -58,8 +62,23 @@ public abstract class JobSubTaskEventHandler<T extends JobSubTaskEvent> implemen
                 exception.getMessage(),
                 AuditStackTraceUtil.createStackTraceString(exception)
             ));
+        } catch (Exception exception) {
+            handleUnknownException(exception, jobExecutionId, event);
         }
     }
 
     protected abstract void handleEvent(T event) throws AlertException;
+
+    protected void handleUnknownException(Exception e, UUID jobExecutionId, T event) {
+        logger.error("An unexpected error occurred while handling the following issue tracker event: {}.", event.getEventId(), e);
+        executingJobManager.endStage(jobExecutionId, jobStage, Instant.now());
+        executingJobManager.incrementSentNotificationCount(jobExecutionId, event.getNotificationIds().size());
+        eventManager.sendEvent(new AuditFailedEvent(
+            event.getJobExecutionId(),
+            event.getJobId(),
+            event.getNotificationIds(),
+            "An unexpected error occurred during issue tracker distribution. Please refer to the logs for more details.",
+            AuditStackTraceUtil.createStackTraceString(e)
+        ));
+    }
 }

--- a/api-distribution/src/test/java/com/blackduck/integration/alert/api/distribution/JobSubTaskEventHandlerTest.java
+++ b/api-distribution/src/test/java/com/blackduck/integration/alert/api/distribution/JobSubTaskEventHandlerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.blackduck.integration.alert.api.common.model.exception.AlertException;
+import com.blackduck.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJob;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.blackduck.integration.alert.api.distribution.execution.JobStage;
@@ -47,7 +48,6 @@ class JobSubTaskEventHandlerTest {
     @Test
     void testHandleEvent() {
         String destination = "destination";
-        UUID parentEventId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
@@ -73,9 +73,7 @@ class JobSubTaskEventHandlerTest {
 
     @Test
     void testHandleExceptionEvent() {
-
         String destination = "destination";
-        UUID parentEventId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
@@ -92,7 +90,6 @@ class JobSubTaskEventHandlerTest {
     @Test
     void testHandleEventCountToZero() {
         String destination = "destination";
-        UUID parentEventId = UUID.randomUUID();
         UUID jobExecutionId = UUID.randomUUID();
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
@@ -102,6 +99,23 @@ class JobSubTaskEventHandlerTest {
         handler.handle(event);
 
         assertTrue(handler.wasHandlerCalled());
+    }
+
+    @Test
+    void testHandleUnknownException() {
+        String destination = "destination";
+        UUID jobExecutionId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L);
+
+        TestHandler handler = new TestHandler(eventManager, executingJobManager);
+        handler.setShouldThrowRuntimeException(true);
+
+        TestEvent event = new TestEvent(destination, jobExecutionId, jobId, notificationIds);
+        handler.handle(event);
+
+        assertTrue(handler.wasHandlerCalled(), "Handler should have been called before the exception was thrown");
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
     }
 
     private static class TestEvent extends JobSubTaskEvent {
@@ -115,6 +129,7 @@ class JobSubTaskEventHandlerTest {
     private static class TestHandler extends JobSubTaskEventHandler<TestEvent> {
         private boolean handlerCalled = false;
         private boolean shouldThrowException = false;
+        private boolean shouldThrowRuntimeException = false;
 
         protected TestHandler(
             EventManager eventManager,
@@ -130,6 +145,9 @@ class JobSubTaskEventHandlerTest {
             if (shouldThrowException) {
                 throw new AlertException("Test handler throws exception");
             }
+            if (shouldThrowRuntimeException) {
+                throw new RuntimeException("Test handler throws unexpected runtime exception");
+            }
         }
 
         public boolean wasHandlerCalled() {
@@ -142,6 +160,10 @@ class JobSubTaskEventHandlerTest {
 
         public void setShouldThrowException(boolean shouldThrowException) {
             this.shouldThrowException = shouldThrowException;
+        }
+
+        public void setShouldThrowRuntimeException(boolean shouldThrowRuntimeException) {
+            this.shouldThrowRuntimeException = shouldThrowRuntimeException;
         }
     }
 }

--- a/api-distribution/src/test/java/com/blackduck/integration/alert/api/distribution/mock/MockNotificationContentRepository.java
+++ b/api-distribution/src/test/java/com/blackduck/integration/alert/api/distribution/mock/MockNotificationContentRepository.java
@@ -8,6 +8,7 @@
 package com.blackduck.integration.alert.api.distribution.mock;
 
 import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
@@ -32,6 +33,7 @@ import com.blackduck.integration.alert.test.common.database.MockRepositoryContai
 
 public class MockNotificationContentRepository extends MockRepositoryContainer<Long, NotificationEntity> implements NotificationContentRepository {
     private final MockNotificationBatchRepository mockNotificationBatchRepository;
+
     public MockNotificationContentRepository(final Function<NotificationEntity, Long> idGenerator) {
         super(idGenerator);
         mockNotificationBatchRepository = new MockNotificationBatchRepository();
@@ -202,7 +204,7 @@ public class MockNotificationContentRepository extends MockRepositoryContainer<L
     }
 
     @Override
-    public Page<NotificationEntity> findNotMappedAndNotProcessedNotifications(long providerConfigId, UUID batchId,  Pageable pageable) {
+    public Page<NotificationEntity> findNotMappedAndNotProcessedNotifications(long providerConfigId, UUID batchId, Pageable pageable) {
         Set<Long> notificationsInBatch = mockNotificationBatchRepository.findAll().stream()
             .filter(entity -> entity.getBatchId().equals(batchId))
             .map(NotificationBatchEntity::getNotificationId)
@@ -212,12 +214,12 @@ public class MockNotificationContentRepository extends MockRepositoryContainer<L
         Predicate<NotificationEntity> notProcessed = Predicate.not(NotificationEntity::getProcessed);
         Predicate<NotificationEntity> providerConfigIdEqual = notificationEntity -> notificationEntity.getProviderConfigId().equals(providerConfigId);
         List<NotificationEntity> notifications = findAll().stream()
-                .sorted(Comparator.comparing(NotificationEntity::getProviderCreationTime))
-                .filter(providerConfigIdEqual)
-                .filter(notificationInBatch)
-                .filter(mappingFalse)
-                .filter(notProcessed)
-                .toList();
+            .sorted(Comparator.comparing(NotificationEntity::getProviderCreationTime))
+            .filter(providerConfigIdEqual)
+            .filter(notificationInBatch)
+            .filter(mappingFalse)
+            .filter(notProcessed)
+            .toList();
         int pageSize = pageable.getPageSize();
         int pageNumber = pageable.getPageNumber();
         List<List<NotificationEntity>> partitionedLists = ListUtils.partition(notifications, pageSize);
@@ -235,14 +237,14 @@ public class MockNotificationContentRepository extends MockRepositoryContainer<L
         Predicate<NotificationEntity> notMapped = Predicate.not(NotificationEntity::isMappingToJobs);
         Predicate<NotificationEntity> providerAndMappingToJobsFalse = providerConfigIdEqual.and(notMapped);
         return findAll()
-                .stream()
-                .anyMatch(providerAndMappingToJobsFalse);
+            .stream()
+            .anyMatch(providerAndMappingToJobsFalse);
     }
 
     @Override
     public void setMappingToJobsByIds(Set<Long> notificationIds) {
         findAllById(notificationIds)
-                .forEach(NotificationEntity::setMappingToJobsToTrue);
+            .forEach(NotificationEntity::setMappingToJobsToTrue);
     }
 
     @Override
@@ -253,27 +255,29 @@ public class MockNotificationContentRepository extends MockRepositoryContainer<L
         Predicate<NotificationEntity> providerMappingAndProcessedFalse = providerConfigIdEqual.and(notMapped).and(notProcessed);
 
         List<NotificationEntity> entities = findAll().stream()
-                .filter(providerMappingAndProcessedFalse)
-                .toList();
+            .filter(providerMappingAndProcessedFalse)
+            .toList();
 
         List<NotificationEntity> updatedEntities = entities.stream()
-                .map(this::setMappingAndProcessedToFalse)
-                .toList();
+            .map(this::setMappingAndProcessedToFalse)
+            .toList();
 
         saveAll(updatedEntities);
     }
 
     private NotificationEntity setMappingAndProcessedToFalse(NotificationEntity entity) {
-        return new NotificationEntity(entity.getId(),
-                entity.getCreatedAt(),
-                entity.getProvider(),
-                entity.getProviderConfigId(),
-                entity.getProviderCreationTime(),
-                entity.getNotificationType(),
-                entity.getContent(),
-                false,
-                entity.getContentId(),
-                false);
+        return new NotificationEntity(
+            entity.getId(),
+            entity.getCreatedAt(),
+            entity.getProvider(),
+            entity.getProviderConfigId(),
+            entity.getProviderCreationTime(),
+            entity.getNotificationType(),
+            entity.getContent(),
+            false,
+            entity.getContentId(),
+            false
+        );
     }
 
     @Override
@@ -285,6 +289,30 @@ public class MockNotificationContentRepository extends MockRepositoryContainer<L
         return notificationsPerHourMap.entrySet().stream()
             .map(entry -> new NotificationCountsPerHour(entry.getKey(), entry.getValue()))
             .sorted(Comparator.comparing(NotificationCountsPerHour::getAccumulationHour))
+            .toList();
+    }
+
+    @Override
+    public void saveIgnoreContentIdConflict(
+        final OffsetDateTime createdAt,
+        final String provider,
+        final Long providerConfigId,
+        final OffsetDateTime providerCreationTime,
+        final String notificationType,
+        final String content,
+        final boolean processed,
+        final String contentId,
+        final boolean mappingToJobs
+    ) {
+        if (!existsByContentId(contentId)) {
+            super.save(new NotificationEntity(createdAt, provider, providerConfigId, providerCreationTime, notificationType, content, processed, contentId, mappingToJobs));
+        }
+    }
+
+    @Override
+    public List<NotificationEntity> findByContentIdIn(final Collection<String> contentIds) {
+        return findAll().stream()
+            .filter(entity -> contentIds.contains(entity.getContentId()))
             .toList();
     }
 }

--- a/api-processor/src/main/java/com/blackduck/integration/alert/api/processor/mapping/JobNotificationMapper2.java
+++ b/api-processor/src/main/java/com/blackduck/integration/alert/api/processor/mapping/JobNotificationMapper2.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -27,6 +29,7 @@ import com.blackduck.integration.alert.common.rest.model.AlertPagedDetails;
 
 @Component
 public class JobNotificationMapper2 {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final ProcessingJobAccessor2 processingJobAccessor;
     private final JobNotificationMappingAccessor jobNotificationMappingAccessor;
 
@@ -83,6 +86,8 @@ public class JobNotificationMapper2 {
             pageNumber,
             pageSize
         );
+
+        boolean anyMapped = false;
         while (jobs.getCurrentPage() <= jobs.getTotalPages()) {
             List<JobToNotificationMappingModel> mappings = new LinkedList<>();
             for (SimpleFilteredDistributionJobResponseModel job : jobs.getModels()) {
@@ -91,7 +96,12 @@ public class JobNotificationMapper2 {
                 }
             }
             if (!mappings.isEmpty()) {
+                anyMapped = true;
                 jobNotificationMappingAccessor.addJobMappings(mappings);
+                if (logger.isDebugEnabled()) {
+                    mappings.forEach(mapping ->
+                        logger.debug("Notification [{}] mapped to job {} [correlationId: {}]", mapping.getNotificationId(), mapping.getJobId(), correlationId));
+                }
             }
             pageNumber++;
             jobs = processingJobAccessor.getMatchingEnabledJobsForNotifications(
@@ -100,5 +110,28 @@ public class JobNotificationMapper2 {
                 pageSize
             );
         }
+
+        if (!anyMapped && logger.isDebugEnabled()) {
+            String additionalNotificationContext = getAdditionalNotificationContext(filteredDistributionJobRequestModel);
+            logger.debug(
+                "Notification [{}] matched no enabled distribution jobs [correlationId: {}, project: {}, version: {}, types: {}{}]",
+                filteredDistributionJobRequestModel.getNotificationId().map(Object::toString).orElse("unknown"),
+                correlationId,
+                projectName,
+                projectVersionName,
+                filteredDistributionJobRequestModel.getNotificationTypes(),
+                additionalNotificationContext
+            );
+        }
+    }
+
+    private String getAdditionalNotificationContext(final FilteredDistributionJobRequestModel filteredDistributionJobRequestModel) {
+        String additionalNotificationContext = "";
+        if (!filteredDistributionJobRequestModel.getPolicyNames().isEmpty()) {
+            additionalNotificationContext = ", policy names: " + filteredDistributionJobRequestModel.getPolicyNames();
+        } else if (!filteredDistributionJobRequestModel.getVulnerabilitySeverities().isEmpty()) {
+            additionalNotificationContext = ", vulnerability severities: " + filteredDistributionJobRequestModel.getVulnerabilitySeverities();
+        }
+        return additionalNotificationContext;
     }
 }

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.blackduck.integration.jira.common.cloud.builder.IssueRequestModelFieldsBuilder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,6 +75,8 @@ public class JiraCloudCommentEventHandler extends IssueTrackerCommentEventHandle
     @Override
     public void handleEvent(JiraCloudCommentEvent event) {
         UUID jobId = event.getJobId();
+        IssueCommentModel<String> commentModel = event.getCommentModel();
+        logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), commentModel.getAlertIssueId());
         Optional<JiraCloudJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(jobId);
         if (details.isPresent()) {
             try {
@@ -105,14 +108,14 @@ public class JiraCloudCommentEventHandler extends IssueTrackerCommentEventHandle
                     jiraErrorMessageUtility,
                     jiraCloudQueryExecutor
                 );
-                IssueCommentModel<String> commentModel = event.getCommentModel();
                 List<IssueTrackerIssueResponseModel<String>> responses = messageSender.sendMessage(commentModel);
                 postProcess(new IssueTrackerResponse<>("Success", responses));
             } catch (AlertException ex) {
-                logger.error("Cannot comment on issue for job {}", jobId);
+                logger.error("Cannot comment on issue for job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
+                logger.error("Cause: ", ex);
             }
         } else {
-            logger.error("No Jira Cloud job found with id {}", jobId);
+            logger.error("No Jira Cloud job found with job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
         }
     }
 

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandler.java
@@ -73,7 +73,7 @@ public class JiraCloudCommentEventHandler extends IssueTrackerCommentEventHandle
     }
 
     @Override
-    public void handleEvent(JiraCloudCommentEvent event) {
+    public void handleEvent(JiraCloudCommentEvent event) throws AlertException {
         UUID jobId = event.getJobId();
         IssueCommentModel<String> commentModel = event.getCommentModel();
         logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), commentModel.getAlertIssueId());
@@ -113,9 +113,13 @@ public class JiraCloudCommentEventHandler extends IssueTrackerCommentEventHandle
             } catch (AlertException ex) {
                 logger.error("Cannot comment on issue for job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
                 logger.error("Cause: ", ex);
+                // Re-throw the error so the base class can publish an AuditFailedEvent with detailed error information.
+                throw ex;
             }
         } else {
-            logger.error("No Jira Cloud job found with job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
+            String errorMessage = String.format("No Jira Cloud job found with job id: %s, Alert Issue ID: %s", jobId, commentModel.getAlertIssueId());
+            logger.error(errorMessage);
+            throw new AlertException(errorMessage);
         }
     }
 

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandler.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.blackduck.integration.jira.common.cloud.builder.IssueRequestModelFieldsBuilder;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,6 +77,7 @@ public class JiraCloudCreateIssueEventHandler extends IssueTrackerCreateIssueEve
     public synchronized void handleEvent(IssueTrackerCreateIssueEvent event) {
         UUID jobId = event.getJobId();
         IssueCreationModel creationModel = event.getCreationModel();
+        logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), creationModel.getAlertIssueId());
         Optional<JiraCloudJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(event.getJobId());
         if (details.isPresent()) {
             try {
@@ -116,15 +118,17 @@ public class JiraCloudCreateIssueEventHandler extends IssueTrackerCreateIssueEve
                     List<String> issuePairs = responses.stream()
                         .map(response -> response.getIssueId() + " | " + response.getIssueKey())
                         .toList();
-                    logger.info("Created issues (Issue ID | Issue Key): {}", issuePairs);
+                    logger.info("Created issues for Alert Issue ID: {}, (Issue ID | Issue Key): {}", creationModel.getAlertIssueId(), issuePairs);
+                } else {
+                    logger.debug("Issue already exists. Alert Issue ID: {}, JQL query: {}", creationModel.getAlertIssueId(), jqlQuery);
                 }
             } catch (AlertException ex) {
-                logger.error("Cannot create issue for job {}", jobId);
+                logger.error("Cannot create issue for job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
                 logger.error("Query: {}", creationModel.getQueryString());
                 logger.error("Cause: ", ex);
             }
         } else {
-            logger.error("No Jira Cloud job found with id {}", jobId);
+            logger.error("No Jira Cloud job found with job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
         }
     }
 

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandler.java
@@ -74,7 +74,7 @@ public class JiraCloudCreateIssueEventHandler extends IssueTrackerCreateIssueEve
     }
 
     @Override
-    public synchronized void handleEvent(IssueTrackerCreateIssueEvent event) {
+    public synchronized void handleEvent(IssueTrackerCreateIssueEvent event) throws AlertException {
         UUID jobId = event.getJobId();
         IssueCreationModel creationModel = event.getCreationModel();
         logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), creationModel.getAlertIssueId());
@@ -126,9 +126,13 @@ public class JiraCloudCreateIssueEventHandler extends IssueTrackerCreateIssueEve
                 logger.error("Cannot create issue for job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
                 logger.error("Query: {}", creationModel.getQueryString());
                 logger.error("Cause: ", ex);
+                // Re-throw the error so the base class can publish an AuditFailedEvent with detailed error information.
+                throw ex;
             }
         } else {
-            logger.error("No Jira Cloud job found with job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
+            String errorMessage = String.format("No Jira Cloud job found with job id: %s, Alert Issue ID: %s", jobId, creationModel.getAlertIssueId());
+            logger.error(errorMessage);
+            throw new AlertException(errorMessage);
         }
     }
 

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandler.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.blackduck.integration.jira.common.cloud.builder.IssueRequestModelFieldsBuilder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,6 +75,8 @@ public class JiraCloudTransitionEventHandler extends IssueTrackerTransitionEvent
     @Override
     public void handleEvent(JiraCloudTransitionEvent event) {
         UUID jobId = event.getJobId();
+        IssueTransitionModel<String> transitionModel = event.getTransitionModel();
+        logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), transitionModel.getAlertIssueId());
         Optional<JiraCloudJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(event.getJobId());
         if (details.isPresent()) {
             try {
@@ -105,14 +108,14 @@ public class JiraCloudTransitionEventHandler extends IssueTrackerTransitionEvent
                     jiraErrorMessageUtility,
                     jiraCloudQueryExecutor
                 );
-                IssueTransitionModel<String> commentModel = event.getTransitionModel();
-                List<IssueTrackerIssueResponseModel<String>> responses = messageSender.sendMessage(commentModel);
+                List<IssueTrackerIssueResponseModel<String>> responses = messageSender.sendMessage(transitionModel);
                 postProcess(new IssueTrackerResponse<>("Success", responses));
             } catch (AlertException ex) {
-                logger.error("Cannot transition issue for job {}", jobId);
+                logger.error("Cannot transition issue for job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
+                logger.error("Cause: ", ex);
             }
         } else {
-            logger.error("No Jira Cloud job found with id {}", jobId);
+            logger.error("No Jira Cloud job found with job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
         }
     }
 }

--- a/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandler.java
+++ b/channel-jira-cloud/src/main/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandler.java
@@ -73,7 +73,7 @@ public class JiraCloudTransitionEventHandler extends IssueTrackerTransitionEvent
     }
 
     @Override
-    public void handleEvent(JiraCloudTransitionEvent event) {
+    public void handleEvent(JiraCloudTransitionEvent event) throws AlertException {
         UUID jobId = event.getJobId();
         IssueTransitionModel<String> transitionModel = event.getTransitionModel();
         logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), transitionModel.getAlertIssueId());
@@ -113,9 +113,13 @@ public class JiraCloudTransitionEventHandler extends IssueTrackerTransitionEvent
             } catch (AlertException ex) {
                 logger.error("Cannot transition issue for job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
                 logger.error("Cause: ", ex);
+                // Re-throw the error so the base class can publish an AuditFailedEvent with detailed error information.
+                throw ex;
             }
         } else {
-            logger.error("No Jira Cloud job found with job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
+            String errorMessage = String.format("No Jira Cloud job found with job id: %s, Alert Issue ID: %s", jobId, transitionModel.getAlertIssueId());
+            logger.error(errorMessage);
+            throw new AlertException(errorMessage);
         }
     }
 }

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandlerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventHandlerTest.java
@@ -27,7 +27,9 @@ import com.blackduck.integration.alert.api.channel.issue.tracker.search.Existing
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.IssueCategoryRetriever;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueCategory;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueStatus;
+import com.blackduck.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.blackduck.integration.alert.api.descriptor.model.ChannelKeys;
+import com.blackduck.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.blackduck.integration.alert.api.event.EventManager;
 import com.blackduck.integration.alert.channel.jira.cloud.JiraCloudProperties;
@@ -101,6 +103,52 @@ class JiraCloudCommentEventHandlerTest {
         );
         handler.handle(event);
         assertEquals(0, issueCounter.get());
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
+    }
+
+    @Test
+    void handleEventExceptionSendsAuditFailedEvent() throws Exception {
+        UUID jobExecutionId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
+
+        JiraCloudPropertiesFactory propertiesFactory = Mockito.mock(JiraCloudPropertiesFactory.class);
+        Mockito.when(propertiesFactory.createJiraProperties()).thenThrow(new AlertConfigurationException("Simulated connection failure"));
+
+        IssueTrackerCallbackInfoCreator callbackInfoCreator = new IssueTrackerCallbackInfoCreator();
+        IssueCategoryRetriever issueCategoryRetriever = new IssueCategoryRetriever();
+        JiraCloudMessageSenderFactory messageSenderFactory = new JiraCloudMessageSenderFactory(
+            gson,
+            ChannelKeys.JIRA_CLOUD,
+            propertiesFactory,
+            callbackInfoCreator,
+            issueCategoryRetriever,
+            eventManager,
+            executingJobManager
+        );
+        JobDetailsAccessor<JiraCloudJobDetailsModel> jobDetailsAccessor = jobId1 -> Optional.of(createJobDetails(jobId));
+
+        JiraCloudCommentEventHandler handler = new JiraCloudCommentEventHandler(
+            eventManager,
+            gson,
+            propertiesFactory,
+            messageSenderFactory,
+            jobDetailsAccessor,
+            responsePostProcessor,
+            executingJobManager
+        );
+        ExistingIssueDetails<String> existingIssueDetails = new ExistingIssueDetails<>("id", "key", "summary", "link", IssueStatus.UNKNOWN, IssueCategory.BOM);
+        IssueCommentModel<String> model = new IssueCommentModel<>(existingIssueDetails, List.of("A comment"), null);
+        JiraCloudCommentEvent event = new JiraCloudCommentEvent(
+            IssueTrackerCommentEvent.createDefaultEventDestination(ChannelKeys.JIRA_CLOUD),
+            jobExecutionId,
+            jobId,
+            notificationIds,
+            model
+        );
+
+        handler.handle(event);
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
     }
 
     @Test

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventListenerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCommentEventListenerTest.java
@@ -35,7 +35,7 @@ class JiraCloudCommentEventListenerTest {
     private final Gson gson = BlackDuckServicesFactory.createDefaultGson();
 
     @Test
-    void onMessageTest() {
+    void onMessageTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -74,7 +74,7 @@ class JiraCloudCommentEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsFinishedTest() {
+    void onMessageJobWithRemainingEventsFinishedTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -114,7 +114,7 @@ class JiraCloudCommentEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsTest() {
+    void onMessageJobWithRemainingEventsTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandlerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventHandlerTest.java
@@ -15,10 +15,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.blackduck.integration.jira.common.cloud.builder.AtlassianDocumentFormatModelBuilder;
-import com.blackduck.integration.jira.common.cloud.model.AtlassianDocumentFormatModel;
-import com.blackduck.integration.jira.common.cloud.model.JiraCloudIssueResponseModel;
-import com.blackduck.integration.jira.common.cloud.model.component.JiraCloudIssueFieldsComponent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -31,9 +27,16 @@ import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueBomC
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueCreationModel;
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.ProjectIssueModel;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.IssueCategoryRetriever;
+import com.blackduck.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.blackduck.integration.alert.api.descriptor.model.ChannelKeys;
+import com.blackduck.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.blackduck.integration.alert.api.event.EventManager;
+
+import com.blackduck.integration.jira.common.cloud.builder.AtlassianDocumentFormatModelBuilder;
+import com.blackduck.integration.jira.common.cloud.model.AtlassianDocumentFormatModel;
+import com.blackduck.integration.jira.common.cloud.model.JiraCloudIssueResponseModel;
+import com.blackduck.integration.jira.common.cloud.model.component.JiraCloudIssueFieldsComponent;
 import com.blackduck.integration.alert.api.processor.extract.model.ProviderDetails;
 import com.blackduck.integration.alert.channel.jira.cloud.JiraCloudProperties;
 import com.blackduck.integration.alert.channel.jira.cloud.JiraCloudPropertiesFactory;
@@ -52,10 +55,8 @@ import com.blackduck.integration.jira.common.cloud.service.IssueSearchService;
 import com.blackduck.integration.jira.common.cloud.service.IssueService;
 import com.blackduck.integration.jira.common.cloud.service.JiraCloudServiceFactory;
 import com.blackduck.integration.jira.common.cloud.service.ProjectService;
-import com.blackduck.integration.jira.common.model.components.IssueFieldsComponent;
 import com.blackduck.integration.jira.common.model.components.ProjectComponent;
 import com.blackduck.integration.jira.common.model.response.IssueCreationResponseModel;
-import com.blackduck.integration.jira.common.model.response.IssueResponseModel;
 import com.blackduck.integration.jira.common.model.response.PageOfProjectsResponseModel;
 import com.blackduck.integration.jira.common.rest.service.IssuePropertyService;
 import com.google.gson.Gson;
@@ -125,6 +126,55 @@ class JiraCloudCreateIssueEventHandlerTest {
         );
 
         handler.handle(event);
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
+    }
+
+    @Test
+    void handleEventExceptionSendsAuditFailedEvent() throws Exception {
+        UUID jobExecutionId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
+
+        JiraCloudJobDetailsModel jobDetailsModel = createJobDetails(jobId);
+
+        JiraCloudPropertiesFactory propertiesFactory = Mockito.mock(JiraCloudPropertiesFactory.class);
+        Mockito.when(propertiesFactory.createJiraProperties()).thenThrow(new AlertConfigurationException("Simulated connection failure"));
+
+        IssueTrackerCallbackInfoCreator callbackInfoCreator = new IssueTrackerCallbackInfoCreator();
+        IssueCategoryRetriever issueCategoryRetriever = new IssueCategoryRetriever();
+        JiraCloudMessageSenderFactory messageSenderFactory = new JiraCloudMessageSenderFactory(
+            gson,
+            ChannelKeys.JIRA_CLOUD,
+            propertiesFactory,
+            callbackInfoCreator,
+            issueCategoryRetriever,
+            eventManager,
+            executingJobManager
+        );
+
+        jobDetailsAccessor.saveJiraCloudJobDetails(jobId, jobDetailsModel);
+        JiraCloudCreateIssueEventHandler handler = new JiraCloudCreateIssueEventHandler(
+            eventManager,
+            gson,
+            propertiesFactory,
+            messageSenderFactory,
+            jobDetailsAccessor,
+            responsePostProcessor,
+            executingJobManager
+        );
+
+        LinkableItem provider = new LinkableItem("provider", "test-provider");
+        IssueCreationModel issueCreationModel = IssueCreationModel.simple("title", "description", List.of(), provider);
+        JiraCloudCreateIssueEvent event = new JiraCloudCreateIssueEvent(
+            IssueTrackerCreateIssueEvent.createDefaultEventDestination(ChannelKeys.JIRA_CLOUD),
+            jobExecutionId,
+            jobId,
+            notificationIds,
+            issueCreationModel
+        );
+
+        handler.handle(event);
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
     }
 
     @Test
@@ -368,7 +418,20 @@ class JiraCloudCreateIssueEventHandlerTest {
         AtlassianDocumentFormatModelBuilder atlassianDocumentFormatModelBuilder = new AtlassianDocumentFormatModelBuilder();
         atlassianDocumentFormatModelBuilder.addSingleParagraphTextNode("description");
         AtlassianDocumentFormatModel descriptionModel = atlassianDocumentFormatModelBuilder.build();
-        JiraCloudIssueFieldsComponent issueFieldsComponent = new JiraCloudIssueFieldsComponent(List.of(), null, null, "summary", descriptionModel, List.of(), null, List.of(), null, null, null, null);
+        JiraCloudIssueFieldsComponent issueFieldsComponent = new JiraCloudIssueFieldsComponent(
+            List.of(),
+            null,
+            null,
+            "summary",
+            descriptionModel,
+            List.of(),
+            null,
+            List.of(),
+            null,
+            null,
+            null,
+            null
+        );
 
         return new JiraCloudIssueResponseModel("", id, "", id, Map.of(), Map.of(), Map.of(), null, null, null, null, issueFieldsComponent);
     }

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventListenerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudCreateIssueEventListenerTest.java
@@ -35,7 +35,7 @@ class JiraCloudCreateIssueEventListenerTest {
     private final Gson gson = BlackDuckServicesFactory.createDefaultGson();
 
     @Test
-    void onMessageTest() {
+    void onMessageTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -75,7 +75,7 @@ class JiraCloudCreateIssueEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsFinishedTest() {
+    void onMessageJobWithRemainingEventsFinishedTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -116,7 +116,7 @@ class JiraCloudCreateIssueEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsTest() {
+    void onMessageJobWithRemainingEventsTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandlerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventHandlerTest.java
@@ -28,7 +28,9 @@ import com.blackduck.integration.alert.api.channel.issue.tracker.search.Existing
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.IssueCategoryRetriever;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueCategory;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueStatus;
+import com.blackduck.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.blackduck.integration.alert.api.descriptor.model.ChannelKeys;
+import com.blackduck.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.blackduck.integration.alert.api.event.EventManager;
 import com.blackduck.integration.alert.channel.jira.cloud.JiraCloudProperties;
@@ -107,6 +109,52 @@ class JiraCloudTransitionEventHandlerTest {
         );
         handler.handle(event);
         assertEquals(0, issueCounter.get());
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
+    }
+
+    @Test
+    void handleEventExceptionSendsAuditFailedEvent() throws Exception {
+        UUID jobExecutionId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
+
+        JiraCloudPropertiesFactory propertiesFactory = Mockito.mock(JiraCloudPropertiesFactory.class);
+        Mockito.when(propertiesFactory.createJiraProperties()).thenThrow(new AlertConfigurationException("Simulated connection failure"));
+
+        IssueTrackerCallbackInfoCreator callbackInfoCreator = new IssueTrackerCallbackInfoCreator();
+        IssueCategoryRetriever issueCategoryRetriever = new IssueCategoryRetriever();
+        JiraCloudMessageSenderFactory messageSenderFactory = new JiraCloudMessageSenderFactory(
+            gson,
+            ChannelKeys.JIRA_CLOUD,
+            propertiesFactory,
+            callbackInfoCreator,
+            issueCategoryRetriever,
+            eventManager,
+            executingJobManager
+        );
+        JobDetailsAccessor<JiraCloudJobDetailsModel> jobDetailsAccessor = jobId1 -> Optional.of(createJobDetails(jobId));
+
+        JiraCloudTransitionEventHandler handler = new JiraCloudTransitionEventHandler(
+            eventManager,
+            gson,
+            propertiesFactory,
+            messageSenderFactory,
+            jobDetailsAccessor,
+            responsePostProcessor,
+            executingJobManager
+        );
+        ExistingIssueDetails<String> existingIssueDetails = new ExistingIssueDetails<>("id", "key", "summary", "link", IssueStatus.UNKNOWN, IssueCategory.BOM);
+        IssueTransitionModel<String> model = new IssueTransitionModel<>(existingIssueDetails, IssueOperation.RESOLVE, List.of(), null);
+        JiraCloudTransitionEvent event = new JiraCloudTransitionEvent(
+            IssueTrackerTransitionIssueEvent.createDefaultEventDestination(ChannelKeys.JIRA_CLOUD),
+            jobExecutionId,
+            jobId,
+            notificationIds,
+            model
+        );
+
+        handler.handle(event);
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
     }
 
     @Test

--- a/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventListenerTest.java
+++ b/channel-jira-cloud/src/test/java/com/blackduck/integration/alert/channel/jira/cloud/distribution/event/JiraCloudTransitionEventListenerTest.java
@@ -36,7 +36,7 @@ class JiraCloudTransitionEventListenerTest {
     private final Gson gson = BlackDuckServicesFactory.createDefaultGson();
 
     @Test
-    void onMessageTest() {
+    void onMessageTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -75,7 +75,7 @@ class JiraCloudTransitionEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsFinishedTest() {
+    void onMessageJobWithRemainingEventsFinishedTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -115,7 +115,7 @@ class JiraCloudTransitionEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsTest() {
+    void onMessageJobWithRemainingEventsTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandler.java
@@ -71,7 +71,7 @@ public class JiraServerCommentEventHandler extends IssueTrackerCommentEventHandl
     }
 
     @Override
-    public void handleEvent(JiraServerCommentEvent event) {
+    public void handleEvent(JiraServerCommentEvent event) throws AlertException {
         UUID jobId = event.getJobId();
         IssueCommentModel<String> commentModel = event.getCommentModel();
         logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), commentModel.getAlertIssueId());
@@ -111,9 +111,13 @@ public class JiraServerCommentEventHandler extends IssueTrackerCommentEventHandl
             } catch (AlertException ex) {
                 logger.error("Cannot comment on issue for job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
                 logger.error("Cause: ", ex);
+                // Re-throw the error so the base class can publish an AuditFailedEvent with detailed error information.
+                throw ex;
             }
         } else {
-            logger.error("No Jira Server job found with job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
+            String errorMessage = String.format("No Jira Server job found with job id: %s, Alert Issue ID: %s", jobId, commentModel.getAlertIssueId());
+            logger.error(errorMessage);
+            throw new AlertException(errorMessage);
         }
     }
 }

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandler.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.blackduck.integration.jira.common.server.builder.IssueRequestModelFieldsBuilder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,8 +73,9 @@ public class JiraServerCommentEventHandler extends IssueTrackerCommentEventHandl
     @Override
     public void handleEvent(JiraServerCommentEvent event) {
         UUID jobId = event.getJobId();
+        IssueCommentModel<String> commentModel = event.getCommentModel();
+        logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), commentModel.getAlertIssueId());
         Optional<JiraServerJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(event.getJobId());
-        logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), event.getCommentModel().getAlertIssueId());
         if (details.isPresent()) {
             try {
                 JiraServerProperties jiraProperties = jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jobId);
@@ -104,15 +106,14 @@ public class JiraServerCommentEventHandler extends IssueTrackerCommentEventHandl
                     jiraErrorMessageUtility,
                     jiraServerQueryExecutor
                 );
-                IssueCommentModel<String> commentModel = event.getCommentModel();
                 List<IssueTrackerIssueResponseModel<String>> responses = messageSender.sendMessage(commentModel);
                 postProcess(new IssueTrackerResponse<>("Success", responses));
             } catch (AlertException ex) {
-                logger.error("Cannot comment on issue for job {}", jobId);
+                logger.error("Cannot comment on issue for job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
                 logger.error("Cause: ", ex);
             }
         } else {
-            logger.error("No Jira Server job found with id {}", jobId);
+            logger.error("No Jira Server job found with job id: {}, Alert Issue ID: {}", jobId, commentModel.getAlertIssueId());
         }
     }
 }

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
@@ -73,7 +73,7 @@ public class JiraServerCreateIssueEventHandler extends IssueTrackerCreateIssueEv
     }
 
     @Override
-    public synchronized void handleEvent(IssueTrackerCreateIssueEvent event) {
+    public synchronized void handleEvent(IssueTrackerCreateIssueEvent event) throws AlertException {
         UUID jobId = event.getJobId();
         IssueCreationModel creationModel = event.getCreationModel();
         logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), creationModel.getAlertIssueId());
@@ -125,9 +125,13 @@ public class JiraServerCreateIssueEventHandler extends IssueTrackerCreateIssueEv
                 logger.error("Cannot create issue for job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
                 logger.error("Query: {}", creationModel.getQueryString());
                 logger.error("Cause: ", ex);
+                // Re-throw the error so the base class can publish an AuditFailedEvent with detailed error information.
+                throw ex;
             }
         } else {
-            logger.error("No Jira Server job found with job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
+            String errorMessage = String.format("No Jira Server job found with job id: %s, Alert Issue ID: %s", jobId, creationModel.getAlertIssueId());
+            logger.error(errorMessage);
+            throw new AlertException(errorMessage);
         }
     }
 

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandler.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.blackduck.integration.jira.common.server.builder.IssueRequestModelFieldsBuilder;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -116,17 +117,17 @@ public class JiraServerCreateIssueEventHandler extends IssueTrackerCreateIssueEv
                     List<String> issuePairs = responses.stream()
                         .map(response -> response.getIssueId() + " | " + response.getIssueKey())
                         .toList();
-                    logger.info("Created issues (Issue ID | Issue Key): {}", issuePairs);
+                    logger.info("Created issues for Alert Issue ID: {}, (Issue ID | Issue Key): {}", creationModel.getAlertIssueId(), issuePairs);
                 } else {
-                    logger.debug("Issue already exists for query: {}", jqlQuery);
+                    logger.debug("Issue already exists. Alert Issue ID: {}, JQL query: {}", creationModel.getAlertIssueId(), jqlQuery);
                 }
             } catch (AlertException ex) {
-                logger.error("Cannot create issue for job {}", jobId);
+                logger.error("Cannot create issue for job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
                 logger.error("Query: {}", creationModel.getQueryString());
                 logger.error("Cause: ", ex);
             }
         } else {
-            logger.error("No Jira Server job found with id {}", jobId);
+            logger.error("No Jira Server job found with job id: {}, Alert Issue ID: {}", jobId, creationModel.getAlertIssueId());
         }
     }
 

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandler.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.blackduck.integration.jira.common.server.builder.IssueRequestModelFieldsBuilder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,8 +73,9 @@ public class JiraServerTransitionEventHandler extends IssueTrackerTransitionEven
     @Override
     public void handleEvent(JiraServerTransitionEvent event) {
         UUID jobId = event.getJobId();
+        IssueTransitionModel<String> transitionModel = event.getTransitionModel();
+        logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), transitionModel.getAlertIssueId());
         Optional<JiraServerJobDetailsModel> details = jobDetailsAccessor.retrieveDetails(event.getJobId());
-        logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), event.getTransitionModel().getAlertIssueId());
         if (details.isPresent()) {
             try {
                 JiraServerProperties jiraProperties = jiraServerPropertiesFactory.createJiraPropertiesWithJobId(jobId);
@@ -104,14 +106,14 @@ public class JiraServerTransitionEventHandler extends IssueTrackerTransitionEven
                     jiraErrorMessageUtility,
                     jiraServerQueryExecutor
                 );
-                IssueTransitionModel<String> transitionModel = event.getTransitionModel();
                 List<IssueTrackerIssueResponseModel<String>> responses = messageSender.sendMessage(transitionModel);
                 postProcess(new IssueTrackerResponse<>("Success", responses));
             } catch (AlertException ex) {
-                logger.error("Cannot transition issue for job {}", jobId);
+                logger.error("Cannot transition issue for job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
+                logger.error("Cause: ", ex);
             }
         } else {
-            logger.error("No Jira Server job found with id {}", jobId);
+            logger.error("No Jira Server job found with job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
         }
     }
 }

--- a/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandler.java
+++ b/channel-jira-server/src/main/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandler.java
@@ -71,7 +71,7 @@ public class JiraServerTransitionEventHandler extends IssueTrackerTransitionEven
     }
 
     @Override
-    public void handleEvent(JiraServerTransitionEvent event) {
+    public void handleEvent(JiraServerTransitionEvent event) throws AlertException {
         UUID jobId = event.getJobId();
         IssueTransitionModel<String> transitionModel = event.getTransitionModel();
         logger.debug("Begin Handle Event: {} for Alert Issue ID: {}", getClass().getSimpleName(), transitionModel.getAlertIssueId());
@@ -111,9 +111,13 @@ public class JiraServerTransitionEventHandler extends IssueTrackerTransitionEven
             } catch (AlertException ex) {
                 logger.error("Cannot transition issue for job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
                 logger.error("Cause: ", ex);
+                // Re-throw the error so the base class can publish an AuditFailedEvent with detailed error information.
+                throw ex;
             }
         } else {
-            logger.error("No Jira Server job found with job id: {}, Alert Issue ID: {}", jobId, transitionModel.getAlertIssueId());
+            String errorMessage = String.format("No Jira Server job found with job id: %s, Alert Issue ID: %s", jobId, transitionModel.getAlertIssueId());
+            logger.error(errorMessage);
+            throw new AlertException(errorMessage);
         }
     }
 }

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandlerTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventHandlerTest.java
@@ -27,7 +27,9 @@ import com.blackduck.integration.alert.api.channel.issue.tracker.search.Existing
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.IssueCategoryRetriever;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueCategory;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueStatus;
+import com.blackduck.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.blackduck.integration.alert.api.descriptor.model.ChannelKeys;
+import com.blackduck.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.blackduck.integration.alert.api.event.EventManager;
 import com.blackduck.integration.alert.channel.jira.server.JiraServerProperties;
@@ -113,6 +115,54 @@ class JiraServerCommentEventHandlerTest {
         );
         handler.handle(event);
         assertEquals(0, issueCounter.get());
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
+    }
+
+    @Test
+    void handleEventExceptionSendsAuditFailedEvent() throws Exception {
+        UUID jobExecutionId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
+
+        JiraServerJobDetailsModel jobDetailsModel = createJobDetails(jobId);
+
+        JiraServerPropertiesFactory propertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
+        Mockito.when(propertiesFactory.createJiraPropertiesWithJobId(jobId)).thenThrow(new AlertConfigurationException("Simulated connection failure"));
+
+        IssueTrackerCallbackInfoCreator callbackInfoCreator = new IssueTrackerCallbackInfoCreator();
+        IssueCategoryRetriever issueCategoryRetriever = new IssueCategoryRetriever();
+        JiraServerMessageSenderFactory messageSenderFactory = new JiraServerMessageSenderFactory(
+            gson,
+            ChannelKeys.JIRA_SERVER,
+            propertiesFactory,
+            callbackInfoCreator,
+            issueCategoryRetriever,
+            eventManager,
+            executingJobManager
+        );
+
+        jobDetailsAccessor.saveConcreteJobDetails(jobId, jobDetailsModel);
+        JiraServerCommentEventHandler handler = new JiraServerCommentEventHandler(
+            eventManager,
+            gson,
+            propertiesFactory,
+            messageSenderFactory,
+            jobDetailsAccessor,
+            responsePostProcessor,
+            executingJobManager
+        );
+        ExistingIssueDetails<String> existingIssueDetails = new ExistingIssueDetails<>("id", "key", "summary", "link", IssueStatus.UNKNOWN, IssueCategory.BOM);
+        IssueCommentModel<String> model = new IssueCommentModel<>(existingIssueDetails, List.of("A comment"), null);
+        JiraServerCommentEvent event = new JiraServerCommentEvent(
+            IssueTrackerCommentEvent.createDefaultEventDestination(ChannelKeys.JIRA_SERVER),
+            jobExecutionId,
+            jobId,
+            notificationIds,
+            model
+        );
+
+        handler.handle(event);
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
     }
 
     @Test

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventListenerTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCommentEventListenerTest.java
@@ -35,7 +35,7 @@ class JiraServerCommentEventListenerTest {
     private final Gson gson = BlackDuckServicesFactory.createDefaultGson();
 
     @Test
-    void onMessageTest() {
+    void onMessageTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -74,7 +74,7 @@ class JiraServerCommentEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsFinishedTest() {
+    void onMessageJobWithRemainingEventsFinishedTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -114,7 +114,7 @@ class JiraServerCommentEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsTest() {
+    void onMessageJobWithRemainingEventsTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandlerTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventHandlerTest.java
@@ -29,7 +29,9 @@ import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueBomC
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.IssueCreationModel;
 import com.blackduck.integration.alert.api.channel.issue.tracker.model.ProjectIssueModel;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.IssueCategoryRetriever;
+import com.blackduck.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.blackduck.integration.alert.api.descriptor.model.ChannelKeys;
+import com.blackduck.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.blackduck.integration.alert.api.event.EventManager;
 import com.blackduck.integration.alert.api.processor.extract.model.ProviderDetails;
@@ -127,6 +129,55 @@ class JiraServerCreateIssueEventHandlerTest {
 
         handler.handle(event);
         assertEquals(0, issueCounter.get());
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
+    }
+
+    @Test
+    void handleEventExceptionSendsAuditFailedEvent() throws Exception {
+        UUID jobExecutionId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
+
+        JiraServerJobDetailsModel jobDetailsModel = createJobDetails(jobId);
+
+        JiraServerPropertiesFactory propertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
+        Mockito.when(propertiesFactory.createJiraPropertiesWithJobId(jobId)).thenThrow(new AlertConfigurationException("Simulated connection failure"));
+
+        IssueTrackerCallbackInfoCreator callbackInfoCreator = new IssueTrackerCallbackInfoCreator();
+        IssueCategoryRetriever issueCategoryRetriever = new IssueCategoryRetriever();
+        JiraServerMessageSenderFactory messageSenderFactory = new JiraServerMessageSenderFactory(
+            gson,
+            ChannelKeys.JIRA_SERVER,
+            propertiesFactory,
+            callbackInfoCreator,
+            issueCategoryRetriever,
+            eventManager,
+            executingJobManager
+        );
+
+        jobDetailsAccessor.saveConcreteJobDetails(jobId, jobDetailsModel);
+        JiraServerCreateIssueEventHandler handler = new JiraServerCreateIssueEventHandler(
+            eventManager,
+            gson,
+            propertiesFactory,
+            messageSenderFactory,
+            jobDetailsAccessor,
+            responsePostProcessor,
+            executingJobManager
+        );
+
+        LinkableItem provider = new LinkableItem("provider", "test-provider");
+        IssueCreationModel issueCreationModel = IssueCreationModel.simple("title", "description", List.of(), provider);
+        JiraServerCreateIssueEvent event = new JiraServerCreateIssueEvent(
+            IssueTrackerCreateIssueEvent.createDefaultEventDestination(ChannelKeys.JIRA_SERVER),
+            jobExecutionId,
+            jobId,
+            notificationIds,
+            issueCreationModel
+        );
+
+        handler.handle(event);
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
     }
 
     @Test

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventListenerTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerCreateIssueEventListenerTest.java
@@ -35,7 +35,7 @@ class JiraServerCreateIssueEventListenerTest {
     private final Gson gson = BlackDuckServicesFactory.createDefaultGson();
 
     @Test
-    void onMessageTestJob() {
+    void onMessageTestJob() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -75,7 +75,7 @@ class JiraServerCreateIssueEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsFinishedTest() {
+    void onMessageJobWithRemainingEventsFinishedTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -116,7 +116,7 @@ class JiraServerCreateIssueEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsTest() {
+    void onMessageJobWithRemainingEventsTest() throws Exception {
 
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandlerTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventHandlerTest.java
@@ -28,7 +28,9 @@ import com.blackduck.integration.alert.api.channel.issue.tracker.search.Existing
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.IssueCategoryRetriever;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueCategory;
 import com.blackduck.integration.alert.api.channel.issue.tracker.search.enumeration.IssueStatus;
+import com.blackduck.integration.alert.api.common.model.exception.AlertConfigurationException;
 import com.blackduck.integration.alert.api.descriptor.model.ChannelKeys;
+import com.blackduck.integration.alert.api.distribution.audit.AuditFailedEvent;
 import com.blackduck.integration.alert.api.distribution.execution.ExecutingJobManager;
 import com.blackduck.integration.alert.api.event.EventManager;
 import com.blackduck.integration.alert.channel.jira.server.JiraServerProperties;
@@ -118,6 +120,54 @@ class JiraServerTransitionEventHandlerTest {
         );
         handler.handle(event);
         assertEquals(0, issueCounter.get());
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
+    }
+
+    @Test
+    void handleEventExceptionSendsAuditFailedEvent() throws Exception {
+        UUID jobExecutionId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        Set<Long> notificationIds = Set.of(1L, 2L, 3L, 4L);
+
+        JiraServerJobDetailsModel jobDetailsModel = createJobDetails(jobId);
+
+        JiraServerPropertiesFactory propertiesFactory = Mockito.mock(JiraServerPropertiesFactory.class);
+        Mockito.when(propertiesFactory.createJiraPropertiesWithJobId(jobId)).thenThrow(new AlertConfigurationException("Simulated connection failure"));
+
+        IssueTrackerCallbackInfoCreator callbackInfoCreator = new IssueTrackerCallbackInfoCreator();
+        IssueCategoryRetriever issueCategoryRetriever = new IssueCategoryRetriever();
+        JiraServerMessageSenderFactory messageSenderFactory = new JiraServerMessageSenderFactory(
+            gson,
+            ChannelKeys.JIRA_SERVER,
+            propertiesFactory,
+            callbackInfoCreator,
+            issueCategoryRetriever,
+            eventManager,
+            executingJobManager
+        );
+
+        jobDetailsAccessor.saveConcreteJobDetails(jobId, jobDetailsModel);
+        JiraServerTransitionEventHandler handler = new JiraServerTransitionEventHandler(
+            eventManager,
+            gson,
+            propertiesFactory,
+            messageSenderFactory,
+            jobDetailsAccessor,
+            responsePostProcessor,
+            executingJobManager
+        );
+        ExistingIssueDetails<String> existingIssueDetails = new ExistingIssueDetails<>("id", "key", "summary", "link", IssueStatus.UNKNOWN, IssueCategory.BOM);
+        IssueTransitionModel<String> model = new IssueTransitionModel<>(existingIssueDetails, IssueOperation.RESOLVE, List.of(), null);
+        JiraServerTransitionEvent event = new JiraServerTransitionEvent(
+            IssueTrackerTransitionIssueEvent.createDefaultEventDestination(ChannelKeys.JIRA_SERVER),
+            jobExecutionId,
+            jobId,
+            notificationIds,
+            model
+        );
+
+        handler.handle(event);
+        Mockito.verify(eventManager).sendEvent(Mockito.any(AuditFailedEvent.class));
     }
 
     @Test

--- a/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventListenerTest.java
+++ b/channel-jira-server/src/test/java/com/blackduck/integration/alert/channel/jira/server/distribution/event/JiraServerTransitionEventListenerTest.java
@@ -36,7 +36,7 @@ class JiraServerTransitionEventListenerTest {
     private final Gson gson = BlackDuckServicesFactory.createDefaultGson();
 
     @Test
-    void onMessageTest() {
+    void onMessageTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -75,7 +75,7 @@ class JiraServerTransitionEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsFinishedTest() {
+    void onMessageJobWithRemainingEventsFinishedTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);
@@ -115,7 +115,7 @@ class JiraServerTransitionEventListenerTest {
     }
 
     @Test
-    void onMessageJobWithRemainingEventsTest() {
+    void onMessageJobWithRemainingEventsTest() throws Exception {
         UUID jobId = UUID.randomUUID();
         Set<Long> notificationIds = Set.of(1L, 2L, 3L);
         EventManager eventManager = Mockito.mock(EventManager.class);

--- a/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/issue/BlackDuckIssueTrackerCallbackEventHandler.java
+++ b/provider-blackduck/src/main/java/com/blackduck/integration/alert/provider/blackduck/issue/BlackDuckIssueTrackerCallbackEventHandler.java
@@ -38,7 +38,11 @@ public class BlackDuckIssueTrackerCallbackEventHandler implements AlertEventHand
     private final BlackDuckPropertiesFactory blackDuckPropertiesFactory;
     private final ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor;
 
-    public BlackDuckIssueTrackerCallbackEventHandler(Gson gson, BlackDuckPropertiesFactory blackDuckPropertiesFactory, ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor) {
+    public BlackDuckIssueTrackerCallbackEventHandler(
+        Gson gson,
+        BlackDuckPropertiesFactory blackDuckPropertiesFactory,
+        ConfigurationModelConfigurationAccessor configurationModelConfigurationAccessor
+    ) {
         this.gson = gson;
         this.blackDuckPropertiesFactory = blackDuckPropertiesFactory;
         this.configurationModelConfigurationAccessor = configurationModelConfigurationAccessor;
@@ -47,11 +51,19 @@ public class BlackDuckIssueTrackerCallbackEventHandler implements AlertEventHand
     @Override
     public void handle(IssueTrackerCallbackEvent event) {
         String eventId = event.getEventId();
-        logger.debug("Handling issue-tracker callback event with id '{}' for issue key: {}", eventId, event.getIssueKey());
-
         IssueTrackerCallbackInfo callbackInfo = event.getCallbackInfo();
+        logger.debug(
+            "Start handling issue-tracker callback. event id: '{}', issue key: {}, issue summary: {}, provider id: {}, project-version URL: {}, callback URL: {}",
+            eventId,
+            event.getIssueKey(),
+            event.getIssueSummary(),
+            callbackInfo.getProviderConfigId(),
+            callbackInfo.getBlackDuckProjectVersionUrl(),
+            callbackInfo.getCallbackUrl()
+        );
+
         Optional<BlackDuckServicesFactory> optionalBlackDuckServicesFactory = createBlackDuckProperties(callbackInfo.getProviderConfigId())
-                                                                                  .flatMap(this::createBlackDuckServicesFactory);
+            .flatMap(this::createBlackDuckServicesFactory);
         if (optionalBlackDuckServicesFactory.isPresent()) {
             BlackDuckServicesFactory blackDuckServicesFactory = optionalBlackDuckServicesFactory.get();
             BlackDuckApiClient blackDuckApiClient = blackDuckServicesFactory.getBlackDuckApiClient();
@@ -61,12 +73,12 @@ public class BlackDuckIssueTrackerCallbackEventHandler implements AlertEventHand
             BlackDuckProviderIssueModel issueModel = createBlackDuckIssueModel(event);
             createOrUpdateBlackDuckIssue(blackDuckProviderIssueHandler, issueModel, callbackInfo);
         }
-        logger.debug("Finished handling issue-tracker callback event with id '{}' for issue key: {}", eventId, event.getIssueKey());
+        logger.debug("Finished handling issue-tracker callback. event id: '{}', issue key: {}", eventId, event.getIssueKey());
     }
 
     private Optional<BlackDuckProperties> createBlackDuckProperties(Long providerConfigId) {
         return configurationModelConfigurationAccessor.getConfigurationById(providerConfigId)
-                   .map(blackDuckPropertiesFactory::createProperties);
+            .map(blackDuckPropertiesFactory::createProperties);
     }
 
     private Optional<BlackDuckServicesFactory> createBlackDuckServicesFactory(BlackDuckProperties blackDuckProperties) {
@@ -81,11 +93,23 @@ public class BlackDuckIssueTrackerCallbackEventHandler implements AlertEventHand
         }
     }
 
-    private void createOrUpdateBlackDuckIssue(BlackDuckProviderIssueHandler blackDuckProviderIssueHandler, BlackDuckProviderIssueModel issueModel, IssueTrackerCallbackInfo callbackInfo) {
+    private void createOrUpdateBlackDuckIssue(
+        BlackDuckProviderIssueHandler blackDuckProviderIssueHandler,
+        BlackDuckProviderIssueModel issueModel,
+        IssueTrackerCallbackInfo callbackInfo
+    ) {
         try {
             blackDuckProviderIssueHandler.createOrUpdateBlackDuckIssue(issueModel, callbackInfo.getCallbackUrl(), callbackInfo.getBlackDuckProjectVersionUrl());
         } catch (IntegrationException e) {
-            logger.error("Failed to create or update Black Duck issue: {}", issueModel, e);
+            logger.debug(
+                "An error occurred while trying to map an issue to a Black Duck project/version. issue key: {}, issue summary: {}, provider id: {}, project-version URL: {}, callback URL: {}",
+                issueModel.getKey(),
+                issueModel.getSummary(),
+                callbackInfo.getProviderConfigId(),
+                callbackInfo.getBlackDuckProjectVersionUrl(),
+                callbackInfo.getCallbackUrl()
+            );
+            logger.error("Failed to create or update Black Duck project/version. issue key: {}", issueModel.getKey(), e);
         }
     }
 
@@ -95,15 +119,11 @@ public class BlackDuckIssueTrackerCallbackEventHandler implements AlertEventHand
     }
 
     private String mapOperationToAlertStatus(IssueOperation issueOperation) {
-        switch (issueOperation) {
-            case OPEN:
-            case UPDATE:
-                return "Created by Alert";
-            case RESOLVE:
-                return "Resolved by Alert";
-            default:
-                return "Unknown";
-        }
+        return switch (issueOperation) {
+            case OPEN, UPDATE -> "Created by Alert";
+            case RESOLVE -> "Resolved by Alert";
+            default -> "Unknown";
+        };
     }
 
 }

--- a/src/main/java/com/blackduck/integration/alert/processing/NotificationReceivedEventHandler.java
+++ b/src/main/java/com/blackduck/integration/alert/processing/NotificationReceivedEventHandler.java
@@ -59,22 +59,36 @@ public class NotificationReceivedEventHandler implements AlertEventHandler<Notif
         UUID correlationID = event.getCorrelationId();
         long providerConfigId = event.getProviderConfigId();
         UUID accumulationBatchId = event.getBatchId();
-        AlertPagedModel<AlertNotificationModel> pageOfAlertNotificationModels = notificationAccessor.getFirstPageOfNotificationsNotMapped(providerConfigId, accumulationBatchId, PAGE_SIZE);
+        AlertPagedModel<AlertNotificationModel> pageOfAlertNotificationModels = notificationAccessor.getFirstPageOfNotificationsNotMapped(
+            providerConfigId,
+            accumulationBatchId,
+            PAGE_SIZE
+        );
         if (!CollectionUtils.isEmpty(pageOfAlertNotificationModels.getModels())) {
             List<AlertNotificationModel> notifications = pageOfAlertNotificationModels.getModels();
-            logger.info("Starting to process batch for provider({}): batch: {} correlation id: {} = {} notifications.", providerConfigId, accumulationBatchId, correlationID, notifications.size());
+            logger.info(
+                "Starting to process batch for provider({}): batch: {} correlation id: {} = {} notifications.",
+                providerConfigId,
+                accumulationBatchId,
+                correlationID,
+                notifications.size()
+            );
             notificationMappingProcessor.processNotifications(correlationID, notifications, List.of(FrequencyType.REAL_TIME));
             boolean hasMoreNotificationsToMap = notificationAccessor.hasMoreNotificationsToMap(providerConfigId, accumulationBatchId);
             String sendingMappedEvent = "";
 
             if (logger.isDebugEnabled()) {
-                sendingMappedEvent = String.format("Sending mapped event for correlation id %s", correlationID);
+                sendingMappedEvent = String.format("Sending mapped event for correlation id: %s", correlationID);
             }
 
             if (hasMoreNotificationsToMap) {
                 NotificationReceivedEvent continueProcessingEvent;
                 if (notificationMappingProcessor.hasExceededBatchLimit(correlationID)) {
-                    logger.info("Mapping batch limit of {} exceeded for correlation id: {}. Continuing processing in next batch.", notificationMappingProcessor.getNotificationMappingBatchLimit(), correlationID);
+                    logger.info(
+                        "Mapping batch limit of {} exceeded for correlation id: {}. Continuing processing in next batch.",
+                        notificationMappingProcessor.getNotificationMappingBatchLimit(),
+                        correlationID
+                    );
                     logger.debug(sendingMappedEvent);
                     eventManager.sendEvent(new JobNotificationMappedEvent(correlationID));
                     continueProcessingEvent = new NotificationReceivedEvent(providerConfigId, accumulationBatchId);
@@ -88,7 +102,16 @@ public class NotificationReceivedEventHandler implements AlertEventHandler<Notif
                 eventManager.sendEvent(new JobNotificationMappedEvent(correlationID));
             }
         } else {
-            logger.debug("No notifications to process for provider({}): batch: {} correlation id: {}", providerConfigId, accumulationBatchId, correlationID);
+            // Edge-case guard: If the unprocessed notifications are removed in between mapping cycles, a batch that has been mapped but never transmitted by the continuation
+            // event (JobNotificationMappedEvent) will be orphaned. This will send any already mapped notifications if they have been removed externally during these cycles.
+            // Empty notification-job mappings are filtered downstream. See IALERT-3979.
+            logger.debug(
+                "No notifications left to process in accumulation batch. Sending mapped event for any existing mappings. provider({}): batch: {} correlation id: {}",
+                providerConfigId,
+                accumulationBatchId,
+                correlationID
+            );
+            eventManager.sendEvent(new JobNotificationMappedEvent(correlationID));
         }
         logger.info("Finished processing batch for provider({}): batch: {} correlation id: {} event for notifications.", providerConfigId, accumulationBatchId, correlationID);
     }

--- a/src/test/java/com/blackduck/integration/alert/NotificationAccessorTestIT.java
+++ b/src/test/java/com/blackduck/integration/alert/NotificationAccessorTestIT.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -119,7 +120,6 @@ class NotificationAccessorTestIT {
     }
 
     private void cleanDB() {
-        notificationContentRepository.deleteAllInBatch();
         notificationContentRepository.deleteAllInBatch();
         auditNotificationRepository.deleteAllInBatch();
         auditEntryRepository.deleteAllInBatch();
@@ -290,7 +290,12 @@ class NotificationAccessorTestIT {
         notificationManager.saveAllNotifications(List.of(entityToFind1));
         notificationManager.saveAllNotifications(List.of(entityToFind2));
 
-        List<AlertNotificationModel> foundList = notificationManager.findByCreatedAtBetween(startDate, endDate, AlertPagedModel.DEFAULT_PAGE_NUMBER, AlertPagedModel.DEFAULT_PAGE_SIZE).getModels();
+        List<AlertNotificationModel> foundList = notificationManager.findByCreatedAtBetween(
+            startDate,
+            endDate,
+            AlertPagedModel.DEFAULT_PAGE_NUMBER,
+            AlertPagedModel.DEFAULT_PAGE_SIZE
+        ).getModels();
 
         assertEquals(2, foundList.size());
         assertNotificationModel(entityToFind1, foundList.get(0));
@@ -310,7 +315,12 @@ class NotificationAccessorTestIT {
         entity = createNotificationModel(createdAtLater);
         notificationManager.saveAllNotifications(List.of(entity));
 
-        List<AlertNotificationModel> foundList = notificationManager.findByCreatedAtBetween(startDate, endDate, AlertPagedModel.DEFAULT_PAGE_NUMBER, AlertPagedModel.DEFAULT_PAGE_SIZE).getModels();
+        List<AlertNotificationModel> foundList = notificationManager.findByCreatedAtBetween(
+            startDate,
+            endDate,
+            AlertPagedModel.DEFAULT_PAGE_NUMBER,
+            AlertPagedModel.DEFAULT_PAGE_SIZE
+        ).getModels();
 
         assertTrue(foundList.isEmpty());
     }
@@ -380,6 +390,90 @@ class NotificationAccessorTestIT {
         assertEquals(notification1.getCreatedAt(), remainingNotification.getCreatedAt());
     }
 
+    /**
+     * Verifies that only the first occurrence of a duplicate {@code contentId} within a single batch is persisted.
+     */
+    @Test
+    void testSaveSkipsDuplicateContentIdInBatch() {
+        String sharedContentId = "duplicate-content-id-" + UUID.randomUUID();
+        OffsetDateTime createdAt = DateUtils.createCurrentDateTimestamp();
+
+        AlertNotificationModel firstOccurrence = createNotificationModelWithContentId(createdAt, sharedContentId);
+        AlertNotificationModel duplicateOccurrence = createNotificationModelWithContentId(createdAt, sharedContentId);
+
+        List<AlertNotificationModel> savedModels = notificationManager.saveAllNotifications(List.of(firstOccurrence, duplicateOccurrence));
+
+        assertEquals(1, savedModels.size(), "Only the first occurrence of a duplicate contentId in a batch should be saved");
+        assertEquals(1, notificationContentRepository.count(), "Only one row should exist in the database after saving a batch with a duplicate contentId");
+    }
+
+    /**
+     * Verifies that a notification whose {@code contentId} already exists in the database is not persisted again.
+     */
+    @Test
+    void testSaveSkipsNotificationAlreadyInDatabase() {
+        String sharedContentId = "existing-content-id-" + UUID.randomUUID();
+        OffsetDateTime createdAt = DateUtils.createCurrentDateTimestamp();
+
+        AlertNotificationModel original = createNotificationModelWithContentId(createdAt, sharedContentId);
+        List<AlertNotificationModel> firstSave = notificationManager.saveAllNotifications(List.of(original));
+        assertEquals(1, firstSave.size(), "First save should persist the notification");
+
+        AlertNotificationModel duplicate = createNotificationModelWithContentId(createdAt, sharedContentId);
+        List<AlertNotificationModel> secondSave = notificationManager.saveAllNotifications(List.of(duplicate));
+
+        assertTrue(secondSave.isEmpty(), "Saving a notification whose contentId already exists in the database should return an empty list");
+        assertEquals(1, notificationContentRepository.count(), "The database should still contain only one notification after a duplicate save attempt");
+    }
+
+    /**
+     * Verifies that {@link DefaultNotificationAccessor#saveAllNotifications} correctly handles a batch
+     * containing all three deduplication scenarios simultaneously:
+     * <ul>
+     *   <li>Notifications whose {@code contentId} is new — these should be persisted and returned.</li>
+     *   <li>Notifications whose {@code contentId} already exists in the database — these should be silently skipped.</li>
+     *   <li>Notifications whose {@code contentId} appears more than once within the same batch — only the first
+     *       occurrence should be persisted; subsequent duplicates should be filtered.</li>
+     * </ul>
+     */
+    @Test
+    void testSaveMixedBatchContentIds() {
+        OffsetDateTime createdAt = DateUtils.createCurrentDateTimestamp();
+
+        // Save 2 notifications so they already exist in the database
+        String existingContentId1 = "existing-1-" + UUID.randomUUID();
+        String existingContentId2 = "existing-2-" + UUID.randomUUID();
+        notificationManager.saveAllNotifications(List.of(
+            createNotificationModelWithContentId(createdAt, existingContentId1),
+            createNotificationModelWithContentId(createdAt, existingContentId2)
+        ));
+
+        // Build a mixed batch:
+        // - 2 new unique notifications (should be saved)
+        // - 2 already in the database (should be skipped)
+        // - 1 in-batch duplicate of a new notification (should be skipped)
+        String newContentId1 = "new-1-" + UUID.randomUUID();
+        String newContentId2 = "new-2-" + UUID.randomUUID();
+        List<AlertNotificationModel> mixedBatch = List.of(
+            createNotificationModelWithContentId(createdAt, newContentId1),
+            createNotificationModelWithContentId(createdAt, newContentId2),
+            createNotificationModelWithContentId(createdAt, existingContentId1),
+            createNotificationModelWithContentId(createdAt, existingContentId2),
+            createNotificationModelWithContentId(createdAt, newContentId1)
+        );
+
+        List<AlertNotificationModel> savedModels = notificationManager.saveAllNotifications(mixedBatch);
+
+        assertEquals(2, savedModels.size(), "Only the 2 new unique notifications should be returned when saving.");
+        assertEquals(4, notificationContentRepository.count(), "The database should contain 2 pre-existing + 2 new notifications.");
+
+        List<String> savedContentIds = savedModels.stream()
+            .map(AlertNotificationModel::getContentId)
+            .toList();
+        assertTrue(savedContentIds.contains(newContentId1), "The first new notification should be in the returned list");
+        assertTrue(savedContentIds.contains(newContentId2), "The second new notification should be in the returned list");
+    }
+
     @Test
     void testDeleteNotification() {
         AlertNotificationModel notificationEntity = createNotificationModel();
@@ -423,28 +517,42 @@ class NotificationAccessorTestIT {
         assertTrue(alertNotificationModelTest.get().getProcessed());
     }
 
+    private AlertNotificationModel createNotificationModel() {
+        OffsetDateTime createdAt = DateUtils.createCurrentDateTimestamp();
+        return createNotificationModel(createdAt);
+    }
+
     private AlertNotificationModel createNotificationModel(OffsetDateTime createdAt) {
+        return createNotificationModelWithContentId(createdAt, String.format("content-id-%s", UUID.randomUUID()));
+    }
+
+    private AlertNotificationModel createNotificationModelWithContentId(OffsetDateTime createdAt, String contentId) {
+        // Truncate to microseconds to match PostgreSQL TIMESTAMP WITH TIME ZONE precision.
+        // Without this, some systems with only microsecond precision will result in tests failures.
+        OffsetDateTime microsCreatedAt = createdAt.truncatedTo(ChronoUnit.MICROS);
         return new AlertNotificationModel(
             providerConfigModel.getConfigurationId(),
             "provider",
             "providerConfigName",
             NOTIFICATION_TYPE,
             "{content: \"content is here...\"}",
-            createdAt,
-            createdAt,
+            microsCreatedAt,
+            microsCreatedAt,
             false,
-            String.format("content-id-%s", UUID.randomUUID()),
+            contentId,
             false
         );
     }
 
-    private AlertNotificationModel createNotificationModel() {
-        OffsetDateTime createdAt = DateUtils.createCurrentDateTimestamp();
-        return createNotificationModel(createdAt);
-    }
-
     private NotificationEntity createNotificationContent(OffsetDateTime createdAt) {
-        MockNotificationContent mockedNotificationContent = new MockNotificationContent(createdAt, "provider", createdAt, NOTIFICATION_TYPE, "{content: \"content is here...\"}", providerConfigModel.getConfigurationId());
+        MockNotificationContent mockedNotificationContent = new MockNotificationContent(
+            createdAt,
+            "provider",
+            createdAt,
+            NOTIFICATION_TYPE,
+            "{content: \"content is here...\"}",
+            providerConfigModel.getConfigurationId()
+        );
         return mockedNotificationContent.createEntity();
     }
 

--- a/src/test/java/com/blackduck/integration/alert/database/notification/NotificationContentRepositoryTestIT.java
+++ b/src/test/java/com/blackduck/integration/alert/database/notification/NotificationContentRepositoryTestIT.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
@@ -36,6 +37,7 @@ import com.blackduck.integration.alert.test.common.TestTags;
 import com.blackduck.integration.alert.util.AlertIntegrationTest;
 import com.blackduck.integration.blackduck.api.manual.enumeration.NotificationType;
 
+@Transactional
 @AlertIntegrationTest
 @Tag(TestTags.DEFAULT_INTEGRATION)
 class NotificationContentRepositoryTestIT {
@@ -56,7 +58,6 @@ class NotificationContentRepositoryTestIT {
     }
 
     @Test
-    @Transactional
     void findByProcessedFalseOrderByProviderCreationTimeAscTestIT() {
         // Create provider config (required for FK constraint)
         DescriptorConfigEntity providerConfig = createProviderConfig();
@@ -94,7 +95,6 @@ class NotificationContentRepositoryTestIT {
     }
 
     @Test
-    @Transactional
     void countByProcessedTest() {
         DescriptorConfigEntity providerConfig = createProviderConfig();
         Long providerConfigId = providerConfig.getId();
@@ -107,6 +107,99 @@ class NotificationContentRepositoryTestIT {
 
         assertEquals(1, notificationContentRepository.countByProcessed(true));
         assertEquals(2, notificationContentRepository.countByProcessed(false));
+    }
+
+    @Test
+    void saveIgnoreContentIdConflictInsertsNewNotificationTest() {
+        DescriptorConfigEntity providerConfig = createProviderConfig();
+        String contentId = String.format("content-id-%s", UUID.randomUUID());
+
+        saveNotificationWithContentId(providerConfig.getId(), contentId);
+
+        assertEquals(1, notificationContentRepository.count(), "A new notification with a unique contentId should be inserted");
+    }
+
+    @Test
+    void saveIgnoreContentIdConflictIgnoresDuplicateContentIdTest() {
+        DescriptorConfigEntity providerConfig = createProviderConfig();
+        String contentId = String.format("content-id-%s", UUID.randomUUID());
+
+        saveNotificationWithContentId(providerConfig.getId(), contentId);
+        saveNotificationWithContentId(providerConfig.getId(), contentId);
+
+        assertEquals(1, notificationContentRepository.count(), "A duplicate contentId should not produce a second row");
+    }
+
+    @Test
+    void saveIgnoreContentIdConflictSequentialIdIncrementTest() {
+        DescriptorConfigEntity providerConfig = createProviderConfig();
+        int numberOfNotifications = 5;
+        List<String> contentIds = new ArrayList<>();
+        for (int i = 0; i < numberOfNotifications; i++) {
+            String contentId = String.format("content-id-%s", UUID.randomUUID());
+            contentIds.add(contentId);
+            saveNotificationWithContentId(providerConfig.getId(), contentId);
+        }
+
+        List<NotificationEntity> savedNotificationEntities = notificationContentRepository.findByContentIdIn(contentIds);
+        savedNotificationEntities.sort(Comparator.comparing(NotificationEntity::getId));
+
+        assertEquals(numberOfNotifications, savedNotificationEntities.size());
+        long firstId = savedNotificationEntities.get(0).getId();
+        for (int i = 0; i < savedNotificationEntities.size(); i++) {
+            assertEquals(firstId + i, savedNotificationEntities.get(i).getId(), "Notification IDs should be sequential starting from the first inserted ID");
+        }
+    }
+
+    @Test
+    void findByContentIdInReturnsMatchingEntitiesTest() {
+        DescriptorConfigEntity providerConfig = createProviderConfig();
+        OffsetDateTime now = OffsetDateTime.now();
+
+        NotificationEntity first = createNotification(providerConfig.getId(), now);
+        NotificationEntity second = createNotification(providerConfig.getId(), now);
+        notificationContentRepository.saveAll(List.of(first, second));
+
+        List<NotificationEntity> result = notificationContentRepository.findByContentIdIn(List.of(first.getContentId(), second.getContentId()));
+
+        assertEquals(2, result.size(), "Both saved notifications should be returned when queried by their contentIds");
+    }
+
+    @Test
+    void findByContentIdInReturnsEmptyWhenNoMatchesTest() {
+        List<NotificationEntity> result = notificationContentRepository.findByContentIdIn(
+            List.of(String.format("non-existent-content-id-%s", UUID.randomUUID()), String.format("non-existent-content-id-%s", UUID.randomUUID()))
+        );
+
+        assertTrue(result.isEmpty(), "No entities should be returned when none of the contentIds exist in the database");
+    }
+
+    @Test
+    void findByContentIdInReturnsSubsetForPartialMatchesTest() {
+        DescriptorConfigEntity providerConfig = createProviderConfig();
+        NotificationEntity saved = createNotification(providerConfig.getId(), OffsetDateTime.now());
+        notificationContentRepository.save(saved);
+
+        List<NotificationEntity> result = notificationContentRepository.findByContentIdIn(
+            List.of(saved.getContentId(), String.format("non-existent-content-id-%s", UUID.randomUUID()))
+        );
+
+        assertEquals(1, result.size(), "Only the notification with a matching contentId should be returned");
+        assertEquals(saved.getContentId(), result.get(0).getContentId(), "The returned entity should match the saved contentId");
+    }
+
+    private void saveNotificationWithContentId(Long providerConfigId, String contentId) {
+        notificationContentRepository.saveIgnoreContentIdConflict(
+            OffsetDateTime.now(),
+            BLACK_DUCK_PROVIDER_KEY.getUniversalKey(),
+            providerConfigId,
+            OffsetDateTime.now(),
+            NotificationType.VULNERABILITY.name(),
+            "{\"content\": {}}",
+            false,
+            contentId,
+            false
+        );
     }
 
     private DescriptorConfigEntity createProviderConfig() {

--- a/src/test/java/com/blackduck/integration/alert/processing/NotificationReceivedEventHandlerTest.java
+++ b/src/test/java/com/blackduck/integration/alert/processing/NotificationReceivedEventHandlerTest.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.blackduck.integration.alert.api.processor.detail.NotificationDetailExtractionDelegator;
 import com.blackduck.integration.alert.api.processor.event.JobNotificationMappedEvent;
 import com.blackduck.integration.alert.api.processor.mapping.JobNotificationMapper2;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -62,13 +63,52 @@ class NotificationReceivedEventHandlerTest {
         NotificationDetailExtractionDelegator notificationDetailExtractionDelegator = Mockito.mock(NotificationDetailExtractionDelegator.class);
         JobNotificationMapper2 jobNotificationMapper = Mockito.mock(JobNotificationMapper2.class);
 
-        NotificationMappingProcessor notificationMappingProcessor = new NotificationMappingProcessor(notificationDetailExtractionDelegator, jobNotificationMapper, notificationAccessor, alertProperties);
+        NotificationMappingProcessor notificationMappingProcessor = new NotificationMappingProcessor(
+            notificationDetailExtractionDelegator,
+            jobNotificationMapper,
+            notificationAccessor,
+            alertProperties
+        );
         RecordingEventManager eventManager = mockEventManager();
 
         NotificationReceivedEventHandler eventHandler = new NotificationReceivedEventHandler(notificationAccessor, notificationMappingProcessor, eventManager);
         eventHandler.handle(new NotificationReceivedEvent(2L, batchId));
 
-        Assertions.assertTrue(eventManager.getEventList().isEmpty());
+        Assertions.assertEquals(1, eventManager.getEventList().size(), "Expected one JobNotificationMappedEvent when the notification table is empty.");
+        Assertions.assertEquals(
+            JobNotificationMappedEvent.NOTIFICATION_MAPPED_EVENT_TYPE,
+            eventManager.getEventList().get(0).getDestination(),
+            "Expected event type to be NOTIFICATION_MAPPED_EVENT_TYPE."
+        );
+    }
+
+    @Test
+    void allNotificationsAlreadyMappedSendsJobNotificationMappedEvent() throws IOException {
+        AlertNotificationModel alreadyMappedNotification = createAlertNotificationModel(1L, false, true);
+        NotificationAccessor notificationAccessor = new MockNotificationAccessor(List.of(alreadyMappedNotification), batchId);
+        NotificationDetailExtractionDelegator notificationDetailExtractionDelegator = Mockito.mock(NotificationDetailExtractionDelegator.class);
+        JobNotificationMapper2 jobNotificationMapper = Mockito.mock(JobNotificationMapper2.class);
+
+        NotificationMappingProcessor notificationMappingProcessor = new NotificationMappingProcessor(
+            notificationDetailExtractionDelegator,
+            jobNotificationMapper,
+            notificationAccessor,
+            alertProperties
+        );
+        RecordingEventManager eventManager = mockEventManager();
+
+        UUID correlationId = UUID.randomUUID();
+        NotificationReceivedEventHandler eventHandler = new NotificationReceivedEventHandler(notificationAccessor, notificationMappingProcessor, eventManager);
+        eventHandler.handle(new NotificationReceivedEvent(correlationId, 2L, batchId));
+
+        Assertions.assertEquals(1, eventManager.getEventList().size(), "Expected exactly one event when all notifications are already mapped.");
+        Assertions.assertEquals(
+            JobNotificationMappedEvent.NOTIFICATION_MAPPED_EVENT_TYPE,
+            eventManager.getEventList().get(0).getDestination(),
+            "Expected event to be a JobNotificationMappedEvent."
+        );
+        JobNotificationMappedEvent sentEvent = (JobNotificationMappedEvent) eventManager.getEventList().get(0);
+        Assertions.assertEquals(correlationId, sentEvent.getCorrelationId(), "Expected JobNotificationMappedEvent to carry the original correlationId.");
     }
 
     @Test
@@ -77,27 +117,32 @@ class NotificationReceivedEventHandlerTest {
         int count = 10;
         List<AlertNotificationModel> alertNotificationModels = new ArrayList<>(count);
         AtomicLong counter = new AtomicLong(notificationId);
-        for(int index = 0; index < count; index++) {
+        for (int index = 0; index < count; index++) {
             alertNotificationModels.add(createAlertNotificationModel(counter.getAndIncrement(), false, false));
         }
-        NotificationAccessor notificationAccessor = new MockNotificationAccessor(alertNotificationModels,batchId);
+        NotificationAccessor notificationAccessor = new MockNotificationAccessor(alertNotificationModels, batchId);
         NotificationDetailExtractionDelegator notificationDetailExtractionDelegator = Mockito.mock(NotificationDetailExtractionDelegator.class);
         JobNotificationMapper2 jobNotificationMapper = Mockito.mock(JobNotificationMapper2.class);
         // the batch limit has been exceeded
         Mockito.when(jobNotificationMapper.hasBatchReachedSizeLimit(Mockito.any(UUID.class), Mockito.anyInt())).thenReturn(true);
 
-        NotificationMappingProcessor notificationMappingProcessor = new NotificationMappingProcessor(notificationDetailExtractionDelegator, jobNotificationMapper, notificationAccessor, alertProperties);
+        NotificationMappingProcessor notificationMappingProcessor = new NotificationMappingProcessor(
+            notificationDetailExtractionDelegator,
+            jobNotificationMapper,
+            notificationAccessor,
+            alertProperties
+        );
         RecordingEventManager eventManager = mockEventManager();
 
         NotificationReceivedEventHandler eventHandler = new NotificationReceivedEventHandler(notificationAccessor, notificationMappingProcessor, eventManager);
         eventHandler.handle(new NotificationReceivedEvent(2L, batchId));
 
         List<Long> notificationIds = alertNotificationModels.stream()
-                                .map(AlertNotificationModel::getId)
-                                .toList();
+            .map(AlertNotificationModel::getId)
+            .toList();
         List<AlertNotificationModel> updatedNotificationModels = notificationAccessor.findByIds(notificationIds);
         boolean allNotificationsMapping = updatedNotificationModels.stream()
-                .allMatch(AlertNotificationModel::isMappingToJobs);
+            .allMatch(AlertNotificationModel::isMappingToJobs);
 
         Assertions.assertTrue(allNotificationsMapping, "Expected all notifications to be marked as mapping to jobs.");
         // Send an event to continue processing notifications that have not been mapped
@@ -111,26 +156,31 @@ class NotificationReceivedEventHandlerTest {
         int count = NotificationReceivedEventHandler.PAGE_SIZE + 10;
         List<AlertNotificationModel> alertNotificationModels = new ArrayList<>(count);
         AtomicLong counter = new AtomicLong(notificationId);
-        for(int index = 0; index < count; index++) {
+        for (int index = 0; index < count; index++) {
             alertNotificationModels.add(createAlertNotificationModel(counter.getAndIncrement(), false, false));
         }
         NotificationAccessor notificationAccessor = new MockNotificationAccessor(alertNotificationModels, batchId);
         NotificationDetailExtractionDelegator notificationDetailExtractionDelegator = Mockito.mock(NotificationDetailExtractionDelegator.class);
         JobNotificationMapper2 jobNotificationMapper = Mockito.mock(JobNotificationMapper2.class);
 
-        NotificationMappingProcessor notificationMappingProcessor = new NotificationMappingProcessor(notificationDetailExtractionDelegator, jobNotificationMapper, notificationAccessor, alertProperties);
+        NotificationMappingProcessor notificationMappingProcessor = new NotificationMappingProcessor(
+            notificationDetailExtractionDelegator,
+            jobNotificationMapper,
+            notificationAccessor,
+            alertProperties
+        );
         RecordingEventManager eventManager = mockEventManager();
 
         NotificationReceivedEventHandler eventHandler = new NotificationReceivedEventHandler(notificationAccessor, notificationMappingProcessor, eventManager);
         eventHandler.handle(new NotificationReceivedEvent(2L, batchId));
 
         List<Long> notificationIds = alertNotificationModels.stream()
-                .map(AlertNotificationModel::getId)
-                .toList();
+            .map(AlertNotificationModel::getId)
+            .toList();
         List<AlertNotificationModel> updatedNotificationModels = notificationAccessor.findByIds(notificationIds);
         boolean allNotificationsMapping = updatedNotificationModels.stream()
-                .limit(NotificationReceivedEventHandler.PAGE_SIZE)
-                .allMatch(AlertNotificationModel::isMappingToJobs);
+            .limit(NotificationReceivedEventHandler.PAGE_SIZE)
+            .allMatch(AlertNotificationModel::isMappingToJobs);
 
         Assertions.assertTrue(allNotificationsMapping, "Expected all notifications to be marked as mapping to jobs.");
         // Send an event to continue processing notifications that have not been mapped
@@ -144,7 +194,7 @@ class NotificationReceivedEventHandlerTest {
         int count = NotificationReceivedEventHandler.PAGE_SIZE + 10;
         List<AlertNotificationModel> alertNotificationModels = new ArrayList<>(count);
         AtomicLong counter = new AtomicLong(notificationId);
-        for(int index = 0; index < count; index++) {
+        for (int index = 0; index < count; index++) {
             alertNotificationModels.add(createAlertNotificationModel(counter.getAndIncrement(), false, false));
         }
         NotificationAccessor notificationAccessor = new MockNotificationAccessor(alertNotificationModels, batchId);
@@ -153,12 +203,18 @@ class NotificationReceivedEventHandlerTest {
         // the batch limit has been exceeded
         Mockito.when(jobNotificationMapper.hasBatchReachedSizeLimit(Mockito.any(UUID.class), Mockito.anyInt())).thenReturn(true);
 
-        NotificationMappingProcessor notificationMappingProcessor = new NotificationMappingProcessor(notificationDetailExtractionDelegator, jobNotificationMapper, notificationAccessor, alertProperties);
+        NotificationMappingProcessor notificationMappingProcessor = new NotificationMappingProcessor(
+            notificationDetailExtractionDelegator,
+            jobNotificationMapper,
+            notificationAccessor,
+            alertProperties
+        );
         RecordingEventManager eventManager = mockEventManager();
 
         NotificationReceivedEventHandler eventHandler = new NotificationReceivedEventHandler(notificationAccessor, notificationMappingProcessor, eventManager);
         eventHandler.handle(new NotificationReceivedEvent(2L, batchId));
-        AlertNotificationModel updatedNotificationModel = notificationAccessor.findById(notificationId).orElseThrow(() -> new AssertionError("Expected notification not found.  Expected to find a notification with id: " + notificationId));
+        AlertNotificationModel updatedNotificationModel = notificationAccessor.findById(notificationId)
+            .orElseThrow(() -> new AssertionError("Expected notification not found.  Expected to find a notification with id: " + notificationId));
 
         Assertions.assertTrue(updatedNotificationModel.isMappingToJobs());
         Assertions.assertTrue(updatedNotificationModel.getProcessed());
@@ -170,7 +226,7 @@ class NotificationReceivedEventHandlerTest {
         Assertions.assertEquals(NotificationReceivedEvent.NOTIFICATION_RECEIVED_EVENT_TYPE, eventManager.getEventList().get(1).getDestination());
     }
 
-    private AlertNotificationModel createAlertNotificationModel(Long id, boolean processed,boolean mappingToJobs) throws IOException {
+    private AlertNotificationModel createAlertNotificationModel(Long id, boolean processed, boolean mappingToJobs) throws IOException {
         Long providerConfigId = 2L;
         String provider = "provider-test";
         String notificationType = "PROJECT_VERSION";


### PR DESCRIPTION
This MR is the merging of the IALERT-3979 feature branch into master. This MR is the combination of many other already previously reviewed MRs.

MRs and IALERT ticket numbers included in this merge:
  - IALERT-4053 — Edge case handling for orphaned job mappings
  - IALERT-4054 — Issue tracker logging improvements
  - IALERT-4057 — Fix audit failure handling for issue trackers
  - IALERT-4064 — Prevent DB constraint violations when saving duplicate notifications by content ID